### PR TITLE
Fix typo in BitmapLayer

### DIFF
--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -188,7 +188,7 @@ export default class BitmapLayer extends Layer {
         bitmapTexture.resize({width: image.videoWidth, height: image.videoHeight, mipmaps: true});
         bitmapTexture.setSubImageData({
           data: image,
-          paramters: DEFAULT_TEXTURE_PARAMETERS
+          parameters: DEFAULT_TEXTURE_PARAMETERS
         });
       } else {
         bitmapTexture.setSubImageData({


### PR DESCRIPTION
Haven't touched the video side of the BitmapLayer, but this looks like a typo and might prevent errors in the future