### PR TITLE
pydeck: Fix iframe rendering width default value

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -142,7 +142,7 @@ class Deck(JSONMixin):
         filename=None,
         open_browser=False,
         notebook_display=None,
-        iframe_width=700,
+        iframe_width='100%',
         iframe_height=500,
         as_string=False,
         offline=False,

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -104,7 +104,7 @@ def deck_to_html(
     google_maps_key=None,
     filename=None,
     open_browser=False,
-    notebook_display=in_jupyter(),
+    notebook_display=None,
     css_background_color=None,
     iframe_height=500,
     iframe_width="100%",
@@ -123,6 +123,8 @@ def deck_to_html(
         custom_libraries=custom_libraries,
         offline=offline,
     )
+    if notebook_display is None:
+        notebook_display = in_jupyter()
 
     if not filename and notebook_display and in_google_colab:
         render_for_colab(html_str, iframe_height)
@@ -136,10 +138,11 @@ def deck_to_html(
 
     elif not filename:
         raise TypeError(
-            "To save to a file, provide a file path. To get an HTML string, set as_string=True. To render a visual in Jupyter, set jupyter_display=True"
+            "To save to a file, provide a file path. To get an HTML string, set as_string=True. To render a visual in Jupyter, set notebook_display=True"
         )
 
     with open(filename, "w+") as f:
         f.write(html_str)
+
     if open_browser:
         display_html(realpath(f.name))

--- a/bindings/pydeck/tests/dev-containers/build-and-screenshot.sh
+++ b/bindings/pydeck/tests/dev-containers/build-and-screenshot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PYDECK_VERSION="0.3.0-b.2"
+export PYDECK_VERSION="0.4.0"
 export PYPI_INSTALL_URL=https://test.pypi.org/simple/
 docker-compose build --force-rm --no-cache --parallel && docker-compose up --no-build -d
 python snap.py


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

Fix `to_html` typo around iframe width (700px in the source vs '100%' listed in the docs for the default value) and call function that auto-detects a Jupyter environment on the correct line