### PR TITLE
Remove docs references to Seer

### DIFF
--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -4,7 +4,6 @@ deck.gl provides support for debugging applications and layers, which includes:
 
 * deck.gl logging
 * luma.gl debugging support
-* The Seer Chrome Extension
 
 
 ## deck.gl logging

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,7 @@ Every time you change your layer, you create a new layer and pass it to Deck or 
 
 ## How do I **debug** deck.gl applications?
 
-Both deck.gl and luma.gl have powerful logging capabilities, as well as the `seer` Chrome extension.
+Both deck.gl and luma.gl have powerful logging capabilities.
 
 See the article about [debugging](/docs/developer-guide/debugging.md).
 

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -67,7 +67,6 @@ function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR, linkToLuma) {
         // Versions will be controlled by the deck.gl top level package.json
         'math.gl': resolve(LIB_DIR, './node_modules/math.gl'),
         'viewport-mercator-project': resolve(LIB_DIR, './node_modules/viewport-mercator-project'),
-        seer: resolve(LIB_DIR, './node_modules/seer'),
         react: resolve(LIB_DIR, './node_modules/react')
       })
     },


### PR DESCRIPTION
It seems that support for the Seer Chrome extension has been removed, but some misleading references to it lingered in the docs.

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->

#### Background
<!-- For all the PRs -->

#### Change List
-
