### PR TITLE
Always initialize new layers with the current viewport

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -275,6 +275,8 @@ export default class Deck {
     // If initialized, update sub manager props
     if (this.layerManager) {
       this.viewManager.setProps(resolvedProps);
+      // Make sure that any new layer gets initialized with the current viewport
+      this.layerManager.activateViewport(this.getViewports()[0]);
       this.layerManager.setProps(resolvedProps);
       this.effectManager.setProps(resolvedProps);
       this.deckRenderer.setProps(resolvedProps);

--- a/test/render/test-cases/icon-layer.js
+++ b/test/render/test-cases/icon-layer.js
@@ -30,7 +30,7 @@ export default [
       })
     ],
     onAfterRender: ({layers, done}) => {
-      if (layers[0].state.iconManager.getTexture()) {
+      if (layers[0].isLoaded) {
         done();
       }
     },
@@ -213,7 +213,7 @@ export default [
       })
     ],
     onAfterRender: ({layers, done}) => {
-      if (layers[0].state.iconManager.getTexture()) {
+      if (layers[0].isLoaded) {
         done();
       }
     },


### PR DESCRIPTION
#### Background

Currently, a viewport update is propagated to layers during render. If any new layer is set in `props`, it is initialized with the last viewport.

Technically layers should not be affected by viewport change after initialization. However, many layers do make assumptions during data update based on the type of view being used. This is mostly a problem during the render tests, where views may change between test cases. Using the previous viewport to initialize layers makes the test result dependent on the previous test case and is causing confusing behavior.

The change proposed by this PR does not have any perf impact. When `activateViewport` is called again during render, `viewportChanged` flag is false and therefore does not trigger duplicate layer updates.

#### Change List
- activate the current viewport before updating layers
