### PR TITLE
Fix TextLayer fragment shader in Edge Legacy browser

### DIFF
--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.js
@@ -55,20 +55,20 @@ void main(void) {
       if (shouldDrawBackground) {
         // draw background color and return if not picking
         gl_FragColor = vec4(backgroundColor, vColor.a);
-        return;
       } else {
         // no background and no picking
         discard;
       }
-    }
-
-    if (shouldDrawBackground) {
-      gl_FragColor = vec4(mix(backgroundColor, vColor.rgb, alpha), vColor.a * opacity);
     } else {
-      gl_FragColor = vec4(vColor.rgb, a * opacity);
+      if (shouldDrawBackground) {
+        gl_FragColor = vec4(mix(backgroundColor, vColor.rgb, alpha), vColor.a * opacity);
+      } else {
+        gl_FragColor = vec4(vColor.rgb, a * opacity);
+      }
+      DECKGL_FILTER_COLOR(gl_FragColor, geometry);
     }
+  } else {
+    DECKGL_FILTER_COLOR(gl_FragColor, geometry);
   }
-
-  DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }
 `;


### PR DESCRIPTION
I had a bug that crashed the Edge Legacy browser. Determined the cause to be usage of the "return" statement in the fragment shader. Re-worked the logic flow with "else" clauses to achieve the same logic without using "return."
