### PR TITLE
Misc fixes of mapstyle in examples

### DIFF
--- a/examples/website/safegraph/README.md
+++ b/examples/website/safegraph/README.md
@@ -8,6 +8,16 @@ Note that this example demonstrates using deck.gl [as a Mapbox addon](https://me
 
 Copy the content of this folder to your project. 
 
+To run this example, you need a [Mapbox access token](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/). You can either set an environment variable:
+
+```bash
+export MapboxAccessToken=<mapbox_access_token>
+```
+
+Or set `MAPBOX_TOKEN` directly in `app.js`.
+
+Other options can be found at [using with Mapbox GL](../../../docs/get-started/using-with-mapbox-gl.md).
+
 ```bash
 # install dependencies
 npm install
@@ -21,7 +31,3 @@ npm start
 ### Data Source
 
 To build your own application with deck.gl as Mapbox custom layers, check out the [documentation of @deck.gl/mapbox module](../../../docs/api-reference/mapbox/overview.md)
-
-### Basemap
-
-The basemap in this example is provided by [CARTO free basemap service](https://carto.com/basemaps). To use an alternative base map solution, visit [this guide](https://deck.gl/docs/get-started/using-with-map#using-other-basemap-services)

--- a/examples/website/safegraph/app.js
+++ b/examples/website/safegraph/app.js
@@ -8,6 +8,9 @@ import {h3ToGeo} from 'h3-js';
 import {load} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 
+// Set your mapbox token here
+mapboxgl.accessToken = process.env.MapboxAccessToken; // eslint-disable-line
+
 const colorScale = scaleLog()
   .domain([10, 100, 1000, 10000])
   .range([[255, 255, 178], [254, 204, 92], [253, 141, 60], [227, 26, 28]]);
@@ -15,7 +18,7 @@ const colorScale = scaleLog()
 export function renderToDOM(container, data) {
   const map = new mapboxgl.Map({
     container,
-    style: 'https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json',
+    style: 'mapbox://styles/mapbox/light-v9',
     antialias: true,
     center: [-122.4034, 37.7845],
     zoom: 15.5,

--- a/examples/website/scenegraph/app.js
+++ b/examples/website/scenegraph/app.js
@@ -133,7 +133,7 @@ export default function App({sizeScale = 25, onDataLoad, mapStyle = MAP_STYLE}) 
       controller={true}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} mapStyle={MAP_STYLE} />
+      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/website/src/doc-demos/layer-demo.js
+++ b/website/src/doc-demos/layer-demo.js
@@ -141,7 +141,7 @@ export default function makeLayerDemo({layer, getTooltip, parameters, mapStyle =
           controller={true}
           layers={layers}
         >
-          {mapStyle && <StaticMap reuseMaps mapStyle={mapStyle.LIGHT} preventStyleDiffing={true} />}
+          {mapStyle && <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />}
         </DeckGL>
       );
     }

--- a/website/static/mapstyle/deck-light.json
+++ b/website/static/mapstyle/deck-light.json
@@ -5963,35 +5963,6 @@
         "line-opacity": 1
       },
       "source-layer": "boundary"
-    },
-    {
-      "id": "lagos-routes-2pjyce",
-      "type": "line",
-      "source": "carto",
-      "source-layer": "lagos_routes-2pjyce",
-      "interactive": true,
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round",
-        "line-cap": "round"
-      },
-      "paint": {
-        "line-color": "#31A1A5",
-        "line-opacity": 0.1,
-        "line-width": {
-          "base": 1.33,
-          "stops": [
-            [
-              8,
-              0.5
-            ],
-            [
-              22,
-              15
-            ]
-          ]
-        }
-      }
     }
   ],
   "id": "cive48w2e001a2imn5mcu2vrs",


### PR DESCRIPTION
Follow up of #5079

#### Change List
- Restore Mapbox custom layer example (requires 3D buildings)
- Fix basemap of the ScenegraphLayer example
- Fix basemap of embedded doc demos
- Fix console error in website light style