### PR TITLE
Improve SolidPolygonLayer shaders performance (side polygons)

### DIFF
--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.js
@@ -24,13 +24,8 @@ export default `\
 precision highp float;
 
 varying vec4 vColor;
-varying float isValid;
 
 void main(void) {
-  if (isValid < 0.5) {
-    discard;
-  }
-
   gl_FragColor = vColor;
 
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.js
@@ -29,7 +29,6 @@ uniform float elevationScale;
 uniform float opacity;
 
 varying vec4 vColor;
-varying float isValid;
 
 struct PolygonProps {
   vec4 fillColors;
@@ -52,6 +51,13 @@ vec3 project_offset_normal(vec3 vector) {
 }
 
 void calculatePosition(PolygonProps props) {
+#ifdef IS_SIDE_VERTEX
+  if(vertexValid < 0.5){
+    gl_Position = vec4(0.);
+    return;
+  }
+#endif
+
   vec3 pos;
   vec3 pos64Low;
   vec3 normal;
@@ -64,11 +70,9 @@ void calculatePosition(PolygonProps props) {
 #ifdef IS_SIDE_VERTEX
   pos = mix(props.positions, props.nextPositions, vertexPositions.x);
   pos64Low = mix(props.positions64Low, props.nextPositions64Low, vertexPositions.x);
-  isValid = vertexValid;
 #else
   pos = props.positions;
   pos64Low = props.positions64Low;
-  isValid = 1.0;
 #endif
 
   if (extruded) {


### PR DESCRIPTION
#### Background
Extruded `SolidPolygonLayer` can produce a lot of overdraw. 
Right now each extruded loop (e.g. a building) is connected to the next one with a rectangular polygon (which is discarded in fs).
For our test map with an extruded single `SolidPolygonLayer` FPS goes up from 12 > 26 FPS with this fix.

#### Change List
- create "degenerate" triangles in `SolidPolygonLayer`'s vertex shader instead of per fragment discard.