### PR TITLE
[ScenegraphLayer] Fix context.animationProps undefined

### DIFF
--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -242,7 +242,7 @@ export default class ScenegraphLayer extends Layer {
     if (!this.state.scenegraph) return;
 
     if (this.props._animations && this.state.animator && context.deck) {
-      this.state.animator.animate(context.deck.animationLoop.animationProps.time);
+      this.state.animator.animate(context.deck.animationLoop.timeline.time);
     }
 
     const {viewport} = this.context;

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -241,7 +241,7 @@ export default class ScenegraphLayer extends Layer {
   draw({moduleParameters = null, parameters = {}, context}) {
     if (!this.state.scenegraph) return;
 
-    if (this.props._animations && this.state.animator) {
+    if (this.props._animations && this.state.animator && context.deck) {
       this.state.animator.animate(context.deck.animationLoop.animationProps.time);
     }
 

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -242,7 +242,7 @@ export default class ScenegraphLayer extends Layer {
     if (!this.state.scenegraph) return;
 
     if (this.props._animations && this.state.animator) {
-      this.state.animator.animate(context.animationProps.time);
+      this.state.animator.animate(context.deck.animationLoop.animationProps.time);
     }
 
     const {viewport} = this.context;

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -241,8 +241,9 @@ export default class ScenegraphLayer extends Layer {
   draw({moduleParameters = null, parameters = {}, context}) {
     if (!this.state.scenegraph) return;
 
-    if (this.props._animations && this.state.animator && context.deck) {
-      this.state.animator.animate(context.deck.animationLoop.timeline.time);
+    if (this.props._animations && this.state.animator) {
+      this.state.animator.animate(context.timeline.getTime());
+      this.setNeedsRedraw();
     }
 
     const {viewport} = this.context;


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
After upgrading a project that used animations embedded in a gltf model from deck 7 to 8, a new error appeared in the console and the model with the animation wasn't rendering. Other models without animations still render correctly, and removing the animation prop from the broken model fixed the rendering (although it was static). The issue was isolated to an undefined object that was previously defined.

![Screen Shot 2020-05-01 at 9 11 27 PM](https://user-images.githubusercontent.com/2461547/81353518-2472be00-907e-11ea-8330-6a229126dbf2.png)

I think the `animationProps` object in question was deprecated and now we should use `timeline` under `context.deck.animationLoop`, and perhaps @tsherif has some more context around this history.

<!-- For all the PRs -->
#### Change List
- Reference `timeline` from `deck.animationLoop` instead of `context.animationProps.time`
