### PR TITLE
Refresh declarative function on accessors

### DIFF
--- a/examples/playground/json-examples/carto-bq-tiler.json
+++ b/examples/playground/json-examples/carto-bq-tiler.json
@@ -11,7 +11,7 @@
     {
       "@@type": "MapView",
       "controller": true,
-      "mapStyle": "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+      "mapStyle": "@@#CARTO_BASEMAP.POSITRON"    
     }
   ],
   "layers": [

--- a/examples/playground/json-examples/carto-sql.json
+++ b/examples/playground/json-examples/carto-sql.json
@@ -11,19 +11,19 @@
     {
       "@@type": "MapView",
       "controller": true,
-      "mapStyle": "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+      "mapStyle": "@@#CARTO_BASEMAP.POSITRON"
     }
   ],
   "layers": [
     {
       "@@type": "CartoSQLLayer",
-      "data": "SELECT the_geom_webmercator FROM populated_places",
+      "data": "SELECT the_geom_webmercator, gn_pop FROM populated_places",
       "credentials": {
         "username": "public",
         "apiKey": "default_public"
       },
       "getLineColor": [255, 255, 255],
-      "getFillColor": [238, 77, 90],
+      "getFillColor": "@@= properties.gn_pop > 10000 ? [225, 83, 131] : [255, 221, 154]",
       "pointRadiusMinPixels": 5,
       "lineWidthMinPixels": 1
     }

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.local --env.production=true"
   },
   "dependencies": {
+    "@deck.gl/google-maps": "^8.3.3",
     "@loaders.gl/3d-tiles": "^2.3.0",
     "@loaders.gl/core": "^2.3.0",
     "@loaders.gl/csv": "^2.3.0",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -8,7 +8,6 @@
     "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.local --env.production=true"
   },
   "dependencies": {
-    "@deck.gl/google-maps": "^8.3.3",
     "@loaders.gl/3d-tiles": "^2.3.0",
     "@loaders.gl/core": "^2.3.0",
     "@loaders.gl/csv": "^2.3.0",

--- a/examples/playground/src/app.js
+++ b/examples/playground/src/app.js
@@ -21,6 +21,24 @@ const INITIAL_TEMPLATE = Object.keys(JSON_TEMPLATES)[0];
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 const GOOGLE_MAPS_TOKEN = process.env.GoogleMapsToken; // eslint-disable-line
 
+function addUpdateTriggersForAccesors(json) {
+  if (!json || !json.layers) return;
+
+  for (const layer of json.layers) {
+    const updateTriggers = {};
+    for (const [key, value] of Object.entries(layer)) {
+      if (key.startsWith('get') && typeof value === 'string') {
+        // it's an accesor and it's a string
+        // we add the value of the accesor to update trigger to refresh when it changes
+        updateTriggers[key] = value;
+      }
+    }
+    if (Object.keys(updateTriggers).length) {
+      layer.updateTriggers = updateTriggers;
+    }
+  }
+}
+
 export class App extends Component {
   constructor(props) {
     super(props);
@@ -59,6 +77,7 @@ export class App extends Component {
   }
 
   _setJSON(json) {
+    addUpdateTriggersForAccesors(json);
     const jsonProps = this.jsonConverter.convert(json);
     this._updateViewState(jsonProps);
     this.setState({jsonProps});

--- a/examples/playground/src/configuration.js
+++ b/examples/playground/src/configuration.js
@@ -5,7 +5,7 @@ import * as Layers from '@deck.gl/layers';
 import * as AggregationLayers from '@deck.gl/aggregation-layers';
 import * as GeoLayers from '@deck.gl/geo-layers';
 import * as MeshLayers from '@deck.gl/mesh-layers';
-import * as CartoLayers from '@deck.gl/carto';
+import {CartoSQLLayer, CartoBQTilerLayer, BASEMAP} from '@deck.gl/carto';
 
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
@@ -28,7 +28,7 @@ export default {
     AggregationLayers,
     GeoLayers,
     MeshLayers,
-    CartoLayers,
+    {CartoBQTilerLayer, CartoSQLLayer},
     // Any non-standard views
     {}
   ),
@@ -37,7 +37,8 @@ export default {
   // Will be resolved as `<enum-name>.<enum-value>`
   enumerations: {
     COORDINATE_SYSTEM,
-    GL
+    GL,
+    CARTO_BASEMAP: BASEMAP
   },
 
   // Constants that should be resolved with the provided values by JSON converter

--- a/examples/playground/src/deck-with-google-maps.js
+++ b/examples/playground/src/deck-with-google-maps.js
@@ -1,6 +1,6 @@
 /* global console, document, window */
 import React, {Component} from 'react';
-import {GoogleMapsOverlay} from 'deck.gl';
+import {GoogleMapsOverlay} from '@deck.gl/google-maps';
 
 const HOST = 'https://maps.googleapis.com/maps/api/js';
 const LOADING_GIF = 'https://upload.wikimedia.org/wikipedia/commons/d/de/Ajax-loader.gif';


### PR DESCRIPTION
This PR allows refreshing the layers at playground when a declarative function is changed.

It automatically appends `updateTriggers` for layers with accessors which its value is a string.

![refresh](https://user-images.githubusercontent.com/1161870/97091049-2a168d00-1639-11eb-8ed9-1abf4ca02322.gif)

As bonus, I've added constants for the mapStyle. So instead of:
```js
{"mapStyle": "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"}
```
just do:
```js
{"mapStyle": "@@#CARTO_BASEMAP.POSITRON" }
```


