### PR TITLE
Fix Quickly Aborted Tiles

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -54,17 +54,16 @@ export default class Tile2DHeader {
       return tile.isSelected ? 1 : -1;
     });
 
-    // A tile can be cancelled while being scheduled
-    if (this._isCancelled) {
-      requestToken && requestToken.done(); // eslint-disable-line no-unused-expressions
-      return;
-    }
     if (!requestToken) {
       this._isCancelled = true;
       return;
     }
+    // A tile can be cancelled while being scheduled
+    if (this._isCancelled) {
+      requestToken.done();
+      return;
+    }
 
-    this._isCancelled = false;
     let tileData;
     let error;
     try {

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -55,7 +55,11 @@ export default class Tile2DHeader {
     });
 
     // A tile can be cancelled while being scheduled
-    if (!requestToken || this._isCancelled) {
+    if (this._isCancelled) {
+      requestToken && requestToken.done(); // eslint-disable-line no-unused-expressions
+      return;
+    }
+    if (!requestToken) {
       this._isCancelled = true;
       return;
     }

--- a/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
@@ -46,3 +46,21 @@ test('Tile2DHeader#Cancel request if not selected', async t => {
   t.ok(tile2.isCancelled, 'Second request was cancelled');
   t.end();
 });
+
+test('Tile2DHeader#Abort quickly', async t => {
+  const requestScheduler = new RequestScheduler({throttleRequests: true, maxRequests: 1});
+
+  const getTileData = () => null;
+  const onTileLoad = () => null;
+  const onTileError = () => null;
+
+  const tile = new Tile2DHeader({onTileLoad, onTileError});
+
+  // Await later so that request scheduler the abort could go off before the getTileData call.
+  const loader = tile._loadData(getTileData, requestScheduler);
+  tile.abort();
+  await loader;
+
+  t.notOk(requestScheduler.requestMap.has(tile), 'Scheduler deletes tile on abort');
+  t.end();
+});

--- a/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
@@ -50,11 +50,12 @@ test('Tile2DHeader#Cancel request if not selected', async t => {
 test('Tile2DHeader#Abort quickly', async t => {
   const requestScheduler = new RequestScheduler({throttleRequests: true, maxRequests: 1});
 
-  const getTileData = () => null;
+  const getTileData = await new Promise(resolve => setTimeout(resolve, 0)); // eslint-disable-line no-undef
   const onTileLoad = () => null;
   const onTileError = () => null;
 
   const tile = new Tile2DHeader({onTileLoad, onTileError});
+  tile.isSelected = true;
 
   // Await later so that the abort could go off before the getTileData call.
   const loader = tile._loadData(getTileData, requestScheduler);

--- a/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
@@ -56,7 +56,7 @@ test('Tile2DHeader#Abort quickly', async t => {
 
   const tile = new Tile2DHeader({onTileLoad, onTileError});
 
-  // Await later so that request scheduler the abort could go off before the getTileData call.
+  // Await later so that the abort could go off before the getTileData call.
   const loader = tile._loadData(getTileData, requestScheduler);
   tile.abort();
   await loader;

--- a/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
@@ -50,7 +50,7 @@ test('Tile2DHeader#Cancel request if not selected', async t => {
 test('Tile2DHeader#Abort quickly', async t => {
   const requestScheduler = new RequestScheduler({throttleRequests: true, maxRequests: 1});
 
-  const getTileData = await new Promise(resolve => setTimeout(resolve, 0)); // eslint-disable-line no-undef
+  const getTileData = () => null;
   const onTileLoad = () => null;
   const onTileError = () => null;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
I tried my hand at fixing #5041 (using Kyle's recommendation) and added a test case.
#### Background
In #5041 Kyle/Xiaoji noted that the individual tiles were not calling `done` on their `requestToken` if the `AbortSignal` was raised before the actual call to `getTileData`.  This PR should fix this.
<!-- For all the PRs -->
#### Change List
- Update `TileHeader2D` to handle quickly-aborted tiles, before calling `getTileData`.
- Add a test that calls `abort` before awaiting the response of `_loadData`.
