### PR TITLE
Avoid canvas resizing when not owned by deck.gl (i.e. when `props._framebuffer` is set)

### DIFF
--- a/modules/arcgis/src/commons.js
+++ b/modules/arcgis/src/commons.js
@@ -54,6 +54,10 @@ export function initializeResources(gl) {
     // This deck renders into an auxiliary framebuffer.
     _framebuffer: this.deckFbo,
 
+    // To disable canvas resizing, since the FBO is owned by the ArcGIS API for JavaScript.
+    width: null,
+    height: null,
+
     _customRender: redrawReason => {
       if (redrawReason === 'arcgis') {
         this.deckInstance._drawLayers(redrawReason);

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -274,9 +274,7 @@ export default class Deck {
     Object.assign(this.props, props);
 
     // Update CSS size of canvas
-    if (!this.props || !this.props._framebuffer) {
-      this._setCanvasSize(this.props);
-    }
+    this._setCanvasSize(this.props);
 
     // We need to overwrite CSS style width and height with actual, numeric values
     const resolvedProps = Object.create(this.props);

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -274,7 +274,9 @@ export default class Deck {
     Object.assign(this.props, props);
 
     // Update CSS size of canvas
-    this._setCanvasSize(this.props);
+    if (!this.props || !this.props._framebuffer) {
+      this._setCanvasSize(this.props);
+    }
 
     // We need to overwrite CSS style width and height with actual, numeric values
     const resolvedProps = Object.create(this.props);


### PR DESCRIPTION
This fixes an issue that can arise when deck.gl is sharing the WebGL context and the `deck.props._framebuffer` property is set.

deck.gl will try, under certain circumstances, to resize the canvas even when it is intended to be managed externally and this can lead to all sorts of bugs.

For #4948.

#### Change List
- Don't resize the canvas if an external framebuffer was specified
