### PR TITLE
mesh-layers: Add `_useMeshColors` prop to `SimpleMeshLayer`

### DIFF
--- a/docs/api-reference/mesh-layers/simple-mesh-layer.md
+++ b/docs/api-reference/mesh-layers/simple-mesh-layer.md
@@ -119,6 +119,14 @@ Whether to render the mesh in wireframe mode.
 This is an object that contains material props for [lighting effect](/docs/api-reference/core/lighting-effect.md) applied on extruded polygons.
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
+##### `_useMeshColors` (Boolean, optional)
+
+- Default: `false`
+
+Whether to color pixels using vertex colors supplied in the mesh (the `COLOR_0` or `colors` attribute). If set to `true`, vertex colors will be used. If set to `false` (default) vertex colors will be ignored.
+
+Remarks:
+- In the next major release of deck.gl, vertex colors are expected to always be used when supplied with a mesh. This property will then likely be removed and effectively default to true.
 
 ### Data Accessors
 

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.js
@@ -43,8 +43,10 @@ function getTextureFromData(gl, data, opts) {
   return new Texture2D(gl, Object.assign({data}, opts));
 }
 
-function validateGeometryAttributes(attributes) {
-  if (!attributes.COLOR_0 && !attributes.colors) {
+function validateGeometryAttributes(attributes, useMeshColors) {
+  const hasColorAttribute = attributes.COLOR_0 || attributes.colors;
+  const useColorAttribute = hasColorAttribute && useMeshColors;
+  if (!useColorAttribute) {
     attributes.colors = {constant: true, value: new Float32Array([1, 1, 1])};
   }
   log.assert(
@@ -57,16 +59,16 @@ function validateGeometryAttributes(attributes) {
  * Convert mesh data into geometry
  * @returns {Geometry} geometry
  */
-function getGeometry(data) {
+function getGeometry(data, useMeshColors) {
   if (data.attributes) {
-    validateGeometryAttributes(data.attributes);
+    validateGeometryAttributes(data.attributes, useMeshColors);
     if (data instanceof Geometry) {
       return data;
     } else {
       return new Geometry(data);
     }
   } else if (data.positions || data.POSITION) {
-    validateGeometryAttributes(data);
+    validateGeometryAttributes(data, useMeshColors);
     return new Geometry({
       attributes: data
     });
@@ -80,6 +82,10 @@ const defaultProps = {
   mesh: {value: null, type: 'object', async: true},
   texture: {type: 'object', value: null, async: true},
   sizeScale: {type: 'number', value: 1, min: 0},
+  // Whether the color attribute in a mesh will be used
+  // This prop will be removed and set to true in next major release
+  _useMeshColors: {type: 'boolean', value: false},
+
   // TODO - parameters should be merged, not completely overridden
   parameters: {
     depthTest: true,
@@ -218,7 +224,7 @@ export default class SimpleMeshLayer extends Layer {
       this.context.gl,
       Object.assign({}, this.getShaders(), {
         id: this.props.id,
-        geometry: getGeometry(mesh),
+        geometry: getGeometry(mesh, this.props._useMeshColors),
         isInstanced: true
       })
     );


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #4749
<!-- For other PRs without open issue -->

#### Background
- Address concern that enabling vertex colors in SimpleMeshLayer in 8.2 will silently start rendering colors in existing meshes.

#### Change List
- Add a new pro `_useMeshColors` requiring users to explicitly enable mesh colors.
