### PR TITLE
Add missing @loaders.gl/core dependency

### DIFF
--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@loaders.gl/3d-tiles": "^2.2.3",
+    "@loaders.gl/core": "^2.2.3",
     "@loaders.gl/loader-utils": "^2.2.3",
     "@loaders.gl/mvt": "^2.2.3",
     "@loaders.gl/terrain": "^2.2.3",


### PR DESCRIPTION
#### Background
Add a missing `@loaders.gl/core` dependency to `@deck.gl/geo-layers`. I came across this while moving a repo from Yarn to PNPM (which is stricter about requiring dependencies to be fully declared). 

#### Change List
-Add missing @loaders.gl/core dependency