### PR TITLE
WIP add quantized mesh loader to terrain layer

### DIFF
--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -107,7 +107,7 @@ export default class TerrainLayer extends CompositeLayer {
         elevationDecoder
       },
       'quantized-mesh': {
-        bounds
+        bounds: [bounds[0], bounds[3], bounds[2], bounds[1]]
       }
     };
     if (workerUrl !== null) {
@@ -130,7 +130,7 @@ export default class TerrainLayer extends CompositeLayer {
     });
     const bottomLeft = viewport.projectFlat([bbox.west, bbox.south]);
     const topRight = viewport.projectFlat([bbox.east, bbox.north]);
-    const bounds = [bottomLeft[0], topRight[1], topRight[0], bottomLeft[1]];
+    const bounds = [bottomLeft[0], bottomLeft[1], topRight[0], topRight[1]];
 
     const terrain = this.loadTerrain({
       elevationData: dataUrl,

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -22,7 +22,7 @@ import {CompositeLayer} from '@deck.gl/core';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {WebMercatorViewport, COORDINATE_SYSTEM} from '@deck.gl/core';
 import {load} from '@loaders.gl/core';
-import {TerrainLoader} from '@loaders.gl/terrain';
+import {TerrainLoader, QuantizedMeshLoader} from '@loaders.gl/terrain';
 import TileLayer from '../tile-layer/tile-layer';
 import {urlType, getURLFromTemplate} from '../tile-layer/utils';
 
@@ -105,12 +105,16 @@ export default class TerrainLayer extends CompositeLayer {
         bounds,
         meshMaxError,
         elevationDecoder
+      },
+      'quantized-mesh': {
+        bounds
       }
     };
     if (workerUrl !== null) {
       options.terrain.workerUrl = workerUrl;
+      options['quantized-mesh'].workerUrl = workerUrl;
     }
-    return load(elevationData, TerrainLoader, options);
+    return load(elevationData, [TerrainLoader, QuantizedMeshLoader], options);
   }
 
   getTiledTerrainData(tile) {
@@ -126,7 +130,7 @@ export default class TerrainLayer extends CompositeLayer {
     });
     const bottomLeft = viewport.projectFlat([bbox.west, bbox.south]);
     const topRight = viewport.projectFlat([bbox.east, bbox.north]);
-    const bounds = [bottomLeft[0], bottomLeft[1], topRight[0], topRight[1]];
+    const bounds = [bottomLeft[0], topRight[1], topRight[0], bottomLeft[1]];
 
     const terrain = this.loadTerrain({
       elevationData: dataUrl,


### PR DESCRIPTION
#### Background

The Quantized Mesh loader was added in loaders.gl 2.2, which parses the [Quantized Mesh format](https://github.com/CesiumGS/quantized-mesh).

#### Change List

- Add QuantizedMeshLoader to the loaders list when loading terrain

#### Notes

##### Web Mercator Projection only

Quantized Mesh is often tiled in the EPSG: 4326 projection, which is incompatible with the current TileLayer, which only accepts Web Mercator/OSM indexing.

##### Mesh orientation

This is an issue I've struggled with before. Without changing the existing code when I use quantized mesh I see the images flipped:

![image](https://user-images.githubusercontent.com/15164633/97117984-056bf500-16cd-11eb-847a-496d4887cba5.png)

I might need to check that I'm serving the mesh according to the spec

cc @davidbrochart, #4531 