### PR TITLE
pydeck: Simplify Deck.to_html()

### DIFF
--- a/bindings/pydeck/pydeck/__init__.py
+++ b/bindings/pydeck/pydeck/__init__.py
@@ -4,7 +4,7 @@
 # Copyright (c) Uber Technologies, Inc.
 # Distributed under the terms of the Modified BSD License.
 
-from .bindings import Deck, Layer, LightSettings, View, ViewState  # noqa
+from .bindings import map_styles, Deck, Layer, LightSettings, View, ViewState  # noqa
 
 from .widget import DeckGLWidget  # noqa
 

--- a/bindings/pydeck/pydeck/bindings/__init__.py
+++ b/bindings/pydeck/pydeck/bindings/__init__.py
@@ -3,3 +3,5 @@ from .layer import Layer  # noqa
 from .light_settings import LightSettings  # noqa
 from .view import View  # noqa
 from .view_state import ViewState  # noqa
+
+import map_styles  # noqa

--- a/bindings/pydeck/pydeck/bindings/__init__.py
+++ b/bindings/pydeck/pydeck/bindings/__init__.py
@@ -4,4 +4,4 @@ from .light_settings import LightSettings  # noqa
 from .view import View  # noqa
 from .view_state import ViewState  # noqa
 
-import map_styles  # noqa
+from . import map_styles # noqa

--- a/bindings/pydeck/pydeck/bindings/__init__.py
+++ b/bindings/pydeck/pydeck/bindings/__init__.py
@@ -4,4 +4,4 @@ from .light_settings import LightSettings  # noqa
 from .view import View  # noqa
 from .view_state import ViewState  # noqa
 
-from . import map_styles # noqa
+from . import map_styles  # noqa

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -9,6 +9,7 @@ from ..settings import settings as pydeck_settings
 from ..widget import DeckGLWidget
 from .view import View
 from .providers import Providers
+from .map_styles import LIGHT
 
 
 class Deck(JSONMixin):
@@ -16,7 +17,7 @@ class Deck(JSONMixin):
         self,
         layers=[],
         views=[View(type="MapView", controller=True)],
-        map_style="mapbox://styles/mapbox/dark-v9",
+        map_style=LIGHT,
         mapbox_key=None,
         google_maps_key=None,
         initial_view_state=None,
@@ -51,7 +52,7 @@ class Deck(JSONMixin):
             to get an API token.
             If not using a basemap, you can set this value to `''`.
         google_maps_key : str, default None
-            Read on initialization from the ``GOOGLE_MAPS_API_KEY`` environment variable if not set.
+            Read on initialization from the ``PYDECK_GOOGLE_MAPS_API_KEY`` environment variable if not set.
             Defaults to None if the environment variable is also not set.
             Not used on all layers.
         map_provider : str, default 'mapbox'
@@ -87,7 +88,7 @@ class Deck(JSONMixin):
 
         self.mapbox_key = mapbox_key or os.getenv("MAPBOX_API_KEY")
         self.deck_widget.mapbox_key = self.mapbox_key
-        self.google_maps_key = google_maps_key or os.getenv("GOOGLE_MAPS_API_KEY")
+        self.google_maps_key = google_maps_key or os.getenv("PYDECK_GOOGLE_MAPS_API_KEY")
         self.deck_widget.google_maps_key = self.google_maps_key
 
         self.deck_widget.height = height

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -158,7 +158,7 @@ class Deck(JSONMixin):
             Display the HTML output in an iframe if True. Set to True automatically if rendering in Jupyter.
         iframe_width : str or int, default '100%'
             Width of Jupyter notebook iframe in pixels, if rendered in a Jupyter environment.
-        iframe_heigth : int, default 500
+        iframe_height : int, default 500
             Height of Jupyter notebook iframe in pixels, if rendered in Jupyter or Colab.
         as_string : bool, default False
             Returns HTML as a string, if True and ``filename`` is None.

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -9,7 +9,7 @@ from ..settings import settings as pydeck_settings
 from ..widget import DeckGLWidget
 from .view import View
 from .providers import Providers
