### PR TITLE
Add dependencies to CARTO pure-js example

### DIFF
--- a/examples/get-started/pure-js/carto/package.json
+++ b/examples/get-started/pure-js/carto/package.json
@@ -10,6 +10,9 @@
   "dependencies": {
     "@deck.gl/core": "^8.2.7",
     "@deck.gl/layers": "^8.2.7",
+    "@deck.gl/geo-layers": "^8.2.7",
+    "@deck.gl/mesh-layers": "^8.2.7",
+    "@deck.gl/carto": "^8.3.0",
     "mapbox-gl": "^1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It adds the dependencies to @deck.gl/carto at pure-js example.

I've linked against the final module, so right now yarn asks to select the right version but once published it won't appear. 

Related with https://github.com/visgl/deck.gl/issues/4998
