### PR TITLE
Fix NaN values in recycled typedarray for PathLayer

### DIFF
--- a/modules/core/src/utils/typed-array-manager.js
+++ b/modules/core/src/utils/typed-array-manager.js
@@ -6,7 +6,8 @@ export class TypedArrayManager {
     this._pool = [];
   }
 
-  allocate(typedArray, count, {size = 1, type, padding = 0, copy = false}) {
+  // eslint-disable-next-line complexity
+  allocate(typedArray, count, {size = 1, type, padding = 0, copy = false, initialize = false}) {
     const Type = type || (typedArray && typedArray.constructor) || Float32Array;
 
     const newSize = count * size + padding;
@@ -19,13 +20,12 @@ export class TypedArrayManager {
       }
     }
 
-    const newArray = this._allocate(Type, newSize);
+    const newArray = this._allocate(Type, newSize, initialize);
 
     if (typedArray && copy) {
       newArray.set(typedArray);
-    } else {
-      // Hack - viewing a buffer with a different type may create NaNs
-      // which crashes the Attribute validation
+    } else if (!initialize) {
+      // Hack - always initialize the first 4 elements. NaNs crashe the Attribute validation
       newArray.fill(0, 0, 4);
     }
 
@@ -37,7 +37,7 @@ export class TypedArrayManager {
     this._release(typedArray);
   }
 
-  _allocate(Type, size) {
+  _allocate(Type, size, initialize) {
     // Allocate at least one element to ensure a valid buffer
     size = Math.max(Math.ceil(size * this.overAlloc), 1);
 
@@ -47,7 +47,12 @@ export class TypedArrayManager {
     const i = pool.findIndex(b => b.byteLength >= byteLength);
     if (i >= 0) {
       // Create a new array using an existing buffer
-      return new Type(pool.splice(i, 1)[0], 0, size);
+      const array = new Type(pool.splice(i, 1)[0], 0, size);
+      if (initialize) {
+        // Viewing a buffer with a different type may create NaNs
+        array.fill(0);
+      }
+      return array;
     }
     return new Type(size);
   }

--- a/modules/core/src/utils/typed-array-manager.js
+++ b/modules/core/src/utils/typed-array-manager.js
@@ -6,7 +6,6 @@ export class TypedArrayManager {
     this._pool = [];
   }
 
-  // eslint-disable-next-line complexity
   allocate(typedArray, count, {size = 1, type, padding = 0, copy = false, initialize = false}) {
     const Type = type || (typedArray && typedArray.constructor) || Float32Array;
 

--- a/modules/layers/src/path-layer/path-tesselator.js
+++ b/modules/layers/src/path-layer/path-tesselator.js
@@ -32,7 +32,12 @@ export default class PathTesselator extends Tesselator {
       attributes: {
         // Padding covers shaderAttributes for last segment in largest case fp64
         // additional vertex + hi & low parts, 3 * 6
-        positions: {size: 3, padding: 18, type: opts.fp64 ? Float64Array : Float32Array},
+        positions: {
+          size: 3,
+          padding: 18,
+          initialize: true,
+          type: opts.fp64 ? Float64Array : Float32Array
+        },
         segmentTypes: {size: 1, type: Uint8ClampedArray}
       }
     });

--- a/test/modules/core/utils/typed-array-manager.spec.js
+++ b/test/modules/core/utils/typed-array-manager.spec.js
@@ -37,6 +37,25 @@ test('TypedArrayManager#allocate', t => {
   t.end();
 });
 
+test('TypedArrayManager#initialize', t => {
+  const typedArrayManager = new TypedArrayManager({overAlloc: 1, poolSize: 1});
+
+  let array = typedArrayManager.allocate(null, 32, {size: 1, type: Uint8Array});
+  array.fill(255);
+  typedArrayManager.release(array);
+
+  array = typedArrayManager.allocate(null, 2, {
+    size: 3,
+    padding: 2,
+    type: Float32Array,
+    initialize: true
+  });
+
+  t.ok(array.every(Number.isFinite), 'The array is initialized');
+
+  t.end();
+});
+
 test('TypedArrayManager#release', t => {
   const typedArrayManager = new TypedArrayManager({overAlloc: 1, poolSize: 2});
 


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/4604

The padded area in `PathLayer`'s interleaved `positions` attribute is never assigned. The numbers are uploaded to the WebGL buffer as `Infinity`s and are causing problems in `mix()`.

#### Change List
- TypedArrayManager initializes padded area with 0s
- Unit test