### PR TITLE
Wipe the current cached layers when updateTrigger variables are updated

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -74,12 +74,12 @@ export default class TileLayer extends CompositeLayer {
         onTileError: this._onTileError.bind(this)
       });
       this.setState({tileset});
-    } else if (changeFlags.propsChanged) {
+    } else if (changeFlags.propsChanged || changeFlags.updateTriggersChanged) {
       tileset.setOptions(props);
       // if any props changed, delete the cached layers
       this.state.tileset.tiles.forEach(tile => {
         tile.layers = null;
-      });
+      })
     }
 
     if (createTileCache || changeFlags.viewportChanged) {

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -79,7 +79,7 @@ export default class TileLayer extends CompositeLayer {
       // if any props changed, delete the cached layers
       this.state.tileset.tiles.forEach(tile => {
         tile.layers = null;
-      })
+      });
     }
 
     if (createTileCache || changeFlags.viewportChanged) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4608 
<!-- For other PRs without open issue -->
#### Background
Described in #4608 
<!-- For all the PRs -->
#### Change List
- Change the check to wipe the current cached layers when updateTrigger variables are updated.
