### PR TITLE
Add GPU-based counter to DataFilterExtension

### DIFF
--- a/docs/api-reference/extensions/data-filter-extension.md
+++ b/docs/api-reference/extensions/data-filter-extension.md
@@ -64,6 +64,7 @@ new DataFilterExtension({filterSize, fp64});
 
 * `filterSize` (Number) - the size of the filter (number of columns to filter by). The data filter can show/hide data based on 1-4 numeric properties of each object. Default `1`.
 * `fp64` (Boolean) - if `true`, use 64-bit precision instead of 32-bit. Default `false`. See the "remarks" section below for use cases and limitations.
+* `countItems` (Boolean) - if `true`, reports the number of filtered objects with the `onFilteredItemsChange` callback. Default `false`. This option requires [WebGL features](https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float#Browser_compatibility) that are not supported by all browsers.
 
 
 ## Layer Properties
@@ -165,6 +166,13 @@ When an object is "faded", manipulate its opacity so that it appears more transl
 
 Enable/disable the data filter. If the data filter is disabled, all objects are rendered.
 
+##### `onFilteredItemsChange` (Function, optional)
+
+Only used if the `countItems` option is enabled. Called with the following arguments when the filter changes:
+
+- `event` (Object)
+  + `id` (String) - the id of the source layer. Note when this prop is specified on a [CompositeLayer](/docs/api-reference/composite-layer.md), such as `GeoJsonLayer`, the callback is called once by each sub layer.
+  + `count` (Number) - the number of data objects that pass the filter.
 
 ## Remarks
 

--- a/docs/api-reference/extensions/data-filter-extension.md
+++ b/docs/api-reference/extensions/data-filter-extension.md
@@ -64,7 +64,7 @@ new DataFilterExtension({filterSize, fp64});
 
 * `filterSize` (Number) - the size of the filter (number of columns to filter by). The data filter can show/hide data based on 1-4 numeric properties of each object. Default `1`.
 * `fp64` (Boolean) - if `true`, use 64-bit precision instead of 32-bit. Default `false`. See the "remarks" section below for use cases and limitations.
-* `countItems` (Boolean) - if `true`, reports the number of filtered objects with the `onFilteredItemsChange` callback. Default `false`. This option requires [WebGL features](https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float#Browser_compatibility) that are not supported by all browsers.
+* `countItems` (Boolean) - if `true`, reports the number of filtered objects with the `onFilteredItemsChange` callback. Default `false`.
 
 
 ## Layer Properties

--- a/modules/extensions/src/data-filter/aggregator.js
+++ b/modules/extensions/src/data-filter/aggregator.js
@@ -4,12 +4,32 @@ import GL from '@luma.gl/constants';
 const AGGREGATE_VS = `\
 #define SHADER_NAME data-filter-vertex-shader
 
-attribute float filterIndices;
-attribute float filterPrevIndices;
+#ifdef FLOAT_TARGET
+  attribute float filterIndices;
+  attribute float filterPrevIndices;
+#else
+  attribute vec2 filterIndices;
+  attribute vec2 filterPrevIndices;
+#endif
+
+varying vec4 vColor;
+const float component = 1.0 / 255.0;
 
 void main() {
-  dataFilter_value *= float(filterIndices != filterPrevIndices);
-  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+  #ifdef FLOAT_TARGET
+    dataFilter_value *= float(filterIndices != filterPrevIndices);
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    vColor = vec4(0.0, 0.0, 0.0, 1.0);
+  #else
+    // Float texture is not supported: pack result into 4 channels x 256 px x 64px
+    dataFilter_value *= float(filterIndices.x != filterPrevIndices.x);
+    float col = filterIndices.x;
+    float row = filterIndices.y * 4.0;
+    float channel = floor(row);
+    row = fract(row);
+    vColor = component * vec4(bvec4(channel == 0.0, channel == 1.0, channel == 2.0, channel == 3.0));
+    gl_Position = vec4(col * 2.0 - 1.0, row * 2.0 - 1.0, 0.0, 1.0);
+  #endif
   gl_PointSize = 1.0;
 }
 `;
@@ -18,37 +38,55 @@ const AGGREGATE_FS = `\
 #define SHADER_NAME data-filter-fragment-shader
 precision highp float;
 
+varying vec4 vColor;
+
 void main() {
   if (dataFilter_value < 0.5) {
-    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
-  } else {
-    gl_FragColor = vec4(1.0);
+    discard;
   }
+  gl_FragColor = vColor;
 }
 `;
 
-export function isSupported(gl) {
-  return Framebuffer.isSupported(gl, {colorBufferFloat: true});
+export function supportsFloatTarget(gl) {
+  // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#Support_for_float_textures_doesnt_mean_you_can_render_into_them!
+  return (
+    gl.getExtension('EXT_float_blend') &&
+    // WebGL 2
+    (gl.getExtension('EXT_color_buffer_float') ||
+      // WebGL 1
+      gl.getExtension('WEBGL_color_buffer_float'))
+  );
 }
 
 // A 1x1 framebuffer object that encodes the total count of filtered items
-export function getFramebuffer(gl) {
+export function getFramebuffer(gl, useFloatTarget) {
+  if (useFloatTarget) {
+    return new Framebuffer(gl, {
+      width: 1,
+      height: 1,
+      attachments: {
+        [GL.COLOR_ATTACHMENT0]: new Texture2D(gl, {
+          format: isWebGL2(gl) ? GL.RGBA32F : GL.RGBA,
+          type: GL.FLOAT,
+          mipmaps: false
+        })
+      }
+    });
+  }
   return new Framebuffer(gl, {
-    width: 1,
-    height: 1,
-    attachments: {
-      [GL.COLOR_ATTACHMENT0]: new Texture2D(gl, {
-        format: isWebGL2(gl) ? GL.RGBA32F : GL.RGBA,
-        type: GL.FLOAT,
-        mipmaps: false
-      })
-    }
+    width: 256,
+    height: 64,
+    depth: false
   });
 }
 
 // Increments the counter based on dataFilter_value
-export function getModel(gl, shaderOptions) {
+export function getModel(gl, shaderOptions, useFloatTarget) {
   shaderOptions.defines.NON_INSTANCED_MODEL = 1;
+  if (useFloatTarget) {
+    shaderOptions.defines.FLOAT_TARGET = 1;
+  }
 
   return new Model(gl, {
     id: 'data-filter-aggregation-model',
@@ -62,7 +100,6 @@ export function getModel(gl, shaderOptions) {
 }
 
 export const parameters = {
-  viewport: [0, 0, 1, 1],
   blend: true,
   blendFunc: [GL.ONE, GL.ONE, GL.ONE, GL.ONE],
   blendEquation: [GL.FUNC_ADD, GL.FUNC_ADD],

--- a/modules/extensions/src/data-filter/aggregator.js
+++ b/modules/extensions/src/data-filter/aggregator.js
@@ -1,0 +1,59 @@
+import {Model, Texture2D, Framebuffer, isWebGL2} from '@luma.gl/core';
+import GL from '@luma.gl/constants';
+
+const AGGREGATE_VS = `\
+#define SHADER_NAME data-filter-vertex-shader
+
+attribute float instanceFilterIndex;
+attribute float instanceFilterPrevIndex;
+
+void main() {
+  dataFilter_value *= float(instanceFilterIndex != instanceFilterPrevIndex);
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+  gl_PointSize = 1.0;
+}
+`;
+
+const AGGREGATE_FS = `\
+#define SHADER_NAME data-filter-fragment-shader
+precision highp float;
+
+void main() {
+  if (dataFilter_value < 0.5) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+  } else {
+    gl_FragColor = vec4(1.0);
+  }
+}
+`;
+
+export function isSupported(gl) {
+  return Framebuffer.isSupported(gl, {colorBufferFloat: true});
+}
+
+export function getFramebuffer(gl) {
+  const fb = new Framebuffer(gl, {
+    width: 1,
+    height: 1,
+    attachments: {
+      [GL.COLOR_ATTACHMENT0]: new Texture2D(gl, {
+        format: isWebGL2(gl) ? GL.RGBA32F : GL.RGBA,
+        type: GL.FLOAT
+      })
+    }
+  });
+
+  return fb;
+}
+
+export function getModel(gl, shaderOptions) {
+  return new Model(gl, {
+    id: 'data-filter-aggregation-model',
+    vertexCount: 1,
+    isInstanced: true,
+    drawMode: GL.POINTS,
+    vs: AGGREGATE_VS,
+    fs: AGGREGATE_FS,
+    ...shaderOptions
+  });
+}

--- a/test/apps/data-filter/src/app.js
+++ b/test/apps/data-filter/src/app.js
@@ -7,7 +7,11 @@ import {DataFilterExtension} from '@deck.gl/extensions';
 
 import DATA from './data-sample';
 
-const dataFilterExtension = new DataFilterExtension({filterSize: 2, softMargin: true});
+const dataFilterExtension = new DataFilterExtension({
+  filterSize: 2,
+  softMargin: true,
+  countItems: true
+});
 
 const INITIAL_VIEW_STATE = {
   longitude: -122.45,
@@ -58,6 +62,8 @@ class Root extends Component {
         getLineWidth: 10,
         getRadius: f => f.properties.radius,
         getFilterValue: f => f.properties.centroid,
+
+        onFilteredItemsChange: console.log, // eslint-disable-line
 
         // Filter
         filterRange,

--- a/test/modules/extensions/data-filter.spec.js
+++ b/test/modules/extensions/data-filter.spec.js
@@ -76,3 +76,47 @@ test('DataFilterExtension', t => {
 
   t.end();
 });
+
+test('DataFilterExtension#countItems', t => {
+  let cbCalled = 0;
+
+  // TODO - counter does not seem to work in headless-gl
+  const testCases = [
+    {
+      props: {
+        data: [
+          {position: [-122.453, 37.782], timestamp: 120},
+          {position: [-122.454, 37.781], timestamp: 140}
+        ],
+        getPosition: d => d.position,
+        getFilterValue: d => d.timestamp,
+        onFilteredItemsChange: () => cbCalled++,
+        filterRange: [80, 160],
+        extensions: [new DataFilterExtension({filterSize: 1, countItems: true})]
+      },
+      onAfterUpdate: () => {
+        t.is(cbCalled, 1, 'onFilteredItemsChange is called');
+      }
+    },
+    {
+      updateProps: {
+        radiusMinPixels: 10
+      },
+      onAfterUpdate: () => {
+        t.is(cbCalled, 1, 'onFilteredItemsChange should not be called without filter change');
+      }
+    },
+    {
+      updateProps: {
+        filterRange: [80, 100]
+      },
+      onAfterUpdate: () => {
+        t.is(cbCalled, 2, 'onFilteredItemsChange is called');
+      }
+    }
+  ];
+
+  testLayer({Layer: ScatterplotLayer, testCases, onError: t.notOk});
+
+  t.end();
+});


### PR DESCRIPTION
See doc change

#### Change List
- Add `countItems` option and `onFilteredItemsChange` prop to `DataFilterExtension`
- Documentation

#### Tested Environments
- ✔ Chrome (Mac, Win)
- ✔ FF
- ✔ Safari
- ✔ Chrome on Android
- ✔ Safari on iOS
- ❌ Headless-gl
