### PR TITLE
[rgb]Scale -> [rgb]Scaler in docs

### DIFF
--- a/docs/api-reference/geo-layers/terrain-layer.md
+++ b/docs/api-reference/geo-layers/terrain-layer.md
@@ -98,9 +98,9 @@ Martini error tolerance in meters, smaller number results in more detailed mesh.
 Parameters used to convert a pixel to elevation in meters.
 An object containing the following fields:
 
-- `rScale`: Multiplier of the red channel.
-- `gScale`: Multiplier of the green channel.
-- `bScale`: Multiplier of the blue channel.
+- `rScaler`: Multiplier of the red channel.
+- `gScaler`: Multiplier of the green channel.
+- `bScaler`: Multiplier of the blue channel.
 - `offset`: Translation of the sum.
 
 Each color channel (r, g, and b) is a number between `[0, 255]`.
@@ -115,9 +115,9 @@ The corresponding `elevationDecoder` is:
 
 ```
 {
-  "rScale": 6553.6,
-  "gScale": 25.6,
-  "bScale": 0.1,
+  "rScaler": 6553.6,
+  "gScaler": 25.6,
+  "bScaler": 0.1,
   "offset": -10000
 }
 ```
@@ -126,9 +126,9 @@ The default value of `elevationDecoder` decodes a grayscale image:
 
 ```
 {
-  "rScale": 1,
-  "gScale": 0,
-  "bScale": 0,
+  "rScaler": 1,
+  "gScaler": 0,
+  "bScaler": 0,
   "offset": 0
 }
 ```


### PR DESCRIPTION
The docs refer to `rScale`/`gScale`/`bScale`, but it's actually Scaler instead of Scale

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
