### PR TITLE
Fix MEAN aggregation on Windows

### DIFF
--- a/modules/aggregation-layers/src/utils/gpu-grid-aggregation/transform-mean-vs.glsl.js
+++ b/modules/aggregation-layers/src/utils/gpu-grid-aggregation/transform-mean-vs.glsl.js
@@ -30,5 +30,8 @@ void main()
   // aggregationValues:  XYZ contain aggregated values, W contains count
   meanValues.xyz = isCellValid ? aggregationValues.xyz/aggregationValues.w : vec3(0, 0, 0);
   meanValues.w = aggregationValues.w;
+
+  // Enforce default value for ANGLE issue (https://bugs.chromium.org/p/angleproject/issues/detail?id=3941)
+  gl_PointSize = 1.0;
 }
 `;


### PR DESCRIPTION
For #5051

This bug affects ContourLayer, GridLayer and ScreenGridLayer

#### Background

Same work around for ANGLE bug in https://github.com/visgl/deck.gl/pull/4113, applied to MEAN aggregation

#### Change List

- Explicitly set `gl_pointSize`
