### PR TITLE
Fix async iterable data diff handling

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -741,6 +741,11 @@ export default class Layer extends Component {
       if (flags[key] && !changeFlags[key]) {
         changeFlags[key] = flags[key];
         debug(TRACE_CHANGE_FLAG, this, key, flags);
+      } else if (flags[key] && key === 'dataChanged' && Array.isArray(changeFlags[key])) {
+        changeFlags[key] = Array.isArray(flags[key])
+          ? changeFlags[key].concat(flags[key])
+          : flags[key];
+        debug(TRACE_CHANGE_FLAG, this, key, flags);
       }
     }
 

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -346,8 +346,9 @@ test('Layer#Async Iterable Data', async t => {
     yield [0, 1, 2];
     await sleep(50);
     yield [3, 4];
+    yield [5];
     await sleep(50);
-    yield [5, 6, 7];
+    yield [6, 7];
   }
 
   let data = await testAsyncData(t, getData());


### PR DESCRIPTION
For #4841

#### Change List
- If `diffProps` is called multiple times in a render cycle, merge the `dataChanged` results
