### PR TITLE
CPU Aggregator accessor conformance

### DIFF
--- a/docs/api-reference/aggregation-layers/contour-layer.md
+++ b/docs/api-reference/aggregation-layers/contour-layer.md
@@ -134,13 +134,16 @@ A very small z offset that is added for each vertex of a contour (Isoline or Iso
 
 * Default: `object => object.position`
 
-Method called to retrieve the position of each point.
+Method called to retrieve the position of each object.
 
 ##### `getWeight` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
 
-* Default: `object => 1`
+* Default: `1`
 
-Method called to retrieve weight of each point. By default each point will use a weight of `1`.
+The weight of each object.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
 
 
 ## Sub Layers

--- a/docs/api-reference/aggregation-layers/cpu-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/cpu-grid-layer.md
@@ -127,7 +127,7 @@ Elevation scale output range
 * Default: `1`
 
 Cell elevation multiplier. The elevation of cell is calculated by
-`elevationScale * getElevation(d)`.
+`elevationScale * getElevationValue(d)`.
 `elevationScale` is a handy property to scale all cells without updating the data.
 
 ##### `extruded` (Boolean, optional)
@@ -177,50 +177,14 @@ Scaling function used to determine the color of the grid cell, default value is 
 This is an object that contains material props for [lighting effect](/docs/api-reference/core/lighting-effect.md) applied on extruded polygons.
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
-### Data Accessors
-
-##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
-
-* Default: `object => object.position`
-
-Method called to retrieve the position of each point.
-
-##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `points => points.length`
-
-`getColorValue` is the accessor function to get the value that cell color is based on.
-It takes an array of points inside each cell as arguments, returns a number. For example,
-You can pass in `getColorValue` to color the cells by avg/mean/max of a specific attributes of each point.
-By default `getColorValue` returns the length of the points array.
-
-```js
- class MyGridLayer {
-    renderLayers() {
-      return new CPUGridLayer({
-        id: 'grid-layer',
-        getColorValue: points => points.length
-        data,
-        cellSize: 500
-      });
-    }
- }
-```
-
-
-##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `point => 1`
-
-`getColorWeight` is the accessor function to get the weight of a point used to calculate the color value for a cell.
 
 ##### `colorAggregation` (String, optional)
 
 * Default: 'SUM'
 
-`colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
+`getColorWeight` and `colorAggregation` together determine the elevation value of each cell. If the `getColorValue` prop is supplied, they will be ignored.
 
 ###### Example1 : Using count of data elements that fall into a cell to encode the its color
 
@@ -277,31 +241,16 @@ const layer = new CPUGridLayer({
 });
 ```
 
-If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function.
 
-
-##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `points => points.length`
-
-Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that cell elevation is based on.
-It takes an array of points inside each cell as arguments, returns a number.
-By default `getElevationValue` returns the length of the points array.
-
-##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `point => 1`
-
-`getElevationWeight` is the accessor function to get the weight of a point used to calculate the elevation value for a cell.
 
 ##### `elevationAggregation` (String, optional)
 
 * Default: 'SUM'
 
-`elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable GPU aggregation, former props must be provided instead of later.
-
+`getElevationWeight` and `elevationAggregation` together determine the elevation value of each cell. If the `getElevationValue` prop is supplied, they will be ignored.
 
 ###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
 
@@ -357,19 +306,81 @@ const layer = new CPUGridLayer({
 });
 ```
 
-If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function.
+
+
+### Data Accessors
+
+##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
+
+* Default: `object => object.position`
+
+Method called to retrieve the position of each point.
+
+
+##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `1`
+
+The weight of a data point used to calculate the color value for a cell.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
+
+##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `null`
+
+After data points are aggregated into cells, this accessor is called on each cell to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props.
+
+Arguments:
+
+- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
+  + `source` (Object) - the original data object
+  + `index` (Number) - the index of the object in `data`
+- `context` (Object) - contains the following fields:
+  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+
+
+##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `1`
+
+The weight of a data point used to calculate the elevation value for a cell.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
+
+##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `null`
+
+After data points are aggregated into cells, this accessor is called on each cell to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props.
+
+Arguments:
+
+- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
+  + `source` (Object) - the original data object
+  + `index` (Number) - the index of the object in `data`
+- `context` (Object) - contains the following fields:
+  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+
+
+### Callbacks
 
 ##### `onSetColorDomain` (Function, optional)
 
-* Default: `() => {}`
+* Default: `([min, max]) => {}`
 
-This callback will be called when bin color domain has been calculated.
+This callback will be called when cell color domain has been calculated.
 
 ##### `onSetElevationDomain` (Function, optional)
 
-* Default: `() => {}`
+* Default: `([min, max]) => {}`
 
-This callback will be called when bin elevation domain has been calculated.
+This callback will be called when cell elevation domain has been calculated.
 
 
 ## Sub Layers

--- a/docs/api-reference/aggregation-layers/cpu-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/cpu-grid-layer.md
@@ -336,11 +336,10 @@ After data points are aggregated into cells, this accessor is called on each cel
 
 Arguments:
 
-- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
-  + `source` (Object) - the original data object
-  + `index` (Number) - the index of the object in `data`
-- `context` (Object) - contains the following fields:
-  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+- `objects` (Array) - a list of objects whose positions fall inside this cell.
+- `objectInfo` (Object) - contains the following fields:
+  + `indices` (Array) - the indices of `objects` in the original data
+  + `data` - the value of the `data` prop.
 
 
 ##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
@@ -361,11 +360,10 @@ After data points are aggregated into cells, this accessor is called on each cel
 
 Arguments:
 
-- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
-  + `source` (Object) - the original data object
-  + `index` (Number) - the index of the object in `data`
-- `context` (Object) - contains the following fields:
-  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+- `objects` (Array) - a list of objects whose positions fall inside this cell.
+- `objectInfo` (Object) - contains the following fields:
+  + `indices` (Array) - the indices of `objects` in the original data
+  + `data` - the value of the `data` prop.
 
 
 ### Callbacks

--- a/docs/api-reference/aggregation-layers/cpu-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/cpu-grid-layer.md
@@ -8,9 +8,9 @@ import {CPUGridLayerDemo} from 'website-components/doc-demos/aggregation-layers'
 
 # CPUGridLayer
 
-The `CPUGridLayer` renders a grid heatmap based on an array of points.
-It takes the constant cell size, aggregates input points into cells. Aggregation is performed on CPU. The color
-and height of the cell is scaled by number of points it contains.
+The `CPUGridLayer` renders a grid heatmap based on an array of inputs.
+It takes the constant cell size and aggregates input objects into cells. The color
+and height of a cell are determined based on the objects it contains. Aggregation is performed on CPU.
 
 `CPUGridLayer` is one of the sublayers for [GridLayer](/docs/api-reference/aggregation-layers/grid-layer.md), and is provided to customize CPU Aggregation for advanced use cases. For any regular use case, [GridLayer](/docs/api-reference/aggregation-layers/grid-layer.md) is recommended.
 
@@ -91,9 +91,11 @@ Size of each cell in meters
 
 ##### `colorDomain` (Array, optional)
 
-* Default: `[min(count), max(count)]`
+* Default: `[min(colorWeight), max(colorWeight)]`
 
-Color scale domain, default is set to the range of point counts in each cell.
+Color scale domain, default is set to the extent of aggregated weights in each cell.
+You can control how the colors of cells are mapped to weights by passing in an arbitrary color domain.
+This is useful when you want to render different data input with the same color mapping for comparison.
 
 ##### `colorRange` (Array, optional)
 
@@ -106,15 +108,16 @@ Specified as an array of 6 colors [color1, color2, ... color6]. Each color is an
 
 * Default: `1`
 
-Cell size multiplier, clamped between 0 - 1. The final size of cell
-is calculated by `coverage * cellSize`. Note: coverage does not affect how points
-are binned. Coverage are linear based.
+Cell size multiplier, clamped between 0 - 1. The displayed size of cell is calculated by `coverage * cellSize`.
+Note: coverage does not affect how objects are binned.
 
 ##### `elevationDomain` (Array, optional)
 
-* Default: `[0, max(count)]`
+* Default: `[0, max(elevationWeight)]`
 
-Elevation scale input domain, default is set to the extent of point counts in each cell.
+Elevation scale input domain, default is set to between 0 and the max of aggregated weights in each cell.
+You can control how the elevations of cells are mapped to weights by passing in an arbitrary elevation domain.
+This is useful when you want to render different data input with the same elevation scale for comparison.
 
 ##### `elevationRange` (Array, optional)
 
@@ -126,15 +129,14 @@ Elevation scale output range
 
 * Default: `1`
 
-Cell elevation multiplier. The elevation of cell is calculated by
-`elevationScale * getElevationValue(d)`.
-`elevationScale` is a handy property to scale all cells without updating the data.
+Cell elevation multiplier.
+This is a handy property to scale all cells without updating the data.
 
 ##### `extruded` (Boolean, optional)
 
 * Default: `true`
 
-Whether to enable cell elevation. Cell elevation scale by count of points in each cell. If set to false, all cell will be flat.
+Whether to enable cell elevation. If set to false, all cell will be flat.
 
 ##### `upperPercentile` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
@@ -182,11 +184,11 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getColorWeight` and `colorAggregation` together determine the elevation value of each cell. If the `getColorValue` prop is supplied, they will be ignored.
 
-###### Example1 : Using count of data elements that fall into a cell to encode the its color
+###### Example 1 : Using count of data elements that fall into a cell to encode the its color
 
 * Using `getColorValue`
 ```js
@@ -213,7 +215,7 @@ const layer = new CPUGridLayer({
 });
 ```
 
-###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
+###### Example 2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
 
 * Using `getColorValue`
 ```js
@@ -248,11 +250,11 @@ If your use case requires aggregating using an operation that is not one of 'SUM
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getElevationWeight` and `elevationAggregation` together determine the elevation value of each cell. If the `getElevationValue` prop is supplied, they will be ignored.
 
-###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
+###### Example 1 : Using count of data elements that fall into a cell to encode the its elevation
 
 * Using `getElevationValue`
 
@@ -278,7 +280,7 @@ const layer = new CPUGridLayer({
 });
 ```
 
-###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
+###### Example 2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
 
 * Using `getElevationValue`
 ```js
@@ -315,14 +317,14 @@ If your use case requires aggregating using an operation that is not one of 'SUM
 
 * Default: `object => object.position`
 
-Method called to retrieve the position of each point.
+Method called to retrieve the position of each object.
 
 
 ##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
 
-The weight of a data point used to calculate the color value for a cell.
+The weight of a data object used to calculate the color value for a cell.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -332,7 +334,7 @@ The weight of a data point used to calculate the color value for a cell.
 
 * Default: `null`
 
-After data points are aggregated into cells, this accessor is called on each cell to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props.
+After data objects are aggregated into cells, this accessor is called on each cell to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props.
 
 Arguments:
 
@@ -346,7 +348,7 @@ Arguments:
 
 * Default: `1`
 
-The weight of a data point used to calculate the elevation value for a cell.
+The weight of a data object used to calculate the elevation value for a cell.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -356,7 +358,7 @@ The weight of a data point used to calculate the elevation value for a cell.
 
 * Default: `null`
 
-After data points are aggregated into cells, this accessor is called on each cell to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props.
+After data objects are aggregated into cells, this accessor is called on each cell to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props.
 
 Arguments:
 

--- a/docs/api-reference/aggregation-layers/gpu-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/gpu-grid-layer.md
@@ -141,6 +141,25 @@ Whether to enable cell elevation. Cell elevation scale by count of points in eac
 This is an object that contains material props for [lighting effect](/docs/api-reference/core/lighting-effect.md) applied on extruded polygons.
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
+
+
+##### `colorAggregation` (String, optional)
+
+* Default: 'SUM'
+
+Defines the operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+
+`getColorWeight` and `colorAggregation` together determine the elevation value of each cell.
+
+##### `elevationAggregation` (String, optional)
+
+* Default: 'SUM'
+
+Defines the operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+
+`getElevationWeight` and `elevationAggregation` together determine the elevation value of each cell.
+
+
 ### Data Accessors
 
 ##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
@@ -149,44 +168,25 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 Method called to retrieve the position of each point.
 
+
 ##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
-* Default: `point => 1`
+* Default: `1`
 
-`getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
-By default `getColorWeight` returns `1`.
+The weight of a data point used to calculate the color value for a cell.
 
-Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
-
-
-##### `colorAggregation` (String, optional)
-
-* Default: 'SUM'
-
-`colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
-
-Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
 
 
 ##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
-* Default: `point => 1`
+* Default: `1`
 
-`getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
-By default `getElevationWeight` returns `1`.
+The weight of a data point used to calculate the elevation value for a cell.
 
-Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
-
-
-##### `elevationAggregation` (String, optional)
-
-* Default: 'SUM'
-
-`elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
-
-Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
 
 
 ## Differences compared to CPUGridLayer

--- a/docs/api-reference/aggregation-layers/gpu-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/gpu-grid-layer.md
@@ -93,6 +93,13 @@ Inherits from all [Base Layer](/docs/api-reference/core/layer.md) and [Composite
 
 Size of each cell in meters. Must be greater than `0`.
 
+##### `colorDomain` (Array, optional)
+
+* Default: `[min(count), max(count)]`
+
+Color scale domain, default is set to the range of point counts in each cell.
+
+
 ##### `colorRange` (Array, optional)
 
 * Default: <img src="/website/src/static/images/colorbrewer_YlOrRd_6.png"/>

--- a/docs/api-reference/aggregation-layers/gpu-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/gpu-grid-layer.md
@@ -8,9 +8,9 @@ import {GPUGridLayerDemo} from 'website-components/doc-demos/aggregation-layers'
 
 # GPUGridLayer (WebGL2)
 
-The `GPUGridLayer` renders a grid heatmap based on an array of points.
-It takes the constant cell size, aggregates input points into cells. This layer performs aggregation on GPU hence not supported in non WebGL2 browsers. The color
-and height of the cell is scaled by number of points it contains.
+The `GPUGridLayer` renders a grid heatmap based on an array of inputs.
+It takes the constant cell size and aggregates input objects into cells. The color
+and height of a cell are determined based on the objects it contains. This layer performs aggregation on GPU hence not supported in non WebGL2 browsers.
 
 `GPUGridLayer` is one of the sublayers for [GridLayer](/docs/api-reference/aggregation-layers/grid-layer.md) and is only supported when using `WebGL2` enabled browsers. It is provided to customize GPU Aggregation for advanced use cases. For any regular use case, [GridLayer](/docs/api-reference/aggregation-layers/grid-layer.md) is recommended.
 
@@ -46,7 +46,7 @@ function App({data, viewState}) {
 
 **Note:** The `GPUGridLayer` at the moment only works with `COORDINATE_SYSTEM.LNGLAT`.
 
-**Note:** GPU Aggregation is faster only when using large data sets (point count is more than 500K), for smaller data sets GPU Aggregation could be potentially slower than CPU Aggregation.
+**Note:** GPU Aggregation is faster only when using large data sets (data size is more than 500K), for smaller data sets GPU Aggregation could be potentially slower than CPU Aggregation.
 
 **Note:** This layer is similar to [CPUGridLayer](/docs/api-reference/aggregation-layers/cpu-grid-layer.md) but performs aggregation on GPU. Check below for more detailed differences of this layer compared to `CPUGridLayer`.
 
@@ -95,9 +95,11 @@ Size of each cell in meters. Must be greater than `0`.
 
 ##### `colorDomain` (Array, optional)
 
-* Default: `[min(count), max(count)]`
+* Default: `[min(colorWeight), max(colorWeight)]`
 
-Color scale domain, default is set to the range of point counts in each cell.
+Color scale domain, default is set to the extent of aggregated weights in each cell.
+You can control how the colors of cells are mapped to weights by passing in an arbitrary color domain.
+This is useful when you want to render different data input with the same color mapping for comparison.
 
 
 ##### `colorRange` (Array, optional)
@@ -111,15 +113,16 @@ Specified as an array of 6 colors [color1, color2, ... color6]. Each color is an
 
 * Default: `1`
 
-Cell size multiplier, clamped between 0 - 1. The final size of cell
-is calculated by `coverage * cellSize`. Note: coverage does not affect how points
-are binned. Coverage are linear based.
+Cell size multiplier, clamped between 0 - 1. The displayed size of cell is calculated by `coverage * cellSize`.
+Note: coverage does not affect how objects are binned.
 
 ##### `elevationDomain` (Array, optional)
 
-* Default: `[0, max(count)]`
+* Default: `[0, max(elevationWeight)]`
 
-Elevation scale input domain, default is set to the extent of point counts in each cell.
+Elevation scale input domain, default is set to between 0 and the max of aggregated weights in each cell.
+You can control how the elevations of cells are mapped to weights by passing in an arbitrary elevation domain.
+This is useful when you want to render different data input with the same elevation scale for comparison.
 
 ##### `elevationRange` (Array, optional)
 
@@ -131,15 +134,14 @@ Elevation scale output range
 
 * Default: `1`
 
-Cell elevation multiplier. The elevation of cell is calculated by
-`elevationScale * getElevation(d)`.
-`elevationScale` is a handy property to scale all cells without updating the data.
+Cell elevation multiplier.
+This is a handy property to scale the height of all cells without updating the data.
 
 ##### `extruded` (Boolean, optional)
 
 * Default: `true`
 
-Whether to enable cell elevation. Cell elevation scale by count of points in each cell. If set to false, all cell will be flat.
+Whether to enable cell elevation. If set to false, all cell will be flat.
 
 ##### `material` (Object, optional)
 
@@ -154,7 +156,7 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getColorWeight` and `colorAggregation` together determine the elevation value of each cell.
 
@@ -162,7 +164,7 @@ Defines the operation used to aggregate all data point weights to calculate a ce
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getElevationWeight` and `elevationAggregation` together determine the elevation value of each cell.
 
@@ -173,14 +175,14 @@ Defines the operation used to aggregate all data point weights to calculate a ce
 
 * Default: `object => object.position`
 
-Method called to retrieve the position of each point.
+Method called to retrieve the position of each object.
 
 
 ##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
 
-The weight of a data point used to calculate the color value for a cell.
+The weight of a data object used to calculate the color value for a cell.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -190,7 +192,7 @@ The weight of a data point used to calculate the color value for a cell.
 
 * Default: `1`
 
-The weight of a data point used to calculate the elevation value for a cell.
+The weight of a data object used to calculate the elevation value for a cell.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -208,7 +210,7 @@ Instead of `getColorValue`, `getColorWeight` and `colorAggregation` should be us
 
 ### Picking
 
-When picking mode is `hover`, only the elevation value, color value of selected cell are included in picking result. Array of all points that aggregated into that cell is not provided. For all other modes, picking results match with `CPUGridLayer`, for these cases data is aggregated on CPU to provide array of all points that aggregated to the cell.
+When picking mode is `hover`, only the elevation value, color value of selected cell are included in picking result. Array of all objects that aggregated into that cell is not provided. For all other modes, picking results match with `CPUGridLayer`, for these cases data is aggregated on CPU to provide array of all objects that aggregated to the cell.
 
 
 ## Source

--- a/docs/api-reference/aggregation-layers/grid-layer.md
+++ b/docs/api-reference/aggregation-layers/grid-layer.md
@@ -330,11 +330,10 @@ After data points are aggregated into cells, this accessor is called on each cel
 
 Arguments:
 
-- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
-  + `source` (Object) - the original data object
-  + `index` (Number) - the index of the object in `data`
-- `context` (Object) - contains the following fields:
-  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+- `objects` (Array) - a list of objects whose positions fall inside this cell.
+- `objectInfo` (Object) - contains the following fields:
+  + `indices` (Array) - the indices of `objects` in the original data
+  + `data` - the value of the `data` prop.
 
 
 ### Data Accessors
@@ -364,12 +363,10 @@ After data points are aggregated into cells, this accessor is called on each cel
 
 Arguments:
 
-- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
-  + `source` (Object) - the original data object
-  + `index` (Number) - the index of the object in `data`
-- `context` (Object) - contains the following fields:
-  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
-
+- `objects` (Array) - a list of objects whose positions fall inside this cell.
+- `objectInfo` (Object) - contains the following fields:
+  + `indices` (Array) - the indices of `objects` in the original data
+  + `data` - the value of the `data` prop.
 
 
 ##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")

--- a/docs/api-reference/aggregation-layers/grid-layer.md
+++ b/docs/api-reference/aggregation-layers/grid-layer.md
@@ -192,89 +192,36 @@ This is an object that contains material props for [lighting effect](/docs/api-r
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
 
-### Data Accessors
-
-##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
-
-* Default: `object => object.position`
-
-Method called to retrieve the position of each point.
-
-##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `points => points.length`
-
-`getColorValue` is the accessor function to get the value that cell color is based on.
-It takes an array of points inside each cell as arguments, returns a number. For example,
-You can pass in `getColorValue` to color the cells by avg/mean/max of a specific attributes of each point.
-By default `getColorValue` returns the length of the points array.
-
-Note: grid layer compares whether `getColorValue` has changed to recalculate the value for each bin that its color based on.
-You should pass in the function defined outside the render function so it doesn't create a new function on every rendering pass.
-
-```js
- class MyGridLayer {
-    getColorValue (points) {
-        return points.length;
-    }
-
-    renderLayers() {
-      return new GridLayer({
-        id: 'grid-layer',
-        getColorValue: this.getColorValue // instead of getColorValue: (points) => { return points.length; }
-        data,
-        cellSize: 500
-      });
-    }
- }
-```
-
-
-##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `point => 1`
-
-`getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getColorWeight` should be set to `point => point.SPACES`.
-By default `getColorWeight` returns `1`.
-
-Note: similar to `getColorValue`, grid layer compares whether `getColorWeight` has changed to recalculate the value for each bin that its color based on.
-
-
 ##### `colorAggregation` (String, optional)
 
 * Default: 'SUM'
 
-`colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+`getColorWeight` and `colorAggregation` together determine the elevation value of each cell. If the `getColorValue` prop is supplied, they will be ignored. Note that supplying `getColorValue` disables GPU aggregation.
 
 ###### Example1 : Using count of data elements that fall into a cell to encode the its color
 
 * Using `getColorValue`
 ```js
-function getCount(points) {
-  return points.length;
-}
+
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
-  getColorValue: getCount,
+  getColorValue: points => points.length,
   ...
 });
 ```
 
 * Using `getColorWeight` and `colorAggregation`
 ```js
-function getWeight(point) {
-  return 1;
-}
+
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
-  getColorWeight: getWeight,
+  getColorWeight: point => 1,
   colorAggregation: 'SUM'
   ...
 });
@@ -288,7 +235,7 @@ function getMean(points) {
   return points.reduce((sum, p) => sum += p.SPACES, 0) / points.length;
 }
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
   getColorValue: getMean,
@@ -298,14 +245,11 @@ const layer = new GridLayer({
 
 * Using `getColorWeight` and `colorAggregation`
 ```js
-function getWeight(point) {
-  return point.SPACES;
-}
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
-  getColorWeight: getWeight,
+  getColorWeight: point => point.SPACES,
   colorAggregation: 'SUM'
   ...
 });
