### PR TITLE
Fix GlobeView tile traversal

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-2d-traversal.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-traversal.js
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
-import {CullingVolume, Plane, AxisAlignedBoundingBox} from '@math.gl/culling';
-import {WebMercatorViewport} from '@deck.gl/core';
-import {fitBounds} from '@math.gl/web-mercator';
+import {CullingVolume, Plane, AxisAlignedBoundingBox, BoundingSphere} from '@math.gl/culling';
+import {Vector3} from 'math.gl';
+import {osmTile2lngLat} from './utils';
 
 const TILE_SIZE = 512;
 // number of world copies to check
@@ -30,8 +30,8 @@ class OSMNode {
   }
 
   update(params) {
-    const {viewport, cullingVolume, elevationBounds, minZ, maxZ, offset} = params;
-    const boundingVolume = this.getBoundingVolume(elevationBounds, offset);
+    const {viewport, cullingVolume, elevationBounds, minZ, maxZ, offset, project} = params;
+    const boundingVolume = this.getBoundingVolume(elevationBounds, offset, project);
 
     // First, check if this tile is visible
     const isInside = cullingVolume.computeVisibility(boundingVolume);
@@ -77,7 +77,25 @@ class OSMNode {
     return result;
   }
 
-  getBoundingVolume(zRange, worldOffset) {
+  getBoundingVolume(zRange, worldOffset, project) {
+    if (project) {
+      // Custom projection
+      const corner0 = osmTile2lngLat(this.x, this.y, this.z);
+      const corner1 = osmTile2lngLat(this.x + 1, this.y + 1, this.z);
+      const center = osmTile2lngLat(this.x + 0.5, this.y + 0.5, this.z);
+      corner0.z = zRange[1];
+      corner1.z = zRange[1];
+      center.z = zRange[0];
+
+      const cornerPos0 = project(corner0);
+      const cornerPos1 = project(corner1);
+      const centerPos = new Vector3(project(center));
+      const R = Math.max(centerPos.distance(cornerPos0), centerPos.distance(cornerPos1));
+
+      return new BoundingSphere(centerPos, R);
+    }
+
+    // Use WebMercator projection
     const scale = Math.pow(2, this.z);
     const extent = TILE_SIZE / scale;
     const originX = this.x * extent + worldOffset * TILE_SIZE;
@@ -92,25 +110,7 @@ class OSMNode {
 }
 
 export function getOSMTileIndices(viewport, maxZ, zRange) {
-  if (!(viewport instanceof WebMercatorViewport)) {
-    const bbox = viewport.getBounds();
-    // The width and height here are arbitrary - they just need to form a reasonable aspect ratio
-    // so that we don't get too many world copies
-    const {longitude, latitude, zoom} = fitBounds({
-      width: 100,
-      height: 100,
-      bounds: [[bbox[0], bbox[1]], [bbox[2], bbox[3]]]
-    });
-
-    viewport = new WebMercatorViewport({
-      width: 100,
-      height: 100,
-      longitude,
-      latitude,
-      zoom,
-      repeat: true
-    });
-  }
+  const project = viewport.resolution > 0 ? viewport.projectPosition : null;
 
   // Get the culling volume of the current camera
   const planes = Object.values(viewport.getFrustumPlanes()).map(
@@ -129,6 +129,7 @@ export function getOSMTileIndices(viewport, maxZ, zRange) {
   const root = new OSMNode(0, 0, 0);
   const traversalParams = {
     viewport,
+    project,
     cullingVolume,
     elevationBounds: [elevationMin, elevationMax],
     minZ,

--- a/modules/geo-layers/src/tile-layer/tile-2d-traversal.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-traversal.js
@@ -110,7 +110,7 @@ class OSMNode {
 }
 
 export function getOSMTileIndices(viewport, maxZ, zRange) {
-  const project = viewport.resolution > 0 ? viewport.projectPosition : null;
+  const project = viewport.resolution ? viewport.projectPosition : null;
 
   // Get the culling volume of the current camera
   const planes = Object.values(viewport.getFrustumPlanes()).map(

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -121,7 +121,7 @@ function getScale(z) {
 }
 
 // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Lon..2Flat._to_tile_numbers_2
-function osmTile2lngLat(x, y, z) {
+export function osmTile2lngLat(x, y, z) {
   const scale = getScale(z);
   const lng = (x / scale) * 360 - 180;
   const n = Math.PI - (2 * Math.PI * y) / scale;

--- a/test/modules/geo-layers/tile-layer/utils.spec.js
+++ b/test/modules/geo-layers/tile-layer/utils.spec.js
@@ -5,7 +5,7 @@ import {
   urlType,
   getURLFromTemplate
 } from '@deck.gl/geo-layers/tile-layer/utils';
-import {WebMercatorViewport, OrthographicView} from '@deck.gl/core';
+import {WebMercatorViewport, OrthographicView, _GlobeView as GlobeView} from '@deck.gl/core';
 import {Matrix4} from 'math.gl';
 
 const TEST_CASES = [
@@ -225,6 +225,31 @@ const TEST_CASES = [
       .scale(2)
       .invert(),
     output: []
+  },
+  {
+    title: 'globe',
+    viewport: new GlobeView().makeViewport({
+      width: 800,
+      height: 800,
+      viewState: {
+        longitude: -6,
+        latitude: 58,
+        zoom: 0.5
+      }
+    }),
+    tileSize: 256,
+    output: [
+      '0,0,2',
+      '0,1,1',
+      '0,1,2',
+      '1,0,2',
+      '1,1,1',
+      '1,1,2',
+      '2,0,2',
+      '2,1,2',
+      '3,0,2',
+      '3,1,2'
+    ]
   }
 ];
 
@@ -290,7 +315,7 @@ test('getTileIndices', t => {
 
 test('tileToBoundingBox', t => {
   for (const testCase of TEST_CASES) {
-    if (testCase.output.length) {
+    if (testCase.output.length && !testCase.viewport.resolution) {
       const {viewport, minZoom, maxZoom, tileSize, zRange} = testCase;
       const boundingBoxes = getTileIndices({viewport, maxZoom, minZoom, zRange, tileSize}).map(
         tile => tileToBoundingBox(viewport, tile.x, tile.y, tile.z)


### PR DESCRIPTION
For #5124

Note that the tile indices generated by this change are no longer culled by the view horizon; at low zoom levels, it will load the back of the earth if the back is not clipped by the far plane.

#### Change List
- Use frustum culling for globe tile traversal
- Test
