### PR TITLE
Set per-layer viewportChanged flag

### DIFF
--- a/docs/developer-guide/views.md
+++ b/docs/developer-guide/views.md
@@ -318,6 +318,29 @@ const deck = new Deck({
 });
 ```
 
+Some layers, including `TileLayer`, `Tile3DLayer`, `HeatmapLayer` and `ScreenGridLayer`, perform expensive operations (data fetching/aggregation) on viewport change. Therefore, it is generally NOT recommended to render them into multiple views. If you do need to show e.g. tiled base map in multiple views, create one layer instance for each view and limit their rendering with `layerFilter`:
+
+```js
+const deck = new Deck({
+  ...
+  views: [
+    new MapView({id: 'main', ...}),
+    new MapView({id: 'mini-map', ...})
+  ],
+  layers: [
+    new TileLayer({id: 'tiles-for-main', ...}),
+    new TileLayer({id: 'tiles-for-mini-map', ...})
+  ],
+  layerFilter: ({layer, viewport} => {
+    if (layer.id.startsWith('tiles-for')) {
+      return layer.id.startsWith(`tiles-for-${viewport.id}`);
+    }
+    return true;
+  });
+});
+```
+
+
 ### Picking in Multiple Views
 
 deck.gl's built-in picking support extends naturally to multiple viewports. The picking process renders all viewports.

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
@@ -123,8 +123,8 @@ export default class ScreenGridLayer extends GridAggregationLayer {
   finalizeState() {
     super.finalizeState();
 
-    const {aggregationBuffer, maxBuffer, gpuGridAggregator, maxTexture} = this.state;
-    gpuGridAggregator.delete();
+    const {aggregationBuffer, maxBuffer, maxTexture} = this.state;
+
     if (aggregationBuffer) {
       aggregationBuffer.delete();
     }

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -210,22 +210,9 @@ export default class LayerManager {
   activateViewport(viewport) {
     assert(viewport, 'LayerManager: viewport not set');
 
-    const oldViewport = this.context.viewport;
-    const viewportChanged = !oldViewport || !viewport.equals(oldViewport);
+    debug(TRACE_ACTIVATE_VIEWPORT, this, viewport);
 
-    if (viewportChanged) {
-      debug(TRACE_ACTIVATE_VIEWPORT, this, viewport);
-
-      this.context.viewport = viewport;
-      const changeFlags = {viewportChanged: true};
-
-      // Update layers states
-      // Let screen space layers update their state based on viewport
-      for (const layer of this.layers) {
-        layer.setChangeFlags(changeFlags);
-        this._updateLayer(layer);
-      }
-    }
+    this.context.viewport = viewport;
 
     return this;
   }

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -371,9 +371,9 @@ export default class Layer extends Component {
   // INTERNAL METHODS
   activateViewport(viewport) {
     const oldViewport = this.internalState.viewport;
+    this.internalState.viewport = viewport;
 
     if (!oldViewport || !areViewportsEqual({oldViewport, viewport})) {
-      this.internalState.viewport = viewport;
       this.setChangeFlags({viewportChanged: true});
       this._update();
     }

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -95,10 +95,8 @@ export default class LayersPass extends Pass {
       }
       if (layer.isComposite) {
         renderStatus.compositeCount++;
-      }
-
-      // Draw the layer
-      if (shouldDrawLayer) {
+      } else if (shouldDrawLayer) {
+        // Draw the layer
         renderStatus.visibleCount++;
 
         const _moduleParameters = this._getModuleParameters(layer, effects, pass, moduleParameters);
@@ -141,7 +139,7 @@ export default class LayersPass extends Pass {
 
   /* Private */
   _shouldDrawLayer(layer, viewport, pass, layerFilter) {
-    let shouldDrawLayer = this.shouldDrawLayer(layer) && !layer.isComposite && layer.props.visible;
+    let shouldDrawLayer = this.shouldDrawLayer(layer) && layer.props.visible;
 
     if (shouldDrawLayer && layerFilter) {
       shouldDrawLayer = layerFilter({
@@ -151,6 +149,11 @@ export default class LayersPass extends Pass {
         renderPass: pass
       });
     }
+    if (shouldDrawLayer) {
+      // If a layer is drawn, update its viewportChanged flag
+      layer.activateViewport(viewport);
+    }
+
     return shouldDrawLayer;
   }
 

--- a/modules/core/src/viewports/viewport.js
+++ b/modules/core/src/viewports/viewport.js
@@ -108,6 +108,9 @@ export default class Viewport {
     if (!(viewport instanceof Viewport)) {
       return false;
     }
+    if (this === viewport) {
+      return true;
+    }
 
     return (
       viewport.width === this.width &&

--- a/test/render/test-cases/mvt-layer.js
+++ b/test/render/test-cases/mvt-layer.js
@@ -44,7 +44,7 @@ export default [
     },
     layers: [
       new MVTLayer({
-        id: 'mvt-layer',
+        id: 'mvt-layer-highlight',
         data: ['./test/data/mvt-tiles/{z}/{x}/{y}.mvt'],
         getFillColor: [0, 0, 0, 128],
         getLineColor: [255, 0, 0, 128],


### PR DESCRIPTION
For #4712

![deck gl-multi-view-tile-layer](https://user-images.githubusercontent.com/2059298/85632533-563ee480-b62c-11ea-855d-93b060aa5825.gif)

This change allows the following layers to be used in a multi-view application:

- `TileLayer`
- `Tile3DLayer`
- `HeatmapLayer`
- `HexagonLayer`
- `H3HexagonLayer`
- `ScreenGridLayer`

#### Change List

- `layerManager.activateViewport` no longer sets the `viewportChanged` flag for all
- Add `layer.activateViewport` method - this is called when a layer is actually drawn.
- `changeFlags.viewportChanged` is only set if:
  + the layer has `props.visible: true`
  + the layer passes the `layerFilter`
  + the active viewport has changed deeply
- `this.context.viewport` during `layer.updateState` now reflects:
  + the current viewport, if this layer is being initialized
  + the last active viewport, if this layer has been drawn
- Some minor perf improvements on viewport comparison
