### PR TITLE
Fix composite layer update on viewport change

### DIFF
--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -205,6 +205,12 @@ export default class CompositeLayer extends Layer {
     return newProps;
   }
 
+  _onViewportChange() {
+    if (this.needsUpdate()) {
+      this.setNeedsUpdate();
+    }
+  }
+
   _getAttributeManager() {
     return null;
   }

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -205,12 +205,6 @@ export default class CompositeLayer extends Layer {
     return newProps;
   }
 
-  _onViewportChange() {
-    if (this.needsUpdate()) {
-      this.setNeedsUpdate();
-    }
-  }
-
   _getAttributeManager() {
     return null;
   }

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -395,7 +395,17 @@ export default class Layer extends Component {
 
     if (!oldViewport || !areViewportsEqual({oldViewport, viewport})) {
       this.setChangeFlags({viewportChanged: true});
-      this._onViewportChange();
+
+      if (this.isComposite) {
+        if (this.needsUpdate()) {
+          // Composite layers may add/remove sublayers on viewport change
+          // Because we cannot change the layers list during a draw cycle, we don't want to update sublayers right away
+          // This will not call update immediately, but mark the layerManager as needs update on the next frame
+          this.setNeedsUpdate();
+        }
+      } else {
+        this._update();
+      }
     }
   }
 
@@ -417,10 +427,6 @@ export default class Layer extends Component {
     for (const model of this.getModels()) {
       this._setModelAttributes(model, changedAttributes);
     }
-  }
-
-  _onViewportChange() {
-    this._update();
   }
 
   // Calls attribute manager to update any WebGL attributes

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -395,7 +395,7 @@ export default class Layer extends Component {
 
     if (!oldViewport || !areViewportsEqual({oldViewport, viewport})) {
       this.setChangeFlags({viewportChanged: true});
-      this._update();
+      this._onViewportChange();
     }
   }
 
@@ -417,6 +417,10 @@ export default class Layer extends Component {
     for (const model of this.getModels()) {
       this._setModelAttributes(model, changedAttributes);
     }
+  }
+
+  _onViewportChange() {
+    this._update();
   }
 
   // Calls attribute manager to update any WebGL attributes

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -199,15 +199,22 @@ function runLayerTestUpdate(testCase, {layerManager, deckRenderer}, layer, spies
   // Create a map of spies that the test case can inspect
   spies = testCase.spies || spies;
   const spyMap = injectSpies(layer, spies);
+  const drawLayers = () => {
+    deckRenderer.renderLayers({
+      viewports: [viewport],
+      layers: layerManager.getLayers(),
+      onViewportActive: layerManager.activateViewport
+    });
+  };
 
   layerManager.setLayers([layer]);
+  drawLayers();
 
-  // call draw layer
-  deckRenderer.renderLayers({
-    viewports: [viewport],
-    layers: layerManager.getLayers(),
-    onViewportActive: layerManager.activateViewport
-  });
+  // clear update flags set by viewport change, if any
+  if (layerManager.needsUpdate()) {
+    layerManager.updateLayers();
+    drawLayers();
+  }
 
   return {layer, spyMap};
 }


### PR DESCRIPTION
For #5165

#### Background

Right now, if a composite layer requires an update on viewport change (e.g. `TileLayer`, `HeatmapLayer`), `updateState` and `renderLayers` methods are called from `activateViewport`. However, we do not perform recursive updates during this phase, which means the new sublayers become orphans -- they are never used by the LayerManager.

This bug has been hidden by the fact that none of the official layers change sub layer props based on viewport properties. The TileLayer adds/removes sub layers during a separate update cycle, triggered when a tile is loaded.

#### Change List
- If a composite layer requires an update on viewport change, delay the call to `updateState` and `renderLayers` to the next update cycle
- `testLayer` util handles delayed update
- Unit test
