### PR TITLE
Fix: Maps APIv2 has changed the endpoints

### DIFF
--- a/modules/carto/src/api/maps-api-client.js
+++ b/modules/carto/src/api/maps-api-client.js
@@ -84,7 +84,10 @@ function buildURL({mapConfig, credentials}) {
   const encodedApiKey = encodeParameter('api_key', credentials.apiKey);
   const encodedClient = encodeParameter('client', `deck-gl-carto`);
   const parameters = [encodedApiKey, encodedClient];
-  return `${mapsUrl(credentials)}?${parameters.join('&')}&${encodeParameter('config', cfg)}`;
+  return `${mapsUrl(credentials)}/tilejson?${parameters.join('&')}&${encodeParameter(
+    'config',
+    cfg
+  )}`;
 }
 
 /**

--- a/modules/carto/src/config.js
+++ b/modules/carto/src/config.js
@@ -7,7 +7,7 @@ const defaultCredentials = {
   // SQL API URL
   sqlUrl: 'https://{user}.carto.com/api/v2/sql',
   // Maps API URL
-  mapsUrl: 'https://maps-api-v2.{region}.carto.com/user/{user}/map'
+  mapsUrl: 'https://maps-api-v2.{region}.carto.com/user/{user}'
 };
 
 let credentials = defaultCredentials;

--- a/modules/carto/src/layers/carto-sql-layer.js
+++ b/modules/carto/src/layers/carto-sql-layer.js
@@ -42,7 +42,7 @@ export default class CartoSQLLayer extends CartoLayer {
           tile_extent: tileExtent,
           layers: [
             {
-              type: 'query',
+              type: 'sql',
               source: 'postgres',
               options: {
                 sql: sql.trim(),

--- a/test/modules/carto/config.spec.js
+++ b/test/modules/carto/config.spec.js
@@ -15,7 +15,7 @@ test('config#getDefaultCredentials', t => {
   t.ok(credentials.username === 'a-new-username', 'user update');
   t.ok(credentials.apiKey === 'default_public', 'keep default apiKey');
   t.ok(
-    credentials.mapsUrl === 'https://maps-api-v2.{region}.carto.com/user/{user}/map',
+    credentials.mapsUrl === 'https://maps-api-v2.{region}.carto.com/user/{user}',
     'keep default mapsUrl'
   );
   t.ok(credentials.sqlUrl === 'https://{user}.carto.com/api/v2/sql', 'keep default sqlUrl');


### PR DESCRIPTION
During the beta of Maps API v2 we've changed the URLs and these changes are in production and they're not backward compatible.