### PR TITLE
Fix border display in osm tile example

### DIFF
--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -58,6 +58,7 @@ export default function App({showBorder = false, onTilesLoad = null}) {
         showBorder &&
           new PathLayer({
             id: `${props.id}-border`,
+            visible: props.visible,
             data: [[[west, north], [west, south], [east, south], [east, north], [west, north]]],
             getPath: d => d,
             getColor: [255, 0, 0],


### PR DESCRIPTION
Hide the borders of invisible tiles