### PR TITLE
Shader support for extreme latitude coordinates

### DIFF
--- a/modules/core/src/shaderlib/project/project.glsl.js
+++ b/modules/core/src/shaderlib/project/project.glsl.js
@@ -103,9 +103,10 @@ vec2 project_mercator_(vec2 lnglat) {
   if (project_uWrapLongitude) {
     x = mod(x - project_uAntimeridian, 360.0) + project_uAntimeridian;
   }
+  float y = clamp(lnglat.y, -89.9, 89.9);
   return vec2(
     radians(x) + PI,
-    PI + log(tan_fp32(PI * 0.25 + radians(lnglat.y) * 0.5))
+    PI + log(tan_fp32(PI * 0.25 + radians(y) * 0.5))
   );
 }
 


### PR DESCRIPTION
For #4981

Latitude 90/-90 projects to Infinity/-Infinity in Web Mercator projection. When passed to the project shader module they end up being clipped. This affects paths/polygons with vertices over the poles.

#### Change List
- Clamp latitude to reasonable range
