### PR TITLE
Fix image-tile example crash on unmount

### DIFF
--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -32,7 +32,7 @@ export default function App({autoHighlight = true, onTilesLoad}) {
 
       if (Number(dziXML.getElementsByTagName('Image')[0].attributes.Overlap.value) !== 0) {
         // eslint-disable-next-line no-undef, no-console
-        console.warn('Overlap paramter is nonzero and should be 0');
+        console.warn('Overlap parameter is nonzero and should be 0');
       }
       setDimensions({
         height: Number(dziXML.getElementsByTagName('Size')[0].attributes.Height.value),

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -23,21 +23,24 @@ function getTooltip({tile}) {
 export default function App({autoHighlight = true, onTilesLoad}) {
   const [dimensions, setDimensions] = useState(null);
 
-  useEffect(async () => {
-    const dziSource = `${ROOT_URL}/moon.image.dzi`;
-    const response = await fetch(dziSource);
-    const xmlText = await response.text();
-    const dziXML = new DOMParser().parseFromString(xmlText, 'text/xml');
+  useEffect(() => {
+    const getMetaData = async () => {
+      const dziSource = `${ROOT_URL}/moon.image.dzi`;
+      const response = await fetch(dziSource);
+      const xmlText = await response.text();
+      const dziXML = new DOMParser().parseFromString(xmlText, 'text/xml');
 
-    if (Number(dziXML.getElementsByTagName('Image')[0].attributes.Overlap.value) !== 0) {
-      // eslint-disable-next-line no-undef, no-console
-      console.warn('Overlap paramter is nonzero and should be 0');
-    }
-    setDimensions({
-      height: Number(dziXML.getElementsByTagName('Size')[0].attributes.Height.value),
-      width: Number(dziXML.getElementsByTagName('Size')[0].attributes.Width.value),
-      tileSize: Number(dziXML.getElementsByTagName('Image')[0].attributes.TileSize.value)
-    });
+      if (Number(dziXML.getElementsByTagName('Image')[0].attributes.Overlap.value) !== 0) {
+        // eslint-disable-next-line no-undef, no-console
+        console.warn('Overlap paramter is nonzero and should be 0');
+      }
+      setDimensions({
+        height: Number(dziXML.getElementsByTagName('Size')[0].attributes.Height.value),
+        width: Number(dziXML.getElementsByTagName('Size')[0].attributes.Width.value),
+        tileSize: Number(dziXML.getElementsByTagName('Image')[0].attributes.TileSize.value)
+      });
+    };
+    getMetaData();
   }, []);
 
   const tileLayer =


### PR DESCRIPTION
This is not an issue when running stand-alone, but crashes the website when navigating between example pages.

#### Change List
- `useEffect` should not return a non-function
