### PR TITLE
[test-utils] Fix generateLayerTests crash when onBeforeUpdate is not supplied

### DIFF
--- a/modules/test-utils/src/generate-layer-tests.js
+++ b/modules/test-utils/src/generate-layer-tests.js
@@ -32,8 +32,8 @@ export function generateLayerTests({
   Layer,
   sampleProps = {},
   assert = defaultAssert,
-  onBeforeUpdate,
-  onAfterUpdate = () => {},
+  onBeforeUpdate = noop,
+  onAfterUpdate = noop,
   runDefaultAsserts = true
 }) {
   assert(Layer.layerName, 'Layer should have display name');


### PR DESCRIPTION
For #5219
