### PR TITLE
[Feat] add lineOpacity prop to scatterplot layer

### DIFF
--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.js
@@ -35,6 +35,7 @@ uniform float opacity;
 uniform float radiusScale;
 uniform float radiusMinPixels;
 uniform float radiusMaxPixels;
+uniform float lineOpacity;
 uniform float lineWidthScale;
 uniform float lineWidthMinPixels;
 uniform float lineWidthMaxPixels;
@@ -55,7 +56,7 @@ void main(void) {
     project_size_to_pixel(radiusScale * instanceRadius),
     radiusMinPixels, radiusMaxPixels
   );
-  
+
   // Multiply out line width and clamp to limits
   float lineWidthPixels = clamp(
     project_size_to_pixel(lineWidthScale * instanceLineWidths),
@@ -71,7 +72,7 @@ void main(void) {
   geometry.pickingColor = instancePickingColors;
 
   innerUnitRadius = 1.0 - stroked * lineWidthPixels / outerRadiusPixels;
-  
+
   vec3 offset = positions * project_pixel_size(outerRadiusPixels);
   DECKGL_FILTER_SIZE(offset, geometry);
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset, geometry.position);
@@ -80,7 +81,7 @@ void main(void) {
   // Apply opacity to instance color, or return instance picking color
   vFillColor = vec4(instanceFillColors.rgb, instanceFillColors.a * opacity);
   DECKGL_FILTER_COLOR(vFillColor, geometry);
-  vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * opacity);
+  vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * lineOpacity);
   DECKGL_FILTER_COLOR(vLineColor, geometry);
 }
 `;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -32,6 +32,7 @@ const defaultProps = {
   radiusMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
   radiusMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
 
+  lineOpacity: {type: 'number', min: 0, value: 1},
   lineWidthUnits: 'meters',
   lineWidthScale: {type: 'number', min: 0, value: 1},
   lineWidthMinPixels: {type: 'number', min: 0, value: 0},
@@ -117,6 +118,8 @@ export default class ScatterplotLayer extends Layer {
       radiusMaxPixels,
       stroked,
       filled,
+      opacity,
+      lineOpacity,
       lineWidthUnits,
       lineWidthScale,
       lineWidthMinPixels,
@@ -133,6 +136,7 @@ export default class ScatterplotLayer extends Layer {
         radiusScale,
         radiusMinPixels,
         radiusMaxPixels,
+        lineOpacity: lineOpacity === undefined ? opacity : lineOpacity,
         lineWidthScale: lineWidthScale * widthMultiplier,
         lineWidthMinPixels,
         lineWidthMaxPixels

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -32,7 +32,6 @@ const defaultProps = {
   radiusMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
   radiusMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
 
-  lineOpacity: {type: 'number', min: 0, value: 1},
   lineWidthUnits: 'meters',
   lineWidthScale: {type: 'number', min: 0, value: 1},
   lineWidthMinPixels: {type: 'number', min: 0, value: 0},


### PR DESCRIPTION
#### Feature
It would be nice to be able to adjust fill opacity and line opacity separately. In Geojson layer e.g. I can achieve this by passing _sublayerProps to override opacity of polygon stroke and line string layer. But for point layer, there is currrently no way to control them separately. Here this PR

#### Background

related kepler.gl issue: [Separately adjust opacity of stroke and fill](https://github.com/keplergl/kepler.gl/issues/959)