-from .map_styles import LIGHT
+from .map_styles import DARK
 
 
 class Deck(JSONMixin):
@@ -17,7 +17,7 @@ class Deck(JSONMixin):
         self,
         layers=[],
         views=[View(type="MapView", controller=True)],
-        map_style=LIGHT,
+        map_style=DARK,
         mapbox_key=None,
         google_maps_key=None,
         initial_view_state=None,
@@ -138,7 +138,7 @@ class Deck(JSONMixin):
         self,
         filename=None,
         open_browser=False,
-        notebook_display=True,
+        notebook_display=None,
         iframe_width=700,
         iframe_height=500,
         as_string=False,
@@ -151,17 +151,19 @@ class Deck(JSONMixin):
         Parameters
         ----------
         filename : str, default None
-            Name of the file. If no name is provided, a randomly named file will be written locally.
+            Name of the file.
         open_browser : bool, default False
-            Whether a browser window will open or not after write
-        notebook_display : bool, default True
-            Attempts to display the HTML output in an iframe if True. Only works in a Jupyter environment.
-        iframe_width : int, default 700
-            Height of Jupyter notebook iframe in pixels, if rendered in a Jupyter environment.
-        iframe_height : int, default 500
+            Whether a browser window will open or not after write.
+        notebook_display : bool, default None
+            Display the HTML output in an iframe if True. Set to True automatically if rendering in Jupyter.
+        iframe_width : str or int, default '100%'
             Width of Jupyter notebook iframe in pixels, if rendered in a Jupyter environment.
+        iframe_heigth : int, default 500
+            Height of Jupyter notebook iframe in pixels, if rendered in Jupyter or Colab.
         as_string : bool, default False
-            Whether the HTML should be written as a string rather than to a file. Defaults to writing to a file.
+            Returns HTML as a string, if True and ``filename`` is None.
+        css_background_color : str, default None
+            Background color for visualization, specified as a string in any format accepted for CSS colors.
 
         Returns
         -------

--- a/bindings/pydeck/pydeck/bindings/map_styles.py
+++ b/bindings/pydeck/pydeck/bindings/map_styles.py
@@ -1,0 +1,4 @@
+SATELLITE = "mapbox://styles/mapbox/light-v9"
+LIGHT = "mapbox://styles/mapbox/light-v9"
+DARK = "mapbox://styles/mapbox/dark-v9"
+DARK_NO_LABELS = 'https://rivulet-zhang.github.io/dataRepo/mapbox/style/map-style-dark-v9-no-labels.json'

--- a/bindings/pydeck/pydeck/bindings/map_styles.py
+++ b/bindings/pydeck/pydeck/bindings/map_styles.py
@@ -1,4 +1,4 @@
 SATELLITE = "mapbox://styles/mapbox/light-v9"
 LIGHT = "mapbox://styles/mapbox/light-v9"
 DARK = "mapbox://styles/mapbox/dark-v9"
-DARK_NO_LABELS = 'https://rivulet-zhang.github.io/dataRepo/mapbox/style/map-style-dark-v9-no-labels.json'
+DARK_NO_LABELS = "https://rivulet-zhang.github.io/dataRepo/mapbox/style/map-style-dark-v9-no-labels.json"

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -27,7 +27,7 @@ def convert_js_bool(py_bool):
     return "true" if py_bool else "false"
 
 
-in_google_collab = "google.colab" in sys.modules
+in_google_colab = "google.colab" in sys.modules
 
 
 TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), "./templates/")
@@ -92,7 +92,7 @@ def iframe_with_srcdoc(html_str, width="100%", height=500):
     return HTML(iframe)
 
 
-def render_for_collab(html_str, iframe_height):
+def render_for_colab(html_str, iframe_height):
     js_height_snippet = "google.colab.output.setIframeHeight(0, true, {maxHeight: %s})" % iframe_height
     display(Javascript(js_height_snippet))  # noqa
     display(HTML(html_str))  # noqa
@@ -124,8 +124,8 @@ def deck_to_html(
         offline=offline,
     )
 
