### PR TITLE
Remove double buffer overallocation

### DIFF
--- a/modules/core/src/lib/attribute/data-column.js
+++ b/modules/core/src/lib/attribute/data-column.js
@@ -236,10 +236,12 @@ export default class DataColumn {
       if (this.doublePrecision && value instanceof Float64Array) {
         value = toDoublePrecisionArray(value, accessor);
       }
-      // TODO: support offset in buffer.setData?
-      if (buffer.byteLength < value.byteLength + byteOffset) {
-        // Over allocation is required because shader attributes may have bigger offsets
-        buffer.reallocate((value.byteLength + byteOffset) * 2);
+
+      // A small over allocation is used as safety margin
+      // Shader attributes may try to access this buffer with bigger offsets
+      const requiredBufferSize = value.byteLength + byteOffset + accessor.stride * 2;
+      if (buffer.byteLength < requiredBufferSize) {
+        buffer.reallocate(requiredBufferSize);
       }
       // Hack: force Buffer to infer data type
       buffer.setAccessor(null);

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -510,14 +510,13 @@ test('Attribute#updateBuffer#noAlloc', t => {
   });
 
   // 1 vertex + 1 vertexOffset => 2 vertices * 2 floats => 16 bytes
-  // overallocation x 2
+  // overallocation: 2 floats * 2 = 16 bytes
   value = new Float32Array([1, 1]);
   attribute.setNeedsUpdate(true);
   attribute.updateBuffer({data: value});
   t.is(attribute.buffer.byteLength, 32, `overallocated buffer for ${value.byteLength} bytes`);
 
-  // 2 vertices + 1 vertexOffset => 3 vertices * 2 floats => 24 bytes
-  value = new Float32Array([1, 1, 2, 2]);
+  value = new Float32Array([1, 2]);
   attribute.setNeedsUpdate(true);
   attribute.updateBuffer({data: value});
   t.is(attribute.buffer.byteLength, 32, `buffer is big enough ${value.byteLength} bytes`);
@@ -526,7 +525,7 @@ test('Attribute#updateBuffer#noAlloc', t => {
   value = new Float32Array([1, 1, 2, 2, 3, 3, 4, 4]);
   attribute.setNeedsUpdate(true);
   attribute.updateBuffer({data: value});
-  t.is(attribute.buffer.byteLength, 80, `re-allocated buffer for ${value.byteLength} bytes`);
+  t.is(attribute.buffer.byteLength, 56, `re-allocated buffer for ${value.byteLength} bytes`);
 
   attribute.delete();
   t.end();


### PR DESCRIPTION
- When using the default attribute packing, `value` is already overallocated, and we should not overallocate again when creating the WebGL buffer.
- When using custom attribute packing (binary attribute, `instancePickingColors`), this will be less efficient if the data size increases frequently over time. It is arguably a small use case comparing to the memory savings.

#### Change List
- Be conservative when allocating WebGL buffer size
