### PR TITLE
Fix H3HexagonLayer in GlobeView

### DIFF
--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -155,8 +155,10 @@ export default class H3HexagonLayer extends CompositeLayer {
 
   _shouldUseHighPrecision() {
     const {resolution, hasPentagon, hasMultipleRes} = this.state;
+    const {viewport} = this.context;
     return (
       this.props.highPrecision ||
+      viewport.resolution ||
       hasMultipleRes ||
       hasPentagon ||
       (resolution >= 0 && resolution <= 5)
@@ -193,9 +195,10 @@ export default class H3HexagonLayer extends CompositeLayer {
     const [centerX, centerY] = viewport.projectFlat([centerLng, centerLat]);
     vertices = vertices.map(p => {
       const worldPosition = viewport.projectFlat(p);
-      worldPosition[0] = (worldPosition[0] - centerX) / unitsPerMeter[0];
-      worldPosition[1] = (worldPosition[1] - centerY) / unitsPerMeter[1];
-      return worldPosition;
+      return [
+        (worldPosition[0] - centerX) / unitsPerMeter[0],
+        (worldPosition[1] - centerY) / unitsPerMeter[1]
+      ];
     });
 
     this.setState({centerHex: hex, vertices});


### PR DESCRIPTION
For #5125

There are two issues:
- `_updateVertices` was mutating the points in `vertices`. Because the first and last points are the same object, it gets manipulated twice, resulting in a wild position.
- `ColumnLayer` unable to render the base disk along the curvature of the globe. This makes it impossible for `H3HexagonLayer` to generate vertices described by meter offsets. Temporary solution is to always use `PolygonLayer` to render the hexagons.

#### Change List
- Avoid mutating vertices
- Always use high precision mode in GlobeView