-    if not filename and notebook_display and in_google_collab:
-        render_for_collab(html_str, iframe_height)
+    if not filename and notebook_display and in_google_colab:
+        render_for_colab(html_str, iframe_height)
         return
 
     elif not filename and notebook_display:

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -85,7 +85,8 @@ def display_html(filename):
 
 def iframe_with_srcdoc(html_str, width="100%", height=500):
     width = f'"{width}"' if type(width) == str else width
-    iframe = f"""<iframe src="about:blank" srcdoc="{html.escape(html_str)}" width={width} height={height}></iframe>"""
+    iframe = """<iframe src="about:blank" srcdoc="{}" width={} height={}></iframe>""".format(
+        html.escape(html_str), width, height)
     from IPython.display import HTML  # noqa
 
     return HTML(iframe)

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -109,7 +109,7 @@ def deck_to_html(
     iframe_width="100%",
     tooltip=True,
     custom_libraries=None,
-    as_string=True,
+    as_string=False,
     offline=False,
 ):
     """Converts deck.gl format JSON to an HTML page"""

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -84,7 +84,7 @@ def display_html(filename):
 
 
 def iframe_with_srcdoc(html_str, width="100%", height=500):
-    width = f'"{width}"' if type(width) == str else width
+    width = '"{}"'.format(width) if type(width) == str else width
     iframe = """<iframe src="about:blank" srcdoc="{}" width={} height={}></iframe>""".format(
         html.escape(html_str), width, height)
     from IPython.display import HTML  # noqa

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -15,8 +15,7 @@ def in_jupyter():
     try:
         ip = get_ipython()  # noqa
 
-        if ip.has_trait("kernel"):
-            return True
+        return ip.has_trait("kernel")
     except NameError:
         return False
 

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -15,7 +15,7 @@ def in_jupyter():
     try:
         ip = get_ipython()  # noqa
 
-        if ip.has_trait('kernel'):
+        if ip.has_trait("kernel"):
             return True
     except NameError:
         return False

--- a/bindings/pydeck/tests/io/test_html.py
+++ b/bindings/pydeck/tests/io/test_html.py
@@ -14,14 +14,7 @@ try:
 except ImportError:
     from mock import MagicMock
 
-from pydeck.io.html import (
-    cdn_picker,
-    display_html,
-    iframe_with_srcdoc,
-    in_jupyter,
-    render_json_to_html,
-    CDN_URL
-)
+from pydeck.io.html import cdn_picker, display_html, iframe_with_srcdoc, in_jupyter, render_json_to_html, CDN_URL
 
 from ..fixtures import fixtures
 
@@ -42,7 +35,7 @@ def test_cdn_picker(monkeypatch):
     assert len(cdn_picker(offline=True)) > 1000
     PORT = 8080
     monkeypatch.setenv("PYDECK_DEV_PORT", PORT)
-    assert f'localhost:{PORT}' in cdn_picker()
+    assert f"localhost:{PORT}" in cdn_picker()
     monkeypatch.delenv("PYDECK_DEV_PORT", raising=False)
     assert CDN_URL in cdn_picker()
 

--- a/bindings/pydeck/tests/io/test_html.py
+++ b/bindings/pydeck/tests/io/test_html.py
@@ -35,7 +35,7 @@ def test_cdn_picker(monkeypatch):
     assert len(cdn_picker(offline=True)) > 1000
     PORT = 8080
     monkeypatch.setenv("PYDECK_DEV_PORT", PORT)
-    assert f"localhost:{PORT}" in cdn_picker()
+    assert "localhost:{}".format(PORT) in cdn_picker()
     monkeypatch.delenv("PYDECK_DEV_PORT", raising=False)
     assert CDN_URL in cdn_picker()
 

--- a/bindings/pydeck/tests/io/test_html.py
+++ b/bindings/pydeck/tests/io/test_html.py
@@ -1,17 +1,27 @@
 import pytest
 
+import html
 import os
 import sys
 import tempfile
 from pathlib import Path
 import webbrowser
 