@@ -314,64 +258,35 @@ const layer = new GridLayer({
 If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
 
-##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `points => points.length`
-
-Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that cell elevation is based on.
-It takes an array of points inside each cell as arguments, returns a number.
-By default `getElevationValue` returns the length of the points array.
-
-Note: grid layer compares whether `getElevationValue` has changed to recalculate the value for each cell for its elevation.
-You should pass in the function defined outside the render function so it doesn't create a new function on every rendering pass.
-
-
-##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `point => 1`
-
-`getElevationWeight` is the accessor function to get the weight of a point used to calculate the elevation value for a cell.
-It takes the data prop array element and returns the weight, for example, to use `SPACE` field, `getElevationWeight` should be set to `point => point.SPACES`.
-By default `getElevationWeight` returns `1`.
-
-Note: similar to `getElevationValue`, grid layer compares whether `getElevationWeight` has changed to recalculate the value for each bin that its color based on.
-
-
 ##### `elevationAggregation` (String, optional)
 
 * Default: 'SUM'
 
-`elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+`getElevationWeight` and `elevationAggregation` together determine the elevation value of each cell. If the `getElevationValue` prop is supplied, they will be ignored. Note that supplying `getElevationValue` disables GPU aggregation.
 
-
-###### Example1 : Using count of data elements that fall into a cell to encode its elevation
+###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
 
 * Using `getElevationValue`
+
 ```js
-function getCount(points) {
-  return points.length;
-}
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
-  getElevationValue: getCount,
+  getElevationValue: points => points.length
   ...
 });
 ```
 
 * Using `getElevationWeight` and `elevationAggregation`
 ```js
