### PR TITLE
Use pull_request instead of pull_request_target in Github Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-  pull_request_target:
+  pull_request:
 
 jobs:
   test-node:


### PR DESCRIPTION
#### Change List

See the PR in `react-map-gl` for a description of why we should be using `pull_request` instead of `pull_request_target`: https://github.com/visgl/react-map-gl/pull/1251