### PR TITLE
MVTLayer coordinates transformation to WGS84

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -22,6 +22,10 @@ new Deck({
 
 A legacy field `pickingInfo.lngLat` has been removed. Use `pickingInfo.coordinate` instead.
 
+### MVTLayer
+
+- `onHover` and `onClick` callbacks now throw the `info.object` feature coordinates in WGS84 standard.
+
 
 ## Upgrading from deck.gl v8.2 to v8.3
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -48,11 +48,6 @@ export default class CartoLayer extends CompositeLayer {
     return mvtLayer ? mvtLayer.onHover(info, pickingEvent) : super.onHover(info, pickingEvent);
   }
 
-  onClick(info, pickingEvent) {
-    const [mvtLayer] = this.getSubLayers();
-    return mvtLayer ? mvtLayer.onClick(info, pickingEvent) : super.onClick(info, pickingEvent);
-  }
-
   renderLayers() {
     if (!this.state.tilejson) return null;
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -48,6 +48,11 @@ export default class CartoLayer extends CompositeLayer {
     return mvtLayer ? mvtLayer.onHover(info, pickingEvent) : super.onHover(info, pickingEvent);
   }
 
+  onClick(info, pickingEvent) {
+    const [mvtLayer] = this.getSubLayers();
+    return mvtLayer ? mvtLayer.onClick(info, pickingEvent) : super.onClick(info, pickingEvent);
+  }
+
   renderLayers() {
     if (!this.state.tilejson) return null;
 

--- a/modules/geo-layers/src/mvt-layer/coordinate-transform.js
+++ b/modules/geo-layers/src/mvt-layer/coordinate-transform.js
@@ -9,11 +9,9 @@ const availableTransformations = {
   MultiPolygon
 };
 
-function Point([pointX, pointY], bbox, viewport) {
-  const [minX, minY] = viewport.projectFlat([bbox.west, bbox.north]);
-  const [maxX, maxY] = viewport.projectFlat([bbox.east, bbox.south]);
-  const x = lerp(minX, maxX, pointX);
-  const y = lerp(minY, maxY, pointY);
+function Point([pointX, pointY], [nw, se], viewport) {
+  const x = lerp(nw[0], se[0], pointX);
+  const y = lerp(nw[1], se[1], pointY);
 
   return viewport.unprojectFlat([x, y]);
 }
@@ -43,8 +41,16 @@ function MultiPolygon(multiPolygon, bbox, viewport) {
 }
 
 export function transform(geometry, bbox, viewport) {
+  const nw = viewport.projectFlat([bbox.west, bbox.north]);
+  const se = viewport.projectFlat([bbox.east, bbox.south]);
+  const projectedBbox = [nw, se];
+
   return {
     ...geometry,
-    coordinates: availableTransformations[geometry.type](geometry.coordinates, bbox, viewport)
+    coordinates: availableTransformations[geometry.type](
+      geometry.coordinates,
+      projectedBbox,
+      viewport
+    )
   };
 }

--- a/modules/geo-layers/src/mvt-layer/coordinate-transform.js
+++ b/modules/geo-layers/src/mvt-layer/coordinate-transform.js
@@ -7,25 +7,29 @@ const availableTransformations = {
   MultiPolygon
 };
 
-function Point(point, tile) {
-  const originX = tile.x;
-  const originY = tile.y;
-  const zoomLevelSize = Math.pow(2, tile.z);
+function Point([pointX, pointY], {x, y, z}) {
+  const originX = x;
+  const originY = y;
+  const zoomLevelSize = Math.pow(2, z);
 
-  const y2 = 180 - ((point[1] + originY) * 360) / zoomLevelSize;
+  const y2 = 180 - ((pointY + originY) * 360) / zoomLevelSize;
 
   return [
-    ((point[0] + originX) * 360) / zoomLevelSize - 180,
+    ((pointX + originX) * 360) / zoomLevelSize - 180,
     (360 / Math.PI) * Math.atan(Math.exp((y2 * Math.PI) / 180)) - 90
   ];
 }
 
+function getPoints(geometry, tile) {
+  return geometry.map(g => availableTransformations.Point(g, tile));
+}
+
 function MultiPoint(multiPoint, tile) {
-  return multiPoint.map(point => availableTransformations.Point(point, tile));
+  return getPoints(multiPoint, tile);
 }
 
 function LineString(line, tile) {
-  return line.map(linePoint => availableTransformations.Point(linePoint, tile));
+  return getPoints(line, tile);
 }
 
 function MultiLineString(multiLineString, tile) {
@@ -33,7 +37,7 @@ function MultiLineString(multiLineString, tile) {
 }
 
 function Polygon(polygon, tile) {
-  return polygon.map(polygonRing => availableTransformations.LineString(polygonRing, tile));
+  return polygon.map(polygonRing => getPoints(polygonRing, tile));
 }
 
 function MultiPolygon(multiPolygon, tile) {

--- a/modules/geo-layers/src/mvt-layer/coordinate-transform.js
+++ b/modules/geo-layers/src/mvt-layer/coordinate-transform.js
@@ -1,0 +1,48 @@
+const availableTransformations = {
+  Point,
+  MultiPoint,
+  LineString,
+  MultiLineString,
+  Polygon,
+  MultiPolygon
+};
+
+function Point(point, tile) {
+  const originX = tile.x;
+  const originY = tile.y;
+  const zoomLevelSize = Math.pow(2, tile.z);
+
+  const y2 = 180 - ((point[1] + originY) * 360) / zoomLevelSize;
+
+  return [
+    ((point[0] + originX) * 360) / zoomLevelSize - 180,
+    (360 / Math.PI) * Math.atan(Math.exp((y2 * Math.PI) / 180)) - 90
+  ];
+}
+
+function MultiPoint(multiPoint, tile) {
+  return multiPoint.map(point => availableTransformations.Point(point, tile));
+}
+
+function LineString(line, tile) {
+  return line.map(linePoint => availableTransformations.Point(linePoint, tile));
+}
+
+function MultiLineString(multiLineString, tile) {
+  return multiLineString.map(lineString => availableTransformations.LineString(lineString, tile));
+}
+
+function Polygon(polygon, tile) {
+  return polygon.map(polygonRing => availableTransformations.LineString(polygonRing, tile));
+}
+
+function MultiPolygon(multiPolygon, tile) {
+  return multiPolygon.map(polygon => availableTransformations.Polygon(polygon, tile));
+}
+
+export function transform(geometry, tile) {
+  return {
+    ...geometry,
+    coordinates: availableTransformations[geometry.type](geometry.coordinates, tile)
+  };
+}

--- a/modules/geo-layers/src/mvt-layer/coordinate-transform.js
+++ b/modules/geo-layers/src/mvt-layer/coordinate-transform.js
@@ -19,7 +19,7 @@ function Point([pointX, pointY], bbox, viewport) {
 }
 
 function getPoints(geometry, bbox, viewport) {
-  return geometry.map(g => availableTransformations.Point(g, bbox, viewport));
+  return geometry.map(g => Point(g, bbox, viewport));
 }
 
 function MultiPoint(multiPoint, bbox, viewport) {
@@ -31,9 +31,7 @@ function LineString(line, bbox, viewport) {
 }
 
 function MultiLineString(multiLineString, bbox, viewport) {
-  return multiLineString.map(lineString =>
-    availableTransformations.LineString(lineString, bbox, viewport)
-  );
+  return multiLineString.map(lineString => LineString(lineString, bbox, viewport));
 }
 
 function Polygon(polygon, bbox, viewport) {
@@ -41,7 +39,7 @@ function Polygon(polygon, bbox, viewport) {
 }
 
 function MultiPolygon(multiPolygon, bbox, viewport) {
-  return multiPolygon.map(polygon => availableTransformations.Polygon(polygon, bbox, viewport));
+  return multiPolygon.map(polygon => Polygon(polygon, bbox, viewport));
 }
 
 export function transform(geometry, bbox, viewport) {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -153,13 +153,11 @@ export default class MVTLayer extends TileLayer {
   }
 
   getPickingInfo({info, sourceLayer}) {
-    info.sourceLayer = sourceLayer;
-    info.tile = sourceLayer.props.tile;
-
     const isWGS84 = this.context.viewport.resolution;
 
     if (!isWGS84 && info.object) {
-      info = {...info, object: transformTileCoordsToWGS84(info, this.context.viewport)};
+      info.tile = sourceLayer.props.tile;
+      info.object = transformTileCoordsToWGS84(info.object, info.tile, this.context.viewport);
     }
 
     return info;
@@ -250,14 +248,18 @@ function isFeatureIdDefined(value) {
   return value !== undefined && value !== null && value !== '';
 }
 
-function transformTileCoordsToWGS84({object, tile}, viewport) {
-  const {properties, geometry} = object;
-  const feature = {properties, geometry: {type: geometry.type}};
+function transformTileCoordsToWGS84(object, tile, viewport) {
+  const feature = {
+    ...object,
+    geometry: {
+      type: object.geometry.type
+    }
+  };
 
   // eslint-disable-next-line accessor-pairs
   Object.defineProperty(feature.geometry, 'coordinates', {
     get: () => {
-      return transform(geometry, tile.bbox, viewport);
+      return transform(object.geometry, tile.bbox, viewport);
     }
   });
 

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -152,11 +152,12 @@ export default class MVTLayer extends TileLayer {
     return super.onHover(info, pickingEvent);
   }
 
-  getPickingInfo({info, sourceLayer}) {
+  getPickingInfo(params) {
+    const info = super.getPickingInfo(params);
+
     const isWGS84 = this.context.viewport.resolution;
 
     if (!isWGS84 && info.object) {
-      info.tile = sourceLayer.props.tile;
       info.object = transformTileCoordsToWGS84(info.object, info.tile, this.context.viewport);
     }
 

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -52,7 +52,7 @@ export default class MVTLayer extends TileLayer {
   }
 
   async _updateTileData({props}) {
-    const {onDataLoad, tileExtent = 4096} = this.props;
+    const {onDataLoad} = this.props;
     let {data} = props;
     let tileJSON = null;
     let {minZoom, maxZoom} = props;
@@ -83,7 +83,7 @@ export default class MVTLayer extends TileLayer {
       }
     }
 
-    this.setState({data, tileJSON, minZoom, maxZoom, tileExtent});
+    this.setState({data, tileJSON, minZoom, maxZoom});
   }
 
   renderLayers() {

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -2,6 +2,7 @@ import test from 'tape-catch';
 import {testLayer} from '@deck.gl/test-utils';
 import {MVTLayer} from '@deck.gl/geo-layers';
 import ClipExtension from '@deck.gl/geo-layers/mvt-layer/clip-extension';
+import {transform} from '@deck.gl/geo-layers/mvt-layer/coordinate-transform';
 import {GeoJsonLayer} from '@deck.gl/layers';
 
 import {ScatterplotLayer} from '@deck.gl/layers';
@@ -28,6 +29,103 @@ const geoJSONData = [
     properties: {
       cartodb_id: 148
     }
+  }
+];
+
+const TARGET_TILE = {
+  x: 16059,
+  y: 12349,
+  z: 15
+};
+
+const TRANSFORM_COORDS_DATA = [
+  {
+    result: {type: 'Point', coordinates: [-3.56781005859375, 40.46993497635157]},
+    geom: {
+      type: 'Point',
+      coordinates: [0.25, 0.25] // local coords
+    },
+    tile: TARGET_TILE
+  },
+  {
+    result: {
+      type: 'MultiPoint',
+      coordinates: [[-3.56781005859375, 40.46993497635157], [-3.5650634765625, 40.46784549077253]]
+    },
+    geom: {
+      type: 'MultiPoint',
+      coordinates: [[0.25, 0.25], [0.5, 0.5]] // local coords
+    },
+    tile: TARGET_TILE
+  },
+  {
+    result: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-3.570556640625, 40.46366632458768],
+          [-3.5595703125, 40.46366632458768],
+          [-3.5595703125, 40.46784549077253],
+          [-3.570556640625, 40.46366632458768]
+        ]
+      ]
+    },
+    geom: {
+      type: 'Polygon',
+      coordinates: [[[0, 1], [1, 1], [1, 0.5], [0, 1]]] // local coords
+    },
+    tile: TARGET_TILE
+  },
+  {
+    result: {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          [
+            [-3.570556640625, 40.46366632458768],
+            [-3.5595703125, 40.46366632458768],
+            [-3.5595703125, 40.46784549077253],
+            [-3.570556640625, 40.46366632458768]
+          ],
+          [
+            [-3.570556640625, 40.46366632458768],
+            [-3.5595703125, 40.45948689837198],
+            [-3.5595703125, 40.46157664398328],
+            [-3.570556640625, 40.46366632458768]
+          ]
+        ]
+      ]
+    },
+    geom: {
+      type: 'MultiPolygon',
+      coordinates: [[[[0, 1], [1, 1], [1, 0.5], [0, 1]], [[0, 1], [1, 1.5], [1, 1.25], [0, 1]]]] // local coords
+    },
+    tile: TARGET_TILE
+  },
+  {
+    result: {
+      type: 'LineString',
+      coordinates: [[-3.570556640625, 40.472024396920574], [-3.570556640625, 40.46366632458768]]
+    },
+    geom: {
+      type: 'LineString',
+      coordinates: [[0, 0], [0, 1]] // local coords
+    },
+    tile: TARGET_TILE
+  },
+  {
+    result: {
+      type: 'MultiLineString',
+      coordinates: [
+        [[-3.570556640625, 40.472024396920574], [-3.570556640625, 40.46366632458768]],
+        [[-3.5650634765625, 40.46784549077253], [-3.570556640625, 40.46366632458768]]
+      ]
+    },
+    geom: {
+      type: 'MultiLineString',
+      coordinates: [[[0, 0], [0, 1]], [[0.5, 0.5], [0, 1]]] // local coords
+    },
+    tile: TARGET_TILE
   }
 ];
 
@@ -59,6 +157,15 @@ test('ClipExtension', t => {
   ];
 
   testLayer({Layer: GeoJsonLayer, testCases, onError: t.notOk});
+
+  t.end();
+});
+
+test('transformCoorsToWGS84', t => {
+  for (const tc of TRANSFORM_COORDS_DATA) {
+    const func = transform(tc.geom, tc.tile, tc.tileExtent);
+    t.deepEqual(func, tc.result, `transform ${tc.geom.type} returned expected WGS84 coordinates`);
+  }
 
   t.end();
 });

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -32,100 +32,68 @@ const geoJSONData = [
   }
 ];
 
-const TARGET_TILE = {
-  x: 16059,
-  y: 12349,
-  z: 15
-};
-
 const TRANSFORM_COORDS_DATA = [
   {
-    result: {type: 'Point', coordinates: [-3.56781005859375, 40.46993497635157]},
+    result: {type: 'Point', coordinates: [-135, 79.17133464081945]},
     geom: {
       type: 'Point',
       coordinates: [0.25, 0.25] // local coords
-    },
-    tile: TARGET_TILE
+    }
   },
   {
     result: {
       type: 'MultiPoint',
-      coordinates: [[-3.56781005859375, 40.46993497635157], [-3.5650634765625, 40.46784549077253]]
+      coordinates: [[-135, 79.17133464081945], [-90, 66.51326044311185]]
     },
     geom: {
       type: 'MultiPoint',
       coordinates: [[0.25, 0.25], [0.5, 0.5]] // local coords
-    },
-    tile: TARGET_TILE
+    }
   },
   {
     result: {
       type: 'Polygon',
-      coordinates: [
-        [
-          [-3.570556640625, 40.46366632458768],
-          [-3.5595703125, 40.46366632458768],
-          [-3.5595703125, 40.46784549077253],
-          [-3.570556640625, 40.46366632458768]
-        ]
-      ]
+      coordinates: [[[-180, 0], [0, 0], [0, 66.51326044311185], [-180, 0]]]
     },
     geom: {
       type: 'Polygon',
       coordinates: [[[0, 1], [1, 1], [1, 0.5], [0, 1]]] // local coords
-    },
-    tile: TARGET_TILE
+    }
   },
   {
     result: {
       type: 'MultiPolygon',
       coordinates: [
         [
-          [
-            [-3.570556640625, 40.46366632458768],
-            [-3.5595703125, 40.46366632458768],
-            [-3.5595703125, 40.46784549077253],
-            [-3.570556640625, 40.46366632458768]
-          ],
-          [
-            [-3.570556640625, 40.46366632458768],
-            [-3.5595703125, 40.45948689837198],
-            [-3.5595703125, 40.46157664398328],
-            [-3.570556640625, 40.46366632458768]
-          ]
+          [[-180, 0], [0, 0], [0, 66.51326044311185], [-180, 0]],
+          [[-180, 0], [0, -66.51326044311185], [0, -40.97989806962013], [-180, 0]]
         ]
       ]
     },
     geom: {
       type: 'MultiPolygon',
       coordinates: [[[[0, 1], [1, 1], [1, 0.5], [0, 1]], [[0, 1], [1, 1.5], [1, 1.25], [0, 1]]]] // local coords
-    },
-    tile: TARGET_TILE
+    }
   },
   {
     result: {
       type: 'LineString',
-      coordinates: [[-3.570556640625, 40.472024396920574], [-3.570556640625, 40.46366632458768]]
+      coordinates: [[-180, 85.0511287798066], [-180, 0]]
     },
     geom: {
       type: 'LineString',
       coordinates: [[0, 0], [0, 1]] // local coords
-    },
-    tile: TARGET_TILE
+    }
   },
   {
     result: {
       type: 'MultiLineString',
-      coordinates: [
-        [[-3.570556640625, 40.472024396920574], [-3.570556640625, 40.46366632458768]],
-        [[-3.5650634765625, 40.46784549077253], [-3.570556640625, 40.46366632458768]]
-      ]
+      coordinates: [[[-180, 85.0511287798066], [-180, 0]], [[-90, 66.51326044311185], [-180, 0]]]
     },
     geom: {
       type: 'MultiLineString',
       coordinates: [[[0, 0], [0, 1]], [[0.5, 0.5], [0, 1]]] // local coords
-    },
-    tile: TARGET_TILE
+    }
   }
 ];
 
@@ -162,8 +130,16 @@ test('ClipExtension', t => {
 });
 
 test('transformCoorsToWGS84', t => {
+  const viewport = new WebMercatorViewport({
+    latitude: 0,
+    longitude: 0,
+    zoom: 1
+  });
+
+  const bbox = {west: -180, north: 85.0511287798066, east: 0, south: 0};
+
   for (const tc of TRANSFORM_COORDS_DATA) {
-    const func = transform(tc.geom, tc.tile, tc.tileExtent);
+    const func = transform(tc.geom, bbox, viewport);
     t.deepEqual(func, tc.result, `transform ${tc.geom.type} returned expected WGS84 coordinates`);
   }
 

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -146,12 +146,14 @@ test('transformCoorsToWGS84', t => {
   t.end();
 });
 
-test.skip('MVT Highlight', t => {
+test('MVT Highlight', async t => {
   class TestMVTLayer extends MVTLayer {
     getTileData() {
       return geoJSONData;
     }
   }
+
+  TestMVTLayer.componentName = 'TestMVTLayer';
 
   const testCases = [
     {
@@ -166,14 +168,14 @@ test.skip('MVT Highlight', t => {
       onAfterUpdate: ({subLayers}) => {
         for (const layer of subLayers) {
           t.ok(layer.props.pickable, 'MVT Sublayer is pickable');
-          t.ok(layer.props.autoHighlight, 'AutoHighlight should be disabled');
+          t.ok(!layer.props.autoHighlight, 'AutoHighlight should be disabled');
           t.equal(layer.props.highlightedObjectIndex, 0, 'Feature highlighted has index 0');
         }
       }
     }
   ];
 
-  testLayer({Layer: TestMVTLayer, testCases, onError: t.notOk});
+  await testLayerAsync({Layer: TestMVTLayer, testCases, onError: t.notOk});
 
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

`MVTLayer` coordinates transformation to WGS84.
<!-- For other PRs without open issue -->
#### Background

Users usually think that something is wrong when trying to extract `object.coordinates` from `onClick/onHover` events in `MVTLayer`. Returned values are relative (0-1) coordinates in the tile, for better performance.

This PR includes a coordinates transformation to WGS84 latitude/longitude for `MVTLayer`.

<!-- For all the PRs -->
#### Change List
- Add coordinates transformation function in `MVTLayer` for `onClick/onHover` events
- Link `MVTLayer` `onClick` method in `carto-layer`
- Unit tests
