### PR TITLE
[POC] Geo projection extension

### DIFF
--- a/modules/core/src/controllers/map-controller.js
+++ b/modules/core/src/controllers/map-controller.js
@@ -38,6 +38,7 @@ const DEFAULT_STATE = {
 
 class MapState extends ViewState {
   constructor({
+    ViewportType = WebMercatorViewport,
     /** Mapbox viewport properties */
     /** The width of the viewport */
     width,
@@ -104,6 +105,8 @@ class MapState extends ViewState {
       startPitch,
       startZoom
     };
+
+    this.ViewportType = ViewportType;
   }
 
   /* Public API */
@@ -251,7 +254,7 @@ class MapState extends ViewState {
 
     const zoom = this._calculateNewZoom({scale, startZoom});
 
-    const zoomedViewport = new WebMercatorViewport(Object.assign({}, this._viewportProps, {zoom}));
+    const zoomedViewport = new this.ViewportType(Object.assign({}, this._viewportProps, {zoom}));
     const [longitude, latitude] = zoomedViewport.getLocationAtPoint({lngLat: startZoomLngLat, pos});
 
     return this._getUpdatedState({
@@ -374,13 +377,13 @@ class MapState extends ViewState {
   }
 
   _unproject(pos) {
-    const viewport = new WebMercatorViewport(this._viewportProps);
+    const viewport = new this.ViewportType(this._viewportProps);
     return pos && viewport.unproject(pos);
   }
 
   // Calculate a new lnglat based on pixel dragging position
   _calculateNewLngLat({startPanLngLat, pos}) {
-    const viewport = new WebMercatorViewport(this._viewportProps);
+    const viewport = new this.ViewportType(this._viewportProps);
     return viewport.getMapCenterByLngLatPosition({lngLat: startPanLngLat, pos});
   }
 

--- a/modules/core/src/lib/layer-extension.js
+++ b/modules/core/src/lib/layer-extension.js
@@ -60,6 +60,10 @@ export class LayerExtension {
     return newProps;
   }
 
+  shouldUpdateState(context, extension) {
+    return false;
+  }
+
   initializeState(context, extension) {}
 
   updateState(params, extension) {}

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -135,7 +135,20 @@ export default class Layer extends Component {
   // Checks if layer attributes needs updating
   needsUpdate() {
     // Call subclass lifecycle method
-    return this.internalState.needsUpdate || this.shouldUpdateState(this._getUpdateParams());
+    if (this.internalState.needsUpdate) {
+      return true;
+    }
+    const updateParams = this._getUpdateParams();
+    if (this.shouldUpdateState(updateParams)) {
+      return true;
+    }
+    // Call extension lifecycle methods
+    for (const extension of this.props.extensions) {
+      if (extension.shouldUpdateState.call(this, updateParams, extension)) {
+        return true;
+      }
+    }
+    return false;
     // End lifecycle method
   }
 

--- a/modules/core/src/utils/tesselator.js
+++ b/modules/core/src/utils/tesselator.js
@@ -38,9 +38,10 @@ export default class Tesselator {
   }
 
   /* Public methods */
-  updateGeometry({data, getGeometry, positionFormat, dataChanged}) {
+  updateGeometry({data, getGeometry, positionFormat, positionTransform, dataChanged}) {
     this.data = data;
     this.getGeometry = getGeometry;
+    this.positionTransform = positionTransform;
     this.positionSize = positionFormat === 'XY' ? 2 : 3;
     if (Array.isArray(dataChanged)) {
       // is partial update

--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -91,8 +91,7 @@ export default class OrbitView extends View {
 
   get controller() {
     return this._getControllerProps({
-      type: OrbitController,
-      ViewportType: OrbitViewport
+      type: OrbitController
     });
   }
 }

--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -48,8 +48,7 @@ export default class OrthographicView extends View {
 
   get controller() {
     return this._getControllerProps({
-      type: OrthographicController,
-      ViewportType: OrthographicViewport
+      type: OrthographicController
     });
   }
 }

--- a/modules/core/src/views/view.js
+++ b/modules/core/src/views/view.js
@@ -138,13 +138,10 @@ export default class View {
     if (!opts) {
       return null;
     }
-    if (opts === true) {
-      return defaultOpts;
-    }
     if (typeof opts === 'function') {
       opts = {type: opts};
     }
-    return Object.assign({}, defaultOpts, opts);
+    return Object.assign({ViewportType: this.type}, defaultOpts, opts);
   }
 
   // Overridable method

--- a/modules/extensions/src/geo-projection/geo-controller.js
+++ b/modules/extensions/src/geo-projection/geo-controller.js
@@ -1,0 +1,53 @@
+import {clamp} from 'math.gl';
+import {MapController, Controller} from '@deck.gl/core';
+
+const MapState = new MapController().ControllerState;
+
+class GeoState extends MapState {
+  constructor(opts = {}) {
+    const {
+      /** Viewport constraints */
+      minPitch = -90,
+      maxPitch = 90
+    } = opts;
+    super(Object.assign({}, opts, {maxPitch, minPitch}));
+  }
+
+  /* Modified from MapState source */
+  _getUpdatedState(newProps) {
+    const props = Object.assign(
+      {ViewportType: this.ViewportType},
+      this._viewportProps,
+      this._interactiveState,
+      newProps
+    );
+    const validate = this.ViewportType.isValid;
+    if (validate && !validate([props.longitude, props.latitude])) {
+      return this;
+    }
+    // Update _viewportProps
+    return new GeoState(props);
+  }
+
+  // Apply any constraints (mathematical or defined by _viewportProps) to map state
+  _applyConstraints(props) {
+    props.zoom = clamp(props.zoom, props.minZoom, props.maxZoom);
+    props.pitch = clamp(props.pitch, props.minPitch, props.maxPitch);
+    return props;
+  }
+
+  // Calculates a new pitch and bearing from a position (coming from an event)
+  _calculateNewPitchAndBearing({deltaScaleX, deltaScaleY, startBearing, startPitch}) {
+    return {
+      pitch: startPitch + 180 * deltaScaleY,
+      bearing: startBearing + 180 * deltaScaleX
+    };
+  }
+}
+
+export default class GeoController extends Controller {
+  constructor(props) {
+    super(GeoState, props);
+    this.invertPan = true;
+  }
+}

--- a/modules/extensions/src/geo-projection/geo-projection-view.js
+++ b/modules/extensions/src/geo-projection/geo-projection-view.js
@@ -1,0 +1,82 @@
+import {View, WebMercatorViewport} from '@deck.gl/core';
+import MapController from './geo-controller';
+
+const TILE_SIZE = 512;
+const EARTH_CIRCOMFERENCE = 40075017;
+const ZERO_VECTOR = [0, 0, 0];
+const WORLD = {
+  type: 'Polygon',
+  coordinates: [[[-180, -85], [-180, 85], [180, 85], [180, -85], [-180, -85]]]
+};
+
+/*
+ * @param projection - d3 projection
+ */
+function normalizeProjection(projection) {
+  return projection
+    .fitSize([1, 1], WORLD) // fit world in a 1x1 box
+    .rotate([0, 0, 0]); // reset
+}
+
+function createViewportClass(projection) {
+  normalizeProjection(projection);
+
+  class CustomViewport extends WebMercatorViewport {
+    static isValid(lngLatZ) {
+      const p = projection(lngLatZ);
+      return p.every(Number.isFinite);
+    }
+
+    constructor(opts) {
+      projection.rotate([opts.bearing || 0, -opts.pitch || 0, 0]);
+      super(Object.assign({}, opts, {pitch: 0, bearing: 0}));
+    }
+
+    getRawProjection() {
+      return projection;
+    }
+
+    projectFlat(lngLatZ, scale = this.scale) {
+      scale *= TILE_SIZE;
+      const p = projection(lngLatZ);
+      return [p[0] * scale, p[1] * scale];
+    }
+
+    unprojectFlat(xyz, scale = this.scale) {
+      scale *= TILE_SIZE;
+      const p = [xyz[0] / scale, xyz[1] / scale];
+      return projection.invert(p);
+    }
+
+    getDistanceScales() {
+      const scale = this.scale * TILE_SIZE;
+      const commonUnitsPerWorldUnit = [scale, scale, scale / EARTH_CIRCOMFERENCE];
+      const worldUnitsPerCommonUnit = [1 / scale, 1 / scale, EARTH_CIRCOMFERENCE / scale];
+      return {
+        pixelsPerMeter: commonUnitsPerWorldUnit,
+        metersPerPixel: worldUnitsPerCommonUnit,
+        pixelsPerDegree: commonUnitsPerWorldUnit,
+        pixelsPerDegree2: ZERO_VECTOR
+      };
+    }
+  }
+
+  return CustomViewport;
+}
+
+export default class GeoProjectionView extends View {
+  constructor(props) {
+    const {projection} = props;
+    super(
+      Object.assign({}, props, {
+        type: createViewportClass(projection)
+      })
+    );
+  }
+
+  get controller() {
+    return this._getControllerProps({
+      type: MapController
+    });
+  }
+}

--- a/modules/extensions/src/geo-projection/geo-projection.js
+++ b/modules/extensions/src/geo-projection/geo-projection.js
@@ -1,0 +1,86 @@
+import {LayerExtension, COORDINATE_SYSTEM} from '@deck.gl/core';
+
+const POSITION_ATTRIB_PATTERN = /positions/i;
+
+const geoProjectionShaderModule = {
+  name: 'geo-projection',
+  dependencies: ['project'],
+  getUniforms: opts => {
+    return (
+      opts &&
+      opts.viewport && {
+        project_uCoordinateSystem: COORDINATE_SYSTEM.IDENTITY
+      }
+    );
+  }
+};
+
+export default class GeoProjectionExtension extends LayerExtension {
+  getShaders(extension) {
+    return {
+      modules: [geoProjectionShaderModule]
+    };
+  }
+
+  initializeState(context, extension) {
+    if (!this.getAttributeManager()) {
+      return;
+    }
+
+    const {viewport} = context;
+    // Check the signature of our custom viewport
+    if (!viewport.getRawProjection) {
+      throw new Error('GeoProjectionExtension: must be used with GeoProjectionView');
+    }
+    const projection = viewport.getRawProjection();
+
+    extension._updatePositionAttributes.call(this, projection);
+  }
+
+  shouldUpdateState({context, changeFlags}, extension) {
+    const attributeManager = this.getAttributeManager();
+    if (!attributeManager) {
+      return false;
+    }
+
+    const {viewport} = context;
+    const {lastRotation, lastProjection} = this.state;
+    const projection = viewport.getRawProjection();
+    const rotation = projection.rotate();
+    const projectionChanged =
+      lastProjection !== projection ||
+      lastRotation[0] !== rotation[0] ||
+      lastRotation[1] !== rotation[1] ||
+      lastRotation[2] !== rotation[2];
+
+    if (!projectionChanged) {
+      return false;
+    }
+    extension._updatePositionAttributes.call(this, projection);
+    // Tesselators rely on update triggers to recalculate attributes
+    changeFlags.updateTriggersChanged = changeFlags.updateTriggersChanged || {};
+    changeFlags.updateTriggersChanged.all = true;
+
+    return true;
+  }
+
+  _updatePositionAttributes(projection) {
+    const attributeManager = this.getAttributeManager();
+
+    const attributes = attributeManager.getAttributes();
+    for (const attributeName in attributes) {
+      if (POSITION_ATTRIB_PATTERN.test(attributeName)) {
+        const attribute = attributes[attributeName];
+        attribute.userData.transform = projection;
+        attribute.setNeedsUpdate('projection changed');
+      }
+    }
+
+    this.setState({
+      lastProjection: projection,
+      lastRotation: projection.rotate()
+    });
+  }
+}
+
+GeoProjectionExtension.extensionName = 'GeoProjectionExtension';

--- a/modules/extensions/src/index.js
+++ b/modules/extensions/src/index.js
@@ -1,3 +1,6 @@
 export {default as BrushingExtension} from './brushing/brushing';
 export {default as DataFilterExtension} from './data-filter/data-filter';
 export {default as Fp64Extension} from './fp64/fp64';
+
+export {default as GeoProjectionExtension} from './geo-projection/geo-projection';
+export {default as GeoProjectionView} from './geo-projection/geo-projection-view';

--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.js
@@ -25,7 +25,7 @@ attribute vec3 positions;
 attribute vec4 instanceSourceColors;
 attribute vec4 instanceTargetColors;
 attribute vec4 instancePositions;
-attribute vec4 instancePositions64Low;
+attribute vec4 instancePositions64xyLow;
 attribute vec3 instancePickingColors;
 attribute float instanceWidths;
 attribute float instanceHeights;
@@ -82,8 +82,8 @@ void main(void) {
   geometry.worldPosition = vec3(instancePositions.xy, 0.0);
   geometry.worldPositionAlt = vec3(instancePositions.zw, 0.0);
 
-  vec2 source = project_position(geometry.worldPosition, instancePositions64Low.xy).xy;
-  vec2 target = project_position(geometry.worldPositionAlt, instancePositions64Low.zw).xy;
+  vec2 source = project_position(geometry.worldPosition, instancePositions64xyLow.xy).xy;
+  vec2 target = project_position(geometry.worldPositionAlt, instancePositions64xyLow.zw).xy;
 
   float segmentIndex = positions.x;
   float segmentRatio = getSegmentRatio(segmentIndex);

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -168,16 +168,23 @@ export default class ArcLayer extends Layer {
   calculateInstancePositions(attribute, {startRow, endRow}) {
     const {data, getSourcePosition, getTargetPosition} = this.props;
     const {value, size} = attribute;
+    const transform = attribute.userData.transform;
     let i = startRow * size;
     const {iterable, objectInfo} = createIterable(data, startRow, endRow);
     for (const object of iterable) {
       objectInfo.index++;
-      const sourcePosition = getSourcePosition(object, objectInfo);
+      let sourcePosition = getSourcePosition(object, objectInfo);
+      if (transform) {
+        sourcePosition = transform(sourcePosition);
+      }
       value[i++] = sourcePosition[0];
       value[i++] = sourcePosition[1];
       // Call `getTargetPosition` after `sourcePosition` is used in case both accessors write into
       // the same temp array
-      const targetPosition = getTargetPosition(object, objectInfo);
+      let targetPosition = getTargetPosition(object, objectInfo);
+      if (transform) {
+        targetPosition = transform(targetPosition);
+      }
       value[i++] = targetPosition[0];
       value[i++] = targetPosition[1];
     }

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -148,6 +148,7 @@ export default class PathLayer extends Layer {
         data: props.data,
         getGeometry: props.getPath,
         positionFormat: props.positionFormat,
+        positionTransform: attributeManager.getAttributes().startPositions.userData.transform,
         dataChanged: changeFlags.dataChanged
       });
       this.setState({

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.js
@@ -60,6 +60,17 @@ export default class PolygonTesselator extends Tesselator {
   updateGeometryAttributes(polygon, context) {
     polygon = Polygon.normalize(polygon, this.positionSize, context.geometrySize);
 
+    const {positionSize, positionTransform} = this;
+    const {positions} = polygon;
+    if (positionTransform) {
+      for (let i = 0; i < positions.length; i += positionSize) {
+        const p = positionTransform(positions.slice(i, i + positionSize));
+        for (let j = 0; j < positionSize; j++) {
+          positions[i + j] = p[j] || 0;
+        }
+      }
+    }
+
     this._updateIndices(polygon, context);
     this._updatePositions(polygon, context);
   }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -247,6 +247,7 @@ export default class SolidPolygonLayer extends Layer {
         data: props.data,
         getGeometry: props.getPolygon,
         positionFormat: props.positionFormat,
+        positionTransform: this.getAttributeManager().getAttributes().positions.userData.transform,
         fp64: this.use64bitPositions(),
         dataChanged: changeFlags.dataChanged
       });

--- a/test/apps/custom-projection/app.js
+++ b/test/apps/custom-projection/app.js
@@ -1,0 +1,82 @@
+import {Deck} from '@deck.gl/core';
+import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
+import {GeoProjectionExtension, GeoProjectionView} from '@deck.gl/extensions';
+import * as d3 from 'd3-geo';
+
+// source: Natural Earth http://www.naturalearthdata.com/ via geojson.xyz
+const COUNTRIES =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson'; //eslint-disable-line
+const AIR_PORTS =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson';
+
+const INITIAL_VIEW_STATE = {
+  latitude: 51.47,
+  longitude: 0.45,
+  zoom: 4,
+  bearing: 0,
+  pitch: 0
+};
+
+// Provides the correct viewport and controller
+const VIEW = new GeoProjectionView({
+  // projection: d3.geoEqualEarth()
+  // projection: d3.geoConicConformal()
+  // projection: d3.geoStereographic()
+  projection: d3.geoAzimuthalEqualArea()
+});
+const EXTENSIONS = [new GeoProjectionExtension()];
+
+export const deck = new Deck({
+  views: VIEW,
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: true,
+  layers: [
+    new GeoJsonLayer({
+      id: 'base-map',
+      data: COUNTRIES,
+      // Styles
+      stroked: true,
+      filled: true,
+      lineWidthMinPixels: 2,
+      opacity: 0.4,
+      getLineDashArray: [3, 3],
+      getLineColor: [60, 60, 60],
+      getFillColor: [200, 200, 200],
+      extensions: EXTENSIONS
+    }),
+    new GeoJsonLayer({
+      id: 'airports',
+      data: AIR_PORTS,
+      // Styles
+      filled: true,
+      pointRadiusMinPixels: 2,
+      opacity: 1,
+      pointRadiusScale: 2000,
+      getRadius: f => 11 - f.properties.scalerank,
+      getFillColor: [200, 0, 80, 180],
+      extensions: EXTENSIONS,
+      // Interactive props
+      pickable: true,
+      autoHighlight: true,
+      onClick: info =>
+        // eslint-disable-next-line
+        info.object && alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
+    }),
+    new ArcLayer({
+      id: 'arcs',
+      data: AIR_PORTS,
+      dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
+      // Styles
+      getSourcePosition: f => [-0.4531566, 51.4709959], // London
+      getTargetPosition: f => f.geometry.coordinates,
+      getSourceColor: [0, 128, 200],
+      getTargetColor: [200, 0, 80],
+      extensions: EXTENSIONS,
+      getWidth: 1
+    })
+  ]
+});
+
+// For automated test cases
+/* global document */
+document.body.style.margin = '0px';

--- a/test/apps/custom-projection/package.json
+++ b/test/apps/custom-projection/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pure-js-basic",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build": "webpack -p"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^7.0.0",
+    "@deck.gl/layers": "^7.0.0",
+    "d3-geo-projection": "^2.7.0"
+  },
+  "devDependencies": {
+    "html-webpack-plugin": "^3.0.7",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/test/apps/custom-projection/webpack.config.js
+++ b/test/apps/custom-projection/webpack.config.js
@@ -1,0 +1,17 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: './app.js'
+  },
+
+  plugins: [new HtmlWebpackPlugin({title: 'deck.gl example'})]
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);


### PR DESCRIPTION
The `GeoProjectionView` class accepts any d3-geo projection. The position transform is injected into each layer by the `GeoProjectionExtension`. Panning and zooming is fully working:

![custom-projection](https://user-images.githubusercontent.com/2059298/63629797-53690280-c5c9-11e9-9424-fcda2ff3cc0e.gif)

Pre-projection is performed on the CPU and rendered in IDENTITY mode, so rotating  results in attribute updates:

![custom-projection-2](https://user-images.githubusercontent.com/2059298/63629923-9c6d8680-c5ca-11e9-9647-2b01e03d2d2f.gif)


#### Change List
- Generalize `MapController`
- `View` class passes `ViewportType` to controller
- Add `shouldUpdateState` lifecycle method to `LayerExtension`
- Add `positionTransform` option to `Tesselator` class
- `GeoProjectionExtension` and `GeoProjectionView`
- Test app
