### PR TITLE
Fix bundle config

### DIFF
--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -37,7 +37,7 @@ function getExternals(packageInfo) {
 }
 
 const config = {
-  mode: 'development',
+  mode: 'production',
 
   entry: {
     main: resolve('./bundle')


### PR DESCRIPTION
For #4717 

Looks like an unintended change from #4365

@jesusbotella you can build non-minified bundles by running `yarn build-bundle --env.dev` in each module.
