### PR TITLE
Fix coordinate when picking in multiple views

### DIFF
--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -63,7 +63,7 @@ export function processPickInfo({
   }
 
   const viewport = getViewportFromCoordinates({viewports}); // TODO - add coords
-  const coordinate = viewport && viewport.unproject([x, y], {targetZ: z});
+  const coordinate = viewport && viewport.unproject([x - viewport.x, y - viewport.y], {targetZ: z});
 
   const baseInfo = {
     color: null,


### PR DESCRIPTION

#### Change List
- Fix bug where `pickingInfo.coordinate` is off if the viewport is not top-left aligned
