### PR TITLE
Do not create unnecessary picking colors buffer

### DIFF
--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -294,6 +294,9 @@ export default class Attribute extends DataColumn {
 
   /* eslint-disable max-depth, max-statements */
   _autoUpdater(attribute, {data, startRow, endRow, props, numInstances}) {
+    if (attribute.constant) {
+      return;
+    }
     const {settings, state, value, size, startIndices} = attribute;
 
     const {accessor, transform} = settings;
@@ -342,7 +345,6 @@ export default class Attribute extends DataColumn {
         i += size;
       }
     }
-    attribute.constant = false;
   }
   /* eslint-enable max-depth, max-statements */
 

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -425,6 +425,21 @@ test('Layer#calculateInstancePickingColors', t => {
       },
       onAfterUpdate: ({layer}) => {
         const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+        t.ok(instancePickingColors.state.constant, 'instancePickingColors is set to constant');
+        t.deepEquals(
+          instancePickingColors.value,
+          [0, 0, 0],
+          'instancePickingColors is set to constant'
+        );
+      }
+    },
+    {
+      updateProps: {
+        pickable: true
+      },
+      onAfterUpdate: ({layer}) => {
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+        t.notOk(instancePickingColors.state.constant, 'instancePickingColors is enabled');
         t.deepEquals(
           instancePickingColors.value.subarray(0, 6),
           [1, 0, 0, 2, 0, 0],
@@ -434,7 +449,9 @@ test('Layer#calculateInstancePickingColors', t => {
     },
     {
       updateProps: {
-        data: new Array(3).fill(0)
+        data: new Array(3).fill(0),
+        // If a layer has been pickable once, picking colors attribute is always populated
+        pickable: false
       },
       onAfterUpdate: ({layer}) => {
         const {instancePickingColors} = layer.getAttributeManager().getAttributes();


### PR DESCRIPTION
#### Background

After this PR, if a layer is never pickable or uses auto highlight, its picking colors attribute is not populated. This makes it so that:

- A non-pickable layer using large external binary will not throw the 'index out of picking color range' error
- Saves attribute packing time and memory for non-pickable layers

Note that a layer that was once pickable and then turned off will still update its picking colors buffer.

#### Change List
- Disable `instancePickingColors`/`pickingColors` attribute if `pickable` is off and `highlightedObjectIndex` is not specified
