### PR TITLE
layer-browser: Static scenegraph example

### DIFF
--- a/examples/layer-browser/src/app.js
+++ b/examples/layer-browser/src/app.js
@@ -303,6 +303,7 @@ export default class App extends PureComponent {
           onViewStateChange={this._onViewStateChange}
           effects={effects ? this._effects : []}
           pickingRadius={pickingRadius}
+          onWebGLInitialized={gl => {window.gl = gl;}}
           onHover={this._onHover}
           onClick={this._onClick}
           useDevicePixels={useDevicePixels}

--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -51,33 +51,14 @@ const SimpleMeshLayerExample = {
   }
 };
 
-
-const DUCK_URL = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb';
-let scenegraph = null;
-/* global fetch, window */
-fetch(DUCK_URL).then(response => response.arrayBuffer()).then(arrayBuffer => {
-  return parse(arrayBuffer, GLTFScenegraphLoader, {gl: window.gl});
-}).then(data => {
-  scenegraph = data.scenes[0];
-});
-
 const ScenegraphLayerStaticExample = {
   layer: ScenegraphLayer,
-  getData() {
-    if (!scenegraph) {
-      throw new Error("Scenegraph not loaded");
-    }
-    console.log('Static Scenegraph') // eslint-disable-line
-    return scenegraph;
-  },
   props: {
     id: 'scenegraph-layer',
     data: dataSamples.points,
     pickable: true,
     sizeScale: 50,
-    scenegraph,
-    // scenegraph:
-      // 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb',
+    scenegraph: null,
     getPosition: d => d.COORDINATES,
     getOrientation: d => [Math.random() * 360, Math.random() * 360, Math.random() * 360],
     getTranslation: d => [0, 0, Math.random() * 10000],
@@ -85,10 +66,32 @@ const ScenegraphLayerStaticExample = {
   }
 };
 
+const DUCK_URL =
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb';
+/* global fetch, window */
+fetch(DUCK_URL)
+  .then(response => response.arrayBuffer())
+  .then(arrayBuffer => {
+    const loadOptions = {
+      gl: window.gl,
+      waitForFullLoad: true,
+      modelOptions: {
+        vs: require('../../../../modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.js').default,
+        fs: require('../../../../modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-fragment.glsl.js').default,
+        modules: ['project32', 'picking'],
+        isInstanced: true
+      }
+    };
+    return parse(arrayBuffer, GLTFScenegraphLoader, loadOptions);
+  })
+  .then(data => {
+    ScenegraphLayerStaticExample.props.scenegraph = data.scenes[0];
+  });
+
 const ScenegraphLayerExample = {
   layer: ScenegraphLayer,
   props: {
-    id: 'scenegraph-layer',
+    id: 'scenegraph-layer-static',
     data: dataSamples.points,
     pickable: true,
     sizeScale: 50,

--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -61,7 +61,7 @@ fetch(DUCK_URL).then(response => response.arrayBuffer()).then(arrayBuffer => {
   scenegraph = data.scenes[0];
 });
 
-const ScenegraphLayerExample = {
+const ScenegraphLayerStaticExample = {
   layer: ScenegraphLayer,
   getData() {
     if (!scenegraph) {
@@ -78,6 +78,22 @@ const ScenegraphLayerExample = {
     scenegraph,
     // scenegraph:
       // 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb',
+    getPosition: d => d.COORDINATES,
+    getOrientation: d => [Math.random() * 360, Math.random() * 360, Math.random() * 360],
+    getTranslation: d => [0, 0, Math.random() * 10000],
+    getScale: [1, 1, 1]
+  }
+};
+
+const ScenegraphLayerExample = {
+  layer: ScenegraphLayer,
+  props: {
+    id: 'scenegraph-layer',
+    data: dataSamples.points,
+    pickable: true,
+    sizeScale: 50,
+    scenegraph:
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb',
     getPosition: d => d.COORDINATES,
     getOrientation: d => [Math.random() * 360, Math.random() * 360, Math.random() * 360],
     getTranslation: d => [0, 0, Math.random() * 10000],
@@ -194,7 +210,8 @@ const TripsLayerExample = {
 export default {
   'Mesh Layers': {
     SimpleMeshLayer: SimpleMeshLayerExample,
-    ScenegraphLayer: ScenegraphLayerExample
+    'ScenegraphLayer (URL scenegraph)': ScenegraphLayerExample,
+    'ScenegraphLayer (Static scenegraph)': ScenegraphLayerStaticExample
   },
   'Geo Layers': {
     S2Layer: S2LayerExample,

--- a/examples/layer-browser/src/examples/additional-layers.js
+++ b/examples/layer-browser/src/examples/additional-layers.js
@@ -12,7 +12,7 @@ import {
 import {_GPUGridLayer as GPUGridLayer} from '@deck.gl/aggregation-layers';
 import * as h3 from 'h3-js';
 
-import {registerLoaders} from '@loaders.gl/core';
+import {registerLoaders, parse} from '@loaders.gl/core';
 import {PLYLoader} from '@loaders.gl/ply';
 import {GLTFScenegraphLoader} from '@luma.gl/addons';
 
@@ -51,15 +51,33 @@ const SimpleMeshLayerExample = {
   }
 };
 
+
+const DUCK_URL = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb';
+let scenegraph = null;
+/* global fetch, window */
+fetch(DUCK_URL).then(response => response.arrayBuffer()).then(arrayBuffer => {
+  return parse(arrayBuffer, GLTFScenegraphLoader, {gl: window.gl});
+}).then(data => {
+  scenegraph = data.scenes[0];
+});
+
 const ScenegraphLayerExample = {
   layer: ScenegraphLayer,
+  getData() {
+    if (!scenegraph) {
+      throw new Error("Scenegraph not loaded");
+    }
+    console.log('Static Scenegraph') // eslint-disable-line
+    return scenegraph;
+  },
   props: {
     id: 'scenegraph-layer',
     data: dataSamples.points,
     pickable: true,
     sizeScale: 50,
-    scenegraph:
-      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb',
+    scenegraph,
+    // scenegraph:
+      // 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb',
     getPosition: d => d.COORDINATES,
     getOrientation: d => [Math.random() * 360, Math.random() * 360, Math.random() * 360],
     getTranslation: d => [0, 0, Math.random() * 10000],


### PR DESCRIPTION
# For #3130 

- Using `ScenegraphLayer` with non-URL scenegraphs appears broken.
- This PR reproduces the issue in the layer browser.