+import IPython
+
 try:
     from unittest.mock import MagicMock
 except ImportError:
     from mock import MagicMock
 
-from pydeck.io.html import display_html, render_json_to_html, open_named_or_temporary_file
+from pydeck.io.html import (
+    cdn_picker,
+    display_html,
+    iframe_with_srcdoc,
+    in_jupyter,
+    render_json_to_html,
+    CDN_URL
+)
 
 from ..fixtures import fixtures
 
@@ -24,38 +34,27 @@ def test_rendering_is_not_broken():
 
 def test_display_html():
     webbrowser.open = MagicMock()
-    display_html("test.htm", 500, 500)
+    display_html("test.htm")
     webbrowser.open.assert_called_once_with("file://test.htm")
 
 
-def test_open_named_or_temporary_file(tmp_path):
-    # Verify that a file is created with a .html extension and in write mode
-    path = tmp_path / "test_file"
-    named_file = open_named_or_temporary_file(str(path))
-    assert named_file.mode == "w+"
+def test_cdn_picker(monkeypatch):
+    assert len(cdn_picker(offline=True)) > 1000
+    PORT = 8080
+    monkeypatch.setenv("PYDECK_DEV_PORT", PORT)
+    assert f'localhost:{PORT}' in cdn_picker()
+    monkeypatch.delenv("PYDECK_DEV_PORT", raising=False)
+    assert CDN_URL in cdn_picker()
 
-    path = str(tmp_path / "test_file.html")
-    is_saved_at_path = not os.path.isfile("test_file.html") and os.path.isfile(path)
-    # Verify that a file with the given name is created at the specified path
-    assert is_saved_at_path
 
-    # Verify that a temporary file
-    add_html_file = open_named_or_temporary_file(str(tmp_path / "test_file"))
-    assert add_html_file.name.endswith(".html")
-    assert os.path.isfile(add_html_file.name)
+def test_iframe_with_srcdoc():
+    IPython.display.HTML = MagicMock()
+    html_str = "<html></html>"
+    iframe_with_srcdoc(html_str)
+    escaped_html_str = html.escape("<html></html>")
+    iframe = f"""<iframe src="about:blank" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>"""
+    IPython.display.HTML.assert_called_once_with(iframe)
 
-    # Verify the ability to create a local temporary file
-    try:
-        local_temporary_file = open_named_or_temporary_file()
-        assert add_html_file.name.endswith(".html")
-        assert os.path.isfile(local_temporary_file.name)
-    finally:
-        os.remove(local_temporary_file.name)
 
-    # Verify that there's a directory at the specified path with an html file in it
-    parent_dir = str(tmp_path / "test_dir") + "/"
-    assert not os.path.isdir(parent_dir)
-    directory_given_file = open_named_or_temporary_file(parent_dir)
-    assert directory_given_file.name.endswith(".html")
-    assert os.path.isfile(directory_given_file.name)
-    assert os.path.isdir(parent_dir)
+def test_in_jupyter():
+    assert not in_jupyter()

--- a/bindings/pydeck/tests/io/test_html.py
+++ b/bindings/pydeck/tests/io/test_html.py
@@ -45,7 +45,8 @@ def test_iframe_with_srcdoc():
     html_str = "<html></html>"
     iframe_with_srcdoc(html_str)
     escaped_html_str = html.escape("<html></html>")
-    iframe = f"""<iframe src="about:blank" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>"""
+    iframe = """<iframe src="about:blank" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>"""\
+        .format(escaped_html_str=escaped_html_str)
     IPython.display.HTML.assert_called_once_with(iframe)
 
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Simplifies `Deck.to_html`, which will now return a string or an iframe with a srcdoc depending on which arguments are passed.

The srcdoc is particularly useful because this means that pydeck doesn't have to write a separate document from a Notebook, which makes it easier to get work into nbviewer
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Automatically detect whether or not pydeck is running in a Jupyter environment (with manual override in case this fails)
- Write a srcdoc in an iframe instead of a separate document
- Eliminate temporary files in pydeck