### PR TITLE
Fix: Limit for color picking cache size; overAlloc override.

### DIFF
--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -47,7 +47,7 @@ const TRACE_UPDATE = 'layer.update';
 const TRACE_FINALIZE = 'layer.finalize';
 const TRACE_MATCHED = 'layer.matched';
 
-const MAX_PICKING_COLOR_CACHE_SIZE = 16777215;
+const MAX_PICKING_COLOR_CACHE_SIZE = 2 ** 24;
 
 const EMPTY_ARRAY = Object.freeze([]);
 
@@ -478,17 +478,17 @@ export default class Layer extends Component {
     const cacheSize = pickingColorCache.length / 3;
 
     if (cacheSize < numInstances) {
-      let overAlloc;
       if (numInstances > MAX_PICKING_COLOR_CACHE_SIZE) {
-        log.warn('Index out of picking color range. Picking might not work as expected.');
-        overAlloc = 1;
+        log.warn(
+          'Layer has too many data objects. Picking might not be able to distinguish all objects.'
+        )();
         numInstances = MAX_PICKING_COLOR_CACHE_SIZE;
       }
 
       pickingColorCache = typedArrayManager.allocate(pickingColorCache, numInstances, {
         size: 3,
         copy: true,
-        overAlloc
+        overAllocCountCap: MAX_PICKING_COLOR_CACHE_SIZE
       });
 
       // If the attribute is larger than the cache, resize the cache and populate the missing chunk

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -488,7 +488,7 @@ export default class Layer extends Component {
       pickingColorCache = typedArrayManager.allocate(pickingColorCache, numInstances, {
         size: 3,
         copy: true,
-        maxCount: MAX_PICKING_COLOR_CACHE_SIZE
+        maxCount: Math.max(numInstances, MAX_PICKING_COLOR_CACHE_SIZE)
       });
 
       // If the attribute is larger than the cache, resize the cache and populate the missing chunk

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -47,7 +47,7 @@ const TRACE_UPDATE = 'layer.update';
 const TRACE_FINALIZE = 'layer.finalize';
 const TRACE_MATCHED = 'layer.matched';
 
-const MAX_PICKING_COLOR_CACHE_SIZE = 2 ** 24;
+const MAX_PICKING_COLOR_CACHE_SIZE = 2 ** 24 - 1;
 
 const EMPTY_ARRAY = Object.freeze([]);
 
@@ -488,7 +488,7 @@ export default class Layer extends Component {
       pickingColorCache = typedArrayManager.allocate(pickingColorCache, numInstances, {
         size: 3,
         copy: true,
-        overAllocCountCap: MAX_PICKING_COLOR_CACHE_SIZE
+        maxCount: MAX_PICKING_COLOR_CACHE_SIZE
       });
 
       // If the attribute is larger than the cache, resize the cache and populate the missing chunk

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -482,7 +482,6 @@ export default class Layer extends Component {
         log.warn(
           'Layer has too many data objects. Picking might not be able to distinguish all objects.'
         )();
-        numInstances = MAX_PICKING_COLOR_CACHE_SIZE;
       }
 
       pickingColorCache = typedArrayManager.allocate(pickingColorCache, numInstances, {

--- a/modules/core/src/utils/typed-array-manager.js
+++ b/modules/core/src/utils/typed-array-manager.js
@@ -12,7 +12,7 @@ export class TypedArrayManager {
   allocate(
     typedArray,
     count,
-    {size = 1, type, padding = 0, copy = false, initialize = false, overAllocCountCap}
+    {size = 1, type, padding = 0, copy = false, initialize = false, maxCount}
   ) {
     const Type = type || (typedArray && typedArray.constructor) || Float32Array;
 
@@ -26,12 +26,12 @@ export class TypedArrayManager {
       }
     }
 
-    let overAllocSizeCap;
-    if (overAllocCountCap) {
-      overAllocSizeCap = overAllocCountCap * size;
+    let maxSize;
+    if (maxCount) {
+      maxSize = maxCount * size;
     }
 
-    const newArray = this._allocate(Type, newSize, initialize, overAllocSizeCap);
+    const newArray = this._allocate(Type, newSize, initialize, maxSize);
 
     if (typedArray && copy) {
       newArray.set(typedArray);
@@ -48,14 +48,12 @@ export class TypedArrayManager {
     this._release(typedArray);
   }
 
-  _allocate(Type, size, initialize, overAllocSizeCap) {
+  _allocate(Type, size, initialize, maxSize) {
     // Allocate at least one element to ensure a valid buffer
     let sizeToAllocate = Math.max(Math.ceil(size * this.props.overAlloc), 1);
     // Don't over allocate after certain specified number of elements
-    if (overAllocSizeCap) {
-      if (sizeToAllocate > overAllocSizeCap) {
-        sizeToAllocate = Math.max(size, overAllocSizeCap);
-      }
+    if (sizeToAllocate > maxSize) {
+      sizeToAllocate = Math.max(size, maxSize);
     }
 
     // Check if available in pool

--- a/modules/core/src/utils/typed-array-manager.js
+++ b/modules/core/src/utils/typed-array-manager.js
@@ -9,7 +9,11 @@ export class TypedArrayManager {
     Object.assign(this.props, props);
   }
 
-  allocate(typedArray, count, {size = 1, type, padding = 0, copy = false, initialize = false}) {
+  allocate(
+    typedArray,
+    count,
+    {size = 1, type, padding = 0, copy = false, initialize = false, overAlloc}
+  ) {
     const Type = type || (typedArray && typedArray.constructor) || Float32Array;
 
     const newSize = count * size + padding;
@@ -22,7 +26,7 @@ export class TypedArrayManager {
       }
     }
 
-    const newArray = this._allocate(Type, newSize, initialize);
+    const newArray = this._allocate(Type, newSize, initialize, overAlloc);
 
     if (typedArray && copy) {
       newArray.set(typedArray);
@@ -39,9 +43,9 @@ export class TypedArrayManager {
     this._release(typedArray);
   }
 
-  _allocate(Type, size, initialize) {
+  _allocate(Type, size, initialize, overAlloc) {
     // Allocate at least one element to ensure a valid buffer
-    size = Math.max(Math.ceil(size * this.props.overAlloc), 1);
+    size = Math.max(Math.ceil(size * (overAlloc || this.props.overAlloc)), 1);
 
     // Check if available in pool
     const pool = this._pool;

--- a/modules/core/src/utils/typed-array-manager.js
+++ b/modules/core/src/utils/typed-array-manager.js
@@ -28,7 +28,7 @@ export class TypedArrayManager {
 
     let maxSize;
     if (maxCount) {
-      maxSize = maxCount * size;
+      maxSize = maxCount * size + padding;
     }
 
     const newArray = this._allocate(Type, newSize, initialize, maxSize);
@@ -53,7 +53,7 @@ export class TypedArrayManager {
     let sizeToAllocate = Math.max(Math.ceil(size * this.props.overAlloc), 1);
     // Don't over allocate after certain specified number of elements
     if (sizeToAllocate > maxSize) {
-      sizeToAllocate = Math.max(size, maxSize);
+      sizeToAllocate = maxSize;
     }
 
     // Check if available in pool

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -486,6 +486,17 @@ test('Layer#calculateInstancePickingColors', t => {
           'instancePickingColors is populated'
         );
       }
+    },
+    {
+      updateProps: {
+        data: new Array(2 ** 24 + 1000).fill(0),
+        pickable: true
+      },
+      onAfterUpdate: ({layer}) => {
+        const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+        const {length} = instancePickingColors.value;
+        t.deepEquals(length, 2 ** 24 * 3, `instancePickingColors buffer size is capped`);
+      }
     }
   ];
 

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -489,17 +489,16 @@ test('Layer#calculateInstancePickingColors', t => {
     },
     {
       updateProps: {
-        data: new Array(2 ** 24 + 1000).fill(0),
+        data: new Array(2 ** 24 + 100).fill(0),
         pickable: true
       },
       onAfterUpdate: ({layer}) => {
         const {instancePickingColors} = layer.getAttributeManager().getAttributes();
         const {length} = instancePickingColors.value;
-        t.deepEquals(length, (2 ** 24 - 1) * 3, `instancePickingColors buffer size is capped`);
         t.deepEquals(
-          instancePickingColors.value.slice(-3),
-          [255, 255, 255],
-          'last picking color is correct'
+          length,
+          (2 ** 24 + 100) * 3,
+          `no over allocation for instancePickingColors buffer after 2**24 elements`
         );
       }
     }

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -495,7 +495,12 @@ test('Layer#calculateInstancePickingColors', t => {
       onAfterUpdate: ({layer}) => {
         const {instancePickingColors} = layer.getAttributeManager().getAttributes();
         const {length} = instancePickingColors.value;
-        t.deepEquals(length, 2 ** 24 * 3, `instancePickingColors buffer size is capped`);
+        t.deepEquals(length, (2 ** 24 - 1) * 3, `instancePickingColors buffer size is capped`);
+        t.deepEquals(
+          instancePickingColors.value.slice(-3),
+          [255, 255, 255],
+          'last picking color is correct'
+        );
       }
     }
   ];

--- a/test/modules/core/utils/typed-array-manager.spec.js
+++ b/test/modules/core/utils/typed-array-manager.spec.js
@@ -34,6 +34,11 @@ test('TypedArrayManager#allocate', t => {
   t.is(array2.length, 4, 'Allocated array has correct length');
   t.is(array.buffer, array2.buffer, 'Reused existing arraybuffer');
 
+  // Create a new array with custom over allocation
+  array = typedArrayManager.allocate(null, 1, {size: 2, type: Float32Array, overAlloc: 1});
+  t.is(array.length, 2, 'Allocated array has correct length');
+  array.fill(1);
+
   t.end();
 });
 

--- a/test/modules/core/utils/typed-array-manager.spec.js
+++ b/test/modules/core/utils/typed-array-manager.spec.js
@@ -36,11 +36,13 @@ test('TypedArrayManager#allocate', t => {
 
   // Create a new array with over allocation.
   // Allocated array with over allocation should be smaller than over allocation cap.
+  // 2 elements x 2 bytes x 2 default over alloc => 8
   array = typedArrayManager.allocate(null, 2, {size: 2, type: Float32Array, maxCount: 5});
   t.is(array.length, 8, 'Allocated array has correct length, not affected by over alloc cap');
 
   // Create a new array with over allocation.
   // Allocated array with over allocation is capped by over allocation cap.
+  // 3 elements x 2 bytes x 2 default over alloc => 12; max count limits allocation to 10.
   array = typedArrayManager.allocate(null, 3, {size: 2, type: Float32Array, maxCount: 5});
   t.is(array.length, 10, 'Allocated array has correct length, affected by over alloc cap');
 

--- a/test/modules/core/utils/typed-array-manager.spec.js
+++ b/test/modules/core/utils/typed-array-manager.spec.js
@@ -36,12 +36,12 @@ test('TypedArrayManager#allocate', t => {
 
   // Create a new array with over allocation.
   // Allocated array with over allocation should be smaller than over allocation cap.
-  array = typedArrayManager.allocate(null, 2, {size: 2, type: Float32Array, overAllocCountCap: 5});
+  array = typedArrayManager.allocate(null, 2, {size: 2, type: Float32Array, maxCount: 5});
   t.is(array.length, 8, 'Allocated array has correct length, not affected by over alloc cap');
 
   // Create a new array with over allocation.
   // Allocated array with over allocation is capped by over allocation cap.
-  array = typedArrayManager.allocate(null, 3, {size: 2, type: Float32Array, overAllocCountCap: 5});
+  array = typedArrayManager.allocate(null, 3, {size: 2, type: Float32Array, maxCount: 5});
   t.is(array.length, 10, 'Allocated array has correct length, affected by over alloc cap');
 
   t.end();

--- a/test/modules/core/utils/typed-array-manager.spec.js
+++ b/test/modules/core/utils/typed-array-manager.spec.js
@@ -34,10 +34,15 @@ test('TypedArrayManager#allocate', t => {
   t.is(array2.length, 4, 'Allocated array has correct length');
   t.is(array.buffer, array2.buffer, 'Reused existing arraybuffer');
 
-  // Create a new array with custom over allocation
-  array = typedArrayManager.allocate(null, 1, {size: 2, type: Float32Array, overAlloc: 1});
-  t.is(array.length, 2, 'Allocated array has correct length');
-  array.fill(1);
+  // Create a new array with over allocation.
+  // Allocated array with over allocation should be smaller than over allocation cap.
+  array = typedArrayManager.allocate(null, 2, {size: 2, type: Float32Array, overAllocCountCap: 5});
+  t.is(array.length, 8, 'Allocated array has correct length, not affected by over alloc cap');
+
+  // Create a new array with over allocation.
+  // Allocated array with over allocation is capped by over allocation cap.
+  array = typedArrayManager.allocate(null, 3, {size: 2, type: Float32Array, overAllocCountCap: 5});
+  t.is(array.length, 10, 'Allocated array has correct length, affected by over alloc cap');
 
   t.end();
 });


### PR DESCRIPTION
For #5076 

#### Background

#### Change List
- limit the number of encoded indices in picking buffer to 2**24, log a warning.
- a way to set custom over allocation for buffers.