### PR TITLE
Fix constant update when using TileLayer with repeated maps

### DIFF
--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -47,7 +47,7 @@ export default class LayersPass extends Pass {
     return renderStats;
   }
 
-  // Resolve the paramters needed to draw each layer
+  // Resolve the parameters needed to draw each layer
   // When a viewport contains multiple subviewports (e.g. repeated web mercator map),
   // this is only done once for the parent viewport
   _getDrawLayerParams(

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -69,7 +69,7 @@ test('TileLayer', async t => {
   const testCases = [
     {
       props: {
-        data: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/bart.geo.json'
+        data: 'http://echo.jsontest.com/key/value'
       },
       onBeforeUpdate: () => {
         t.comment('Default getTileData');
@@ -159,5 +159,40 @@ test('TileLayer', async t => {
     }
   ];
   await testLayerAsync({Layer: TileLayer, viewport: testViewport1, testCases, onError: t.notOk});
+  t.end();
+});
+
+test('TileLayer#MapView:repeat', async t => {
+  const renderSubLayers = props => {
+    return new ScatterplotLayer(props);
+  };
+
+  const testViewport = new WebMercatorViewport({
+    width: 1200,
+    height: 400,
+    longitude: 0,
+    latitude: 0,
+    zoom: 1,
+    repeat: true
+  });
+
+  t.is(testViewport.subViewports.length, 3, 'Viewport has more than one sub viewports');
+
+  const testCases = [
+    {
+      props: {
+        data: 'http://echo.jsontest.com/key/value',
+        renderSubLayers
+      },
+      onAfterUpdate: ({layer, subLayers}) => {
+        if (layer.isLoaded) {
+          t.is(subLayers.filter(l => l.props.visible).length, 4, 'Should contain 4 visible tiles');
+        }
+      }
+    }
+  ];
+
+  await testLayerAsync({Layer: TileLayer, viewport: testViewport, testCases, onError: t.notOk});
+
   t.end();
 });


### PR DESCRIPTION
#### Background

When using `TileLayer` and `MapView({repeat: true})`, layers' `viewportChanged` flag is repeatedly set as we iterate through each copy of the world at low zoom levels. This results in `TileLayer` constantly trying to update and displaying incorrect tiles.

The bug was introduced by #4722. Prior to the PR viewport activation was called once per view. The PR started calling `layer.activateViewport` inside `shouldDrawLayer()`, which is executed once per sub-viewport.

#### Change List
- Resolve layer parameters (`shouldDrawLayer`, `renderIndex` etc.) only once per view
