### PR TITLE
Fix transition start delay

### DIFF
--- a/modules/core/src/transitions/transition.js
+++ b/modules/core/src/transitions/transition.js
@@ -33,13 +33,7 @@ export default class Transition {
     this.cancel();
     this.settings = Object.assign({}, DEFAULT_SETTINGS, props);
     this._inProgress = true;
-
-    const {timeline, settings} = this;
-    this._handle = timeline.addChannel({
-      delay: timeline.getTime(),
-      duration: settings.duration
-    });
-    settings.onStart(this);
+    this.settings.onStart(this);
   }
 
   /**
@@ -72,6 +66,18 @@ export default class Transition {
   update() {
     if (!this._inProgress) {
       return false;
+    }
+
+    // It is important to initialize the handle during `update` instead of `start`.
+    // The CPU time that the `start` frame takes should not be counted towards the duration.
+    // On the other hand, `update` always happens during a render cycle. The clock starts when the
+    // transition is rendered for the first time.
+    if (this._handle === null) {
+      const {timeline, settings} = this;
+      this._handle = timeline.addChannel({
+        delay: timeline.getTime(),
+        duration: settings.duration
+      });
     }
 
     this.time = this.timeline.getTime(this._handle);

--- a/test/modules/core/transitions/transition.spec.js
+++ b/test/modules/core/transitions/transition.spec.js
@@ -21,7 +21,6 @@ test('Transition#start', t => {
     customAttribute: 'custom value'
   });
   t.ok(transition.inProgress, 'Transition is in progress');
-  t.ok(transition._handle, 'Sub-timeline is created');
   t.is(
     transition.settings.customAttribute,
     'custom value',
@@ -53,24 +52,26 @@ test('Transition#update', t => {
     duration: 1,
     easing: time => time * time
   });
+  t.notOk(transition._handle, 'No timeline handle yet');
 
-  transition.update();
+  t.ok(transition.update(), 'transition updated');
+  t.ok(transition._handle, 'Timeline handle is created');
   t.ok(transition.inProgress, 'Transition is in progress');
   t.is(transition.time, 0, 'time is correct');
 
   timeline.setTime(0.5);
-  transition.update();
+  t.ok(transition.update(), 'transition updated');
   t.ok(transition.inProgress, 'Transition is in progress');
   t.is(transition.time, 0.5, 'time is correct');
 
   timeline.setTime(1.5);
-  transition.update();
+  t.ok(transition.update(), 'transition updated');
   t.notOk(transition.inProgress, 'Transition has ended');
+  t.notOk(transition._handle, 'Timeline handle is cleared');
   t.is(transition.time, 1, 'time is correct');
 
   timeline.setTime(2);
-  transition.update();
-  t.notOk(transition.inProgress, 'Transition has ended');
+  t.notOk(transition.update(), 'transition is not updated');
 
   t.is(onUpdateCallCount, 3, 'onUpdate is called 3 times');
   t.is(onEndCallCount, 1, 'onEnd is called once');


### PR DESCRIPTION
#### Background

Currently the start time of a transition is recorded when it's triggered, not when it's first rendered. As a result, the CPU time during the start frame eats into the requested duration. This becomes a problem if heavy processing is required to trigger the transition (e.g. attribute transition may need to process the incoming buffer).

#### Change List
- Fix transition start delay
