### PR TITLE
ArcLayer wrapLongitude always draws shortest path

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -6,7 +6,7 @@
 
 The behavior of `wrapLongitude` has changed. Before, setting this prop to `true` would project vertices to a copy of the map that is closer to the current center. Starting with v8.4, enabling this prop would "normalize" the geometry to the [-180, 180] longitude range. See the following list for layer-specific changes:
 
-- `LineLayer`: always draw the shortest path between source and target positions. If the shortest path crosses the 180th meridian, it is split into two segments.
+- `LineLayer` and `ArcLayer`: always draw the shortest path between source and target positions. If the shortest path crosses the 180th meridian, it is split into two segments.
 
 This change makes layers render more predictably at low zoom levels. To draw horizontally continuous map with multiple copies of the world, use [MapView](/docs/api-reference/core/map-view.md) with the `repeat` option:
 

--- a/modules/layers/src/arc-layer/arc-layer.js
+++ b/modules/layers/src/arc-layer/arc-layer.js
@@ -50,6 +50,11 @@ export default class ArcLayer extends Layer {
     return super.getShaders({vs, fs, modules: [project32, picking]}); // 'project' module added by default.
   }
 
+  // This layer has its own wrapLongitude logic
+  get wrapLongitude() {
+    return false;
+  }
+
   initializeState() {
     const attributeManager = this.getAttributeManager();
 
@@ -122,7 +127,14 @@ export default class ArcLayer extends Layer {
 
   draw({uniforms}) {
     const {viewport} = this.context;
-    const {widthUnits, widthScale, widthMinPixels, widthMaxPixels, greatCircle} = this.props;
+    const {
+      widthUnits,
+      widthScale,
+      widthMinPixels,
+      widthMaxPixels,
+      greatCircle,
+      wrapLongitude
+    } = this.props;
 
     const widthMultiplier = widthUnits === 'pixels' ? viewport.metersPerPixel : 1;
 
@@ -132,7 +144,8 @@ export default class ArcLayer extends Layer {
         greatCircle,
         widthScale: widthScale * widthMultiplier,
         widthMinPixels,
-        widthMaxPixels
+        widthMaxPixels,
+        useShortestPath: wrapLongitude
       })
       .draw();
   }


### PR DESCRIPTION
For #4621

Before:

![Screen Shot 2020-11-25 at 12 04 24 AM](https://user-images.githubusercontent.com/2059298/100292254-c54e9b00-2f34-11eb-9833-a2a8f63e6a01.png)


After:

![Screen Shot 2020-11-25 at 12 04 03 AM](https://user-images.githubusercontent.com/2059298/100292255-c7185e80-2f34-11eb-9887-8b7f10fef099.png)


#### Change List
- ArcLayer handling of `wrapLongitude`
- Upgrade guide

cc @heshan0131 