### PR TITLE
Support generic transform in prop types

### DIFF
--- a/docs/developer-guide/custom-layers/prop-types.md
+++ b/docs/developer-guide/custom-layers/prop-types.md
@@ -55,8 +55,18 @@ Each prop in `defaultProps` may be an object in the following shape:
 - `type` (string, required)
 - `value` (any, required) - the default value if this prop is not supplied
 - `async` (boolean, optional) - if `true`, the prop can either be a [Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to its actual value, or an url string (loaded using the base Layer's [fetch](/docs/api-reference/core/layer.md) prop).
-- `validate` (function, optional) - receives `value` as argument and returns `true` if the value is valid. Validation of layer props is only invoked in debug mode. This function is automatically populated if the prop has a built-in type.
-- `equal` (function, optional) - receives `value1`, `value2` as argument and returns `true` if the two values are equal. Comparison of layer props is invoked during layer update and the result is passed to `changeFlags.propsChanged`. This function is automatically populated if the prop has a built-in type.
+- `transform` (function, optional) - transforms an asynchronously loaded value and returns a new form. Receives the following arguments:
+  + `value` - the new value of this prop
+  + `oldValue` - the previous value of this prop
+  + `propType` - this prop type definition
+  + `layer` - the owner of this prop
+- `validate` (function, optional) - returns `true` if the value is valid. Validation of layer props is only invoked in debug mode. This function is automatically populated if the prop has a built-in type. Receives the following arguments:
+  + `value` - the value to be validated
+  + `propType` - this prop type definition
+- `equal` (function, optional) - returns `true` if the two prop values should be considered equal. Comparison of layer props is invoked during layer update and the result is passed to `changeFlags.propsChanged`. This function is automatically populated if the prop has a built-in type. Receives the following arguments:
+  + `value` - the new value of this prop
+  + `oldValue` - the previous value of this prop
+  + `propType` - this prop type definition
 - `deprecatedFor` (string|array, optional) - mark this prop as deprecated. The value is the new prop name(s) that this prop has been deprecated for. If the old prop is supplied instead of the new one, its value will be transferred to the new prop. The user will get a warning about the deprecation.
 - Any additional options, see individual types below.
 

--- a/docs/developer-guide/custom-layers/prop-types.md
+++ b/docs/developer-guide/custom-layers/prop-types.md
@@ -57,7 +57,10 @@ Each prop in `defaultProps` may be an object in the following shape:
 - `async` (boolean, optional) - if `true`, the prop can either be a [Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to its actual value, or an url string (loaded using the base Layer's [fetch](/docs/api-reference/core/layer.md) prop).
 - `transform` (function, optional) - transforms an asynchronously loaded value and returns a new form. Receives the following arguments:
   + `value` - the new value of this prop
-  + `oldValue` - the previous value of this prop
+  + `propType` - this prop type definition
+  + `layer` - the owner of this prop
+- `release` (function, optional) - release a transformed value when it's no longer in use. Receives the following arguments:
+  + `value` - the old value of this prop
   + `propType` - this prop type definition
   + `layer` - the owner of this prop
 - `validate` (function, optional) - returns `true` if the value is valid. Validation of layer props is only invoked in debug mode. This function is automatically populated if the prop has a built-in type. Receives the following arguments:

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -360,6 +360,7 @@ export default class Layer extends Component {
     }
     this.context.resourceManager.unsubscribe({consumerId: this.id});
     this.internalState.uniformTransitions.clear();
+    this.internalState.finalize();
   }
 
   // If state has a model, draw it with supplied uniforms

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -37,9 +37,9 @@ export default class ComponentState {
   finalize() {
     for (const propName in this.asyncProps) {
       const asyncProp = this.asyncProps[propName];
-      if (asyncProp.type && asyncProp.type.transform) {
+      if (asyncProp.type && asyncProp.type.release) {
         // Release any resources created by transforms
-        asyncProp.type.transform(null, asyncProp.resolvedValue, asyncProp.type, this.component);
+        asyncProp.type.release(asyncProp.resolvedValue, asyncProp.type, this.component);
       }
     }
   }
@@ -256,13 +256,14 @@ export default class ComponentState {
 
   // Give the app a chance to post process the loaded data
   _postProcessValue(asyncProp, value) {
-    if (asyncProp.type && asyncProp.type.transform) {
-      return asyncProp.type.transform(
-        value,
-        asyncProp.resolvedValue,
-        asyncProp.type,
-        this.component
-      );
+    const propType = asyncProp.type;
+    if (propType) {
+      if (propType.release) {
+        propType.release(asyncProp.resolvedValue, propType, this.component);
+      }
+      if (propType.transform) {
+        return propType.transform(value, propType, this.component);
+      }
     }
     return value;
   }

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -34,6 +34,16 @@ export default class ComponentState {
     this.oldAsyncProps = null; // Last props before update, with async values copied.
   }
 
+  finalize() {
+    for (const propName in this.asyncProps) {
+      const asyncProp = this.asyncProps[propName];
+      if (asyncProp.type && asyncProp.type.transform) {
+        // Release any resources created by transforms
+        asyncProp.type.transform(null, asyncProp.resolvedValue, asyncProp.type, this.component);
+      }
+    }
+  }
+
   getOldProps() {
     return this.oldAsyncProps || this.oldProps;
   }
@@ -110,14 +120,16 @@ export default class ComponentState {
     // TODO - use async props from the layer's prop types
     for (const propName in resolvedValues) {
       const value = resolvedValues[propName];
-      this._createAsyncPropData(propName, value, defaultValues[propName]);
+      this._createAsyncPropData(propName, defaultValues[propName]);
       this._updateAsyncProp(propName, value);
+      // Use transformed value
+      resolvedValues[propName] = this.getAsyncProp(propName);
     }
 
     for (const propName in originalValues) {
       const value = originalValues[propName];
       // Makes sure a record exists for this prop
-      this._createAsyncPropData(propName, value, defaultValues[propName]);
+      this._createAsyncPropData(propName, defaultValues[propName]);
       this._updateAsyncProp(propName, value);
     }
   }
@@ -155,7 +167,7 @@ export default class ComponentState {
   // Checks if an input value actually changed (to avoid reloading/rewatching promises/urls)
   _didAsyncInputValueChange(propName, value) {
     const asyncProp = this.asyncProps[propName];
-    if (value === asyncProp.lastValue) {
+    if (value === asyncProp.resolvedValue || value === asyncProp.lastValue) {
       return false;
     }
     asyncProp.lastValue = value;
@@ -165,7 +177,7 @@ export default class ComponentState {
   // Set normal, non-async value
   _setPropValue(propName, value) {
     const asyncProp = this.asyncProps[propName];
-    asyncProp.value = value;
+    value = this._postProcessValue(asyncProp, value);
     asyncProp.resolvedValue = value;
     asyncProp.pendingLoadCount++;
     asyncProp.resolvedLoadCount = asyncProp.pendingLoadCount;
@@ -195,7 +207,7 @@ export default class ComponentState {
     const loadCount = asyncProp.pendingLoadCount;
     promise
       .then(data => {
-        data = this._postProcessValue(propName, data);
+        data = this._postProcessValue(asyncProp, data);
         this._setAsyncPropValue(propName, data, loadCount);
 
         const onDataLoad = this.layer && this.layer.props.onDataLoad;
@@ -219,7 +231,12 @@ export default class ComponentState {
     let count = 0;
 
     for await (const chunk of iterable) {
-      data = this._postProcessValue(propName, chunk, data);
+      const {dataTransform} = this.component ? this.component.props : {};
+      if (dataTransform) {
+        data = dataTransform(chunk, data);
+      } else {
+        data = data.concat(chunk);
+      }
 
       // Used by the default _dataDiff function
       Object.defineProperty(data, '__diff', {
@@ -238,24 +255,26 @@ export default class ComponentState {
   }
 
   // Give the app a chance to post process the loaded data
-  _postProcessValue(propName, value, previousValue) {
-    const {dataTransform} = this.component ? this.component.props : {};
-    if (propName !== 'data') {
-      return value;
+  _postProcessValue(asyncProp, value) {
+    if (asyncProp.type && asyncProp.type.transform) {
+      return asyncProp.type.transform(
+        value,
+        asyncProp.resolvedValue,
+        asyncProp.type,
+        this.component
+      );
     }
-    if (dataTransform) {
-      return dataTransform(value, previousValue);
-    }
-    // previousValue is assigned if loaded with async iterator
-    return previousValue ? previousValue.concat(value) : value;
+    return value;
   }
 
   // Creating an asyncProp record if needed
-  _createAsyncPropData(propName, value, defaultValue) {
+  _createAsyncPropData(propName, defaultValue) {
     const asyncProp = this.asyncProps[propName];
     if (!asyncProp) {
+      const propTypes = this.component && this.component.constructor._propTypes;
       // assert(defaultValue !== undefined);
       this.asyncProps[propName] = {
+        type: propTypes && propTypes[propName],
         lastValue: null, // Supplied prop value (can be url/promise, not visible to layer)
         resolvedValue: defaultValue, // Resolved prop value (valid data, can be "shown" to layer)
         pendingLoadCount: 0, // How many loads have been issued

--- a/modules/core/src/lifecycle/prop-types.js
+++ b/modules/core/src/lifecycle/prop-types.js
@@ -54,6 +54,12 @@ const TYPE_DEFINITIONS = {
     equal(value1, value2, propType) {
       return !propType.compare || value1 === value2;
     }
+  },
+  data: {
+    transform: (value, oldValue, propType, component) => {
+      const {dataTransform} = component ? component.props : {};
+      return dataTransform && value ? dataTransform(value) : value;
+    }
   }
 };
 

--- a/modules/core/src/lifecycle/prop-types.js
+++ b/modules/core/src/lifecycle/prop-types.js
@@ -56,7 +56,7 @@ const TYPE_DEFINITIONS = {
     }
   },
   data: {
-    transform: (value, oldValue, propType, component) => {
+    transform: (value, propType, component) => {
       const {dataTransform} = component ? component.props : {};
       return dataTransform && value ? dataTransform(value) : value;
     }


### PR DESCRIPTION
#### Change List

- Add `transform` to prop type definition, remove hard-coded dataTransform call in ComponentState
- This technically changes `dataTransform` behavior - it now applies to synchronously supplied data as well
- Documentation
- Unit tests
