### PR TITLE
pydeck: Better support for GeoPandas

### DIFF
--- a/bindings/pydeck/examples/pydeck_with_geopandas.py
+++ b/bindings/pydeck/examples/pydeck_with_geopandas.py
@@ -1,0 +1,27 @@
+import pydeck
+import geopandas
+
+world = geopandas.read_file(
+    geopandas.datasets.get_path('naturalearth_lowres')
+)
+
+centroids = geopandas.GeoDataFrame()
+centroids['geometry'] = world.geometry.centroid
+centroids['name'] = world.name
+
+layers = [
+    pydeck.Layer(
+        'GeoJsonLayer',
+        data=world,
+        get_fill_color=[255, 255, 0],
+    ),
+    pydeck.Layer(
+        'TextLayer',
+        data=centroids,
+        get_position='geometry.coordinates',
+        get_color=[255, 255, 255],
+        get_text='name'
+    )
+]
+
+pydeck.Deck(layers, map_style='').to_html('pydeck-with-geopandas.html')

--- a/bindings/pydeck/examples/pydeck_with_geopandas.py
+++ b/bindings/pydeck/examples/pydeck_with_geopandas.py
@@ -13,7 +13,7 @@ layers = [
     pydeck.Layer(
         'GeoJsonLayer',
         data=world,
-        get_fill_color=[255, 255, 0],
+        get_fill_color=[0, 0, 0],
     ),
     pydeck.Layer(
         'TextLayer',

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -8,6 +8,7 @@ from ..io.html import deck_to_html
 from ..settings import settings as pydeck_settings
 from ..widget import DeckGLWidget
 from .view import View
+from .view_state import ViewState
 from .providers import Providers
 
 
@@ -19,7 +20,7 @@ class Deck(JSONMixin):
         map_style="mapbox://styles/mapbox/dark-v9",
         mapbox_key=None,
         google_maps_key=None,
-        initial_view_state=None,
+        initial_view_state=ViewState(latitude=0, longitude=0, zoom=1),
         width="100%",
         height=500,
         tooltip=True,
@@ -36,12 +37,12 @@ class Deck(JSONMixin):
 
         layers : pydeck.Layer or list of pydeck.Layer, default []
             List of :class:`pydeck.bindings.layer.Layer` layers to render.
-        views : list of pydeck.View, []
+        views : list of pydeck.View, default ``[pydeck.View(type="MapView", controller=True)]``
             List of :class:`pydeck.bindings.view.View` objects to render.
         map_style : str, default 'mapbox://styles/mapbox/dark-v9'
             URI for Mapbox basemap style. See Mapbox's `gallery <https://www.mapbox.com/gallery/>`_ for examples.
             If not using a basemap, you can set this value to to an empty string, ``''``.
-        initial_view_state : pydeck.ViewState, default None
+        initial_view_state : pydeck.ViewState, default ``pydeck.ViewState(latitude=0, longitude=0, zoom=1)``
             Initial camera angle relative to the map, defaults to a fully zoomed out 0, 0-centered map
             To compute a viewport from data, see :func:`pydeck.data_utils.viewport_helpers.compute_view`
         mapbox_key : str, default None

--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -2,7 +2,7 @@ import uuid
 
 import numpy as np
 
-from ..data_utils import is_pandas_df, is_geopandas_df
+from ..data_utils import is_pandas_df, has_geo_interface, records_from_geo_interface
 from .json_tools import JSONMixin, camel_and_lower
 
 
@@ -124,10 +124,10 @@ class Layer(JSONMixin):
         """
         if self.use_binary_transport:
             self._binary_data = self._prepare_binary_data(data_set)
-        elif is_geopandas_df(data_set) and self.type == "GeoJsonLayer":
-            self._data = data_set.__geo_interface__
         elif is_pandas_df(data_set):
             self._data = data_set.to_dict(orient="records")
+        elif has_geo_interface(data_set):
+            self._data = records_from_geo_interface(data_set)
         else:
             self._data = data_set
 

--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -127,7 +127,7 @@ class Layer(JSONMixin):
         """
         if self.use_binary_transport:
             self._binary_data = self._prepare_binary_data(data_set)
-        elif is_geopandas_df(data_set) and self.type == 'GeoJsonLayer':
+        elif is_geopandas_df(data_set):
             self._data = data_set.__geo_interface__
         elif is_pandas_df(data_set):
             self._data = data_set.to_dict(orient="records")

--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -2,7 +2,7 @@ import uuid
 
 import numpy as np
 
-from ..data_utils import is_pandas_df
+from ..data_utils import is_pandas_df, is_geopandas_df
 from .json_tools import JSONMixin, camel_and_lower
 
 
@@ -127,6 +127,8 @@ class Layer(JSONMixin):
         """
         if self.use_binary_transport:
             self._binary_data = self._prepare_binary_data(data_set)
+        elif is_geopandas_df(data_set) and self.type == 'GeoJsonLayer':
+            self._data = data_set.__geo_interface__
         elif is_pandas_df(data_set):
             self._data = data_set.to_dict(orient="records")
         else:

--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -110,10 +110,7 @@ class Layer(JSONMixin):
         self._data = None
         self.use_binary_transport = use_binary_transport
         self._binary_data = None
-        if not self.use_binary_transport:
-            self.data = data.to_dict(orient="records") if is_pandas_df(data) else data
-        else:
-            self.data = data
+        self.data = data
 
     @property
     def data(self):
@@ -127,7 +124,7 @@ class Layer(JSONMixin):
         """
         if self.use_binary_transport:
             self._binary_data = self._prepare_binary_data(data_set)
-        elif is_geopandas_df(data_set):
+        elif is_geopandas_df(data_set) and self.type == "GeoJsonLayer":
             self._data = data_set.__geo_interface__
         elif is_pandas_df(data_set):
             self._data = data_set.to_dict(orient="records")

--- a/bindings/pydeck/pydeck/data_utils/__init__.py
+++ b/bindings/pydeck/pydeck/data_utils/__init__.py
@@ -1,3 +1,3 @@
 from .viewport_helpers import compute_view  # noqa
-from .type_checking import is_pandas_df  # noqa
+from .type_checking import is_pandas_df, is_geopandas_df  # noqa
 from .color_scales import assign_random_colors  # noqa

--- a/bindings/pydeck/pydeck/data_utils/__init__.py
+++ b/bindings/pydeck/pydeck/data_utils/__init__.py
@@ -1,3 +1,7 @@
 from .viewport_helpers import compute_view  # noqa
-from .type_checking import is_pandas_df, is_geopandas_df  # noqa
+from .type_checking import (
+    has_geo_interface,
+    is_pandas_df,
+    records_from_geo_interface
+)  # noqa
 from .color_scales import assign_random_colors  # noqa

--- a/bindings/pydeck/pydeck/data_utils/__init__.py
+++ b/bindings/pydeck/pydeck/data_utils/__init__.py
@@ -1,7 +1,3 @@
 from .viewport_helpers import compute_view  # noqa
-from .type_checking import (
-    has_geo_interface,
-    is_pandas_df,
-    records_from_geo_interface
-)  # noqa
+from .type_checking import has_geo_interface, is_pandas_df, records_from_geo_interface  # noqa
 from .color_scales import assign_random_colors  # noqa

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -22,6 +22,6 @@ def records_from_geo_interface(data):
         geom = d.get("geometry")
         for k in properties.keys():
             record[k] = properties[k]
-            record["geometry"] = geom
+        record["geometry"] = geom
         flattened_records.append(record)
     return flattened_records

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -1,14 +1,3 @@
-def is_geopandas_df(obj):
-    """Check if an object is a GeoPandas DataFrame
-
-    Returns
-    -------
-    bool
-        Returns True if object is a GeoPandas DataFrame and False otherwise
-    """
-    return obj.__class__.__module__ == "geopandas.geodataframe"
-
-
 def is_pandas_df(obj):
     """Check if an object is a Pandas DataFrame
 
@@ -18,3 +7,21 @@ def is_pandas_df(obj):
         Returns True if object is a Pandas DataFrame and False otherwise
     """
     return obj.__class__.__module__ == "pandas.core.frame" and obj.to_records and obj.to_dict
+
+
+def has_geo_interface(obj):
+    return hasattr(obj, '__geo_interface__')
+
+
+def records_from_geo_interface(data):
+    """Un-nest data from object implementing __geo_interface__ standard"""
+    flattened_records = []
+    for d in data.__geo_interface__.get('features'):
+        record = {}
+        properties = d.get('properties')
+        geom = d.get('geometry')
+        for k in properties.keys():
+            record[k] = properties[k]
+            record['geometry'] = geom
+        flattened_records.append(record)
+    return flattened_records

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -17,11 +17,8 @@ def records_from_geo_interface(data):
     """Un-nest data from object implementing __geo_interface__ standard"""
     flattened_records = []
     for d in data.__geo_interface__.get("features"):
-        record = {}
-        properties = d.get("properties")
-        geom = d.get("geometry")
-        for k in properties.keys():
-            record[k] = properties[k]
+        record = d.get("properties", {})
+        geom = d.get("geometry", {})
         record["geometry"] = geom
         flattened_records.append(record)
     return flattened_records

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -1,10 +1,16 @@
+def is_geopandas_df(obj):
+    """Check if an object is a GeoPandas DataFrame
+
+    Returns
+    -------
+    bool
+        Returns True if object is a GeoPandas DataFrame and False otherwise
+    """
+    return obj.__class__.__module__ == "geopandas.geodataframe"
+
+
 def is_pandas_df(obj):
     """Check if an object is a Pandas DataFrame
-
-    The benefit here is that Pandas doesn't have to be included
-    in the dependencies for pydeck
-
-    The drawback of course is that the Pandas API might change and break this function
 
     Returns
     -------

--- a/bindings/pydeck/pydeck/data_utils/type_checking.py
+++ b/bindings/pydeck/pydeck/data_utils/type_checking.py
@@ -10,18 +10,18 @@ def is_pandas_df(obj):
 
 
 def has_geo_interface(obj):
-    return hasattr(obj, '__geo_interface__')
+    return hasattr(obj, "__geo_interface__")
 
 
 def records_from_geo_interface(data):
     """Un-nest data from object implementing __geo_interface__ standard"""
     flattened_records = []
-    for d in data.__geo_interface__.get('features'):
+    for d in data.__geo_interface__.get("features"):
         record = {}
-        properties = d.get('properties')
-        geom = d.get('geometry')
+        properties = d.get("properties")
+        geom = d.get("geometry")
         for k in properties.keys():
             record[k] = properties[k]
-            record['geometry'] = geom
+            record["geometry"] = geom
         flattened_records.append(record)
     return flattened_records


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4499

Automatically call `__geo_interface__` on objects that implement it. Un-nest properties within the GeoJson.

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Automatically call and un-nest data within a GeoPandas DataFrame if passed to a layer
- Add example

```python
import geopandas as gpd
import pydeck

features = [{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [125.6, 10.1]
  },
  "properties": {
    "name": "Dinagat Islands",
    "radius": 1000000,
    "color": [255, 160, 14]
  }
},{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [0, 0]
  },
  "properties": {
    "name": "Water",
    "radius": 3000000,
    "color": [155, 134, 152]
  }
}]
gdf = gpd.GeoDataFrame.from_features(features)

layer = pydeck.Layer(
    'GeoJsonLayer',
-    data=gdf.__geo_interface__,
+    data=gdf,
    pickable=True,
)
pydeck.Deck(layers=[layer]).show()
```

![image](https://user-images.githubusercontent.com/2204757/86040043-3296e800-b9f8-11ea-82fe-492d7c12f524.png)
