### PR TITLE
TileLayer: adjust zoom by tileSize

### DIFF
--- a/docs/layers/tile-layer.md
+++ b/docs/layers/tile-layer.md
@@ -122,7 +122,7 @@ This prop is not required if `data` points to a supported format (JSON or image 
 
 The pixel dimension of the tiles, usually a power of 2.
 
-The tile size represents the target pixel width and height of each tile when rendered. Smaller tile sizes mean that the layer needs to load more tiles to fill the same viewport.
+The tile size represents the target pixel width and height of each tile when rendered. Smaller tile sizes display the content at higher resolution, while the layer needs to load more tiles to fill the same viewport.
 
 - Default: `512`
 

--- a/docs/layers/tile-layer.md
+++ b/docs/layers/tile-layer.md
@@ -122,9 +122,7 @@ This prop is not required if `data` points to a supported format (JSON or image 
 
 The pixel dimension of the tiles, usually a power of 2.
 
-When using a geospatial view, this prop has no effect.
-
-When using a non-geospatial view, the tile size represents the width and height of each tile in world units at zoom level `0`.
+The tile size represents the target pixel width and height of each tile when rendered. Smaller tile sizes mean that the layer needs to load more tiles to fill the same viewport.
 
 - Default: `512`
 

--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -56,7 +56,6 @@ export default class App extends PureComponent {
         // https://wiki.openstreetmap.org/wiki/Zoom_levels
         minZoom: 0,
         maxZoom: 19,
-        tileSize: 256,
 
         renderSubLayers: props => {
           const {

--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -56,6 +56,7 @@ export default class App extends PureComponent {
         // https://wiki.openstreetmap.org/wiki/Zoom_levels
         minZoom: 0,
         maxZoom: 19,
+        tileSize: 256,
 
         renderSubLayers: props => {
           const {

--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -46,7 +46,11 @@ export default class App extends PureComponent {
     return [
       new TileLayer({
         // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_servers
-        data: 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        data: [
+          'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+          'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+          'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        ],
 
         pickable: true,
         onHover: this._onHover,

--- a/modules/geo-layers/src/tile-layer/tileset-2d.js
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.js
@@ -138,7 +138,7 @@ export default class Tileset2D {
 
   // Add custom metadata to tiles
   getTileMetadata({x, y, z}) {
-    return {bbox: tileToBoundingBox(this._viewport, x, y, z, this.opts.tileSize)};
+    return {bbox: tileToBoundingBox(this._viewport, x, y, z)};
   }
 
   // Returns {x, y, z} of the parent tile

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -70,8 +70,8 @@ function getTileIndex([x, y], scale) {
   return [(x * scale) / TILE_SIZE, (y * scale) / TILE_SIZE];
 }
 
-function getScale(z, tileSize = TILE_SIZE) {
-  return (Math.pow(2, z) * TILE_SIZE) / tileSize;
+function getScale(z) {
+  return Math.pow(2, z);
 }
 
 // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Lon..2Flat._to_tile_numbers_2
@@ -83,25 +83,25 @@ function osmTile2lngLat(x, y, z) {
   return [lng, lat];
 }
 
-function tile2XY(x, y, z, tileSize) {
-  const scale = getScale(z, tileSize);
+function tile2XY(x, y, z) {
+  const scale = getScale(z);
   return [(x / scale) * TILE_SIZE, (y / scale) * TILE_SIZE];
 }
 
-export function tileToBoundingBox(viewport, x, y, z, tileSize = TILE_SIZE) {
+export function tileToBoundingBox(viewport, x, y, z) {
   if (viewport.isGeospatial) {
     const [west, north] = osmTile2lngLat(x, y, z);
     const [east, south] = osmTile2lngLat(x + 1, y + 1, z);
     return {west, north, east, south};
   }
-  const [left, top] = tile2XY(x, y, z, tileSize);
-  const [right, bottom] = tile2XY(x + 1, y + 1, z, tileSize);
+  const [left, top] = tile2XY(x, y, z);
+  const [right, bottom] = tile2XY(x + 1, y + 1, z);
   return {left, top, right, bottom};
 }
 
-function getIdentityTileIndices(viewport, z, tileSize, extent) {
+function getIdentityTileIndices(viewport, z, extent) {
   const bbox = getBoundingBox(viewport, null, extent);
-  const scale = getScale(z, tileSize);
+  const scale = getScale(z);
 
   const [minX, minY] = getTileIndex([bbox[0], bbox[1]], scale);
   const [maxX, maxY] = getTileIndex([bbox[2], bbox[3]], scale);
@@ -125,7 +125,7 @@ function getIdentityTileIndices(viewport, z, tileSize, extent) {
  * return tiles that are on maxZoom.
  */
 export function getTileIndices({viewport, maxZoom, minZoom, zRange, extent, tileSize = TILE_SIZE}) {
-  let z = Math.round(viewport.zoom);
+  let z = Math.floor(viewport.zoom + Math.log2(TILE_SIZE / tileSize));
   if (Number.isFinite(minZoom) && z < minZoom) {
     if (!extent) {
       return [];
@@ -137,5 +137,5 @@ export function getTileIndices({viewport, maxZoom, minZoom, zRange, extent, tile
   }
   return viewport.isGeospatial
     ? getOSMTileIndices(viewport, z, zRange, extent || DEFAULT_EXTENT)
-    : getIdentityTileIndices(viewport, z, tileSize, extent || DEFAULT_EXTENT);
+    : getIdentityTileIndices(viewport, z, extent || DEFAULT_EXTENT);
 }

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -125,7 +125,7 @@ function getIdentityTileIndices(viewport, z, extent) {
  * return tiles that are on maxZoom.
  */
 export function getTileIndices({viewport, maxZoom, minZoom, zRange, extent, tileSize = TILE_SIZE}) {
-  let z = Math.floor(viewport.zoom + Math.log2(TILE_SIZE / tileSize));
+  let z = Math.round(viewport.zoom + Math.log2(TILE_SIZE / tileSize));
   if (Number.isFinite(minZoom) && z < minZoom) {
     if (!extent) {
       return [];

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -125,7 +125,7 @@ function getIdentityTileIndices(viewport, z, tileSize, extent) {
  * return tiles that are on maxZoom.
  */
 export function getTileIndices({viewport, maxZoom, minZoom, zRange, extent, tileSize = TILE_SIZE}) {
-  let z = Math.ceil(viewport.zoom);
+  let z = Math.round(viewport.zoom);
   if (Number.isFinite(minZoom) && z < minZoom) {
     if (!extent) {
       return [];

--- a/test/modules/geo-layers/tile-layer/utils.spec.js
+++ b/test/modules/geo-layers/tile-layer/utils.spec.js
@@ -15,11 +15,11 @@ const TEST_CASES = [
       height: 400,
       longitude: -90,
       latitude: 45,
-      zoom: 3.5
+      zoom: 2.5
     }),
     minZoom: undefined,
     maxZoom: undefined,
-    output: ['1,2,3', '1,3,3', '2,2,3', '2,3,3']
+    output: ['0,2,3', '0,3,3', '1,2,3', '1,3,3', '2,2,3', '2,3,3', '3,2,3', '3,3,3']
   },
   {
     title: 'tilted viewport',
@@ -30,11 +30,11 @@ const TEST_CASES = [
       bearing: -25,
       longitude: -90,
       latitude: 45,
-      zoom: 3.5
+      zoom: 2.5
     }),
     minZoom: undefined,
     maxZoom: undefined,
-    output: ['0,2,3', '1,2,3', '1,3,3', '2,1,3', '2,2,3', '2,3,3']
+    output: ['0,2,3', '0,3,3', '1,2,3', '1,3,3', '2,1,3', '2,2,3', '2,3,3', '3,2,3', '3,3,3']
   },
   {
     title: 'extreme pitch',

--- a/test/modules/geo-layers/tile-layer/utils.spec.js
+++ b/test/modules/geo-layers/tile-layer/utils.spec.js
@@ -15,11 +15,11 @@ const TEST_CASES = [
       height: 400,
       longitude: -90,
       latitude: 45,
-      zoom: 2.5
+      zoom: 3.5
     }),
     minZoom: undefined,
     maxZoom: undefined,
-    output: ['0,2,3', '0,3,3', '1,2,3', '1,3,3', '2,2,3', '2,3,3', '3,2,3', '3,3,3']
+    output: ['1,2,3', '1,3,3', '2,2,3', '2,3,3']
   },
   {
     title: 'tilted viewport',
@@ -30,11 +30,11 @@ const TEST_CASES = [
       bearing: -25,
       longitude: -90,
       latitude: 45,
-      zoom: 2.5
+      zoom: 3.5
     }),
     minZoom: undefined,
     maxZoom: undefined,
-    output: ['0,2,3', '0,3,3', '1,2,3', '1,3,3', '2,1,3', '2,2,3', '2,3,3', '3,2,3', '3,3,3']
+    output: ['0,2,3', '1,2,3', '1,3,3', '2,1,3', '2,2,3', '2,3,3']
   },
   {
     title: 'extreme pitch',
@@ -103,7 +103,6 @@ const TEST_CASES = [
     }),
     minZoom: undefined,
     maxZoom: undefined,
-    tileSize: 128, // this should have no effect!
     output: ['0,0,0']
   },
   {
@@ -142,7 +141,7 @@ const TEST_CASES = [
       }
     }),
     tileSize: 256,
-    output: ['1,2,3', '1,3,3', '2,2,3', '2,3,3', '3,2,3', '3,3,3', '4,2,3', '4,3,3']
+    output: ['1,2,4', '1,3,4', '2,2,4', '2,3,4', '3,2,4', '3,3,4', '4,2,4', '4,3,4']
   }
 ];
 
@@ -199,7 +198,7 @@ test('tileToBoundingBox', t => {
     if (testCase.output.length) {
       const {viewport, minZoom, maxZoom, tileSize, zRange} = testCase;
       const boundingBoxes = getTileIndices({viewport, maxZoom, minZoom, zRange, tileSize}).map(
-        tile => tileToBoundingBox(viewport, tile.x, tile.y, tile.z, tileSize)
+        tile => tileToBoundingBox(viewport, tile.x, tile.y, tile.z)
       );
       const result = mergeBoundingBox(boundingBoxes);
       const corners = [
@@ -272,9 +271,9 @@ test('tileToBoundingBox#Infovis', t => {
   );
 
   t.deepEqual(
-    tileToBoundingBox(viewport, 0, 0, 0, 256),
+    tileToBoundingBox(viewport, 0, 0, 1),
     {left: 0, top: 0, right: 256, bottom: 256},
-    '0,0,0 with custom tileSize Should match the results.'
+    '0,0,1 Should match the results.'
   );
 
   t.deepEqual(
@@ -284,9 +283,9 @@ test('tileToBoundingBox#Infovis', t => {
   );
 
   t.deepEqual(
-    tileToBoundingBox(viewport, 4, -1, 2, 256),
+    tileToBoundingBox(viewport, 4, -1, 3),
     {left: 256, top: -64, right: 320, bottom: 0},
-    '4,-1,2 with custom tileSize Should match the results.'
+    '4,-1,3 Should match the results.'
   );
 
   t.end();


### PR DESCRIPTION
mapbox-gl uses `floor`. We changed from `floor` to `ceil` in https://github.com/visgl/deck.gl/pull/4117 to increase the quality of raster tiles. This results in very aggressive fetching behavior.

The change saves about 40% of tile loads in worst-case scenarios.

#### Change List
- Adjust zoom level by tile size
- Docs

@ilan-gold 
