### PR TITLE
add onDataLoad and onDataError callbacks to carto-layer.js

### DIFF
--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -76,16 +76,16 @@ A string pointing to a tile attribute containing a unique identifier for feature
 
 ### Callbacks
 
-#### `onLoad` (Function, optional)
+#### `onDataLoad` (Function, optional)
 
-`onLoad` is called when the request to the CARTO tiler was completed successfully.
+`onDataLoad` is called when the request to the CARTO tiler was completed successfully.
 
-- Default: `() => {}`
+- Default: `tilejson => {}`
 
 
-##### `onError` (Function, optional)
+##### `onDataLoadError` (Function, optional)
 
-`onError` is called when the request to the CARTO tiler failed.
+`onDataLoadError` is called when the request to the CARTO tiler failed.
 
 - Default: `console.error`
 

--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -74,6 +74,25 @@ Optional. Needed for highlighting a feature split across two or more tiles if no
 
 A string pointing to a tile attribute containing a unique identifier for features across tiles.
 
+### Callbacks
+
+#### `onLoad` (Function, optional)
+
+`onLoad` is called when the request to the CARTO tiler was completed successfully.
+
+- Default: `() => {}`
+
+
+##### `onError` (Function, optional)
+
+`onError` is called when the request to the CARTO tiler failed.
+
+- Default: `console.error`
+
+Receives arguments:
+
+- `error` (`Error`)
+
 
 ## Source
 

--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -86,9 +86,9 @@ Receives arguments:
 
 - `tilejson` (Object) - the response from the tiler service
 
-##### `onDataLoadError` (Function, optional)
+##### `onDataError` (Function, optional)
 
-`onDataLoadError` is called when the request to the CARTO tiler failed.
+`onDataError` is called when the request to the CARTO tiler failed.
 
 - Default: `console.error`
 

--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -82,6 +82,9 @@ A string pointing to a tile attribute containing a unique identifier for feature
 
 - Default: `tilejson => {}`
 
+Receives arguments:
+
+- `tilejson` (Object) - the response from the tiler service
 
 ##### `onDataLoadError` (Function, optional)
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -110,9 +110,9 @@ Optional. Tile extent in tile coordinate space as defined by MVT specification.
 
 ### Callbacks
 
-#### `onLoad` (Function, optional)
+#### `onDataLoad` (Function, optional)
 
-`onLoad` is called when the request to the CARTO tiler was completed successfully.
+`onDataLoad` is called when the request to the CARTO tiler was completed successfully.
 
 - Default: `tilejson => {}`
 
@@ -120,9 +120,9 @@ Receives arguments:
 
 - `tilejson` (Object) - the response from the tiler service
 
-##### `onError` (Function, optional)
+##### `onDataError` (Function, optional)
 
-`onError` is called when the request to the CARTO tiler failed.
+`onDataError` is called when the request to the CARTO tiler failed.
 
 - Default: `console.error`
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -114,7 +114,7 @@ Optional. Tile extent in tile coordinate space as defined by MVT specification.
 
 `onLoad` is called when the request to the CARTO tiler was completed successfully.
 
-- Default: `() => {}`
+- Default: `tilejson => {}`
 
 
 ##### `onError` (Function, optional)

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -108,6 +108,25 @@ Optional. Tile extent in tile coordinate space as defined by MVT specification.
 
 * Default: `4096`
 
+### Callbacks
+
+#### `onLoad` (Function, optional)
+
+`onLoad` is called when the request to the CARTO tiler was completed successfully.
+
+- Default: `() => {}`
+
+
+##### `onError` (Function, optional)
+
+`onError` is called when the request to the CARTO tiler failed.
+
+- Default: `console.error`
+
+Receives arguments:
+
+- `error` (`Error`)
+
 
 ## Source
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -116,6 +116,9 @@ Optional. Tile extent in tile coordinate space as defined by MVT specification.
 
 - Default: `tilejson => {}`
 
+Receives arguments:
+
+- `tilejson` (Object) - the response from the tiler service
 
 ##### `onError` (Function, optional)
 

--- a/modules/carto/src/layers/carto-bqtiler-layer.js
+++ b/modules/carto/src/layers/carto-bqtiler-layer.js
@@ -13,7 +13,6 @@ export default class CartoBQTilerLayer extends CartoLayer {
       }
     });
     const tilejson = await response.json();
-    this.setState({tilejson});
     return tilejson;
   }
 }

