### PR TITLE
Avoid using deprecated KeyboardEvent.keycode

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -428,18 +428,18 @@ export default class Controller {
     let newControllerState;
     const interactionState = {};
 
-    switch (event.srcEvent.keyCode) {
-      case 189: // -
+    switch (event.srcEvent.code) {
+      case 'Minus':
         newControllerState = funcKey
           ? controllerState.zoomOut().zoomOut()
           : controllerState.zoomOut();
         interactionState.isZooming = true;
         break;
-      case 187: // +
+      case 'Equal':
         newControllerState = funcKey ? controllerState.zoomIn().zoomIn() : controllerState.zoomIn();
         interactionState.isZooming = true;
         break;
-      case 37: // left
+      case 'ArrowLeft':
         if (funcKey) {
           newControllerState = controllerState.rotateLeft();
           interactionState.isRotating = true;
@@ -448,7 +448,7 @@ export default class Controller {
           interactionState.isPanning = true;
         }
         break;
-      case 39: // right
+      case 'ArrowRight':
         if (funcKey) {
           newControllerState = controllerState.rotateRight();
           interactionState.isRotating = true;
@@ -457,7 +457,7 @@ export default class Controller {
           interactionState.isPanning = true;
         }
         break;
-      case 38: // up
+      case 'ArrowUp':
         if (funcKey) {
           newControllerState = controllerState.rotateUp();
           interactionState.isRotating = true;
@@ -466,7 +466,7 @@ export default class Controller {
           interactionState.isPanning = true;
         }
         break;
-      case 40: // down
+      case 'ArrowDown':
         if (funcKey) {
           newControllerState = controllerState.rotateDown();
           interactionState.isRotating = true;

--- a/test/modules/core/controllers/test-controller.js
+++ b/test/modules/core/controllers/test-controller.js
@@ -149,25 +149,25 @@ const TEST_CASES = [
     title: 'keyboard',
     props: {},
     events: () =>
-      makeEvents(['keydown'], {keyCode: 189})
-        .concat(makeEvents(['keydown'], {keyCode: 189, shiftKey: true}))
-        .concat(makeEvents(['keydown'], {keyCode: 187}))
-        .concat(makeEvents(['keydown'], {keyCode: 187, shiftKey: true}))
-        .concat(makeEvents(['keydown'], {keyCode: 37}))
-        .concat(makeEvents(['keydown'], {keyCode: 37, shiftKey: true}))
-        .concat(makeEvents(['keydown'], {keyCode: 38}))
-        .concat(makeEvents(['keydown'], {keyCode: 38, shiftKey: true}))
-        .concat(makeEvents(['keydown'], {keyCode: 39}))
-        .concat(makeEvents(['keydown'], {keyCode: 39, shiftKey: true}))
-        .concat(makeEvents(['keydown'], {keyCode: 40}))
-        .concat(makeEvents(['keydown'], {keyCode: 40, shiftKey: true})),
+      makeEvents(['keydown'], {code: 'Minus'})
+        .concat(makeEvents(['keydown'], {code: 'Minus', shiftKey: true}))
+        .concat(makeEvents(['keydown'], {code: 'Equal'}))
+        .concat(makeEvents(['keydown'], {code: 'Equal', shiftKey: true}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowLeft'}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowLeft', shiftKey: true}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowUp'}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowUp', shiftKey: true}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowRight'}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowRight', shiftKey: true}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowDown'}))
+        .concat(makeEvents(['keydown'], {code: 'ArrowDown', shiftKey: true})),
     viewStateChanges: 12,
     interactionStates: 3
   },
   {
     title: 'keyboard#disabled',
     props: {keyboard: false},
-    events: () => makeEvents(['keydown'], {keyCode: 189}),
+    events: () => makeEvents(['keydown'], {code: 'Minus'}),
     viewStateChanges: 0,
     interactionStates: 0
   }


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/4874

#### Change List
- Avoid using deprecated `KeyboardEvent.keycode`, use `code` instead

Tested in Chrome, FF, Safari
