### PR TITLE
Export TransitionInterpolator

### DIFF
--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -75,6 +75,7 @@ export {default as LayerExtension} from './lib/layer-extension';
 
 // Transitions
 export {TRANSITION_EVENTS} from './controllers/transition-manager';
+export {default as TransitionInterpolator} from './transitions/transition-interpolator';
 export {default as LinearInterpolator} from './transitions/linear-interpolator';
 export {default as FlyToInterpolator} from './transitions/viewport-fly-to-interpolator';
 

--- a/modules/main/src/index.js
+++ b/modules/main/src/index.js
@@ -62,6 +62,7 @@ export {
   log,
   // Transition bindings
   TRANSITION_EVENTS,
+  TransitionInterpolator,
   LinearInterpolator,
   FlyToInterpolator,
   // Effects


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
This allows people to write their own `TransitionInterpolator`s without copying that code into their own code base. 
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
This begins to address #4407.   I think, judging by the docs, that this is something that might have been assumed to be happening, but isn't: https://github.com/visgl/deck.gl/blob/master/docs/api-reference/view-state-transitions.md#view-state-transitions: " ...But a user can provide any custom implementation for this object using TrasitionInterpolator base class."
#### Change List
- Export `TransitionInterpolator` from the core.