--- a/modules/carto/src/layers/carto-bqtiler-layer.js
+++ b/modules/carto/src/layers/carto-bqtiler-layer.js
@@ -14,6 +14,7 @@ export default class CartoBQTilerLayer extends CartoLayer {
     });
     const tilejson = await response.json();
     this.setState({tilejson});
+    return tilejson;
   }
 }
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -5,6 +5,7 @@ const defaultProps = {
   data: null,
   credentials: null,
   onDataLoad: {type: 'function', value: tilejson => {}, compare: false},
+  // eslint-disable-next-line
   onDataLoadError: {type: 'function', value: err => console.error(err), compare: false}
 };
 
@@ -22,7 +23,7 @@ export default class CartoLayer extends CompositeLayer {
     }
   }
 
-  async _updateData () {
+  async _updateData() {
     try {
       const tilejson = await this._updateTileJSON();
       this.setState({tilejson});

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -25,9 +25,10 @@ export default class CartoLayer extends CompositeLayer {
   async _updateData () {
     try {
       const tilejson = await this._updateTileJSON();
+      this.setState({tilejson});
       this.props.onDataLoad(tilejson);
     } catch (err) {
-      this.props.onDataLoadError(err);
+      this.props.onDataError(err);
     }
   }
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -3,7 +3,9 @@ import {MVTLayer} from '@deck.gl/geo-layers';
 
 const defaultProps = {
   data: null,
-  credentials: null
+  credentials: null,
+  onLoad: () => {},
+  onError: err => console.error(err)
 };
 
 export default class CartoLayer extends CompositeLayer {
@@ -16,7 +18,17 @@ export default class CartoLayer extends CompositeLayer {
   updateState({changeFlags}) {
     const {data} = this.props;
     if (changeFlags.dataChanged && data) {
-      this._updateTileJSON();
+      this._updateData();
+    }
+  }
+
+  async _updateData () {
+    const { onError, onLoad } = this.props;
+    try {
+      await this._updateTileJSON();
+      onLoad();
+    } catch (err) {
+      onError(err);
     }
   }
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -4,8 +4,8 @@ import {MVTLayer} from '@deck.gl/geo-layers';
 const defaultProps = {
   data: null,
   credentials: null,
-  onLoad: () => {},
-  onError: err => console.error(err)
+  onDataLoad: {type: 'function', value: tilejson => {}, compare: false},
+  onDataLoadError: {type: 'function', value: err => console.error(err), compare: false}
 };
 
 export default class CartoLayer extends CompositeLayer {
@@ -24,10 +24,10 @@ export default class CartoLayer extends CompositeLayer {
 
   async _updateData () {
     try {
-      await this._updateTileJSON();
-      this.props.onLoad();
+      const tilejson = await this._updateTileJSON();
+      this.props.onDataLoad(tilejson);
     } catch (err) {
-      this.props.onError(err);
+      this.props.onDataLoadError(err);
     }
   }
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -23,12 +23,11 @@ export default class CartoLayer extends CompositeLayer {
   }
 
   async _updateData () {
-    const { onError, onLoad } = this.props;
     try {
       await this._updateTileJSON();
-      onLoad();
+      this.props.onLoad();
     } catch (err) {
-      onError(err);
+      this.props.onError(err);
     }
   }
 

--- a/modules/carto/src/layers/carto-sql-layer.js
+++ b/modules/carto/src/layers/carto-sql-layer.js
@@ -12,6 +12,7 @@ export default class CartoSQLLayer extends CartoLayer {
   async _updateTileJSON() {
     const tilejson = await getMapTileJSON(this.props);
     this.setState({tilejson});
+    return tilejson;
   }
 }
 

--- a/modules/carto/src/layers/carto-sql-layer.js
+++ b/modules/carto/src/layers/carto-sql-layer.js
@@ -11,7 +11,6 @@ const defaultProps = {
 export default class CartoSQLLayer extends CartoLayer {
   async _updateTileJSON() {
     const tilejson = await getMapTileJSON(this.props);
-    this.setState({tilejson});
     return tilejson;
   }
 }


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
This PR covers a need that is present in every CARTO-PS project. You need to know if the request to the tiler service failed and when it finished loading, so you can catch the error or display a loading spinner when necessary.
<!-- For all the PRs -->
#### Change List
* Change documentation in carto-bqtiler-layer.md to include the new callbacks
* Change documentation in carto-sql-layer.md to include the new callbacks
* Add callbacks to carto-layer.js

