### PR TITLE
Globe Projection (PR3)

### DIFF
--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -215,4 +215,12 @@ mat3 project_get_orientation_matrix(vec3 up) {
   vec3 uy = cross(uz, ux);
   return mat3(ux, uy, uz);
 }
+
+bool project_needs_rotation(vec3 commonPosition, out mat3 transform) {
+  if (project_uProjectionMode == PROJECTION_MODE_GLOBE) {
+    transform = project_get_orientation_matrix(commonPosition);
+    return true;
+  }
+  return false;
+}
 `;

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -146,7 +146,7 @@ export default class ArcLayer extends Layer {
      *   (0, 1)"-------------(1, 1)
      */
     for (let i = 0; i < NUM_SEGMENTS; i++) {
-      positions = positions.concat([i, -1, 0, i, 1, 0]);
+      positions = positions.concat([i, 1, 0, i, -1, 0]);
     }
 
     const model = new Model(

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -68,8 +68,22 @@ vec3 lineJoin(
   float sideOfPath = positions.y;
   float isJoint = float(sideOfPath == 0.0);
 
-  vec2 deltaA = (currPoint.xy - prevPoint.xy) / width;
-  vec2 deltaB = (nextPoint.xy - currPoint.xy) / width;
+  vec3 deltaA3 = (currPoint - prevPoint);
+  vec3 deltaB3 = (nextPoint - currPoint);
+  vec2 deltaA;
+  vec2 deltaB;
+
+  mat3 rotationMatrix;
+  if (project_uProjectionMode == PROJECTION_MODE_GLOBE && !billboard) {
+    rotationMatrix = project_get_orientation_matrix(currPoint);
+    deltaA = vec2(dot(deltaA3, rotationMatrix[0]), dot(deltaA3, rotationMatrix[1]));
+    deltaB = vec2(dot(deltaB3, rotationMatrix[0]), dot(deltaB3, rotationMatrix[1]));
+  } else {
+    deltaA = deltaA3.xy;
+    deltaB = deltaB3.xy;
+  }
+  deltaA /= width;
+  deltaB /= width;
 
   float lenA = length(deltaA);
   float lenB = length(deltaB);
@@ -142,6 +156,10 @@ vec3 lineJoin(
   float isValid = step(instanceTypes, 3.5);
   vec3 offset = vec3(offsetVec * width * isValid, 0.0);
   DECKGL_FILTER_SIZE(offset, geometry);
+
+  if (project_uProjectionMode == PROJECTION_MODE_GLOBE && !billboard) {
+    offset = rotationMatrix * offset;
+  }
   return currPoint + offset;
 }
 

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -70,20 +70,15 @@ vec3 lineJoin(
 
   vec3 deltaA3 = (currPoint - prevPoint);
   vec3 deltaB3 = (nextPoint - currPoint);
-  vec2 deltaA;
-  vec2 deltaB;
 
   mat3 rotationMatrix;
   if (project_uProjectionMode == PROJECTION_MODE_GLOBE && !billboard) {
     rotationMatrix = project_get_orientation_matrix(currPoint);
-    deltaA = vec2(dot(deltaA3, rotationMatrix[0]), dot(deltaA3, rotationMatrix[1]));
-    deltaB = vec2(dot(deltaB3, rotationMatrix[0]), dot(deltaB3, rotationMatrix[1]));
-  } else {
-    deltaA = deltaA3.xy;
-    deltaB = deltaB3.xy;
+    deltaA3 = deltaA3 * rotationMatrix;
+    deltaB3 = deltaB3 * rotationMatrix;
   }
-  deltaA /= width;
-  deltaB /= width;
+  vec2 deltaA = deltaA3.xy / width;
+  vec2 deltaB = deltaB3.xy / width;
 
   float lenA = length(deltaA);
   float lenB = length(deltaB);

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.js
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.js
@@ -72,8 +72,8 @@ vec3 lineJoin(
   vec3 deltaB3 = (nextPoint - currPoint);
 
   mat3 rotationMatrix;
-  if (project_uProjectionMode == PROJECTION_MODE_GLOBE && !billboard) {
-    rotationMatrix = project_get_orientation_matrix(currPoint);
+  bool needsRotation = !billboard && project_needs_rotation(currPoint, rotationMatrix);
+  if (needsRotation) {
     deltaA3 = deltaA3 * rotationMatrix;
     deltaB3 = deltaB3 * rotationMatrix;
   }
@@ -152,7 +152,7 @@ vec3 lineJoin(
   vec3 offset = vec3(offsetVec * width * isValid, 0.0);
   DECKGL_FILTER_SIZE(offset, geometry);
 
-  if (project_uProjectionMode == PROJECTION_MODE_GLOBE && !billboard) {
+  if (needsRotation) {
     offset = rotationMatrix * offset;
   }
   return currPoint + offset;

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -229,19 +229,19 @@ export default class PathLayer extends Layer {
     const SEGMENT_INDICES = [
       // start corner
       0,
-      2,
       1,
+      2,
       // body
       1,
+      4,
       2,
-      4,
       1,
-      4,
       3,
+      4,
       // end corner
       3,
-      4,
-      5
+      5,
+      4
     ];
 
     // [0] position on segment - 0: start, 1: end

--- a/modules/layers/src/path-layer/path-layer.js
+++ b/modules/layers/src/path-layer/path-layer.js
@@ -226,45 +226,33 @@ export default class PathLayer extends Layer {
      *                                   /     :     o
      */
 
+    // prettier-ignore
     const SEGMENT_INDICES = [
       // start corner
-      0,
-      1,
-      2,
+      0, 1, 2,
       // body
-      1,
-      4,
-      2,
-      1,
-      3,
-      4,
+      1, 4, 2,
+      1, 3, 4,
       // end corner
-      3,
-      5,
-      4
+      3, 5, 4
     ];
 
     // [0] position on segment - 0: start, 1: end
     // [1] side of path - -1: left, 0: center (joint), 1: right
+    // prettier-ignore
     const SEGMENT_POSITIONS = [
       // bevel start corner
-      0,
-      0,
+      0, 0,
       // start inner corner
-      0,
-      -1,
+      0, -1,
       // start outer corner
-      0,
-      1,
+      0, 1,
       // end inner corner
-      1,
-      -1,
+      1, -1,
       // end outer corner
-      1,
-      1,
+      1, 1,
       // bevel end corner
-      1,
-      0
+      1, 0
     ];
 
     return new Model(

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -145,7 +145,7 @@ export default class ScatterplotLayer extends Layer {
 
   _getModel(gl) {
     // a square that minimally cover the unit circle
-    const positions = [-1, -1, 0, -1, 1, 0, 1, 1, 0, 1, -1, 0];
+    const positions = [-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0];
 
     return new Model(
       gl,

--- a/test/apps/globe/app.js
+++ b/test/apps/globe/app.js
@@ -1,0 +1,78 @@
+import {Deck, _GlobeView as GlobeView} from '@deck.gl/core';
+import {GeoJsonLayer, ArcLayer, ColumnLayer} from '@deck.gl/layers';
+
+// source: Natural Earth http://www.naturalearthdata.com/ via geojson.xyz
+const COUNTRIES =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson'; //eslint-disable-line
+const AIR_PORTS =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson';
+
+const INITIAL_VIEW_STATE = {
+  latitude: 51.47,
+  longitude: 0.45,
+  zoom: 0
+};
+
+export const deck = new Deck({
+  views: new GlobeView(),
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: {minZoom: -2},
+  parameters: {
+    cull: true
+  },
+  layers: [
+    new GeoJsonLayer({
+      id: 'base-map',
+      data: COUNTRIES,
+      // Styles
+      stroked: true,
+      filled: true,
+      lineWidthMinPixels: 2,
+      opacity: 0.4,
+      getLineColor: [60, 60, 60],
+      getFillColor: [200, 200, 200]
+    }),
+    new ColumnLayer({
+      id: 'airports-extruded',
+      data: AIR_PORTS,
+      dataTransform: geojson => geojson.features,
+      // Styles
+      radius: 10000,
+      extruded: true,
+      getPosition: f => f.geometry.coordinates,
+      getElevation: f => f.properties.scalerank * 100000,
+      getFillColor: [200, 0, 80, 180]
+    }),
+    new GeoJsonLayer({
+      id: 'airports',
+      data: AIR_PORTS,
+      // Styles
+      filled: true,
+      pointRadiusMinPixels: 2,
+      pointRadiusScale: 2000,
+      getRadius: f => 11 - f.properties.scalerank,
+      getFillColor: [200, 0, 80, 180],
+      // Interactive props
+      pickable: true,
+      autoHighlight: true,
+      onClick: info =>
+        // eslint-disable-next-line
+        info.object && alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
+    }),
+    new ArcLayer({
+      id: 'arcs',
+      data: AIR_PORTS,
+      dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
+      // Styles
+      getSourcePosition: f => [-0.4531566, 51.4709959], // London
+      getTargetPosition: f => f.geometry.coordinates,
+      getSourceColor: [0, 128, 200],
+      getTargetColor: [200, 0, 80],
+      getWidth: 1
+    })
+  ]
+});
+
+// For automated test cases
+/* global document */
+document.body.style.margin = '0px';

--- a/test/apps/globe/index.html
+++ b/test/apps/globe/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>deck.gl globe projection example</title>
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+
+  <body>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/test/apps/globe/package.json
+++ b/test/apps/globe/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build": "webpack -p"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/layers": "^8.0.0"
+  },
+  "devDependencies": {
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/test/apps/globe/webpack.config.js
+++ b/test/apps/globe/webpack.config.js
@@ -1,0 +1,13 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: './app.js'
+  }
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);


### PR DESCRIPTION
For #4638

This PR adds a test application and demonstrate preliminary support for the `GlobeView` among core layers.

A few layers require more substantial work to be done in follow up PRs, see https://github.com/visgl/deck.gl/issues/4638#issuecomment-637927760

#### Change List

- Add test application
- Support globe projection in PathLayer's vertex shader
- Use consistent mesh orientation (front/back) in core layers
