### PR TITLE
jupyter-transport: Start replacing global model fields with props

### DIFF
--- a/modules/jupyter-widget/src/lib/jupyter-transport-view.js
+++ b/modules/jupyter-widget/src/lib/jupyter-transport-view.js
@@ -12,7 +12,11 @@ export default class JupyterTransportView extends DOMWidgetView {
     // Expose Jupyter internals to enable work-arounds
     this.transport.jupyterModel = this.model;
     this.transport.jupyterView = this;
-    this.transport._initialize();
+
+    const jsonInput = this.model.get('json_input');
+    const json = jsonInput ? JSON.parse(jsonInput) : {};
+    this.transport._initialize({json});
+
     super.initialize.apply(this, arguments);
   }
 

--- a/modules/jupyter-widget/src/playground/create-deck.js
+++ b/modules/jupyter-widget/src/playground/create-deck.js
@@ -170,15 +170,15 @@ function createDeck({
   mapboxApiKey,
   googleMapsKey,
   container,
-  jsonInput,
   tooltip,
   handleEvent,
-  customLibraries
+  customLibraries,
+  deckProps
 }) {
   let deckgl;
   try {
-    const oldLayers = jsonInput.layers || [];
-    const props = jsonConverter.convert(jsonInput);
+    const oldLayers = deckProps.layers || [];
+    const props = jsonConverter.convert(deckProps);
 
     addSupportComponents(container, props);
 
@@ -191,18 +191,18 @@ function createDeck({
 
     deckgl = createStandaloneFromProvider({
       mapProvider,
-      props,
       mapboxApiKey,
       googleMapsKey,
       handleEvent,
       getTooltip,
-      container
+      container,
+      props
     });
 
     const onComplete = () => {
       if (layerToLoad.length) {
         // convert input layer again to presist layer order
-        const newProps = jsonConverter.convert({layers: jsonInput.layers});
+        const newProps = jsonConverter.convert({layers: deckProps.layers});
         const newLayers = (newProps.layers || []).filter(l => l);
 
         if (newLayers.length > convertedLayers.length) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #3640 (for instance)

<!-- For other PRs without open issue -->
#### Background
- The goal is that playground app should be portable and work with any transport / on any platform. 
- Moving the initial top-level props from model fields to JSON props is the final step to enabling this

<!-- For all the PRs -->
#### Change List
- This PR adds the ability to transport initial props over JSON, without removing the old implementation.
-
