### PR TITLE
Fix picking coordinate calculation in overlapping views

### DIFF
--- a/docs/developer-guide/interactivity.md
+++ b/docs/developer-guide/interactivity.md
@@ -152,9 +152,13 @@ The picking engine returns "picking info" objects which contains a variety of fi
 | `x`      | Mouse position x relative to the viewport. |
 | `y`      | Mouse position y relative to the viewport. |
 | `coordinate` | Mouse position in geospatial coordinates. Only applies if `layer.props.coordinateSystem` is a geospatial mode such as `COORDINATE_SYSTEM.LNGLAT`. |
+| `viewport` | The viewport that the picked object belongs to. |
 
-> Specific deck.gl Layers may add additional fields to the picking `info` object. Check the documentation of each layer.
 
+Remarks:
+
+- Specific deck.gl Layers may add additional fields to the picking `info` object. Check the documentation of each layer.
+- Limitation when using multiple views: `viewport` could potentially be misidentified if two views that contain the picked layer also overlap with each other and do not clear the background.
 
 ### Example: Display a Tooltip for Hovered Object
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -18,6 +18,11 @@ new Deck({
 })
 ```
 
+### pickingInfo
+
+A legacy field `pickingInfo.lngLat` has been removed. Use `pickingInfo.coordinate` instead.
+
+
 ## Upgrading from deck.gl v8.2 to v8.3
 
 - The following is added to the default image loading options: `{imagebitmap: {premultiplyAlpha: 'none'}}` (previously `default`). This generates more visually similar outcome between `ImageBitmap` and `Image` formats (see changes in 8.2 below). You can override this behavior with the `loadOptions` prop of a layer. See [ImageLoader options](https://loaders.gl/modules/images/docs/api-reference/image-loader#options) for more information.

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -85,15 +85,18 @@ export default class DeckPicker {
   // Returns a new picking info object by assuming the last picked object is still picked
   getLastPickedObject({x, y, layers, viewports}, lastPickedInfo = this.lastPickedInfo.info) {
     const lastPickedLayerId = lastPickedInfo && lastPickedInfo.layer && lastPickedInfo.layer.id;
+    const lastPickedViewportId =
+      lastPickedInfo && lastPickedInfo.viewport && lastPickedInfo.viewport.id;
     const layer = lastPickedLayerId ? layers.find(l => l.id === lastPickedLayerId) : null;
-    const coordinate = viewports[0] && viewports[0].unproject([x, y]);
+    const viewport =
+      (lastPickedViewportId && viewports.find(v => v.id === lastPickedViewportId)) || viewports[0];
+    const coordinate = viewport && viewport.unproject([x - viewport.x, y - viewport.y]);
 
     const info = {
       x,
       y,
+      viewport,
       coordinate,
-      // TODO remove the lngLat prop after compatibility check
-      lngLat: coordinate,
       layer
     };
 

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -247,6 +247,7 @@ export default class DeckPicker {
         lastPickedInfo: this.lastPickedInfo,
         mode,
         layers,
+        layerFilter: this.layerFilter,
         viewports,
         x,
         y,

--- a/test/modules/core/lib/picking.spec.js
+++ b/test/modules/core/lib/picking.spec.js
@@ -50,18 +50,35 @@ const parameters = {
   mode: 'hover',
   viewports: [
     new WebMercatorViewport({
+      id: 'map1',
       longitude: -122,
       latitude: 38,
       zoom: 1,
       width: 200,
       height: 200
+    }),
+    new WebMercatorViewport({
+      id: 'map2',
+      longitude: -122,
+      latitude: 38,
+      zoom: 1,
+      x: 200,
+      y: 0,
+      width: 200,
+      height: 200
+    }),
+    new WebMercatorViewport({
+      id: 'minimap',
+      longitude: -100,
+      latitude: 40,
+      zoom: 1,
+      x: 250,
+      y: 50,
+      width: 100,
+      height: 100
     })
   ],
   layers: [testLayer, testLayerWithCallback, testCompositeLayer],
-  x: 100,
-  y: 100,
-  deviceX: 200,
-  deviceY: 200,
   pixelRatio: 2
 };
 
@@ -80,6 +97,8 @@ test('processPickInfo', t => {
   testInitializeLayer({layer: testLayerWithCallback});
   testInitializeLayer({layer: testCompositeLayer});
 
+  testLayerWithCallback.activateViewport(parameters.viewports[1]);
+
   const TEST_CASES = [
     {
       pickInfo: {
@@ -87,6 +106,8 @@ test('processPickInfo', t => {
         pickedLayer: null,
         pickedObjectIndex: -1
       },
+      x: 100,
+      y: 100,
       size: 1,
       info: {layer: null, index: -1, picked: false, x: 100, coordinate: [-122, 38]},
       lastPickedInfo: {layerId: null, index: -1},
@@ -98,6 +119,8 @@ test('processPickInfo', t => {
         pickedLayer: testLayer,
         pickedObjectIndex: 0
       },
+      x: 100,
+      y: 100,
       size: 2,
       info: {layer: testLayer, object: 'a', index: 0, picked: true, x: 100, coordinate: [-122, 38]},
       lastPickedInfo: {layerId: 'test-layer', index: 0},
@@ -109,6 +132,8 @@ test('processPickInfo', t => {
         pickedLayer: testLayer,
         pickedObjectIndex: 1
       },
+      x: 100,
+      y: 100,
       size: 2,
       info: {layer: testLayer, object: 'b'},
       lastPickedInfo: {layerId: 'test-layer', index: 1},
@@ -120,6 +145,8 @@ test('processPickInfo', t => {
         pickedLayer: testLayerWithCallback,
         pickedObjectIndex: 0
       },
+      x: 100,
+      y: 100,
       size: 3,
       info: {
         layer: testLayerWithCallback,
@@ -143,6 +170,8 @@ test('processPickInfo', t => {
         pickedLayer: testLayerWithCallback,
         pickedObjectIndex: 1
       },
+      x: 100,
+      y: 100,
       size: 2,
       info: {layer: testLayerWithCallback, object: 'b'},
       lastPickedInfo: {layerId: 'test-layer-with-callback', index: 1},
@@ -159,6 +188,8 @@ test('processPickInfo', t => {
         pickedLayer: testCompositeLayer.getSubLayers()[0],
         pickedObjectIndex: 0
       },
+      x: 100,
+      y: 100,
       size: 3,
       info: {
         layer: testCompositeLayer,
@@ -166,6 +197,45 @@ test('processPickInfo', t => {
       },
       lastPickedInfo: {layerId: 'test-composite-layer-points', index: 0},
       testLayerUniforms: {picking_uSelectedColorValid: 0}
+    },
+    {
+      pickInfo: {
+        pickedColor: [1, 0, 0, 0],
+        pickedLayer: testLayer,
+        pickedObjectIndex: 0
+      },
+      x: 300,
+      y: 100,
+      size: 2,
+      info: {layer: testLayer, object: 'a', index: 0, picked: true, x: 300, coordinate: [-100, 40]},
+      lastPickedInfo: {layerId: 'test-layer', index: 0},
+      testLayerUniforms: {picking_uSelectedColorValid: 1, picking_uSelectedColor: [1, 0, 0]}
+    },
+    {
+      pickInfo: {
+        pickedColor: [2, 0, 0, 0],
+        pickedLayer: testLayerWithCallback,
+        pickedObjectIndex: 1
+      },
+      x: 300,
+      y: 100,
+      size: 3,
+      info: {layer: testLayerWithCallback, object: 'b', x: 300, coordinate: [-122, 38]},
+      lastPickedInfo: {layerId: 'test-layer-with-callback', index: 1},
+      testLayerUniforms: {picking_uSelectedColorValid: 0, picking_uSelectedColor: [1, 0, 0]}
+    },
+    {
+      pickInfo: {
+        pickedColor: [0, 0, 0, 0],
+        pickedLayer: null,
+        pickedObjectIndex: -1
+      },
+      x: -1,
+      y: -1,
+      size: 2,
+      info: {layer: testLayerWithCallback, x: -1, viewport: parameters.viewports[0]},
+      lastPickedInfo: {layerId: null, index: -1},
+      testLayerUniforms: {picking_uSelectedColorValid: 0, picking_uSelectedColor: [1, 0, 0]}
     }
   ];
 
@@ -177,6 +247,8 @@ test('processPickInfo', t => {
 
   for (const testCase of TEST_CASES) {
     parameters.pickInfo = testCase.pickInfo;
+    parameters.x = testCase.x;
+    parameters.y = testCase.y;
     const infos = processPickInfo(parameters);
     t.is(infos.size, testCase.size, 'returns expected infos');
 

--- a/test/modules/core/lib/picking.spec.js
+++ b/test/modules/core/lib/picking.spec.js
@@ -79,6 +79,12 @@ const parameters = {
     })
   ],
   layers: [testLayer, testLayerWithCallback, testCompositeLayer],
+  layerFilter: ({layer, viewport}) => {
+    if (viewport.id === 'minimap') {
+      return layer.id !== 'test-layer-with-callback';
+    }
+    return true;
+  },
   pixelRatio: 2
 };
 
@@ -96,8 +102,6 @@ test('processPickInfo', t => {
   testInitializeLayer({layer: testLayer});
   testInitializeLayer({layer: testLayerWithCallback});
   testInitializeLayer({layer: testCompositeLayer});
-
-  testLayerWithCallback.activateViewport(parameters.viewports[1]);
 
   const TEST_CASES = [
     {


### PR DESCRIPTION
For #5177 

When picking with overlapping views, the current behavior is to always use the first viewport in the list.

See inline comment for new behavior.

The result could still be incorrect if the picked layer is rendered into multiple overlapping views. The only way to know which viewport is picked in that scenario is to pick once per view, which has a perf impact. We don't currently have a known use case like that.

This fix covers most use cases (minimap, screen space overlay) that are broken today.

#### Change List
- Be smarter in picking viewport
- Remove legacy `pickingInfo.lngLat`
- Add `pickingInfo.viewport`
- Fix unprojection in `onClick`
- Upgrade guide