### PR TITLE
Support plain object as image source

### DIFF
--- a/docs/api-reference/layers/bitmap-layer.md
+++ b/docs/api-reference/layers/bitmap-layer.md
@@ -55,11 +55,18 @@ new deck.BitmapLayer({});
 
 ### Data
 
-##### `image` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap)
+##### `image` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap|Object)
 
 - Default `null`.
 
-The image to display. If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
+The image to display.
+
+- If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+- One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
+- A luma.gl [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) instance
+- A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
+
+The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
 
 ##### `bounds` (Array)
 

--- a/docs/api-reference/layers/icon-layer.md
+++ b/docs/api-reference/layers/icon-layer.md
@@ -141,9 +141,16 @@ new deck.IconLayer({});
 
 Inherits from all [Base Layer](/docs/api-reference/core/layer.md) properties.
 
-##### `iconAtlas` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap, optional)
+##### `iconAtlas` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap|Object, optional)
 
-The atlas image. If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
+The atlas image. 
+
+- If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+- One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
+- A luma.gl [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) instance
+- A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
+
+The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
 
 If you go with pre-packed strategy, this prop is required.
 

--- a/docs/api-reference/mesh-layers/simple-mesh-layer.md
+++ b/docs/api-reference/mesh-layers/simple-mesh-layer.md
@@ -88,11 +88,18 @@ The following attributes are expected:
 - `texCoords` (Float32Array) - 2d texture coordinates
 
 
-##### `texture` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap, optional)
+##### `texture` (String|Texture2D|Image|ImageData|HTMLCanvasElement|HTMLVideoElement|ImageBitmap|Object, optional)
 
 - Default `null`.
 
-The texture of the geometries. If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
+The texture of the geometries.
+
+- If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+- One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
+- A luma.gl [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) instance
+- A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
+
+The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
 
 If `texture` is supplied, texture is used to render the geometries. Otherwise, object color obtained via the `getColor` accessor is used.
 

--- a/modules/core/src/utils/texture.js
+++ b/modules/core/src/utils/texture.js
@@ -13,21 +13,27 @@ const internalTextures = {};
 
 export function createTexture(layer, image) {
   const gl = layer.context && layer.context.gl;
-  if (!gl) {
+  if (!gl || !image) {
     return null;
   }
-  let texture = null;
+
+  // image could be one of:
+  //  - Texture2D
+  //  - Browser object: Image, ImageData, ImageData, HTMLCanvasElement, HTMLVideoElement, ImageBitmap
+  //  - Plain object: {width: <number>, height: <number>, data: <Uint8Array>}
   if (image instanceof Texture2D) {
     return image;
-  } else if (image) {
-    // Image, ImageData, ImageData, HTMLCanvasElement, HTMLVideoElement, ImageBitmap
-    texture = new Texture2D(gl, {
-      data: image,
-      parameters: {...DEFAULT_TEXTURE_PARAMETERS, ...layer.props.textureParameters}
-    });
-    // Track this texture
-    internalTextures[texture.id] = true;
+  } else if (image.constructor && image.constructor.name !== 'Object') {
+    // Browser object
+    image = {data: image};
   }
+
+  const texture = new Texture2D(gl, {
+    ...image,
+    parameters: {...DEFAULT_TEXTURE_PARAMETERS, ...layer.props.textureParameters}
+  });
+  // Track this texture
+  internalTextures[texture.id] = true;
   return texture;
 }
 

--- a/modules/layers/src/text-layer/font-atlas-manager.js
+++ b/modules/layers/src/text-layer/font-atlas-manager.js
@@ -119,7 +119,7 @@ export default class FontAtlasManager {
   }
 
   get texture() {
-    return this._atlas && this._atlas.data;
+    return this._atlas;
   }
 
   get mapping() {

--- a/test/modules/core/lifecycle/component-state.spec.js
+++ b/test/modules/core/lifecycle/component-state.spec.js
@@ -150,12 +150,12 @@ test('ComponentState#async props with transform', t => {
 
   const testData = [0, 1, 2, 3, 4];
   // prettier-ignore
-  const testImage = new Uint8ClampedArray([
+  const testImage = {data: new Uint8ClampedArray([
     0, 0, 0, 255,
     255, 0, 0, 255,
     0, 255, 0, 255,
     0, 0, 255, 255
-  ]);
+  ]), width: 2, height: 2};
 
   const state = new ComponentState();
 


### PR DESCRIPTION
`image` prop type supports an additional format: plain object (see documentation).

- Fixes an issue in TextLayer where the sub layer does not update if the font atlas canvas is reused
- Provides a way to further customize texture generation, e.g. format, mipmaps
- This allows pydeck users to directly pass pixel data without having to encode it into an image. @ajduberstein 

#### Change List
- image prop transform supports plain object as input
- FontAtlasManager texture format
- Docs
