### PR TITLE
ArcGIS 3D altitude fix

### DIFF
--- a/modules/arcgis/src/deck-renderer.js
+++ b/modules/arcgis/src/deck-renderer.js
@@ -2,6 +2,12 @@
 
 import {initializeResources, render, finalizeResources} from './commons';
 
+function arcgisFOVToDeckAltitude(fov, aspectRatio) {
+  const D = Math.sqrt(1 + aspectRatio ** 2);
+  const halfFOV = fov / 2 / 180 * Math.PI;
+  return D / 2 / Math.tan(halfFOV);
+}
+
 export default function createDeckRenderer(DeckProps, externalRenderers) {
   class DeckRenderer {
     constructor(view, props) {
@@ -36,6 +42,7 @@ export default function createDeckRenderer(DeckProps, externalRenderers) {
         viewState: {
           latitude: this.view.center.latitude,
           longitude: this.view.center.longitude,
+          altitude: arcgisFOVToDeckAltitude(this.view.camera.fov, width / height),
           zoom: this.view.zoom,
           bearing: this.view.camera.heading,
           pitch: this.view.camera.tilt

--- a/modules/arcgis/src/deck-renderer.js
+++ b/modules/arcgis/src/deck-renderer.js
@@ -4,7 +4,7 @@ import {initializeResources, render, finalizeResources} from './commons';
 
 function arcgisFOVToDeckAltitude(fov, aspectRatio) {
   const D = Math.sqrt(1 + aspectRatio ** 2);
-  const halfFOV = fov / 2 / 180 * Math.PI;
+  const halfFOV = (fov / 2 / 180) * Math.PI;
   return D / 2 / Math.tan(halfFOV);
 }
 

--- a/modules/arcgis/src/deck-renderer.js
+++ b/modules/arcgis/src/deck-renderer.js
@@ -2,6 +2,7 @@
 
 import {initializeResources, render, finalizeResources} from './commons';
 
+// ArcGIS fov is corner-to-corner
 function arcgisFOVToDeckAltitude(fov, aspectRatio) {
   const D = Math.sqrt(1 + aspectRatio ** 2);
   const halfFOV = (fov / 2 / 180) * Math.PI;


### PR DESCRIPTION
Seems like it should fix the wrong alignment between an ArcGIS basemap with `SceneView` and deck.gl.

@Pessimistress gets full credit for this; I was on the wrong track by trying to match the FOV of a `FirstPersonView`. Thanks!

For #5065
