### PR TITLE
Fix picking info population

### DIFF
--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -172,11 +172,12 @@ export default class PathLayer extends Layer {
 
   getPickingInfo(params) {
     const info = super.getPickingInfo(params);
-    const {object, index} = info;
+    const {index} = info;
+    const {data} = this.props;
 
-    if (object && object.__source) {
+    if (data[0] && data[0].__source) {
       // data is wrapped
-      info.object = this.props.data.find(d => d.__source.index === index);
+      info.object = data.find(d => d.__source.index === index);
     }
     return info;
   }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -191,11 +191,12 @@ export default class SolidPolygonLayer extends Layer {
 
   getPickingInfo(params) {
     const info = super.getPickingInfo(params);
-    const {object, index} = info;
+    const {index} = info;
+    const {data} = this.props;
 
-    if (object && object.__source) {
+    if (data[0] && data[0].__source) {
       // data is wrapped
-      info.object = this.props.data.find(d => d.__source.index === index);
+      info.object = data.find(d => d.__source.index === index);
     }
     return info;
   }


### PR DESCRIPTION
For #4539

`object` is by default populated as `data[index]` which could be undefined. Use the first data object instead.

#### Change List
- Broken by #4426 
