### PR TITLE
Update changelog to correct web link for docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to deck.gl will be documented in this file.
 
-For a human readable version, visit https://deck.gl/#/documentation/overview/upgrade-guide
+For a human readable version, visit https://deck.gl/docs/upgrade-guide
 
 <!--
 Each version should:


### PR DESCRIPTION
Fix broken link (old one generated a blank white page)