### PR TITLE
Possible solution to the ignored getCursor

### DIFF
--- a/docs/api-reference/arcgis/deck-layer.md
+++ b/docs/api-reference/arcgis/deck-layer.md
@@ -59,6 +59,7 @@ Property names that start with `deck.` are forwarded to a `Deck` instance. The f
 - `deck.onError`
 - `deck.debug`
 - `deck.drawPickingColors`
+- `deck.getCursor`
 
 ## Members
 

--- a/docs/api-reference/arcgis/deck-renderer.md
+++ b/docs/api-reference/arcgis/deck-renderer.md
@@ -65,7 +65,7 @@ new DeckRenderer(sceneView, props)
 - `onError`
 - `debug`
 - `drawPickingColors`
-
+- `getCursor`
 
 ## Members
 

--- a/modules/arcgis/src/deck-props.js
+++ b/modules/arcgis/src/deck-props.js
@@ -13,7 +13,8 @@ const properties = {
   onDragEnd: {},
   onError: {},
   debug: {},
-  drawPickingColors: {}
+  drawPickingColors: {},
+  getCursor: {}
 };
 
 /* eslint-disable callback-return */


### PR DESCRIPTION
Tentative fix for #4895 (I am still evaluating other strategies).

#### Change List
- Add a `getCursor` descriptor in `deck-props.js` so that a `deck.getCursor` property is recognized and copied when specified for a `DeckLayer` (2D, `MapView`) or a `DeckRenderer` (3D, `SceneView`).
