### PR TITLE
WIP Support multiple views within a pydeck visualization

### DIFF
--- a/bindings/pydeck/examples/contour_layer.py
+++ b/bindings/pydeck/examples/contour_layer.py
@@ -81,7 +81,6 @@ poultry = pydeck.Layer(
 r = pydeck.Deck(
     layers=[cattle, poultry],
     initial_view_state=view,
-    map_style="mapbox://styles/mapbox/satellite-v9",
     tooltip={
         "text": "Concentration of cattle in blue, concentration of poultry in orange"
     },

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -13,8 +13,13 @@ class Deck(JSONMixin):
     def __init__(
         self,
         layers=[],
-        views=[View(type="MapView", controller=True)],
-        map_style="mapbox://styles/mapbox/dark-v9",
+        views=[
+            View(
+                type="MapView",
+                controller=True,
+                map_style="mapbox://styles/mapbox/dark-v9",
+            )
+        ],
         mapbox_key=None,
         initial_view_state=None,
         width="100%",
@@ -31,11 +36,9 @@ class Deck(JSONMixin):
 
         layers : pydeck.Layer or list of pydeck.Layer, default []
             List of :class:`pydeck.bindings.layer.Layer` layers to render.
-        views : list of pydeck.View, []
+        views : list of pydeck.View, default `[pydeck.bindings.view.View()]`
             List of :class:`pydeck.bindings.view.View` objects to render.
-        map_style : str, default 'mapbox://styles/mapbox/dark-v9'
-            URI for Mapbox basemap style. See Mapbox's `gallery <https://www.mapbox.com/gallery/>`_ for examples.
-            If not using a basemap, you can set this value to to an empty string, `''`.
+            Defaults to using a Mapbox Dark basemap.
         initial_view_state : pydeck.ViewState, default None
             Initial camera angle relative to the map, defaults to a fully zoomed out 0, 0-centered map
             To compute a viewport from data, see :func:`pydeck.data_utils.viewport_helpers.compute_view`
@@ -61,13 +64,15 @@ class Deck(JSONMixin):
         .. _gallery:
             https://www.mapbox.com/gallery/
         """
+        # NOTE It seems that standalone DeckGL insists on only one map style
+        # This PR is blocked until it can support multiple
+        self.map_style = ""
         self.layers = []
         if isinstance(layers, Layer):
             self.layers.append(layers)
         else:
             self.layers = layers
         self.views = views
-        self.map_style = map_style
         # Use passed view state
         self.initial_view_state = initial_view_state
         self.deck_widget = DeckGLWidget()
@@ -77,6 +82,7 @@ class Deck(JSONMixin):
         self.deck_widget.width = width
         self.deck_widget.tooltip = tooltip
         self.description = description
+        # Clobber default map style
         if self.mapbox_key is None:
             warnings.warn(
                 "Mapbox API key is not set. This may impact available features of pydeck.",

--- a/bindings/pydeck/pydeck/bindings/view.py
+++ b/bindings/pydeck/pydeck/bindings/view.py
@@ -10,16 +10,37 @@ class View(JSONMixin):
     ---------
     type : str, default None
         deck.gl view to display, e.g., MapView
+    map_style : str, default None
+        URI for Mapbox basemap style. See Mapbox's `gallery <https://www.mapbox.com/gallery/>`_ for examples.
+        If not using a basemap, you can set this value to to an empty string, `''`.
     controller : bool, default None
         If enabled, camera becomes interactive.
     """
     def __init__(
         self,
         type=None,
-        controller=None
+        id=None,
+        map_style=None,
+        controller=None,
+        height=None,
+        width=None,
+        clear=None,
+        x=None,
+        y=None,
+        view_state=None,
+        **kwargs
     ):
         self.type = type
         self.controller = controller
+        self.map_style = map_style
+        self.view_state = view_state
+        self.x = x
+        self.y = y
+        self.clear = clear
+        self.height = height
+
+        if kwargs:
+            self.__dict__.update(kwargs)
 
     @property
     def type(self):

--- a/bindings/pydeck/tests/bindings/pydeck_examples/geojson_layer.py
+++ b/bindings/pydeck/tests/bindings/pydeck_examples/geojson_layer.py
@@ -25,7 +25,6 @@ features = {
 def create_geojson_layer_test_object():
     return Deck(
         description="Test of GeoJsonLayer",
-        map_style=None,
         initial_view_state=ViewState(longitude=-122.45, latitude=37.8, zoom=0),
         layers=[
             Layer(

--- a/bindings/pydeck/tests/bindings/pydeck_examples/hexagon_layer_function.py
+++ b/bindings/pydeck/tests/bindings/pydeck_examples/hexagon_layer_function.py
@@ -75,7 +75,6 @@ def create_heatmap_test_object():
                 "bearing": -27.396674584323023,
             }
         ),
-        views=[View(type="MapView", controller=True)],
+        views=[View(type="MapView", controller=True, map_style=None)],
         layers=[failed_hexagon_layer, successful_heatmap_layer],
-        map_style=None,
     )

--- a/bindings/pydeck/tests/bindings/pydeck_examples/stacked.py
+++ b/bindings/pydeck/tests/bindings/pydeck_examples/stacked.py
@@ -40,5 +40,4 @@ def create_stacked_test_object():
         layers=[scatterplot, text_layer],
         initial_view_state=view_state,
         views=None,
-        map_style=None,
     )

--- a/bindings/pydeck/tests/browser/test_html_renderer.py
+++ b/bindings/pydeck/tests/browser/test_html_renderer.py
@@ -1,47 +1,56 @@
 import pytest
 import os
-from pydeck import Deck, Layer, ViewState
+from pydeck import Deck, Layer, ViewState, View
 
 from ..fixtures import fixtures
 
-text_data = [{'text': 'Test', 'position': [0.0, 0.0]}]
+text_data = [{"text": "Test", "position": [0.0, 0.0]}]
 scatterplot_data = [
-    {'rgb': [136, 45, 97], 'position': [-0.002, 0.002]},
-    {'rgb': [170, 57, 57], 'position': [-0.002, -0.002]},
-    {'rgb': [45, 136, 45], 'position': [0.002, -0.002]},
-    {'rgb': [123, 159, 53], 'position': [0.002, 0.002]},
+    {"rgb": [136, 45, 97], "position": [-0.002, 0.002]},
+    {"rgb": [170, 57, 57], "position": [-0.002, -0.002]},
+    {"rgb": [45, 136, 45], "position": [0.002, -0.002]},
+    {"rgb": [123, 159, 53], "position": [0.002, 0.002]},
 ]
-d = Deck(layers=[
-   Layer(
-        'ScatterplotLayer',
-        data=scatterplot_data,
-        get_radius=100,
-        picking_radius=5,
-        pickable=True,
-        get_color='rgb',
-        get_position='position'),
-    Layer(
-        'TextLayer',
-        data=text_data,
-        picking_radius=5,
-        get_color=[255, 255, 255],
-        pickable=True,
-        font_size=72,
-        get_position='position'),
-    ])
+d = Deck(
+    layers=[
+        Layer(
+            "ScatterplotLayer",
+            data=scatterplot_data,
+            get_radius=100,
+            picking_radius=5,
+            pickable=True,
+            get_color="rgb",
+            get_position="position",
+        ),
+        Layer(
+            "TextLayer",
+            data=text_data,
+            picking_radius=5,
+            get_color=[255, 255, 255],
+            pickable=True,
+            font_size=72,
+            get_position="position",
+        ),
+    ]
+)
 v = ViewState(latitude=0, longitude=0, zoom=15)
 d.initial_view_state = v
 
 
-@pytest.mark.skipif(os.environ.get('TRAVIS') == 'true', reason='Skipping this test on Travis CI.')
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS") == "true", reason="Skipping this test on Travis CI."
+)
 @pytest.mark.asyncio
 async def test_standalone_rendering(tmp_path):
     from .screenshot_utils import go_to_page_and_screenshot  # noqa
-    filename = d.to_html(str(tmp_path) + '/', open_browser=False, notebook_display=False)
-    await go_to_page_and_screenshot('file://' + filename, filename, output_dir=tmp_path)
+
+    filename = d.to_html(
+        str(tmp_path) + "/", open_browser=False, notebook_display=False
+    )
+    await go_to_page_and_screenshot("file://" + filename, filename, output_dir=tmp_path)
 
 
-@pytest.mark.skip(reason='Not yet implemented')
+@pytest.mark.skip(reason="Not yet implemented")
 @pytest.mark.asyncio
 async def test_notebook_iframe_rendering():
     pass
@@ -51,5 +60,5 @@ def main():
     asyncio.get_event_loop().run_until_complete(run_html())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->

<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4103 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
Attempting to support multiple map styles and multiple views to correspond with this https://deck.gl/playground examples–

![MapStyles](https://user-images.githubusercontent.com/2204757/73584512-d2eadf80-444d-11ea-90b1-42a382239a06.gif)

It seems that standalone DeckGL insists on only one map style, which we'll need to change for this to be a feature in pydeck

#### Change List
-
