### PR TITLE
Fix layer index resolution in picking

### DIFF
--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -218,12 +218,17 @@ export default class LayersPass extends Pass {
 export function layerIndexResolver(startIndex = 0, layerIndices = {}) {
   const resolvers = {};
 
-  return (layer, isDrawn) => {
+  const resolveLayerIndex = (layer, isDrawn) => {
     const indexOverride = layer.props._offset;
     const layerId = layer.id;
     const parentId = layer.parent && layer.parent.id;
 
     let index;
+
+    if (parentId && !(parentId in layerIndices)) {
+      // Populate layerIndices with the parent layer's index
+      resolveLayerIndex(layer.parent, false);
+    }
 
     if (parentId in resolvers) {
       const resolver = (resolvers[parentId] =
@@ -246,6 +251,7 @@ export function layerIndexResolver(startIndex = 0, layerIndices = {}) {
     layerIndices[layerId] = index;
     return index;
   };
+  return resolveLayerIndex;
 }
 
 // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates

--- a/test/modules/core/passes/layers-pass.spec.js
+++ b/test/modules/core/passes/layers-pass.spec.js
@@ -171,6 +171,7 @@ test('LayersPass#layerIndexResolver', t => {
 
   for (const testCase of TEST_CASES) {
     const resolver = layerIndexResolver();
+    const resolver2 = layerIndexResolver();
 
     const layerManager = new LayerManager(gl, {});
     layerManager.setLayers(testCase.layers);
@@ -181,6 +182,12 @@ test('LayersPass#layerIndexResolver', t => {
       const result = resolver(layer, !layer.isComposite && layer.props.visible);
       const expected = testCase.expected[layer.id];
       t.is(result, expected, layer.id);
+
+      // Should yield the same result even if parent layer is not resolved first
+      if (!layer.isComposite) {
+        const result2 = resolver2(layer, layer.props.visible);
+        t.is(result2, expected, layer.id);
+      }
     }
   }
 


### PR DESCRIPTION

For #4913

#### Background

The layer index resolver (#4388) allows us to draw sublayers from different tiles at the same z-index (polygonOffset).

A bug was introduced by #4586, when we tried to save layer indices by filtering out composite layers during picking. The implementation of the layer index resolver expects a parent layer to be resolved before its children. Because composite layers are never resolved during picking, it creates a discrepancy between the screen pass and the picking pass. 

#### Change List
- Resolve missing parent layer index
- Unit tests
