### PR TITLE
jupyter-widget: playground no longer directly accesses jupyterWidget

### DIFF
--- a/modules/json/src/transports/transport.js
+++ b/modules/json/src/transports/transport.js
@@ -1,3 +1,4 @@
+/* global document */
 const state = {
   onIninitialize: _ => _,
   onFinalize: _ => _,
@@ -24,12 +25,26 @@ export default class Transport {
     this.userData = {};
   }
 
-  // Back-channel messaging
+  /**
+   * Return a root DOM element for this transport connection
+   * @return {HTMLElement} default implementation returns document.body
+   * Jupyter Notebook transports will return an element associated with the notebook cell
+   */
+  getRootDOMElement() {
+    return typeof document !== 'undefined' ? document.body : null;
+  }
+
+  /**
+   * Back-channel messaging
+   */
   sendJSONMessage() {
     // eslint-disable-next-line
     console.error('Back-channel not implemented for this transport');
   }
 
+  /**
+   * Back-channel messaging
+   */
   sendBinaryMessage() {
     // eslint-disable-next-line
     console.error('Back-channel not implemented for this transport');

--- a/modules/jupyter-widget/src/lib/jupyter-transport.js
+++ b/modules/jupyter-widget/src/lib/jupyter-transport.js
@@ -13,6 +13,10 @@ export default class JupyterTransport extends Transport {
     this.jupyterView = null; // Set manually by the Jupyter Widget View
   }
 
+  getRootDOMElement() {
+    return this.jupyterView.el;
+  }
+
   // TODO - implement back-channel messaging for event handling etc
   sendJsonMessage({json, type}) {
     // this.jupyterModel. ...

--- a/modules/jupyter-widget/src/playground/playground.js
+++ b/modules/jupyter-widget/src/playground/playground.js
@@ -18,15 +18,17 @@ export function initPlayground() {
 
       // Load mapbox CSS
       loadMapboxCSS();
+
       // Create container div for deck.gl
-      const container = createContainer(width, height);
-      transport.jupyterView.el.appendChild(container);
+      const transportRootElement = transport.getRootDOMElement();
+      const deckContainer = createContainer(width, height);
+      transportRootElement.appendChild(deckContainer);
 
       const jsonProps = JSON.parse(jsonInput);
 
       const deck = createDeck({
         mapboxApiKey,
-        container,
+        container: deckContainer,
         jsonInput: jsonProps,
         tooltip,
         handleEvent: (name, payload) => sendEventViaTransport(transport, name, payload),


### PR DESCRIPTION
For #3864 etc

### Background
- Continue improving Transport abstraction for jupyter widget

### Change List
- Adds `Transport.getRootDOMElement()` method to ensure playground doesn't directly access the jupyterWidget.
