### PR TITLE
pydeck: set offline javascript read to use utf-8 encoding

### DIFF
--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -26,7 +26,7 @@ CDN_URL = "https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@{}/dist/index.js
 
 def cdn_picker(offline=False):
     if offline:
-        with open(join(dirname(__file__), "./static/index.js"), "r") as file:
+        with open(join(dirname(__file__), "./static/index.js"), "r", encoding="utf-8") as file:
             js = file.read()
         return "<script type=text/javascript>" + js + "</script>"
 


### PR DESCRIPTION
pydeck throws an error on windows due to different environment encodings.

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4576
<!-- For other PRs without open issue -->
#### Background
Previously added in #4405
<!-- For all the PRs -->
#### Change List
- set `encoding="utf-8"` on javascript read when set offline is set to True.

@ajduberstein 