### PR TITLE
Fix typo in data filter example

### DIFF
--- a/website-gatsby/src/examples/example-data-filter-demo.jsx
+++ b/website-gatsby/src/examples/example-data-filter-demo.jsx
@@ -32,7 +32,7 @@ export default class DataFilterDemo extends Component {
         <InfoPanel sourceLink={`${GITHUB_TREE}/${this.props.path}`}>
           <h3>40 Years of Earthquakes</h3>
           <p>
-            Earthquakes of manitude 4.5 and above
+            Earthquakes of magnitude 4.5 and above
             <br />
             (1979 - 2019)
           </p>

--- a/website/src/components/demos/data-filter-demo.js
+++ b/website/src/components/demos/data-filter-demo.js
@@ -29,7 +29,7 @@ export default class DataFilterDemo extends Component {
       <div>
         <h3>40 Years of Earthquakes</h3>
         <p>
-          Earthquakes of manitude 4.5 and above
+          Earthquakes of magnitude 4.5 and above
           <br />
           (1979 - 2019)
         </p>


### PR DESCRIPTION
`manitude` should be `magnitude`