### PR TITLE
Fix MapView center during linear zoom transition

### DIFF
--- a/docs/api-reference/core/linear-interpolator.md
+++ b/docs/api-reference/core/linear-interpolator.md
@@ -10,12 +10,15 @@ See [View State Transitions](/docs/developer-guide/view-state-transitions.md) fo
 ```js
 import {LinearInterpolator} from '@deck.gl/core';
 
-new LinearInterpolator(['target', 'zoom']);
+new LinearInterpolator({transitionProps: ['target', 'zoom']});
 ```
 
 Parameters:
 
-* transitionProps (Array) - Array of prop names that should be linearly interpolated. Default `['longitude', 'latitude', 'zoom', 'bearing', 'pitch']`.
+- options (Object)
+  * `transitionProps` (Array, optional) - Array of prop names that should be linearly interpolated. Default `['longitude', 'latitude', 'zoom', 'bearing', 'pitch']`.
+  * `around` (Array, optional) - A point to zoom/rotate around, `[x, y]` in screen pixels. If provided, the location at this point will not move during the transition.
+  * `makeViewport` (Function, optional) - Called to construct a [viewport](/docs/api-reference/core/viewport.md), e.g. `props => new WebMercatorViewport(props)`. Must be provided if `around` is used.
 
 ## Source
 

--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -466,7 +466,7 @@ export default class Controller {
     const isZoomOut = this.isFunctionKeyPressed(event);
 
     const newControllerState = this.controllerState.zoom({pos, scale: isZoomOut ? 0.5 : 2});
-    this.updateViewport(newControllerState, this._getTransitionProps(), {
+    this.updateViewport(newControllerState, this._getTransitionProps({around: pos}), {
       isZooming: true,
       isPanning: true
     });

--- a/modules/core/src/controllers/map-controller.js
+++ b/modules/core/src/controllers/map-controller.js
@@ -421,9 +421,17 @@ export default class MapController extends Controller {
     super(MapState, props);
   }
 
-  _getTransitionProps() {
+  _getTransitionProps(opts) {
     // Enables Transitions on double-tap and key-down events.
-    return LINEAR_TRANSITION_PROPS;
+    return opts
+      ? {
+          ...LINEAR_TRANSITION_PROPS,
+          transitionInterpolator: new LinearInterpolator({
+            ...opts,
+            makeViewport: this.controllerState.makeViewport
+          })
+        }
+      : LINEAR_TRANSITION_PROPS;
   }
 
   _onPanRotate(event) {


### PR DESCRIPTION
#### Background

Longitude/latitude should not be interpolated linearly when zoom is in transition. This fixes #2360 and is required to enable smooth scroll-zooming for #5089.

#### Change List
- Add `around` option to `LinearInterpolator`
- Controller passes `around` position on double tap
- Documentation
