### PR TITLE
pydeck: Support globe view example

### DIFF
--- a/bindings/pydeck/examples/globe_example.py
+++ b/bindings/pydeck/examples/globe_example.py
@@ -1,0 +1,67 @@
+import pydeck
+import pandas as pd
+
+COUNTRIES = 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson'
+POWER_PLANTS = 'https://raw.githubusercontent.com/ajduberstein/geo_datasets/master/global_power_plant_database.csv'
+
+df = pd.read_csv(POWER_PLANTS)
+
+
+def is_green(fuel_type):
+    if fuel_type.lower() in ('nuclear', 'water', 'wind', 'hydro', 'biomass', 'solar', 'geothermal'):
+        return [0, 255, 0]
+    return [255, 255, 0]
+
+
+df['color'] = df['primary_fuel'].apply(is_green)
+
+view_state = pydeck.ViewState(
+    latitude=51.47,
+    longitude=0.45,
+    zoom=4
+)
+
+layers = []
+# Setting height and width variables
+view = pydeck.View(
+    type='_GlobeView',
+    controller=True,
+    width=1000,
+    height=700
+)
+
+
+layers = [
+    pydeck.Layer(
+        'GeoJsonLayer',
+        id='base-map',
+        data=COUNTRIES,
+        stroked=False,
+        filled=True,
+        get_line_color=[60, 60, 60],
+        get_fill_color=[200, 200, 200]
+    ),
+    pydeck.Layer(
+        'ColumnLayer',
+        id='power-plant',
+        data=df,
+        get_elevation='capacity_mw',
+        get_position=['longitude', 'latitude'],
+        elevation_scale=100,
+        pickable=True,
+        auto_highlight=True,
+        radius=40000,
+        get_fill_color='color'
+    )
+]
+
+deck = pydeck.Deck(
+    views=[view],
+    initial_view_state=view_state,
+    tooltip={'text': '{name}, {primary_fuel} plant, {country}'},
+    layers=layers)
+# Note that this must be set for the globe to be opaque
+deck.parameters = {'cull': True}
+
+
+deck.to_html('pydeck_globe.html', css_background_color='black')

--- a/bindings/pydeck/examples/globe_example.py
+++ b/bindings/pydeck/examples/globe_example.py
@@ -1,67 +1,59 @@
 import pydeck
 import pandas as pd
 
-COUNTRIES = 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson'
-POWER_PLANTS = 'https://raw.githubusercontent.com/ajduberstein/geo_datasets/master/global_power_plant_database.csv'
+COUNTRIES = "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson"
+POWER_PLANTS = "https://raw.githubusercontent.com/ajduberstein/geo_datasets/master/global_power_plant_database.csv"
 
 df = pd.read_csv(POWER_PLANTS)
 
 
 def is_green(fuel_type):
-    if fuel_type.lower() in ('nuclear', 'water', 'wind', 'hydro', 'biomass', 'solar', 'geothermal'):
+    if fuel_type.lower() in ("nuclear", "water", "wind", "hydro", "biomass", "solar", "geothermal"):
         return [0, 255, 0]
     return [255, 255, 0]
 
 
-df['color'] = df['primary_fuel'].apply(is_green)
+df["color"] = df["primary_fuel"].apply(is_green)
 
-view_state = pydeck.ViewState(
-    latitude=51.47,
-    longitude=0.45,
-    zoom=4
-)
+view_state = pydeck.ViewState(latitude=51.47, longitude=0.45, zoom=4)
 
 layers = []
 # Setting height and width variables
-view = pydeck.View(
-    type='_GlobeView',
-    controller=True,
-    width=1000,
-    height=700
-)
+view = pydeck.View(type="_GlobeView", controller=True, width=1000, height=700)
 
 
 layers = [
     pydeck.Layer(
-        'GeoJsonLayer',
-        id='base-map',
+        "GeoJsonLayer",
+        id="base-map",
         data=COUNTRIES,
         stroked=False,
         filled=True,
         get_line_color=[60, 60, 60],
-        get_fill_color=[200, 200, 200]
+        get_fill_color=[200, 200, 200],
     ),
     pydeck.Layer(
-        'ColumnLayer',
-        id='power-plant',
+        "ColumnLayer",
+        id="power-plant",
         data=df,
-        get_elevation='capacity_mw',
-        get_position=['longitude', 'latitude'],
+        get_elevation="capacity_mw",
+        get_position=["longitude", "latitude"],
         elevation_scale=100,
         pickable=True,
         auto_highlight=True,
         radius=40000,
-        get_fill_color='color'
-    )
+        get_fill_color="color",
+    ),
 ]
 
 deck = pydeck.Deck(
     views=[view],
     initial_view_state=view_state,
-    tooltip={'text': '{name}, {primary_fuel} plant, {country}'},
-    layers=layers)
+    tooltip={"text": "{name}, {primary_fuel} plant, {country}"},
+    layers=layers,
+)
 # Note that this must be set for the globe to be opaque
-deck.parameters = {'cull': True}
+deck.parameters = {"cull": True}
 
 
-deck.to_html('pydeck_globe.html', css_background_color='black')
+deck.to_html("pydeck_globe.html", css_background_color="black")

