### PR TITLE
fix: CartoLayer: remap the user's updateTriggers from the parent layer

### DIFF
--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -32,11 +32,14 @@ export default class CartoLayer extends CompositeLayer {
   renderLayers() {
     if (!this.state.tilejson) return null;
 
+    const { updateTriggers } = this.props;
+
     return new MVTLayer(
       this.props,
       this.getSubLayerProps({
         id: 'mvt',
-        data: this.state.tilejson.tiles
+        data: this.state.tilejson.tiles,
+        updateTriggers
       })
     );
   }

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -32,7 +32,7 @@ export default class CartoLayer extends CompositeLayer {
   renderLayers() {
     if (!this.state.tilejson) return null;
 
-    const { updateTriggers } = this.props;
+    const {updateTriggers} = this.props;
 
     return new MVTLayer(
       this.props,


### PR DESCRIPTION
According to composite Layers documentation,  

> to make updateTriggers work when accessors need to be recalculated, we need to remap the user's updateTriggers from the parent layer's prop names to the sublayers' prop names.

Currently, CartoLayer is not remapping the user's updateTriggers so layers like these

`
new CartoSQLLayer({
      ...
      getRadius: d => radius,
      updateTriggers: {
        getRadius: radius
      }
})
`

Is not changing the point radius when radius variable changes