### PR TITLE
MVTLayer: support globe view

### DIFF
--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -15,9 +15,10 @@ In the initial release, this class mainly addresses the need to render an overvi
 - No high-precision rendering at high zoom levels (> 12). Features at the city-block scale may not be rendered accurately.
 - Only supports `COORDINATE_SYSTEM.LNGLAT` (default of the `coordinateSystem` prop).
 - Known rendering issues when using multiple views mixing `GlobeView` and `MapView`, or switching between the two.
+- Support for `TileLayer` and `MVTLayer` is experimental.
 - These layers currently do not work in this view:
   + Aggregation layers: `HeatmapLayer`, `ContourLayer`
-  + Tiled layers: `TerrainLayer`, `MVTLayer`
+  + `TerrainLayer`
 
 When GeoJson paths and polygons are rendered with this view, the straight lines and flat surfaces are warped to the surface of the globe. Note that the warped edges still correspond to straight lines in the Mercator projection. To draw lines along the shortest distance on the globe, use the [GreatCircleLayer](/docs/api-reference/geo-layers/great-circle-layer.md).
 
@@ -43,6 +44,11 @@ To render, `GlobeView` needs to be used together with a `viewState` with the fol
 - `zoom` (`Number`) - zoom level
 - `maxZoom` (`Number`, optional) - max zoom level. Default `20`.
 - `minZoom` (`Number`, optional) - min zoom level. Default `0`.
+
+Additional projection matrix arguments:
+
++ `nearZMultiplier` (Number, optional) - Scaler for the near plane, 1 unit equals to the height of the viewport. Default to `0.1`.
++ `farZMultiplier` (Number, optional) - Scaler for the far plane, 1 unit equals to the distance from the camera to the edge of the screen. Default to `2`.
 
 ## GlobeController
 

--- a/modules/core/src/viewports/globe-viewport.js
+++ b/modules/core/src/viewports/globe-viewport.js
@@ -31,7 +31,7 @@ export default class GlobeViewport extends Viewport {
       longitude = 0,
       zoom = 11,
       nearZMultiplier = 0.1,
-      farZMultiplier = 1,
+      farZMultiplier = 2,
       resolution = 10
     } = opts;
 
@@ -82,6 +82,25 @@ export default class GlobeViewport extends Viewport {
 
   getDistanceScales() {
     return this.distanceScales;
+  }
+
+  getBounds(options = {}) {
+    const unprojectOption = {targetZ: options.z || 0};
+
+    const left = this.unproject([0, this.height / 2], unprojectOption);
+    const top = this.unproject([this.width / 2, 0], unprojectOption);
+    const right = this.unproject([this.width, this.height / 2], unprojectOption);
+    const bottom = this.unproject([this.width / 2, this.height], unprojectOption);
+
+    if (right[0] < this.longitude) right[0] += 360;
+    if (left[0] > this.longitude) left[0] -= 360;
+
+    return [
+      Math.min(left[0], right[0], top[0], bottom[0]),
+      Math.min(left[1], right[1], top[1], bottom[1]),
+      Math.max(left[0], right[0], top[0], bottom[0]),
+      Math.max(left[1], right[1], top[1], bottom[1])
+    ];
   }
 
   unproject(xyz, {topLeft = true, targetZ} = {}) {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -20,7 +20,16 @@ export default class MVTLayer extends TileLayer {
     if (!url) {
       return Promise.reject('Invalid URL');
     }
-    return load(url, MVTLoader, this.getLoadOptions());
+    let options = this.getLoadOptions();
+    options = {
+      ...options,
+      mvt: {
+        ...(options && options.mvt),
+        coordinates: this.context.viewport.resolution ? 'wgs84' : 'local',
+        tileIndex: {x: tile.x, y: tile.y, z: tile.z}
+      }
+    };
+    return load(url, MVTLoader, options);
   }
 
   renderSubLayers(props) {
@@ -36,10 +45,12 @@ export default class MVTLayer extends TileLayer {
     const modelMatrix = new Matrix4().scale([xScale, yScale, 1]);
 
     props.autoHighlight = false;
-    props.modelMatrix = modelMatrix;
-    props.coordinateOrigin = [xOffset, yOffset, 0];
-    props.coordinateSystem = COORDINATE_SYSTEM.CARTESIAN;
-    props.extensions = [...(props.extensions || []), new ClipExtension()];
+    if (!this.context.viewport.resolution) {
+      props.modelMatrix = modelMatrix;
+      props.coordinateOrigin = [xOffset, yOffset, 0];
+      props.coordinateSystem = COORDINATE_SYSTEM.CARTESIAN;
+      props.extensions = [...(props.extensions || []), new ClipExtension()];
+    }
 
     return super.renderSubLayers(props);
   }

--- a/modules/geo-layers/src/tile-layer/tile-2d-traversal.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-traversal.js
@@ -1,5 +1,7 @@
 /* eslint-disable complexity */
 import {CullingVolume, Plane, AxisAlignedBoundingBox} from '@math.gl/culling';
+import {WebMercatorViewport} from '@deck.gl/core';
+import {fitBounds} from '@math.gl/web-mercator';
 
 const TILE_SIZE = 512;
 // number of world copies to check
@@ -90,6 +92,26 @@ class OSMNode {
 }
 
 export function getOSMTileIndices(viewport, maxZ, zRange) {
+  if (!(viewport instanceof WebMercatorViewport)) {
+    const bbox = viewport.getBounds();
+    // The width and height here are arbitrary - they just need to form a reasonable aspect ratio
+    // so that we don't get too many world copies
+    const {longitude, latitude, zoom} = fitBounds({
+      width: 100,
+      height: 100,
+      bounds: [[bbox[0], bbox[1]], [bbox[2], bbox[3]]]
+    });
+
+    viewport = new WebMercatorViewport({
+      width: 100,
+      height: 100,
+      longitude,
+      latitude,
+      zoom,
+      repeat: true
+    });
+  }
+
   // Get the culling volume of the current camera
   const planes = Object.values(viewport.getFrustumPlanes()).map(
     ({normal, distance}) => new Plane(normal.clone().negate(), distance)

--- a/test/modules/core/viewports/globe-viewport.spec.js
+++ b/test/modules/core/viewports/globe-viewport.spec.js
@@ -172,3 +172,13 @@ test('GlobeViewport#project, unproject', t => {
   config.EPSILON = oldEpsilon;
   t.end();
 });
+
+test('GlobeViewport#getBounds', t => {
+  for (const testCase of TEST_VIEWPORTS) {
+    const bounds = new GlobeViewport(testCase).getBounds();
+
+    t.ok(bounds[0] < testCase.longitude && bounds[2] > testCase.longitude);
+  }
+
+  t.end();
+});


### PR DESCRIPTION
Requires bug fixes in `@loaders.gl/mvt` and `@math.gl/polygon`

#### Change List
- Add `GlobeViewport.getBounds`
- Fix tile traversal in non-mercator viewports
- Parse MVT tiles to wgs84 in non-mercator mode
