### PR TITLE
Fix MVTLayer projection precision

### DIFF
--- a/modules/core/src/shaderlib/project/project-functions.js
+++ b/modules/core/src/shaderlib/project/project-functions.js
@@ -79,7 +79,9 @@ export function getWorldPosition(
 
     case COORDINATE_SYSTEM.CARTESIAN:
     default:
-      return viewport.isGeospatial ? [x, y, z] : viewport.projectPosition([x, y, z]);
+      return viewport.isGeospatial
+        ? [x + coordinateOrigin[0], y + coordinateOrigin[1], z + coordinateOrigin[2]]
+        : viewport.projectPosition([x, y, z]);
   }
 }
 

--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -137,6 +137,9 @@ vec4 project_position(vec4 position, vec3 position64Low) {
         position_world.w
       );
     }
+    if (project_uCoordinateSystem == COORDINATE_SYSTEM_CARTESIAN) {
+      position_world.xyz += project_uCoordinateOrigin;
+    }
   }
   if (project_uProjectionMode == PROJECTION_MODE_GLOBE) {
     if (project_uCoordinateSystem == COORDINATE_SYSTEM_LNGLAT) {

--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -80,6 +80,9 @@ export function getOffsetOrigin(
         ];
         // Geospatial origin (wgs84) must match shaderCoordinateOrigin (common)
         geospatialOrigin = viewport.unprojectPosition(shaderCoordinateOrigin);
+        shaderCoordinateOrigin[0] -= coordinateOrigin[0];
+        shaderCoordinateOrigin[1] -= coordinateOrigin[1];
+        shaderCoordinateOrigin[2] -= coordinateOrigin[2];
       }
       break;
 

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -33,10 +33,11 @@ export default class MVTLayer extends TileLayer {
     const xOffset = (WORLD_SIZE * tile.x) / worldScale;
     const yOffset = WORLD_SIZE * (1 - tile.y / worldScale);
 
-    const modelMatrix = new Matrix4().translate([xOffset, yOffset, 0]).scale([xScale, yScale, 1]);
+    const modelMatrix = new Matrix4().scale([xScale, yScale, 1]);
 
     props.autoHighlight = false;
     props.modelMatrix = modelMatrix;
+    props.coordinateOrigin = [xOffset, yOffset, 0];
     props.coordinateSystem = COORDINATE_SYSTEM.CARTESIAN;
     props.extensions = [...(props.extensions || []), new ClipExtension()];
 

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -77,16 +77,18 @@ const TEST_CASES = [
     position: [256, 256, 0],
     params: {
       viewport: TEST_VIEWPORT_2,
-      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      coordinateOrigin: [0, 0, 0]
     },
     result: [256, 256, 0]
   },
   {
     title: 'CARTESIAN:WEB_MERCATOR_AUTO_OFFSET',
-    position: [256, 256, 0],
+    position: [0, 0, 0],
     params: {
       viewport: TEST_VIEWPORT,
-      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+      coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+      coordinateOrigin: [256, 256, 0]
     },
     result: [174.15110778808594, -58.11044311523443, 0]
   },


### PR DESCRIPTION
Might help with https://github.com/visgl/deck.gl/issues/4605

Before:

![Screen Shot 2020-06-19 at 1 26 07 PM](https://user-images.githubusercontent.com/2059298/85177847-d67ed780-b231-11ea-81fe-5ca0bffdc47f.png)


After:

![Screen Shot 2020-06-19 at 1 25 43 PM](https://user-images.githubusercontent.com/2059298/85177850-d8489b00-b231-11ea-8756-1e6709013936.png)


#### Change List
- Support `coordinateOrigin` in CARTESION + MERCATOR mode