-function getWeight(point) {
-  return 1;
-}
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
-  getElevationWeight: getWeight,
+  getElevationWeight: point => 1,
   elevationAggregation: 'SUM'
   ...
 });
@@ -385,7 +300,7 @@ function getMax(points) {
   return points.reduce((max, p) => p.SPACES > max ? p.SPACES : max, -Infinity);
 }
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
   getElevationValue: getMax,
@@ -395,14 +310,11 @@ const layer = new GridLayer({
 
 * Using `getElevationWeight` and `elevationAggregation`
 ```js
-function getWeight(point) {
-  return point.SPACES;
-}
 ...
-const layer = new GridLayer({
+const layer = new CPUGridLayer({
   id: 'my-grid-layer',
   ...
-  getElevationWeight: getWeight,
+  getElevationWeight: point => point.SPACES,
   elevationAggregation: 'MAX'
   ...
 });
@@ -410,19 +322,80 @@ const layer = new GridLayer({
 
 If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
 
+##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `null`
+
+After data points are aggregated into cells, this accessor is called on each cell to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props. Note that supplying this prop disables GPU aggregation.
+
+Arguments:
+
+- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
+  + `source` (Object) - the original data object
+  + `index` (Number) - the index of the object in `data`
+- `context` (Object) - contains the following fields:
+  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+
+
+### Data Accessors
+
+##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
+
+* Default: `object => object.position`
+
+Method called to retrieve the position of each point.
+
+
+##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `1`
+
+The weight of a data point used to calculate the color value for a cell.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
+
+##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `null`
+
+After data points are aggregated into cells, this accessor is called on each cell to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props. Note that supplying this prop disables GPU aggregation.
+
+Arguments:
+
+- `points` (Array) - a list of objects whose positions fall inside this cell. Each element contains the following fields:
+  + `source` (Object) - the original data object
+  + `index` (Number) - the index of the object in `data`
+- `context` (Object) - contains the following fields:
+  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+
+
+
+##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `1`
+
+The weight of a data point used to calculate the elevation value for a cell.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
+
+### Callbacks
+
 ##### `onSetColorDomain` (Function, optional)
 
-* Default: `() => {}`
+* Default: `([min, max]) => {}`
 
-This callback will be called when bin color domain has been calculated.
-Note that this is only fired when using CPU Aggregation (`gpuAggregation: false`).
+This callback will be called when cell color domain has been calculated.
 
 ##### `onSetElevationDomain` (Function, optional)
 
-* Default: `() => {}`
+* Default: `([min, max]) => {}`
 
-This callback will be called when bin elevation domain has been calculated.
-Note that this is only fired when using CPU Aggregation (`gpuAggregation: false`).
+This callback will be called when cell elevation domain has been calculated.
+
 
 ## GPU Aggregation
 

--- a/docs/api-reference/aggregation-layers/grid-layer.md
+++ b/docs/api-reference/aggregation-layers/grid-layer.md
@@ -8,9 +8,9 @@ import {GridLayerDemo} from 'website-components/doc-demos/aggregation-layers';
 
 # GridLayer
 
-The `GridLayer` renders a grid heatmap based on an array of points.
-It takes the constant cell size, aggregates input points into cells. The color
-and height of the cell is scaled by number of points it contains.
+The `GridLayer` renders a grid heatmap based on an array of inputs.
+It takes the constant cell size and aggregates input objects into cells. The color
+and height of a cell are determined based on the objects it contains.
 
 This layer renders either a [GPUGridLayer](/docs/api-reference/aggregation-layers/gpu-grid-layer.md) or a [CPUGridLayer](/docs/api-reference/aggregation-layers/cpu-grid-layer.md), depending on its props and whether GPU aggregation is supported. For more details check the `GPU Aggregation` section below.
 
@@ -91,9 +91,11 @@ Size of each cell in meters
 
 ##### `colorDomain` (Array, optional)
 
-* Default: `[min(count), max(count)]`
+* Default: `[min(colorWeight), max(colorWeight)]`
 
-Color scale domain, default is set to the range of point counts in each cell.
+Color scale domain, default is set to the extent of aggregated weights in each cell.
+You can control how the colors of cells are mapped to weights by passing in an arbitrary color domain.
+This is useful when you want to render different data input with the same color mapping for comparison.
 
 ##### `colorRange` (Array, optional)
 
@@ -106,15 +108,16 @@ Specified as an array of 6 colors [color1, color2, ... color6]. Each color is an
 
 * Default: `1`
 
-Cell size multiplier, clamped between 0 - 1. The final size of cell
-is calculated by `coverage * cellSize`. Note: coverage does not affect how points
-are binned. Coverage are linear based.
+Cell size multiplier, clamped between 0 - 1. The displayed size of cell is calculated by `coverage * cellSize`.
+Note: coverage does not affect how objects are binned.
 
 ##### `elevationDomain` (Array, optional)
 
-* Default: `[0, max(count)]`
+* Default: `[0, max(elevationWeight)]`
 
-Elevation scale input domain, default is set to the extent of point counts in each cell.
+Elevation scale input domain, default is set to between 0 and the max of aggregated weights in each cell.
+You can control how the elevations of cells are mapped to weights by passing in an arbitrary elevation domain.
+This is useful when you want to render different data input with the same elevation scale for comparison.
 
 ##### `elevationRange` (Array, optional)
 
@@ -126,15 +129,14 @@ Elevation scale output range
 
 * Default: `1`
 
-Cell elevation multiplier. The elevation of cell is calculated by
-`elevationScale * getElevation(d)`.
-`elevationScale` is a handy property to scale all cells without updating the data.
+Cell elevation multiplier.
+This is a handy property to scale all cells without updating the data.
 
 ##### `extruded` (Boolean, optional)
 
 * Default: `true`
 
-Whether to enable cell elevation. Cell elevation scale by count of points in each cell. If set to false, all cell will be flat.
+Whether to enable cell elevation.If set to false, all cell will be flat.
 
 ##### `upperPercentile` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
@@ -180,7 +182,7 @@ Whether the aggregation should be performed in high-precision 64-bit mode. Note 
 
 * Default: `false`
 
-When set to true, aggregation is performed on GPU, provided other conditions are met, for more details check the `GPU Aggregation` section below. GPU aggregation can be a lot faster than CPU depending upon the number of points and number of cells.
+When set to true, aggregation is performed on GPU, provided other conditions are met, for more details check the `GPU Aggregation` section below. GPU aggregation can be a lot faster than CPU depending upon the number of objects and number of cells.
 
 **Note:** GPU Aggregation is faster only when using large data sets. For smaller data sets GPU Aggregation could be potentially slower than CPU Aggregation.
 
@@ -196,11 +198,11 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getColorWeight` and `colorAggregation` together determine the elevation value of each cell. If the `getColorValue` prop is supplied, they will be ignored. Note that supplying `getColorValue` disables GPU aggregation.
 
-###### Example1 : Using count of data elements that fall into a cell to encode the its color
+###### Example 1 : Using count of data elements that fall into a cell to encode the its color
 
 * Using `getColorValue`
 ```js
@@ -227,7 +229,7 @@ const layer = new CPUGridLayer({
 });
 ```
 
-###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
+###### Example 2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
 
 * Using `getColorValue`
 ```js
@@ -262,11 +264,11 @@ If your use case requires aggregating using an operation that is not one of 'SUM
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getElevationWeight` and `elevationAggregation` together determine the elevation value of each cell. If the `getElevationValue` prop is supplied, they will be ignored. Note that supplying `getElevationValue` disables GPU aggregation.
 
-###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
+###### Example 1 : Using count of data elements that fall into a cell to encode the its elevation
 
 * Using `getElevationValue`
 
@@ -292,7 +294,7 @@ const layer = new CPUGridLayer({
 });
 ```
 
-###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
+###### Example 2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
 
 * Using `getElevationValue`
 ```js
@@ -326,7 +328,7 @@ If your use case requires aggregating using an operation that is not one of 'SUM
 
 * Default: `null`
 
-After data points are aggregated into cells, this accessor is called on each cell to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props. Note that supplying this prop disables GPU aggregation.
+After data objects are aggregated into cells, this accessor is called on each cell to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props. Note that supplying this prop disables GPU aggregation.
 
 Arguments:
 
@@ -342,14 +344,14 @@ Arguments:
 
 * Default: `object => object.position`
 
-Method called to retrieve the position of each point.
+Method called to retrieve the position of each object.
 
 
 ##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
 
-The weight of a data point used to calculate the color value for a cell.
+The weight of a data object used to calculate the color value for a cell.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -359,7 +361,7 @@ The weight of a data point used to calculate the color value for a cell.
 
 * Default: `null`
 
-After data points are aggregated into cells, this accessor is called on each cell to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props. Note that supplying this prop disables GPU aggregation.
+After data objects are aggregated into cells, this accessor is called on each cell to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props. Note that supplying this prop disables GPU aggregation.
 
 Arguments:
 
@@ -373,7 +375,7 @@ Arguments:
 
 * Default: `1`
 
-The weight of a data point used to calculate the elevation value for a cell.
+The weight of a data object used to calculate the elevation value for a cell.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -398,9 +400,9 @@ This callback will be called when cell elevation domain has been calculated.
 
 ### Performance Metrics
 
-The following table compares the performance between CPU and GPU aggregations using random data points:
+The following table compares the performance between CPU and GPU aggregations using random data:
 
-| #points | CPU #iterations/sec | GPU #iterations/sec | Notes |
+| #objects | CPU #iterations/sec | GPU #iterations/sec | Notes |
 | ---- | --- | --- | --- |
 | 25K | 535 | 359 | GPU is <b style="color:red">33%</b> slower |
 | 100K | 119 | 437 | GPU is <b style="color:green">267%</b> faster |

--- a/docs/api-reference/aggregation-layers/hexagon-layer.md
+++ b/docs/api-reference/aggregation-layers/hexagon-layer.md
@@ -145,7 +145,7 @@ Elevation scale output range
 * Default: `1`
 
 Hexagon elevation multiplier. The actual elevation is calculated by
-  `elevationScale * getElevation(d)`. `elevationScale` is a handy property to scale
+  `elevationScale * getElevationValue(d)`. `elevationScale` is a handy property to scale
 all hexagons without updating the data.
 
 ##### `extruded` (Boolean, optional)
@@ -189,54 +189,16 @@ smaller than the elevationLowerPercentile will be hidden.
 This is an object that contains material props for [lighting effect](/docs/api-reference/core/lighting-effect.md) applied on extruded polygons.
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
-### Data Accessors
-
-##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
-
-* Default: `object => object.position`
-
-Method called to retrieve the position of each point.
-
-
-##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `points => points.length`
-
-`getColorValue` is the accessor function to get the value that bin color is based on.
-It takes an array of points inside each bin as arguments, returns a number. For example,
-You can pass in `getColorValue` to color the bins by avg/mean/max of a specific attributes of each point.
-By default `getColorValue` returns the length of the points array.
-
-
-```js
- class MyHexagonLayer {
-    renderLayers() {
-      return new HexagonLayer({
-        id: 'hexagon-layer',
-        getColorValue: points => points.length
-        data,
-        radius: 500
-      });
-    }
- }
-```
-
-##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `point => 1`
-
-`getColorWeight` is the accessor function to get the weight of a point used to calcuate the color value for a cell.
-
 
 ##### `colorAggregation` (String, optional)
 
 * Default: 'SUM'
 
-`colorAggregation` defines, operation used to aggregate all data point weights to calculate a cell's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data point weights to calculate a bin's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getColorWeight` and `colorAggregation` together define how color value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+`getColorWeight` and `colorAggregation` together determine the elevation value of each bin. If the `getColorValue` prop is supplied, they will be ignored.
 
-###### Example1 : Using count of data elements that fall into a cell to encode the its color
+###### Example1 : Using count of data elements that fall into a bin to encode the its color
 
 * Using `getColorValue`
 ```js
@@ -261,7 +223,7 @@ const layer = new HexagonLayer({
 });
 ```
 
-###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the cell
+###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the bin
 
 * Using `getColorValue`
 ```js
@@ -289,35 +251,18 @@ const layer = new HexagonLayer({
 });
 ```
 
-If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
-
-
-##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `points => points.length`
-
-Similar to `getColorValue`, `getElevationValue` is the accessor function to get the value that bin elevation is based on.
-It takes an array of points inside each bin as arguments, returns a number.
-By default `getElevationValue` returns the length of the points array.
-
-
-##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
-
-* Default: `point => 1`
-
-`getElevationWeight` is the accessor function to get the weight of a point used to calcuate the elevation value for a cell.
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getColorValue` should be used to define such custom aggregation function.
 
 
 ##### `elevationAggregation` (String, optional)
 
 * Default: 'SUM'
 
-`elevationAggregation` defines, operation used to aggregate all data point weights to calculate a cell's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data point weights to calculate a bin's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
-Note: `getElevationWeight` and `elevationAggregation` together define how elevation value of cell is determined, same can be done by setting `getColorValue` prop. But to enable gpu aggregation, former props must be provided instead of later.
+`getElevationWeight` and `elevationAggregation` together determine the elevation value of each bin. If the `getElevationValue` prop is supplied, they will be ignored.
 
-
-###### Example1 : Using count of data elements that fall into a cell to encode the its elevation
+###### Example1 : Using count of data elements that fall into a bin to encode the its elevation
 
 * Using `getElevationValue`
 
@@ -343,7 +288,7 @@ const layer = new HexagonLayer({
 });
 ```
 
-###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the cell
+###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the bin
 
 * Using `getElevationValue`
 ```js
@@ -371,19 +316,82 @@ const layer = new HexagonLayer({
 });
 ```
 
-If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function. In those cases GPU aggregation is not supported.
+If your use case requires aggregating using an operation that is not one of 'SUM', 'MEAN', 'MAX' and 'MIN', `getElevationValue` should be used to define such custom aggregation function.
+
+
+### Data Accessors
+
+##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
+
+* Default: `object => object.position`
+
+Method called to retrieve the position of each point.
+
+
+##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `1`
+
+The weight of a data point used to calculate the color value for a bin.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
+
+##### `getColorValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `null`
+
+After data points are aggregated into bins, this accessor is called on each bin to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props.
+
+Arguments:
+
+- `points` (Array) - a list of objects whose positions fall inside this bin. Each element contains the following fields:
+  + `source` (Object) - the original data object
+  + `index` (Number) - the index of the object in `data`
+- `context` (Object) - contains the following fields:
+  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+
+
+##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `1`
+
+The weight of a data point used to calculate the elevation value for a bin.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
+
+##### `getElevationValue` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `null`
+
+After data points are aggregated into bins, this accessor is called on each bin to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props.
+
+Arguments:
+
+- `points` (Array) - a list of objects whose positions fall inside this bin. Each element contains the following fields:
+  + `source` (Object) - the original data object
+  + `index` (Number) - the index of the object in `data`
+- `context` (Object) - contains the following fields:
+  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+
+
+### Callbacks
 
 ##### `onSetColorDomain` (Function, optional)
 
-* Default: `() => {}`
+* Default: `([min, max]) => {}`
 
 This callback will be called when bin color domain has been calculated.
 
 ##### `onSetElevationDomain` (Function, optional)
 
-* Default: `() => {}`
+* Default: `([min, max]) => {}`
 
 This callback will be called when bin elevation domain has been calculated.
+
 
 
 ## Sub Layers

--- a/docs/api-reference/aggregation-layers/hexagon-layer.md
+++ b/docs/api-reference/aggregation-layers/hexagon-layer.md
@@ -346,11 +346,10 @@ After data points are aggregated into bins, this accessor is called on each bin 
 
 Arguments:
 
-- `points` (Array) - a list of objects whose positions fall inside this bin. Each element contains the following fields:
-  + `source` (Object) - the original data object
-  + `index` (Number) - the index of the object in `data`
-- `context` (Object) - contains the following fields:
-  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+- `objects` (Array) - a list of objects whose positions fall inside this cell.
+- `objectInfo` (Object) - contains the following fields:
+  + `indices` (Array) - the indices of `objects` in the original data
+  + `data` - the value of the `data` prop.
 
 
 ##### `getElevationWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
@@ -371,11 +370,10 @@ After data points are aggregated into bins, this accessor is called on each bin 
 
 Arguments:
 
-- `points` (Array) - a list of objects whose positions fall inside this bin. Each element contains the following fields:
-  + `source` (Object) - the original data object
-  + `index` (Number) - the index of the object in `data`
-- `context` (Object) - contains the following fields:
-  + `data` - the value of the `data` prop. This is useful when data is non-iterable, such as [binary blobs](/docs/developer-guide/performance.md#supply-binary-blobs-to-the-data-prop).
+- `objects` (Array) - a list of objects whose positions fall inside this cell.
+- `objectInfo` (Object) - contains the following fields:
+  + `indices` (Array) - the indices of `objects` in the original data
+  + `data` - the value of the `data` prop.
 
 
 ### Callbacks

--- a/docs/api-reference/aggregation-layers/hexagon-layer.md
+++ b/docs/api-reference/aggregation-layers/hexagon-layer.md
@@ -8,9 +8,9 @@ import {HexagonLayerDemo} from 'website-components/doc-demos/aggregation-layers'
 
 # HexagonLayer
 
-The Hexagon Layer renders a hexagon heatmap based on an array of points.
-It takes the radius of hexagon bin, projects points into hexagon bins. The color
-and height of the hexagon is scaled by number of points it contains.
+The Hexagon Layer renders a hexagon heatmap based on an array of inputs.
+It takes the radius of hexagon bin and aggregates input objects into hexagon bins. The color
+and height of a hexagon are determined based on the objects it contains.
 
 HexagonLayer is a [CompositeLayer](/docs/api-reference/core/composite-layer.md) and at the moment only works with `COORDINATE_SYSTEM.LNGLAT`.
 
@@ -102,12 +102,13 @@ see `modules/layers/src/point-density-hexagon-layer/hexagon-aggregator`
 
 ##### `colorDomain` (Array, optional)
 
-* Default: `[min(count), max(count)]`
+* Default: `[min(colorWeight), max(colorWeight)]`
 
 Color scale input domain. The color scale maps continues numeric domain into
 discrete color range. If not provided, the layer will set `colorDomain` to the
-range of counts in each hexagon. You can control how the color of hexagons mapped
-to number of counts by passing in an arbitrary color domain. This property is extremely handy when you want to render different data input with the same color mapping for comparison.
+extent of aggregated weights in each hexagon.
+You can control how the colors of hexagons are mapped to weights by passing in an arbitrary color domain.
+This is useful when you want to render different data input with the same color mapping for comparison.
 
 ##### `colorRange` (Array, optional)
 
@@ -120,18 +121,18 @@ Specified as an array of 6 colors [color1, color2, ... color6]. Each color is an
 
 * Default: `1`
 
-Hexagon radius multiplier, clamped between 0 - 1. The final radius of hexagon
-is calculated by `coverage * radius`. Note: coverage does not affect how points
-are binned. The radius of the bin is determined only by the `radius` property.
+Hexagon radius multiplier, clamped between 0 - 1. The displayed radius of hexagon is calculated by `coverage * radius`.
+Note: coverage does not affect how objects are binned.
 
 ##### `elevationDomain` (Array, optional)
 
-* Default: `[0, max(count)]`
+* Default: `[0, max(elevationWeight)]`
 
 Elevation scale input domain. The elevation scale is a linear scale that
 maps number of counts to elevation. By default it is set to between
-0 and max of point counts in each hexagon.
-This property is extremely handy when you want to render different data input
+0 and the max of aggregated weights in each hexagon.
+You can control how the elevations of hexagons are mapped to weights by passing in an arbitrary elevation domain.
+This property is useful when you want to render different data input
 with the same elevation scale for comparison.
 
 ##### `elevationRange` (Array, optional)
@@ -152,7 +153,7 @@ all hexagons without updating the data.
 
 * Default: `false`
 
-Whether to enable cell elevation. Cell elevation scale by count of points in each cell. If set to false, all cells will be flat.
+Whether to enable cell elevation. If set to false, all cells will be flat.
 
 ##### `upperPercentile` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
@@ -194,11 +195,11 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a bin's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a bin's color value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getColorWeight` and `colorAggregation` together determine the elevation value of each bin. If the `getColorValue` prop is supplied, they will be ignored.
 
-###### Example1 : Using count of data elements that fall into a bin to encode the its color
+###### Example 1 : Using count of data elements that fall into a bin to encode the its color
 
 * Using `getColorValue`
 ```js
@@ -223,7 +224,7 @@ const layer = new HexagonLayer({
 });
 ```
 
-###### Example2 : Using mean value of 'SPACES' field of data elements to encode the color of the bin
+###### Example 2 : Using mean value of 'SPACES' field of data elements to encode the color of the bin
 
 * Using `getColorValue`
 ```js
@@ -258,11 +259,11 @@ If your use case requires aggregating using an operation that is not one of 'SUM
 
 * Default: 'SUM'
 
-Defines the operation used to aggregate all data point weights to calculate a bin's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
+Defines the operation used to aggregate all data object weights to calculate a bin's elevation value. Valid values are 'SUM', 'MEAN', 'MIN' and 'MAX'. 'SUM' is used when an invalid value is provided.
 
 `getElevationWeight` and `elevationAggregation` together determine the elevation value of each bin. If the `getElevationValue` prop is supplied, they will be ignored.
 
-###### Example1 : Using count of data elements that fall into a bin to encode the its elevation
+###### Example 1 : Using count of data elements that fall into a bin to encode the its elevation
 
 * Using `getElevationValue`
 
@@ -288,7 +289,7 @@ const layer = new HexagonLayer({
 });
 ```
 
-###### Example2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the bin
+###### Example 2 : Using maximum value of 'SPACES' field of data elements to encode the elevation of the bin
 
 * Using `getElevationValue`
 ```js
@@ -325,14 +326,14 @@ If your use case requires aggregating using an operation that is not one of 'SUM
 
 * Default: `object => object.position`
 
-Method called to retrieve the position of each point.
+Method called to retrieve the position of each object.
 
 
 ##### `getColorWeight` (Function, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
 
-The weight of a data point used to calculate the color value for a bin.
+The weight of a data object used to calculate the color value for a bin.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -342,7 +343,7 @@ The weight of a data point used to calculate the color value for a bin.
 
 * Default: `null`
 
-After data points are aggregated into bins, this accessor is called on each bin to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props.
+After data objects are aggregated into bins, this accessor is called on each bin to get the value that its color is based on. If supplied, this will override the effect of `getColorWeight` and `colorAggregation` props.
 
 Arguments:
 
@@ -356,7 +357,7 @@ Arguments:
 
 * Default: `1`
 
-The weight of a data point used to calculate the elevation value for a bin.
+The weight of a data object used to calculate the elevation value for a bin.
 
 * If a number is provided, it is used as the weight for all objects.
 * If a function is provided, it is called on each object to retrieve its weight.
@@ -366,7 +367,7 @@ The weight of a data point used to calculate the elevation value for a bin.
 
 * Default: `null`
 
-After data points are aggregated into bins, this accessor is called on each bin to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props.
+After data objects are aggregated into bins, this accessor is called on each bin to get the value that its elevation is based on. If supplied, this will override the effect of `getElevationWeight` and `elevationAggregation` props.
 
 Arguments:
 

--- a/docs/api-reference/aggregation-layers/screen-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/screen-grid-layer.md
@@ -158,9 +158,13 @@ Method called to retrieve the position of each object.
 
 ##### `getWeight` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)
 
-* Default: `object => 1`
+* Default: `1`
 
-Method called to retrieve the weight of each object.
+The weight of each object.
+
+* If a number is provided, it is used as the weight for all objects.
+* If a function is provided, it is called on each object to retrieve its weight.
+
 
 ## Source
 

--- a/modules/aggregation-layers/src/aggregation-layer.js
+++ b/modules/aggregation-layers/src/aggregation-layer.js
@@ -90,6 +90,9 @@ export default class AggregationLayer extends CompositeLayer {
     const {ignoreProps} = this.state;
     const {props: dataProps, accessors = []} = dimension;
     const {updateTriggersChanged} = changeFlags;
+    if (changeFlags.dataChanged) {
+      return true;
+    }
     if (updateTriggersChanged) {
       if (updateTriggersChanged.all) {
         return true;

--- a/modules/aggregation-layers/src/contour-layer/contour-layer.js
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.js
@@ -36,7 +36,7 @@ const defaultProps = {
   // grid aggregation
   cellSize: {type: 'number', min: 1, max: 1000, value: 1000},
   getPosition: {type: 'accessor', value: x => x.position},
-  getWeight: {type: 'accessor', value: x => 1},
+  getWeight: {type: 'accessor', value: 1},
   gpuAggregation: true,
   aggregation: 'SUM',
 

--- a/modules/aggregation-layers/src/contour-layer/contour-layer.js
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.js
@@ -220,13 +220,13 @@ export default class ContourLayer extends GridAggregationLayer {
   // Private (Aggregation)
 
   _updateAccessors(opts) {
-    const {getWeight, aggregation} = opts.props;
+    const {getWeight, aggregation, data} = opts.props;
     const {count} = this.state.weights;
     if (count) {
       count.getWeight = getWeight;
       count.operation = AGGREGATION_OPERATION[aggregation];
     }
-    this.setState({getValue: getValueFunc(aggregation, getWeight)});
+    this.setState({getValue: getValueFunc(aggregation, getWeight, {data})});
   }
 
   _resetResults() {

--- a/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.js
+++ b/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.js
@@ -32,7 +32,7 @@ const defaultProps = {
   colorDomain: null,
   colorRange: defaultColorRange,
   getColorValue: {type: 'accessor', value: null}, // default value is calculated from `getColorWeight` and `colorAggregation`
-  getColorWeight: {type: 'accessor', value: x => 1},
+  getColorWeight: {type: 'accessor', value: 1},
   colorAggregation: 'SUM',
   lowerPercentile: {type: 'number', min: 0, max: 100, value: 0},
   upperPercentile: {type: 'number', min: 0, max: 100, value: 100},
@@ -43,7 +43,7 @@ const defaultProps = {
   elevationDomain: null,
   elevationRange: [0, 1000],
   getElevationValue: {type: 'accessor', value: null}, // default value is calculated from `getElevationWeight` and `elevationAggregation`
-  getElevationWeight: {type: 'accessor', value: x => 1},
+  getElevationWeight: {type: 'accessor', value: 1},
   elevationAggregation: 'SUM',
   elevationLowerPercentile: {type: 'number', min: 0, max: 100, value: 0},
   elevationUpperPercentile: {type: 'number', min: 0, max: 100, value: 100},

--- a/modules/aggregation-layers/src/cpu-grid-layer/grid-aggregator.js
+++ b/modules/aggregation-layers/src/cpu-grid-layer/grid-aggregator.js
@@ -99,7 +99,10 @@ function pointsToGridHashing(props, aggregationParams) {
 
         gridHash[key] = gridHash[key] || {count: 0, points: [], lonIdx: xIndex, latIdx: yIndex};
         gridHash[key].count += 1;
-        gridHash[key].points.push(pt);
+        gridHash[key].points.push({
+          source: pt,
+          index: objectInfo.index
+        });
       }
     }
   }

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.js
@@ -34,13 +34,13 @@ const defaultProps = {
   // color
   colorDomain: null,
   colorRange: defaultColorRange,
-  getColorWeight: {type: 'accessor', value: x => 1},
+  getColorWeight: {type: 'accessor', value: 1},
   colorAggregation: 'SUM',
 
   // elevation
   elevationDomain: null,
   elevationRange: [0, 1000],
-  getElevationWeight: {type: 'accessor', value: x => 1},
+  getElevationWeight: {type: 'accessor', value: 1},
   elevationAggregation: 'SUM',
   elevationScale: {type: 'number', min: 0, value: 1},
 

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-aggregator.js
@@ -48,14 +48,11 @@ export function pointToHexbin(props, aggregationParams) {
     const position = [positions[posIndex], positions[posIndex + 1]];
     const arrayIsFinite = Number.isFinite(position[0]) && Number.isFinite(position[1]);
     if (arrayIsFinite) {
-      screenPoints.push(
-        Object.assign(
-          {
-            screenCoord: viewport.projectFlat(position)
-          },
-          object
-        )
-      );
+      screenPoints.push({
+        screenCoord: viewport.projectFlat(position),
+        source: object,
+        index: objectInfo.index
+      });
     } else {
       log.warn('HexagonLayer: invalid position')();
     }

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
@@ -34,7 +34,7 @@ const defaultProps = {
   colorDomain: null,
   colorRange: defaultColorRange,
   getColorValue: {type: 'accessor', value: null}, // default value is calcuated from `getColorWeight` and `colorAggregation`
-  getColorWeight: {type: 'accessor', value: x => 1},
+  getColorWeight: {type: 'accessor', value: 1},
   colorAggregation: 'SUM',
   lowerPercentile: {type: 'number', value: 0, min: 0, max: 100},
   upperPercentile: {type: 'number', value: 100, min: 0, max: 100},
@@ -45,7 +45,7 @@ const defaultProps = {
   elevationDomain: null,
   elevationRange: [0, 1000],
   getElevationValue: {type: 'accessor', value: null}, // default value is calcuated from `getElevationWeight` and `elevationAggregation`
-  getElevationWeight: {type: 'accessor', value: x => 1},
+  getElevationWeight: {type: 'accessor', value: 1},
   elevationAggregation: 'SUM',
   elevationLowerPercentile: {type: 'number', value: 0, min: 0, max: 100},
   elevationUpperPercentile: {type: 'number', value: 100, min: 0, max: 100},

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
@@ -230,13 +230,13 @@ export default class ScreenGridLayer extends GridAggregationLayer {
   // Private
 
   _updateAccessors(opts) {
-    const {getWeight, aggregation} = opts.props;
+    const {getWeight, aggregation, data} = opts.props;
     const {count} = this.state.weights;
     if (count) {
       count.getWeight = getWeight;
       count.operation = AGGREGATION_OPERATION[aggregation];
     }
-    this.setState({getValue: getValueFunc(aggregation, getWeight)});
+    this.setState({getValue: getValueFunc(aggregation, getWeight, {data})});
   }
 
   _resetResults() {

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.js
@@ -28,7 +28,7 @@ import {getFloatTexture} from '../utils/resource-utils.js';
 
 const defaultProps = Object.assign({}, ScreenGridCellLayer.defaultProps, {
   getPosition: {type: 'accessor', value: d => d.position},
-  getWeight: {type: 'accessor', value: d => 1},
+  getWeight: {type: 'accessor', value: 1},
 
   gpuAggregation: true,
   aggregation: 'SUM'

--- a/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
+++ b/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
@@ -37,66 +37,73 @@ function minReducer(accu, cur) {
   return cur < accu ? cur : accu;
 }
 
-function wrapAccessor(accessor, context) {
-  return pt => {
-    context.index = pt.index;
-    return accessor(pt.source, context);
-  };
-}
-
-export function getMean(pts, accessor, context) {
+export function getMean(pts, accessor) {
   if (Number.isFinite(accessor)) {
     return pts.length ? accessor : null;
   }
-  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(sumReducer, 0) / filtered.length : null;
 }
 
-export function getSum(pts, accessor, context) {
+export function getSum(pts, accessor) {
   if (Number.isFinite(accessor)) {
     return pts.length ? pts.length * accessor : null;
   }
-  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(sumReducer, 0) : null;
 }
 
-export function getMax(pts, accessor, context) {
+export function getMax(pts, accessor) {
   if (Number.isFinite(accessor)) {
     return pts.length ? accessor : null;
   }
-  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(maxReducer, -Infinity) : null;
 }
 
-export function getMin(pts, accessor, context) {
+export function getMin(pts, accessor) {
   if (Number.isFinite(accessor)) {
     return pts.length ? accessor : null;
   }
-  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(minReducer, Infinity) : null;
 }
 
 // Function to convert from aggregation/accessor props (like colorAggregation and getColorWeight) to getValue prop (like getColorValue)
-export function getValueFunc(aggregation, accessor) {
+export function getValueFunc(aggregation, accessor, context) {
   const op = AGGREGATION_OPERATION[aggregation] || AGGREGATION_OPERATION.SUM;
+  accessor = wrapAccessor(accessor, context);
   switch (op) {
     case AGGREGATION_OPERATION.MIN:
-      return (pts, context) => getMin(pts, accessor, context);
+      return pts => getMin(pts, accessor);
     case AGGREGATION_OPERATION.SUM:
-      return (pts, context) => getSum(pts, accessor, context);
+      return pts => getSum(pts, accessor);
     case AGGREGATION_OPERATION.MEAN:
-      return (pts, context) => getMean(pts, accessor, context);
+      return pts => getMean(pts, accessor);
     case AGGREGATION_OPERATION.MAX:
-      return (pts, context) => getMax(pts, accessor, context);
+      return pts => getMax(pts, accessor);
     default:
       return null;
   }
+}
+
+function wrapAccessor(accessor, context = {}) {
+  if (Number.isFinite(accessor)) {
+    return accessor;
+  }
+  return pt => {
+    context.index = pt.index;
+    return accessor(pt.source, context);
+  };
+}
+
+export function wrapGetValueFunc(getValue, context = {}) {
+  return pts => {
+    context.indices = pts.map(pt => pt.index);
+    return getValue(pts.map(pt => pt.source), context);
+  };
 }

--- a/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
+++ b/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
@@ -39,9 +39,8 @@ function minReducer(accu, cur) {
 
 function wrapAccessor(accessor, context) {
   return pt => {
-    const d = pt && pt.source;
-    context.index = pt && pt.index;
-    return accessor(d, context);
+    context.index = pt.index;
+    return accessor(pt.source, context);
   };
 }
 

--- a/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
+++ b/modules/aggregation-layers/src/utils/aggregation-operation-utils.js
@@ -37,25 +37,49 @@ function minReducer(accu, cur) {
   return cur < accu ? cur : accu;
 }
 
-export function getMean(pts, accessor) {
+function wrapAccessor(accessor, context) {
+  return pt => {
+    const d = pt && pt.source;
+    context.index = pt && pt.index;
+    return accessor(d, context);
+  };
+}
+
+export function getMean(pts, accessor, context) {
+  if (Number.isFinite(accessor)) {
+    return pts.length ? accessor : null;
+  }
+  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(sumReducer, 0) / filtered.length : null;
 }
 
-export function getSum(pts, accessor) {
+export function getSum(pts, accessor, context) {
+  if (Number.isFinite(accessor)) {
+    return pts.length ? pts.length * accessor : null;
+  }
+  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(sumReducer, 0) : null;
 }
 
-export function getMax(pts, accessor) {
+export function getMax(pts, accessor, context) {
+  if (Number.isFinite(accessor)) {
+    return pts.length ? accessor : null;
+  }
+  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(maxReducer, -Infinity) : null;
 }
 
-export function getMin(pts, accessor) {
+export function getMin(pts, accessor, context) {
+  if (Number.isFinite(accessor)) {
+    return pts.length ? accessor : null;
+  }
+  accessor = wrapAccessor(accessor, context);
   const filtered = pts.map(accessor).filter(Number.isFinite);
 
   return filtered.length ? filtered.reduce(minReducer, Infinity) : null;
@@ -66,13 +90,13 @@ export function getValueFunc(aggregation, accessor) {
   const op = AGGREGATION_OPERATION[aggregation] || AGGREGATION_OPERATION.SUM;
   switch (op) {
     case AGGREGATION_OPERATION.MIN:
-      return pts => getMin(pts, accessor);
+      return (pts, context) => getMin(pts, accessor, context);
     case AGGREGATION_OPERATION.SUM:
-      return pts => getSum(pts, accessor);
+      return (pts, context) => getSum(pts, accessor, context);
     case AGGREGATION_OPERATION.MEAN:
-      return pts => getMean(pts, accessor);
+      return (pts, context) => getMean(pts, accessor, context);
     case AGGREGATION_OPERATION.MAX:
-      return pts => getMax(pts, accessor);
+      return (pts, context) => getMax(pts, accessor, context);
     default:
       return null;
   }

--- a/modules/aggregation-layers/src/utils/bin-sorter.js
+++ b/modules/aggregation-layers/src/utils/bin-sorter.js
@@ -62,7 +62,8 @@ export default class BinSorter {
       getValue = defaultGetValue,
       getPoints = defaultGetPoints,
       getIndex = defaultGetIndex,
-      filterData
+      filterData,
+      context = {}
     } = props;
 
     const hasFilter = typeof filterData === 'function';
@@ -79,7 +80,7 @@ export default class BinSorter {
 
       bin.filteredPoints = hasFilter ? filteredPoints : null;
 
-      const value = filteredPoints.length ? getValue(filteredPoints) : null;
+      const value = filteredPoints.length ? getValue(filteredPoints, context) : null;
 
       if (value !== null && value !== undefined) {
         // filter bins if value is null or undefined

--- a/modules/aggregation-layers/src/utils/bin-sorter.js
+++ b/modules/aggregation-layers/src/utils/bin-sorter.js
@@ -62,8 +62,7 @@ export default class BinSorter {
       getValue = defaultGetValue,
       getPoints = defaultGetPoints,
       getIndex = defaultGetIndex,
-      filterData,
-      context = {}
+      filterData
     } = props;
 
     const hasFilter = typeof filterData === 'function';
@@ -80,7 +79,7 @@ export default class BinSorter {
 
       bin.filteredPoints = hasFilter ? filteredPoints : null;
 
-      const value = filteredPoints.length ? getValue(filteredPoints, context) : null;
+      const value = filteredPoints.length ? getValue(filteredPoints) : null;
 
       if (value !== null && value !== undefined) {
         // filter bins if value is null or undefined

--- a/modules/aggregation-layers/src/utils/cpu-aggregator.js
+++ b/modules/aggregation-layers/src/utils/cpu-aggregator.js
@@ -380,7 +380,8 @@ export default class CPUAggregator {
 
     const sortedBins = new BinSorter(this.state.layerData.data || [], {
       getValue,
-      filterData: props._filterData
+      filterData: props._filterData,
+      context: {data: props.data}
     });
     this.setDimensionState(key, {sortedBins});
     this.getDimensionValueDomain(props, dimensionUpdater);

--- a/modules/aggregation-layers/src/utils/cpu-aggregator.js
+++ b/modules/aggregation-layers/src/utils/cpu-aggregator.js
@@ -292,10 +292,12 @@ export default class CPUAggregator {
     return Object.values(dimensionStep.triggers).some(item => {
       if (item.updateTrigger) {
         // check based on updateTriggers change first
+        // if data has changed, always update value
         return (
-          changeFlags.updateTriggersChanged &&
-          (changeFlags.updateTriggersChanged.all ||
-            changeFlags.updateTriggersChanged[item.updateTrigger])
+          changeFlags.dataChanged ||
+          (changeFlags.updateTriggersChanged &&
+            (changeFlags.updateTriggersChanged.all ||
+              changeFlags.updateTriggersChanged[item.updateTrigger]))
         );
       }
       // fallback to direct comparison

--- a/modules/aggregation-layers/src/utils/cpu-aggregator.js
+++ b/modules/aggregation-layers/src/utils/cpu-aggregator.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 import BinSorter from './bin-sorter';
 import {getScaleFunctionByScaleType} from './scale-utils';
-import {getValueFunc} from './aggregation-operation-utils';
+import {getValueFunc, wrapGetValueFunc} from './aggregation-operation-utils';
 
 function nop() {}
 
@@ -221,9 +221,13 @@ export default class CPUAggregator {
         changeFlags
       );
 
-      if (getValueChanged && getValue === null) {
-        // If `getValue` is not provided from props, build it with aggregation and weight.
-        getValue = getValueFunc(props[aggregation.prop], props[weight.prop]);
+      if (getValueChanged) {
+        if (getValue) {
+          getValue = wrapGetValueFunc(getValue, {data: props.data});
+        } else {
+          // If `getValue` is not provided from props, build it with aggregation and weight.
+          getValue = getValueFunc(props[aggregation.prop], props[weight.prop], {data: props.data});
+        }
       }
 
       if (getValue) {
@@ -382,8 +386,7 @@ export default class CPUAggregator {
 
     const sortedBins = new BinSorter(this.state.layerData.data || [], {
       getValue,
-      filterData: props._filterData,
-      context: {data: props.data}
+      filterData: props._filterData
     });
     this.setDimensionState(key, {sortedBins});
     this.getDimensionValueDomain(props, dimensionUpdater);

--- a/test/modules/aggregation-layers/grid-aggregation-layer.spec.js
+++ b/test/modules/aggregation-layers/grid-aggregation-layer.spec.js
@@ -186,13 +186,13 @@ class TestGridAggregationLayer extends GridAggregationLayer {
   // Private
 
   _updateAccessors(opts) {
-    const {getWeight, aggregation} = opts.props;
+    const {getWeight, aggregation, data} = opts.props;
     const {count} = this.state.weights;
     if (count) {
       count.getWeight = getWeight;
       count.operation = AGGREGATION_OPERATION[aggregation];
     }
-    this.setState({getValue: getValueFunc(aggregation, getWeight)});
+    this.setState({getValue: getValueFunc(aggregation, getWeight, {data})});
   }
 
   _resetResults() {

--- a/test/modules/aggregation-layers/grid-layer.spec.js
+++ b/test/modules/aggregation-layers/grid-layer.spec.js
@@ -216,12 +216,12 @@ test('GridLayer#non-iterable data', t => {
       },
       {
         updateProps: {
-          getColorValue: (points, {data}) => {
-            t.ok(Number.isFinite(points[0].index) && data, 'point index and context are populated');
+          getColorValue: (points, {indices, data: {weights}}) => {
+            t.ok(indices && weights, 'context is populated');
             return points.length;
           },
-          getElevationValue: (points, {data}) => {
-            t.ok(Number.isFinite(points[0].index) && data, 'point index and context are populated');
+          getElevationValue: (points, {indices, data: {weights}}) => {
+            t.ok(indices && weights, 'context is populated');
             return points.length;
           },
           updateTriggers: {

--- a/test/modules/aggregation-layers/grid-layer.spec.js
+++ b/test/modules/aggregation-layers/grid-layer.spec.js
@@ -168,3 +168,73 @@ test('GridLayer#updates', t => {
   });
   t.end();
 });
+
+test('GridLayer#non-iterable data', t => {
+  const dataNonIterable = {
+    length: 3,
+    positions: FIXTURES.points.slice(0, 3).flatMap(d => d.COORDINATES),
+    weights: FIXTURES.points.slice(0, 3).map(d => d.SPACES)
+  };
+
+  testLayer({
+    Layer: GridLayer,
+    onError: t.notOk,
+    testCases: [
+      {
+        props: {
+          data: dataNonIterable,
+          radius: 400,
+          getPosition: (_, {index, data}) => [
+            data.positions[index * 2],
+            data.positions[index * 2 + 1]
+          ],
+          getColorWeight: 1,
+          getElevationWeight: 1
+        },
+        onAfterUpdate: ({subLayer}) => {
+          t.pass('Layer updated with constant get*Weight accessors');
+        }
+      },
+      {
+        updateProps: {
+          getColorWeight: (_, {index, data}) => {
+            t.ok(Number.isFinite(index) && data, 'point index and context are populated');
+            return data.weights[index * 2];
+          },
+          getElevationWeight: (_, {index, data}) => {
+            t.ok(Number.isFinite(index) && data, 'point index and context are populated');
+            return data.weights[index * 2];
+          },
+          updateTriggers: {
+            getColorWeight: 1,
+            getElevationWeight: 1
+          }
+        },
+        onAfterUpdate: ({subLayer}) => {
+          t.pass('Layer updated with get*Weight accessors and non-iterable data');
+        }
+      },
+      {
+        updateProps: {
+          getColorValue: (points, {data}) => {
+            t.ok(Number.isFinite(points[0].index) && data, 'point index and context are populated');
+            return points.length;
+          },
+          getElevationValue: (points, {data}) => {
+            t.ok(Number.isFinite(points[0].index) && data, 'point index and context are populated');
+            return points.length;
+          },
+          updateTriggers: {
+            getColorValue: 1,
+            getElevationValue: 1
+          }
+        },
+        onAfterUpdate: ({subLayer}) => {
+          t.pass('Layer updated with get*Value accessors and non-iterable data');
+        }
+      }
+    ]
+  });
+
+  t.end();
+});

--- a/test/modules/aggregation-layers/hexagon-layer.spec.js
+++ b/test/modules/aggregation-layers/hexagon-layer.spec.js
@@ -862,3 +862,79 @@ test('HexagonLayer#renderSubLayer', t => {
 
   t.end();
 });
+
+test('HexagonLayer#non-iterable data', t => {
+  const dataNonIterable = {
+    length: 3,
+    positions: data.points.slice(0, 3).flatMap(d => d.COORDINATES),
+    weights: data.points.slice(0, 3).map(d => d.SPACES)
+  };
+
+  testLayer({
+    Layer: HexagonLayer,
+    onError: t.notOk,
+    testCases: [
+      {
+        props: {
+          data: dataNonIterable,
+          radius: 400,
+          getPosition: (_, {index, data: {positions}}) => [
+            positions[index * 2],
+            positions[index * 2 + 1]
+          ],
+          getColorWeight: 1,
+          getElevationWeight: 1
+        },
+        onAfterUpdate: ({subLayer}) => {
+          t.pass('Layer updated with constant get*Weight accessors');
+        }
+      },
+      {
+        updateProps: {
+          getColorWeight: (_, {index, data: {weights}}) => {
+            t.ok(Number.isFinite(index) && weights, 'point index and context are populated');
+            return weights[index * 2];
+          },
+          getElevationWeight: (_, {index, data: {weights}}) => {
+            t.ok(Number.isFinite(index) && weights, 'point index and context are populated');
+            return weights[index * 2];
+          },
+          updateTriggers: {
+            getColorWeight: 1,
+            getElevationWeight: 1
+          }
+        },
+        onAfterUpdate: ({subLayer}) => {
+          t.pass('Layer updated with get*Weight accessors and non-iterable data');
+        }
+      },
+      {
+        updateProps: {
+          getColorValue: (points, {data: {weights}}) => {
+            t.ok(
+              Number.isFinite(points[0].index) && weights,
+              'point index and context are populated'
+            );
+            return points.length;
+          },
+          getElevationValue: (points, {data: {weights}}) => {
+            t.ok(
+              Number.isFinite(points[0].index) && weights,
+              'point index and context are populated'
+            );
+            return points.length;
+          },
+          updateTriggers: {
+            getColorValue: 1,
+            getElevationValue: 1
+          }
+        },
+        onAfterUpdate: ({subLayer}) => {
+          t.pass('Layer updated with get*Value accessors and non-iterable data');
+        }
+      }
+    ]
+  });
+
+  t.end();
+});

--- a/test/modules/aggregation-layers/hexagon-layer.spec.js
+++ b/test/modules/aggregation-layers/hexagon-layer.spec.js
@@ -910,18 +910,12 @@ test('HexagonLayer#non-iterable data', t => {
       },
       {
         updateProps: {
-          getColorValue: (points, {data: {weights}}) => {
-            t.ok(
-              Number.isFinite(points[0].index) && weights,
-              'point index and context are populated'
-            );
+          getColorValue: (points, {indices, data: {weights}}) => {
+            t.ok(indices && weights, 'context is populated');
             return points.length;
           },
-          getElevationValue: (points, {data: {weights}}) => {
-            t.ok(
-              Number.isFinite(points[0].index) && weights,
-              'point index and context are populated'
-            );
+          getElevationValue: (points, {indices, data: {weights}}) => {
+            t.ok(indices && weights, 'context is populated');
             return points.length;
           },
           updateTriggers: {

--- a/test/modules/aggregation-layers/utils/aggregation-operation-utils.spec.js
+++ b/test/modules/aggregation-layers/utils/aggregation-operation-utils.spec.js
@@ -20,7 +20,10 @@
 
 import test from 'tape-catch';
 
-import {getValueFunc} from '@deck.gl/aggregation-layers/utils/aggregation-operation-utils';
+import {
+  getValueFunc,
+  wrapGetValueFunc
+} from '@deck.gl/aggregation-layers/utils/aggregation-operation-utils';
 
 const data = [
   {source: 10, index: 0},
@@ -105,10 +108,21 @@ const TEST_CASES = [
 test('GridAggregationOperationUtils#getValueFunc', t => {
   TEST_CASES.forEach(tc => {
     const func = getValueFunc(tc.op, tc.accessor);
-    t.is(func(data, {}), tc.expected, `${tc.name} should return expected result`);
+    t.is(func(data), tc.expected, `${tc.name} should return expected result`);
 
     const altData = typeof accessor === 'function' ? nonFiniteData : [];
-    t.is(func(altData, {}), null, `${tc.name} should return expected result on non-finite data`);
+    t.is(func(altData), null, `${tc.name} should return expected result on non-finite data`);
   });
+  t.end();
+});
+
+test('GridAggregationOperationUtils#wrapGetValueFunc', t => {
+  const func = wrapGetValueFunc((values, {indices}) => {
+    t.deepEqual(indices, [0, 1, 2, 3, 4, 5, 6], 'indices are populated');
+    return Math.max.apply(null, values.filter(Number.isFinite));
+  });
+
+  t.is(func(data), 16, 'returns expected result');
+
   t.end();
 });

--- a/test/modules/aggregation-layers/utils/aggregation-operation-utils.spec.js
+++ b/test/modules/aggregation-layers/utils/aggregation-operation-utils.spec.js
@@ -22,50 +22,93 @@ import test from 'tape-catch';
 
 import {getValueFunc} from '@deck.gl/aggregation-layers/utils/aggregation-operation-utils';
 
-const data = [10, 'a', null, 14, -3, 16, 0.2];
-const nonFiniteData = ['a', null, {a: 'a'}];
-const accessor = x => x;
+const data = [
+  {source: 10, index: 0},
+  {source: 'a', index: 1},
+  {source: null, index: 2},
+  {source: 14, index: 3},
+  {source: -3, index: 4},
+  {source: 16, index: 5},
+  {source: 0.2, index: 6}
+];
+const nonFiniteData = [
+  {source: 'a', index: 0},
+  {source: null, index: 1},
+  {source: {a: 'a'}, index: 2}
+];
 const TEST_CASES = [
   {
     name: 'Min Function',
     op: 'MIN',
     data,
+    accessor: x => x,
     expected: -3
   },
   {
     name: 'Max Function',
     op: 'MAX',
     data,
+    accessor: x => x,
     expected: 16
   },
   {
     name: 'Sum Function',
     op: 'SUM',
     data,
+    accessor: x => x,
     expected: 37.2
   },
   {
     name: 'Mean Function',
     op: 'MEAN',
     data,
+    accessor: x => x,
     expected: 37.2 / 5
   },
   {
     name: 'Invalid(should default to SUM)',
     op: 'Invalid',
     data,
+    accessor: x => x,
     expected: 37.2
+  },
+  {
+    name: 'Constant accessor/SUM',
+    op: 'SUM',
+    data,
+    accessor: 1,
+    expected: data.length
+  },
+  {
+    name: 'Constant accessor/MEAN',
+    op: 'MEAN',
+    data,
+    accessor: 1,
+    expected: 1
+  },
+  {
+    name: 'Constant accessor/MAX',
+    op: 'MAX',
+    data,
+    accessor: 1,
+    expected: 1
+  },
+  {
+    name: 'Constant accessor/MIN',
+    op: 'MIN',
+    data,
+    accessor: 1,
+    expected: 1
   }
 ];
 
 test('GridAggregationOperationUtils#getValueFunc', t => {
   TEST_CASES.forEach(tc => {
-    const func = getValueFunc(tc.op, accessor);
-    t.ok(func(data) === tc.expected, `${tc.name} should return expected result`);
-    t.ok(
-      func(nonFiniteData) === null,
-      `${tc.name} should return expected result on non-finite data`
-    );
+    const func = getValueFunc(tc.op, tc.accessor);
+    t.is(func(data, {}), tc.expected, `${tc.name} should return expected result`);
+
+    const altData = typeof accessor === 'function' ? nonFiniteData : [];
+    t.is(func(altData, {}), null, `${tc.name} should return expected result on non-finite data`);
   });
   t.end();
 });

--- a/test/render/test-cases/grid-layer.js
+++ b/test/render/test-cases/grid-layer.js
@@ -28,7 +28,7 @@ const GOLDEN_IMAGE = './test/render/golden-images/grid-lnglat.png';
 const GOLDEN_IMAGE_SIDE = './test/render/golden-images/grid-lnglat-side.png';
 
 export function getMean(pts, key) {
-  const filtered = pts.filter(pt => Number.isFinite(pt[key]));
+  const filtered = pts.filter(pt => Number.isFinite(pt.source[key]));
 
   return filtered.length
     ? filtered.reduce((accu, curr) => accu + curr[key], 0) / filtered.length
@@ -36,7 +36,7 @@ export function getMean(pts, key) {
 }
 
 export function getMax(pts, key) {
-  const filtered = pts.filter(pt => Number.isFinite(pt[key]));
+  const filtered = pts.filter(pt => Number.isFinite(pt.source[key]));
 
   return filtered.length
     ? filtered.reduce((accu, curr) => (curr[key] > accu ? curr[key] : accu), -Infinity)

--- a/test/render/test-cases/grid-layer.js
+++ b/test/render/test-cases/grid-layer.js
@@ -28,7 +28,7 @@ const GOLDEN_IMAGE = './test/render/golden-images/grid-lnglat.png';
 const GOLDEN_IMAGE_SIDE = './test/render/golden-images/grid-lnglat-side.png';
 
 export function getMean(pts, key) {
-  const filtered = pts.filter(pt => Number.isFinite(pt.source[key]));
+  const filtered = pts.filter(pt => Number.isFinite(pt[key]));
 
   return filtered.length
     ? filtered.reduce((accu, curr) => accu + curr[key], 0) / filtered.length
@@ -36,7 +36,7 @@ export function getMean(pts, key) {
 }
 
 export function getMax(pts, key) {
-  const filtered = pts.filter(pt => Number.isFinite(pt.source[key]));
+  const filtered = pts.filter(pt => Number.isFinite(pt[key]));
 
   return filtered.length
     ? filtered.reduce((accu, curr) => (curr[key] > accu ? curr[key] : accu), -Infinity)


### PR DESCRIPTION

For #4449

#### Background

Because CPUAggregator does not use AttributeManager, the usage of accessors are not conforming with [documentation for standard accessor](https://deck.gl/docs/developer-guide/using-layers#accessors).

#### Change List
- All `get*Weight` props are now conforming (constant, callback, callback using non-iterable data)
- `get*Value` props are called with additional information to support non-iterable data usage.
- Documentation
- Unit tests