### PR TITLE
Add more descriptive pydeck types classes

### DIFF
--- a/bindings/pydeck/pydeck/bindings/json_tools.py
+++ b/bindings/pydeck/pydeck/bindings/json_tools.py
@@ -3,6 +3,8 @@ Support serializing objects into JSON
 """
 import json
 
+from .types import Type
+
 # Attributes to ignore during JSON serialization
 IGNORE_KEYS = [
     "mapbox_key",
@@ -60,16 +62,25 @@ def lower_camel_case_keys(attrs):
         camel_key = camel_and_lower(snake_key)
         attrs[camel_key] = attrs.pop(snake_key)
 
+    return attrs
+
 
 def default_serialize(o, remap_function=lower_camel_case_keys):
     """Default method for rendering JSON from a dictionary"""
     attrs = vars(o)
+
+    # Remove keys where value is None
     attrs = {k: v for k, v in attrs.items() if v is not None}
     for ignore_attr in IGNORE_KEYS:
         if attrs.get(ignore_attr):
             del attrs[ignore_attr]
+
+    # For each object of type pydeck.Type, call .json
+    attrs = {k: v.json() if isinstance(v, Type) else v for k, v in attrs.items()}
+
     if remap_function:
-        remap_function(attrs)
+        attrs = remap_function(attrs)
+
     return attrs
 
 

--- a/bindings/pydeck/pydeck/bindings/types.py
+++ b/bindings/pydeck/pydeck/bindings/types.py
@@ -1,0 +1,101 @@
+import abc
+import json
+from collections.abc import Iterable
+
+TYPE_IDENTIFIER = "@@type"
+FUNCTION_IDENTIFIER = "@@="
+ENUM_IDENTIFIER = "@@#"
+
+
+class Type(metaclass=abc.ABCMeta):
+    """Base class for Pydeck defined type"""
+
+    def __init__(self, value):
+        self._value = value
+
+    def __repr__(self):
+        return self.type_name + "(" + str(self.json()) + ")"
+
+    @property
+    @abc.abstractmethod
+    def type_name(self):
+        """Name of Type; used in default __repr__"""
+
+    @abc.abstractmethod
+    def json(self):
+        """JSON representation of object for serialization"""
+
+
+class Enum(Type):
+    """Enum type
+
+    Interpret as an Enum, resolving in the JSON configuration
+    """
+
+    type_name = "Enum"
+
+    def __init__(self, value):
+        if not isinstance(value, str):
+            raise TypeError("Enum value must be a string")
+
+        super(Enum, self).__init__(value)
+
+    def json(self):
+        return ENUM_IDENTIFIER + self._value
+
+
+class Function(Type):
+    """Function type
+
+    Interpret as a function, parsing unquoted character strings as identifiers
+    """
+
+    type_name = "Function"
+
+    def json(self):
+        if isinstance(self._value, Iterable) and not isinstance(self._value, str):
+            return FUNCTION_IDENTIFIER + "[{}]".format(", ".join(map(str, self._value)))
+
+        return FUNCTION_IDENTIFIER + str(self._value)
+
+
+class Identifier(Type):
+    """Identifier type
+    """
+
+    type_name = "Identifier"
+
+    def __init__(self, value):
+        if not isinstance(value, str):
+            raise TypeError("Identifier value must be a string")
+
+        super(Identifier, self).__init__(value)
+
+    def __str__(self):
+        return str(self._value)
+
+    def json(self):
+        return self._value
+
+
+class Literal(Type):
+    """A Literal object
+
+    Can be any JSON-encodable object
+    """
+
+    type_name = "Literal"
+
+    def __init__(self, value):
+        try:
+            json.dumps(value)
+        except TypeError as e:
+            raise TypeError("Literal value must be JSON serializable\n" + e)
+
+        super(Literal, self).__init__(value)
+
+    def __str__(self):
+        return '"{}"'.format(self._value)
+
+    def json(self):
+        return self._value


### PR DESCRIPTION
#### Background

Currently pydeck does a lot of "magic" behind the scenes to coerce user input into the representation sent to `@deck.gl/json`. 

- Strings are always treated as functions unless it includes an extra pair of quotes. So `"properties.valuePerSqm"` becomes the function `datum => datum.properties.valuePerSqm`. To pass a string literal, you need to use `'"literal string"'`.
- When a literal string is passed, it removes all internal occurrences of that string. So `'"literal "" string"'` in Python becomes `'literal string'` in JS.
- Lists of strings are always treated as functions. In order to reference a literal string, you need to include another pair of quotes on that item.

#### Change List

These changes are designed to minimize backwards incompatibility.

- Add helper classes that aim to be a 1:1 equivalent of what is possible in the JSON spec. These are named `Enum`, `Literal`, `Function` and `Identifier`.
- `Enum` takes string input and prefixes `@@#` before serialization
- `Literal` takes any JSON-encodable object and passes it unchanged to JS
- `Function` takes varied input.
  - For string input it prefixes `@@=` for serialization. 
  - For number input it stringifies the number and prefixes `@@=`.
  - For `Literal` input it prefixes `@@=` and surrounds the input with double quotes. I.e. `Literal('foo')` becomes `@@="foo"`. This is necessary because the `@deck.gl/json` docs say:

    > Interpret the rest of the string as a function, parsing unquoted character strings as identifiers
  - The `Identifier` class is included as a more-explicit form of string input. It includes its string unquoted.
  - Each of these should also work within array input. So you should be able to pass `Function([Identifier('x'), Identifier('y'), Literal(0)])` to render data at ground level.
- When a literal string is passed in double quotes, remove only the first and last characters and leave the rest of the string intact. So `'"literal "" string"'` in Python becomes `'literal "" string'` in JS. This is a backwards incompatible change, but the existing behavior is arguably broken.