--- a/bindings/pydeck/examples/globe_example.py
+++ b/bindings/pydeck/examples/globe_example.py
@@ -18,7 +18,7 @@ df["color"] = df["primary_fuel"].apply(is_green)
 view_state = pydeck.ViewState(latitude=51.47, longitude=0.45, zoom=4)
 
 layers = []
-# Setting height and width variables
+# Set height and width variables
 view = pydeck.View(type="_GlobeView", controller=True, width=1000, height=700)
 
 
@@ -51,9 +51,8 @@ deck = pydeck.Deck(
     initial_view_state=view_state,
     tooltip={"text": "{name}, {primary_fuel} plant, {country}"},
     layers=layers,
+    # Note that this must be set for the globe to be opaque
+    parameters={"cull": True}
 )
-# Note that this must be set for the globe to be opaque
-deck.parameters = {"cull": True}
-
 
 deck.to_html("pydeck_globe.html", css_background_color="black")

--- a/bindings/pydeck/examples/pydeck_with_geopandas.py
+++ b/bindings/pydeck/examples/pydeck_with_geopandas.py
@@ -1,27 +1,17 @@
 import pydeck
 import geopandas
 
-world = geopandas.read_file(
-    geopandas.datasets.get_path('naturalearth_lowres')
-)
+world = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
 
 centroids = geopandas.GeoDataFrame()
-centroids['geometry'] = world.geometry.centroid
-centroids['name'] = world.name
+centroids["geometry"] = world.geometry.centroid
+centroids["name"] = world.name
 
 layers = [
+    pydeck.Layer("GeoJsonLayer", data=world, get_fill_color=[0, 0, 0],),
     pydeck.Layer(
-        'GeoJsonLayer',
-        data=world,
-        get_fill_color=[0, 0, 0],
+        "TextLayer", data=centroids, get_position="geometry.coordinates", get_color=[255, 255, 255], get_text="name"
     ),
-    pydeck.Layer(
-        'TextLayer',
-        data=centroids,
-        get_position='geometry.coordinates',
-        get_color=[255, 255, 255],
-        get_text='name'
-    )
 ]
 
-pydeck.Deck(layers, map_style='').to_html('pydeck-with-geopandas.html')
+pydeck.Deck(layers, map_style="").to_html("pydeck-with-geopandas.html")

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -28,6 +28,7 @@ class Deck(JSONMixin):
         description=None,
         effects=None,
         map_provider="mapbox",
+        parameters=None
     ):
         """This is the renderer and configuration for a deck.gl visualization, similar to the
         `Deck <https://deck.gl/#/documentation/deckgl-api-reference/deck>`_ class from deck.gl.
@@ -67,7 +68,7 @@ class Deck(JSONMixin):
             If ``True``/``False``, toggles a default tooltip on visualization hover.
             Layers must have ``pickable=True`` set in order to display a tooltip.
             For more advanced usage, the user can pass a dict to configure more custom tooltip features.
-            Documentation on this is available `in the hosted pydeck documentation <tooltip.html>`_.
+            Further documentation is `here <tooltip.html>`_.
 
 
         .. _Deck:
@@ -105,6 +106,7 @@ class Deck(JSONMixin):
             warnings.warn(
                 "Mapbox API key is not set. This may impact available features of pydeck.", UserWarning,
             )
+        self.parameters = parameters
 
     @property
     def selected_data(self):

--- a/bindings/pydeck/pydeck/bindings/view.py
+++ b/bindings/pydeck/pydeck/bindings/view.py
@@ -15,9 +15,11 @@ class View(JSONMixin):
         If enabled, camera becomes interactive.
     """
 
-    def __init__(self, type=None, controller=None):
+    def __init__(self, type=None, controller=None, width=None, height=None):
         self.type = type
         self.controller = controller
+        self.width = width
+        self.height = height
 
     @property
     def type(self):

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -85,7 +85,8 @@ def display_html(filename):
 def iframe_with_srcdoc(html_str, width="100%", height=500):
     width = '"{}"'.format(width) if type(width) == str else width
     iframe = """<iframe src="about:blank" srcdoc="{}" width={} height={}></iframe>""".format(
-        html.escape(html_str), width, height)
+        html.escape(html_str), width, height
+    )
     from IPython.display import HTML  # noqa
 
     return HTML(iframe)

--- a/bindings/pydeck/tests/io/test_html.py
+++ b/bindings/pydeck/tests/io/test_html.py
@@ -45,8 +45,9 @@ def test_iframe_with_srcdoc():
     html_str = "<html></html>"
     iframe_with_srcdoc(html_str)
     escaped_html_str = html.escape("<html></html>")
-    iframe = """<iframe src="about:blank" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>"""\
-        .format(escaped_html_str=escaped_html_str)
+    iframe = """<iframe src="about:blank" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>""".format(
+        escaped_html_str=escaped_html_str
+    )
     IPython.display.HTML.assert_called_once_with(iframe)
 
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Support the globe view within pydeck

![image](https://user-images.githubusercontent.com/2204757/87001506-7ca46a00-c16c-11ea-9744-50d37e299ba4.png)

<!-- For all the PRs -->
#### Change List
- Add globe example
- Modify view to allow for height and width arguments
- Apply Black py34 formatter
