### PR TITLE
Fix: OrbitView's orbitAxis prop is not used by OrbitController

### DIFF
--- a/modules/core/src/controllers/orbit-controller.js
+++ b/modules/core/src/controllers/orbit-controller.js
@@ -8,7 +8,6 @@ import {mod} from '../utils/math-utils';
 const MOVEMENT_SPEED = 50; // per keyboard click
 
 const DEFAULT_STATE = {
-  orbitAxis: 'Z',
   rotationX: 0,
   rotationOrbit: 0,
   zoom: 0,
@@ -37,7 +36,7 @@ export class OrbitState extends ViewState {
     /* Viewport arguments */
     width, // Width of viewport
     height, // Height of viewport
-    orbitAxis = DEFAULT_STATE.orbitAxis,
+    orbitAxis,
     rotationX = DEFAULT_STATE.rotationX, // Rotation around x axis
     rotationOrbit = DEFAULT_STATE.rotationOrbit, // Rotation around orbit axis
     target = DEFAULT_STATE.target,

--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -91,6 +91,7 @@ export default class OrbitView extends View {
 
   get controller() {
     return this._getControllerProps({
+      orbitAxis: this.props.orbitAxis || 'Z',
       type: OrbitController,
       ViewportType: OrbitViewport
     });

--- a/test/modules/core/views/view.spec.js
+++ b/test/modules/core/views/view.spec.js
@@ -108,6 +108,19 @@ test('OrbitView', t => {
   t.end();
 });
 
+test('OrbitController#orbitAxis', t => {
+  let view = new OrbitView();
+  t.is(view.controller, null, 'controller is disabled');
+
+  view = new OrbitView({controller: true});
+  t.is(view.controller.orbitAxis, 'Z', 'controller.orbitAxis is populated with default value');
+
+  view = new OrbitView({orbitAxis: 'Y', controller: {panRotate: false}});
+  t.is(view.controller.orbitAxis, 'Y', 'controller.orbitAxis is set to user value');
+
+  t.end();
+});
+
 // eslint-disable-next-line complexity
 test('OrbitView#project', t => {
   const view = new OrbitView({id: '3d-view'});


### PR DESCRIPTION
Per documentation, `orbitAxis` should be defined in the `OrbitView` constructor. However, if it's not also specified in `viewState`, `OrbitController`  falls back to the default value. This results in confusing behavior where the controller created by `new OrbitView({orbitAxis: 'Y'})` actually produces viewStates with `orbitAxis: 'Z'`.

### Change List
- `OrbitController` uses `OrbitView`'s `props.orbitAxis` if specified
- Unit tests
