### PR TITLE
Mark primitive layer as needs redraw if props change

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -528,6 +528,7 @@ export default class Layer extends Component {
       // Render or update previously rendered sublayers
       this._renderLayers(updateParams);
     } else {
+      this.setNeedsRedraw();
       // Add any subclass attributes
       this.updateAttributes(this.props);
       this._updateBaseUniforms();


### PR DESCRIPTION
#### Background
Unbreak a change made in https://github.com/uber/deck.gl/pull/2364

Some primitive layers use uniform props in `draw` only, so the model is not marked as needs update after `updateState`.

#### Change List
- Set needs update flag if props of a primitive layer change
