### PR TITLE
Workaround for picking index overflow

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -135,6 +135,9 @@ export default class DeckPicker {
     unproject3D,
     onViewportActive
   }) {
+    // picking can only hanle up to 255 items in `layers`. Drop non-pickable layers from the list.
+    layers = layers.filter(layer => this.pickLayersPass._shouldDrawLayer(layer));
+
     this._resizeBuffer();
     // Convert from canvas top-left to WebGL bottom-left coordinates
     // Top-left coordinates [x, y] to bottom-left coordinates [deviceX, deviceY]
@@ -250,6 +253,9 @@ export default class DeckPicker {
     mode = 'query',
     onViewportActive
   }) {
+    // picking can only hanle up to 255 items in `layers`. Drop non-pickable layers from the list.
+    layers = layers.filter(layer => this.pickLayersPass._shouldDrawLayer(layer));
+
     this._resizeBuffer();
     // Convert from canvas top-left to WebGL bottom-left coordinates
     // And compensate for pixelRatio

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -28,6 +28,7 @@ import {
 } from '@luma.gl/core';
 import GL from '@luma.gl/constants';
 import assert from '../utils/assert';
+import log from '../utils/log';
 import PickLayersPass from '../passes/pick-layers-pass';
 import {getClosestObject, getUniqueObjects} from './picking/query-object';
 import {processPickInfo, getLayerPickingInfo} from './picking/pick-info';
@@ -122,6 +123,16 @@ export default class DeckPicker {
     return this.pickingFBO;
   }
 
+  // picking can only handle up to 255 layers. Drop non-pickable/invisible layers from the list.
+  _getPickable(layers) {
+    const pickableLayers = layers.filter(layer => layer.isPickable() && !layer.isComposite);
+    if (pickableLayers.length > 255) {
+      log.warn('Too many pickable layers, only picking the first 255')();
+      return pickableLayers.slice(0, 255);
+    }
+    return pickableLayers;
+  }
+
   // Pick the closest object at the given (x,y) coordinate
   // eslint-disable-next-line max-statements,complexity
   _pickClosestObject({
@@ -135,8 +146,7 @@ export default class DeckPicker {
     unproject3D,
     onViewportActive
   }) {
-    // picking can only hanle up to 255 items in `layers`. Drop non-pickable layers from the list.
-    layers = layers.filter(layer => this.pickLayersPass._shouldDrawLayer(layer));
+    layers = this._getPickable(layers);
 
     this._resizeBuffer();
     // Convert from canvas top-left to WebGL bottom-left coordinates
@@ -253,8 +263,7 @@ export default class DeckPicker {
     mode = 'query',
     onViewportActive
   }) {
-    // picking can only hanle up to 255 items in `layers`. Drop non-pickable layers from the list.
-    layers = layers.filter(layer => this.pickLayersPass._shouldDrawLayer(layer));
+    layers = this._getPickable(layers);
 
     this._resizeBuffer();
     // Convert from canvas top-left to WebGL bottom-left coordinates
@@ -319,8 +328,7 @@ export default class DeckPicker {
   _drawAndSample({layers, viewports, onViewportActive, deviceRect, pass, redrawReason, pickZ}) {
     assert(deviceRect.width > 0 && deviceRect.height > 0);
 
-    const pickableLayers = layers.filter(layer => layer.isPickable());
-    if (pickableLayers.length < 1) {
+    if (layers.length < 1) {
       return null;
     }
 


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/4584

#### Background

The picking system can handle up to 255 layers.

The above issue is observed when there is a large number of layers (in the reported use case, 4 TileLayers * cached tiles * 4 sublayers per tile). This PR drops non-pickable layers from the list to use indices more efficiently. Although it does not solve all potential issues caused by the tile layer, in normal use cases picking should behave as expected.

This PR is intended to be a quick workaround to patch production.

#### Change List
- Assign layer index more efficiently in the picking pass.
