### PR TITLE
Fix built-in tooltip in GoogleMapsOverlay

### DIFF
--- a/docs/api-reference/google-maps/overview.md
+++ b/docs/api-reference/google-maps/overview.md
@@ -38,6 +38,7 @@ Supported deck.gl features:
 - Auto-highlighting
 - Attribute transitions
 - `onHover` and `onClick` callbacks
+- Tooltip
 
 Not supported features:
 

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -37,7 +37,11 @@ export default class GoogleMapsOverlay {
   setProps(props) {
     Object.assign(this.props, props);
     if (this._deck) {
-      this._deck.setProps(this.props);
+      if (props.style) {
+        Object.assign(this._deck.canvas.parentElement.style, props.style);
+        props.style = null;
+      }
+      this._deck.setProps(props);
     }
   }
 
@@ -80,8 +84,9 @@ export default class GoogleMapsOverlay {
 
     const canSyncWithGoogleMaps = pitch === 0;
 
-    deck.canvas.style.left = `${left}px`;
-    deck.canvas.style.top = `${top}px`;
+    const parentStyle = deck.canvas.parentElement.style;
+    parentStyle.left = `${left}px`;
+    parentStyle.top = `${top}px`;
 
     deck.setProps({
       width,

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -1,4 +1,4 @@
-/* global google */
+/* global google, document */
 import {Deck} from '@deck.gl/core';
 
 // https://en.wikipedia.org/wiki/Web_Mercator_projection#Formulas
@@ -28,7 +28,8 @@ export function createDeckInstance(map, overlay, deck, props) {
 
   deck = new Deck({
     ...props,
-    parent: getContainer(overlay),
+    style: null,
+    parent: getContainer(overlay, props.style),
     initialViewState: {
       longitude: 0,
       latitude: 0,
@@ -51,8 +52,13 @@ export function createDeckInstance(map, overlay, deck, props) {
   return deck;
 }
 
-function getContainer(overlay) {
-  return overlay.getPanes().overlayLayer;
+// Create a container that will host the deck canvas and tooltip
+function getContainer(overlay, style) {
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  Object.assign(container.style, style);
+  overlay.getPanes().overlayLayer.appendChild(container);
+  return container;
 }
 
 /**

--- a/test/modules/google-maps/google-maps-overlay.spec.js
+++ b/test/modules/google-maps/google-maps-overlay.spec.js
@@ -41,6 +41,37 @@ test('GoogleMapsOverlay#constructor', t => {
   t.end();
 });
 
+test('GoogleMapsOverlay#style', t => {
+  const map = new mapsApi.Map({
+    width: 1,
+    height: 1,
+    longitude: 0,
+    latitude: 0,
+    zoom: 1
+  });
+
+  const overlay = new GoogleMapsOverlay({
+    style: {zIndex: 10},
+    layers: []
+  });
+
+  overlay.setMap(map);
+  const deck = overlay._deck;
+
+  t.is(deck.props.parent.style.zIndex, '10', 'parent zIndex is set');
+  t.is(deck.canvas.style.zIndex, '', 'canvas zIndex is not set');
+
+  overlay.setProps({
+    style: {zIndex: 5}
+  });
+  t.is(deck.props.parent.style.zIndex, '5', 'parent zIndex is set');
+  t.is(deck.canvas.style.zIndex, '', 'canvas zIndex is not set');
+
+  overlay.finalize();
+
+  t.end();
+});
+
 test('GoogleMapsOverlay#draw, pick', t => {
   const map = new mapsApi.Map({
     width: 800,


### PR DESCRIPTION
Fix usage of `getTooltip` in GoogleMapsOverlay

The overlay sets top/left offsets of the canvas, which should be applied to the tooltip as well.

#### Change List
- Create a container for deck canvas and tooltip
- Unit test
