### PR TITLE
[test-utils] Add testLayerAsync

### DIFF
--- a/docs/api-reference/test-utils/test-layer.md
+++ b/docs/api-reference/test-utils/test-layer.md
@@ -1,6 +1,8 @@
 # testLayer (Test Function)
 
-This utility initializes a layer, test layer updates and draw calls on a series of new props, and allow test suites to inspect the result.
+The `testLayer` utility initializes a layer, test layer updates and draw calls on a series of new props, and allow test suites to inspect the result.
+
+The `testLayerAsync` utility is like `testLayer`, but designed for layers that need to resolve resources asynchronously.
 
 ## Example
 
@@ -8,7 +10,7 @@ Example of layer unit tests using `tape`. The test utility itself is test framew
 
 ```js
 import test from 'tape-catch';
-import {testLayer} from '@deck.gl/test-utils';
+import {testLayer, testLayerAsync} from '@deck.gl/test-utils';
 import {GeoJsonLayer} from '@deck.gl/layers';
 
 test('GeoJsonLayer#tests', t => {
@@ -49,6 +51,7 @@ test('GeoJsonLayer#tests', t => {
 
 ```js
 testLayer({Layer, spies, testCases, onError});
+await testLayerAsync({Layer, spies, testCases, onError});
 ```
 
 * `Layer` (Object) - the layer component class to test
@@ -74,13 +77,18 @@ A test case is an object with the following fields:
   - `info.testCase` (Object) - the current test case
   - `info.layer` (`Layer`) - the old layer
 * `onAfterUpdate` (Function, Optional) - callback invoked after the layer props have been updated. This allows the test case to verify that the layer's state has been correctly updated, or that certain functions (spies) have been called etc. Receives a single argument `info`:
-{layer, oldState, subLayers, subLayer, spies: spyMap}
+`{layer, oldState, subLayers, subLayer, spies: spyMap}`.
   - `info.testCase` (Object) - the current test case
   - `info.layer` (`Layer`) - the updated layer
   - `info.oldState` (Object) - layer state before the update
   - `info.subLayers` (Array) - sub layers rendered, if the layer is composite
   - `info.subLayer` (`Layer`) - the first sub layer rendered, if the layer is composite
   - `info.spies` (Object) - key are layer method names and values are [spies](https://github.com/uber-web/probe.gl/blob/master/docs/api-reference/test-utils/make-spy.md#methods-and-fields-on-the-wrapped-function).
+
+
+Note that `onAfterUpdate` is called immediately after the props are updated. If the layer contains asynchronous props, they may not have been loaded at this point.
+
+When using `TestLayerAsync`, `onAfterUpdate` is called multiple times until all resources are loaded.
 
 
 ## Source

--- a/modules/test-utils/src/index.js
+++ b/modules/test-utils/src/index.js
@@ -2,7 +2,7 @@ export {toLowPrecision} from './utils/precision';
 export {default as gl} from './utils/setup-gl';
 
 // Utilities for update tests (lifecycle tests)
-export {testLayer, testInitializeLayer, testUpdateLayer, testDrawLayer} from './lifecycle-test';
+export {testLayer, testLayerAsync, testInitializeLayer} from './lifecycle-test';
 export {generateLayerTests} from './generate-layer-tests';
 
 // Basic utility for rendering multiple scenes (could go into "deck.gl/core")

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -42,62 +42,73 @@ export function testInitializeLayer({layer, viewport = testViewport, onError = d
   });
 
   layerManager.setLayers([layer]);
+  layerManager.finalize();
 
   return null;
 }
 
-export function testUpdateLayer({
-  layer,
-  viewport = testViewport,
-  newProps,
-  onError = defaultOnError
-}) {
-  const layerManager = new LayerManager(gl, {viewport});
+export function testLayer(opts) {
+  const {Layer, testCases = [], spies = [], onError = defaultOnError} = opts;
 
-  layerManager.setProps({
-    onError: error => onError(error, `updating ${layer.id}`)
-  });
+  const resources = setupLayerTests(`testing ${Layer.layerName}`, opts);
 
-  layerManager.setLayers([layer]);
-  layerManager.setLayers([layer.clone(newProps)]);
+  let layer = new Layer();
+  // Run successive update tests
+  for (const testCase of testCases) {
+    // Save old state before update
+    const oldState = Object.assign({}, layer.state);
 
-  return null;
+    const {layer: newLayer, spyMap} = runLayerTestUpdate(testCase, resources, layer, spies);
+
+    runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
+
+    // Remove spies
+    Object.keys(spyMap).forEach(k => spyMap[k].reset());
+    layer = newLayer;
+  }
+
+  const error = cleanupAfterLayerTests(resources);
+  if (error) {
+    onError(error, `${Layer.layerName} should delete all resources`);
+  }
 }
 
-export function testDrawLayer({
-  layer,
-  viewport = testViewport,
-  uniforms = {},
-  onError = defaultOnError
-}) {
-  const layerManager = new LayerManager(gl, {viewport});
-  const deckRenderer = new DeckRenderer(gl);
-  const props = {
-    onError: error => onError(error, `drawing ${layer.id}`)
-  };
+export async function testLayerAsync(opts) {
+  const {Layer, testCases = [], spies = [], onError = defaultOnError} = opts;
 
-  layerManager.setProps(props);
-  deckRenderer.setProps(props);
+  const resources = setupLayerTests(`testing ${Layer.layerName}`, opts);
 
-  layerManager.setLayers([layer]);
-  deckRenderer.renderLayers({
-    viewports: [viewport],
-    layers: layerManager.getLayers(),
-    onViewportActive: layerManager.activateViewport
-  });
+  let layer = new Layer();
+  // Run successive update tests
+  for (const testCase of testCases) {
+    // Save old state before update
+    const oldState = Object.assign({}, layer.state);
 
-  return null;
+    const {layer: newLayer, spyMap} = runLayerTestUpdate(testCase, resources, layer, spies);
+
+    runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
+
+    while (!newLayer.isLoaded) {
+      await update(resources);
+      runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
+    }
+
+    // Remove spies
+    Object.keys(spyMap).forEach(k => spyMap[k].reset());
+    layer = newLayer;
+  }
+
+  const error = cleanupAfterLayerTests(resources);
+  if (error) {
+    onError(error, `${Layer.layerName} should delete all resources`);
+  }
 }
 
-export function testLayer({
-  Layer,
-  viewport = testViewport,
-  timeline = null,
-  testCases = [],
-  spies = [],
-  onError = defaultOnError
-}) {
-  // assert(Layer);
+function setupLayerTests(
+  testTitle,
+  {viewport = testViewport, timeline = null, onError = defaultOnError}
+) {
+  const oldResourceCounts = getResourceCounts();
 
   const layerManager = new LayerManager(gl, {viewport, timeline});
   const deckRenderer = new DeckRenderer(gl);
@@ -106,35 +117,30 @@ export function testLayer({
     time: 0
   };
 
-  const initialProps = testCases[0].props;
-  const layer = new Layer(initialProps);
-
   const props = {
-    onError: error => onError(error, `testing ${layer.id}`)
+    onError: error => onError(error, testTitle)
   };
   layerManager.setProps(props);
   deckRenderer.setProps(props);
 
-  const oldResourceCounts = getResourceCounts();
+  return {layerManager, deckRenderer, oldResourceCounts};
+}
 
-  layerManager.setLayers([layer]);
-
-  runLayerTests(layerManager, deckRenderer, layer, testCases, spies, onError);
-
+function cleanupAfterLayerTests({layerManager, deckRenderer, oldResourceCounts}) {
   layerManager.setLayers([]);
+  layerManager.finalize();
+  deckRenderer.finalize();
 
   const resourceCounts = getResourceCounts();
 
   for (const resourceName in resourceCounts) {
     if (resourceCounts[resourceName] !== oldResourceCounts[resourceName]) {
-      onError(
-        new Error(
-          `${resourceCounts[resourceName] - oldResourceCounts[resourceName]} ${resourceName}s`
-        ),
-        `${layer.id} should delete all ${resourceName}s`
+      return new Error(
+        `${resourceCounts[resourceName] - oldResourceCounts[resourceName]} ${resourceName}s`
       );
     }
   }
+  return null;
 }
 
 function getResourceCounts() {
@@ -156,60 +162,75 @@ function injectSpies(layer, spies) {
   return spyMap;
 }
 
-/* eslint-disable max-params, no-loop-func */
-function runLayerTests(layerManager, deckRenderer, layer, testCases, spies, onError) {
-  // Run successive update tests
-  for (let i = 0; i < testCases.length; i++) {
-    const testCase = testCases[i];
-    const {
-      props,
-      updateProps,
-      onBeforeUpdate,
-      onAfterUpdate,
-      viewport = layerManager.context.viewport
-    } = testCase;
-
-    spies = testCase.spies || spies;
-
-    // copy old state before update
-    const oldState = Object.assign({}, layer.state);
-
-    if (onBeforeUpdate) {
-      onBeforeUpdate({layer, testCase});
-    }
-
-    if (props) {
-      // Test case can reset the props on every iteration
-      layer = new layer.constructor(props);
-    } else if (updateProps) {
-      // Test case can override with new props on every iteration
-      layer = layer.clone(updateProps);
-    }
-
-    // Create a map of spies that the test case can inspect
-    const spyMap = injectSpies(layer, spies);
-
-    layerManager.setLayers([layer]);
-
-    // call draw layer
-    deckRenderer.renderLayers({
-      viewports: [viewport],
-      layers: layerManager.getLayers(),
-      onViewportActive: layerManager.activateViewport
-    });
-
+function runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap) {
+  // assert on updated layer
+  if (testCase.onAfterUpdate) {
     // layer manager should handle match subLayer and tranfer state and props
     // here we assume subLayer matches copy over the new props from a new subLayer
-    const subLayers = layer.isComposite ? layer.getSubLayers() : [];
+    const subLayers = newLayer.isComposite ? newLayer.getSubLayers() : [];
     const subLayer = subLayers.length && subLayers[0];
 
-    // assert on updated layer
-    if (onAfterUpdate) {
-      onAfterUpdate({testCase, layer, oldState, subLayers, subLayer, spies: spyMap});
-    }
-
-    // Remove spies
-    Object.keys(spyMap).forEach(k => spyMap[k].reset());
+    testCase.onAfterUpdate({
+      testCase,
+      layer: newLayer,
+      oldState,
+      subLayers,
+      subLayer,
+      spies: spyMap
+    });
   }
 }
-/* eslint-enable max-params, no-loop-func */
+
+function runLayerTestUpdate(testCase, {layerManager, deckRenderer}, layer, spies) {
+  const {props, updateProps, onBeforeUpdate, viewport = layerManager.context.viewport} = testCase;
+
+  if (onBeforeUpdate) {
+    onBeforeUpdate({layer, testCase});
+  }
+
+  if (props) {
+    // Test case can reset the props on every iteration
+    layer = new layer.constructor(props);
+  } else if (updateProps) {
+    // Test case can override with new props on every iteration
+    layer = layer.clone(updateProps);
+  }
+
+  // Create a map of spies that the test case can inspect
+  spies = testCase.spies || spies;
+  const spyMap = injectSpies(layer, spies);
+
+  layerManager.setLayers([layer]);
+
+  // call draw layer
+  deckRenderer.renderLayers({
+    viewports: [viewport],
+    layers: layerManager.getLayers(),
+    onViewportActive: layerManager.activateViewport
+  });
+
+  return {layer, spyMap};
+}
+
+/* global requestAnimationFrame */
+function update({layerManager, deckRenderer}) {
+  return new Promise(resolve => {
+    const onAnimationFrame = () => {
+      if (layerManager.needsUpdate()) {
+        layerManager.updateLayers();
+
+        deckRenderer.renderLayers({
+          viewports: [layerManager.context.viewport],
+          layers: layerManager.getLayers(),
+          onViewportActive: layerManager.activateViewport
+        });
+        resolve();
+        return;
+      }
+
+      requestAnimationFrame(onAnimationFrame);
+    };
+
+    onAnimationFrame();
+  });
+}


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/pull/4365#issuecomment-639642708

Note that the skipped MVTLayer test still does not pass with this PR. It will rely on https://github.com/visgl/deck.gl/pull/4658

#### Change List
- Add `testLayerAsync` to test-utils
- Remove deprecated `testUpdateLayer` and `testDrawLayer` (not documented, not used)
- Docs
