### PR TITLE
Fix picking with multiple views

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -146,6 +146,7 @@ export default class DeckPicker {
   // eslint-disable-next-line max-statements,complexity
   _pickClosestObject({
     layers,
+    views,
     viewports,
     x,
     y,
@@ -190,6 +191,7 @@ export default class DeckPicker {
         deviceRect &&
         this._drawAndSample({
           layers,
+          views,
           viewports,
           onViewportActive,
           deviceRect,
@@ -210,6 +212,7 @@ export default class DeckPicker {
       if (pickInfo.pickedLayer && unproject3D && this.depthFBO) {
         const zValues = this._drawAndSample({
           layers: [pickInfo.pickedLayer],
+          views,
           viewports,
           onViewportActive,
           deviceRect: {x: pickInfo.pickedX, y: pickInfo.pickedY, width: 1, height: 1},
@@ -267,6 +270,7 @@ export default class DeckPicker {
   // Pick all objects within the given bounding box
   _pickVisibleObjects({
     layers,
+    views,
     viewports,
     x,
     y,
@@ -302,6 +306,7 @@ export default class DeckPicker {
 
     const pickedColors = this._drawAndSample({
       layers,
+      views,
       viewports,
       onViewportActive,
       deviceRect,
@@ -337,7 +342,16 @@ export default class DeckPicker {
   }
 
   // returns pickedColor or null if no pickable layers found.
-  _drawAndSample({layers, viewports, onViewportActive, deviceRect, pass, redrawReason, pickZ}) {
+  _drawAndSample({
+    layers,
+    views,
+    viewports,
+    onViewportActive,
+    deviceRect,
+    pass,
+    redrawReason,
+    pickZ
+  }) {
     assert(deviceRect.width > 0 && deviceRect.height > 0);
 
     if (layers.length < 1) {
@@ -350,6 +364,7 @@ export default class DeckPicker {
       layers,
       layerFilter: this.layerFilter,
       onError: this._onError,
+      views,
       viewports,
       onViewportActive,
       pickingFBO,

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -403,6 +403,7 @@ export default class Deck {
       Object.assign(
         {
           layers: this.layerManager.getLayers(opts),
+          views: this.viewManager.getViews(),
           viewports: this.getViewports(opts),
           onViewportActive: this.layerManager.activateViewport
         },

--- a/modules/core/src/passes/pick-layers-pass.js
+++ b/modules/core/src/passes/pick-layers-pass.js
@@ -22,6 +22,7 @@ export default class PickLayersPass extends LayersPass {
   _drawPickingBuffer({
     layers,
     layerFilter,
+    views,
     viewports,
     onViewportActive,
     pickingFBO,
@@ -60,6 +61,7 @@ export default class PickLayersPass extends LayersPass {
           target: pickingFBO,
           layers,
           layerFilter,
+          views,
           viewports,
           onViewportActive,
           pass,


### PR DESCRIPTION
## Background

`PickLayerPass.render` is called without the `views` parameter, so `view.clear` is not respected in picking.

#### Change List
- Pass `views` to the picking render pass
