### PR TITLE
Remove pydeck attribution in Mapbox footer

### DIFF
--- a/modules/jupyter-widget/src/playground/utils/mapbox-utils.js
+++ b/modules/jupyter-widget/src/playground/utils/mapbox-utils.js
@@ -29,13 +29,4 @@ export function modifyMapboxElements() {
       el.style.display = 'none';
     }
   }
-
-  const footer = document.getElementsByClassName('mapboxgl-ctrl-attrib-inner');
-  if (footer && footer[0]) {
-    const aTag = document.createElement('a');
-    aTag.href = 'https://pydeck.gl';
-    aTag.innerText = 'pydeck | ';
-    aTag.target = '_blank';
-    footer[0].prepend(aTag);
-  }
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #4820 

I'll spend some time figuring out [how to incorporate attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/) with the Jupyter widget but for now I'll just remove it.

#### Change List
- Remove code that modifies the mapboxgl attribution footer