### PR TITLE
Add JSON conversion reference to website

### DIFF
--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -759,6 +759,14 @@ export const docPages = generatePath([
           {
             name: 'JSONConverter',
             content: getDocUrl('api-reference/json/json-converter.md')
+          },
+          {
+            name: 'JSONConfiguration',
+            content: getDocUrl('api-reference/json/json-configuration.md')
+          },
+          {
+            name: 'Conversion Reference',
+            content: getDocUrl('api-reference/json/conversion-reference.md')
           }
         ]
       },


### PR DESCRIPTION
I was unaware that there's a `deck.gl/json` [conversion reference](https://github.com/visgl/deck.gl/blob/master/docs/api-reference/json/conversion-reference.md) documentation page, because it isn't available on the website.

This adds the conversion reference page and the [`json-configuration`](https://github.com/visgl/deck.gl/blob/master/docs/api-reference/json/json-configuration.md) page to the website. The latter is just a stub, so if you don't want to include it on the website that's fine, but it would be nice for the conversion reference to be on the website.