### PR TITLE
Improve getShaders() support

### DIFF
--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.js
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.js
@@ -63,7 +63,7 @@ function normalizeData(data) {
 }
 
 export default class PointCloudLayer extends Layer {
-  getShaders(id) {
+  getShaders() {
     return super.getShaders({vs, fs, modules: [project32, gouraudLighting, picking]});
   }
 

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -54,7 +54,7 @@ const defaultProps = {
 };
 
 export default class ScatterplotLayer extends Layer {
-  getShaders(id) {
+  getShaders() {
     return super.getShaders({vs, fs, modules: [project32, picking]});
   }
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -61,9 +61,9 @@ const ATTRIBUTE_TRANSITION = {
 };
 
 export default class SolidPolygonLayer extends Layer {
-  getShaders(vs) {
+  getShaders(type) {
     return super.getShaders({
-      vs,
+      vs: type === 'top' ? vsTop : vsSide,
       fs,
       defines: {},
       modules: [project32, gouraudLighting, picking]
@@ -304,7 +304,7 @@ export default class SolidPolygonLayer extends Layer {
     let sideModel;
 
     if (filled) {
-      const shaders = this.getShaders(vsTop);
+      const shaders = this.getShaders('top');
       shaders.defines.NON_INSTANCED_MODEL = 1;
 
       topModel = new Model(
@@ -327,7 +327,7 @@ export default class SolidPolygonLayer extends Layer {
     if (extruded) {
       sideModel = new Model(
         gl,
-        Object.assign({}, this.getShaders(vsSide), {
+        Object.assign({}, this.getShaders('side'), {
           id: `${id}-side`,
           geometry: new Geometry({
             drawMode: GL.LINES,

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.js
@@ -67,6 +67,16 @@ const defaultProps = {
 };
 
 export default class ScenegraphLayer extends Layer {
+  getShaders() {
+    const modules = [project32, picking];
+
+    if (this.props._lighting === 'pbr') {
+      modules.push(pbr);
+    }
+
+    return {vs, fs, modules};
+  }
+
   initializeState() {
     const attributeManager = this.getAttributeManager();
     attributeManager.addInstanced({
@@ -197,12 +207,7 @@ export default class ScenegraphLayer extends Layer {
   }
 
   _getModelOptions() {
-    const modules = [project32, picking];
-    const {_lighting, _imageBasedLightingEnvironment} = this.props;
-
-    if (_lighting === 'pbr') {
-      modules.push(pbr);
-    }
+    const {_imageBasedLightingEnvironment} = this.props;
 
     let env = null;
     if (_imageBasedLightingEnvironment) {
@@ -218,11 +223,9 @@ export default class ScenegraphLayer extends Layer {
       waitForFullLoad: true,
       imageBasedLightingEnvironment: env,
       modelOptions: {
-        vs,
-        fs,
-        modules,
         isInstanced: true,
-        transpileToGLSL100: !isWebGL2(this.context.gl)
+        transpileToGLSL100: !isWebGL2(this.context.gl),
+        ...this.getShaders()
       },
       // tangents are not supported
       useTangents: false


### PR DESCRIPTION
For #5206 

Make `getShaders()` work consistently across all layers

#### Change List
- SolidPolygonLayer
- ScenegraphLayer
