### PR TITLE
pydeck: Suppress warning for IFrame usage

### DIFF
--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -4,6 +4,7 @@ from os.path import relpath, realpath, join, dirname
 import sys
 import tempfile
 import time
+import warnings
 import webbrowser
 
 import jinja2
@@ -88,8 +89,10 @@ def iframe_with_srcdoc(html_str, width="100%", height=500):
         html.escape(html_str), width, height
     )
     from IPython.display import HTML  # noqa
-
-    return HTML(iframe)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        warnings.filterwarnings('Consider using IPython.display.iframe instead')
+        return HTML(iframe)
 
 
 def render_for_colab(html_str, iframe_height):
@@ -123,26 +126,24 @@ def deck_to_html(
         custom_libraries=custom_libraries,
         offline=offline,
     )
+
+    if filename:
+        with open(filename, "w+") as f:
+            f.write(html_str)
+
+        if open_browser:
+            display_html(realpath(f.name))
+
     if notebook_display is None:
         notebook_display = in_jupyter()
 
-    if not filename and notebook_display and in_google_colab:
+    if notebook_display and in_google_colab:
         render_for_colab(html_str, iframe_height)
         return
-
-    elif not filename and notebook_display:
-        return iframe_with_srcdoc(html_str, iframe_width, iframe_height)
-
     elif not filename and as_string:
         return html_str
-
-    elif not filename:
-        raise TypeError(
-            "To save to a file, provide a file path. To get an HTML string, set as_string=True. To render a visual in Jupyter, set notebook_display=True"
-        )
-
-    with open(filename, "w+") as f:
-        f.write(html_str)
-
-    if open_browser:
-        display_html(realpath(f.name))
+    elif notebook_display:
+        return iframe_with_srcdoc(html_str, iframe_width, iframe_height)
+    raise TypeError(
+        "To save to a file, provide a file path. To get an HTML string, set as_string=True. To render a visual in Jupyter, set notebook_display=True"
+    )

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -89,9 +89,10 @@ def iframe_with_srcdoc(html_str, width="100%", height=500):
         html.escape(html_str), width, height
     )
     from IPython.display import HTML  # noqa
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        warnings.filterwarnings('Consider using IPython.display.iframe instead')
+        warnings.filterwarnings("Consider using IPython.display.iframe instead")
         return HTML(iframe)
 
 

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -91,8 +91,7 @@ def iframe_with_srcdoc(html_str, width="100%", height=500):
     from IPython.display import HTML  # noqa
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        warnings.filterwarnings("Consider using IPython.display.iframe instead")
+        warnings.filterwarnings("ignore", message="Consider using IPython.display.iframe instead")
         return HTML(iframe)
 
 
@@ -145,6 +144,3 @@ def deck_to_html(
         return html_str
     elif notebook_display:
         return iframe_with_srcdoc(html_str, iframe_width, iframe_height)
-    raise TypeError(
-        "To save to a file, provide a file path. To get an HTML string, set as_string=True. To render a visual in Jupyter, set notebook_display=True"
-    )

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -85,7 +85,7 @@ def display_html(filename):
 
 def iframe_with_srcdoc(html_str, width="100%", height=500):
     width = '"{}"'.format(width) if type(width) == str else width
-    iframe = """<iframe src="about:blank" srcdoc="{}" width={} height={}></iframe>""".format(
+    iframe = """<iframe src="about:blank" frameborder="0" srcdoc="{}" width={} height={}></iframe>""".format(
         html.escape(html_str), width, height
     )
     from IPython.display import HTML  # noqa

--- a/bindings/pydeck/tests/io/test_html.py
+++ b/bindings/pydeck/tests/io/test_html.py
@@ -45,7 +45,7 @@ def test_iframe_with_srcdoc():
     html_str = "<html></html>"
     iframe_with_srcdoc(html_str)
     escaped_html_str = html.escape("<html></html>")
-    iframe = """<iframe src="about:blank" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>""".format(
+    iframe = """<iframe src="about:blank" frameborder="0" srcdoc="{escaped_html_str}" width="100%" height=500></iframe>""".format(
         escaped_html_str=escaped_html_str
     )
     IPython.display.HTML.assert_called_once_with(iframe)


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

#### Background

IPython throws a warning when you use don't use its `IFrame` class to write an iframe into a document, but their IFrame class doesn't support srcdoc (class source [here](https://github.com/ipython/ipython/blob/f8c9ea7db42d9830f16318a4ceca0ac1c3688697/IPython/lib/display.py#L245), which we use for writing our documents. 
<!-- For other PRs without open issue -->
<!-- For all the PRs -->
#### Change List
- Suppress IPython warning for iframe usage
- Allow user to write a file and display it simultaneously
