### PR TITLE
Use standard API in point cloud example

### DIFF
--- a/examples/website/point-cloud/app.js
+++ b/examples/website/point-cloud/app.js
@@ -57,11 +57,9 @@ export default function App({onLoad}) {
     [isLoaded]
   );
 
-  const onDataLoad = ({header, loaderData}) => {
-    // metadata from LAZ file header
-    const {mins, maxs} = loaderData.header;
-
-    if (mins && maxs) {
+  const onDataLoad = ({header}) => {
+    if (header.boundingBox) {
+      const [mins, maxs] = header.boundingBox;
       // File contains bounding box info
       updateViewState({
         ...INITIAL_VIEW_STATE,


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/4798

#### Change List
- Use standard loaders.gl mesh header API
