### PR TITLE
Add 'data' argument in HeatmapLayer documentation

### DIFF
--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -21,6 +21,7 @@ function App({data, viewState}) {
    */
   const layer = new HeatmapLayer({
     id: 'heatmapLayer',
+    data,
     getPosition: d => d.COORDINATES,
     getWeight: d => d.WEIGHT,
     aggregation: 'SUM'


### PR DESCRIPTION
Example did not use 'data' in layer declaration, which could cause confusion for newer users since no heatmap is rendered without the data.

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
