### PR TITLE
feature(core): Add pixel picking to BitmapLayer

### DIFF
--- a/docs/api-reference/layers/bitmap-layer.md
+++ b/docs/api-reference/layers/bitmap-layer.md
@@ -153,6 +153,28 @@ The color to use for transparent pixels, in `[r, g, b, a]`. Each component is in
 
 The color to tint the bitmap by, in `[r, g, b]`. Each component is in the `[0, 255]` range.
 
+### Callbacks
+
+From v8.4, `BitmapLayer` provides information on which pixel was picked. Picking callbacks (`onHover`, `onClick`) now contain an additional field `bitmap` field, with `pixel` coordinates.
+
+```typescript
+{
+  PickingInfo,
+  bitmap?: {
+    /** Size of bitmap imn pixels */
+    size: {
+      width: number;
+      height: number;
+    },
+    /* Integer coordinates into the bitmap */
+    pixel: [number, number];
+    /* Relative (0-1) floating point coordinates */
+    uv: [number, number];
+    /* Picked texture */
+    texture: Texture2D;
+  }
+};
+```
 
 ## Source
 

--- a/docs/api-reference/layers/bitmap-layer.md
+++ b/docs/api-reference/layers/bitmap-layer.md
@@ -155,26 +155,14 @@ The color to tint the bitmap by, in `[r, g, b]`. Each component is in the `[0, 2
 
 ### Callbacks
 
-From v8.4, `BitmapLayer` provides information on which pixel was picked. Picking callbacks (`onHover`, `onClick`) now contain an additional field `bitmap` field, with `pixel` coordinates.
+From v8.4, `BitmapLayer` provides information on which pixel was picked. Picking callbacks (`onHover`, `onClick`) contain an additional `bitmap` field with the following shape.
 
-```typescript
-{
-  PickingInfo,
-  bitmap?: {
-    /** Size of bitmap imn pixels */
-    size: {
-      width: number;
-      height: number;
-    },
-    /* Integer coordinates into the bitmap */
-    pixel: [number, number];
-    /* Relative (0-1) floating point coordinates */
-    uv: [number, number];
-    /* Picked texture */
-    texture: Texture2D;
-  }
-};
-```
+    
+- `pixel` ([number, number])  Integer coordinates into the bitmap
+- `size` ({width: number; height: number})  Size of bitmap in pixels
+- `uv` ([number, number]) Normalized (0-1) floating point coordinates
+
+Note that the `bitmap` field can be `null` if the layer is being deselected or the bitmap has not yet loaded.
 
 ## Source
 

--- a/docs/api-reference/layers/bitmap-layer.md
+++ b/docs/api-reference/layers/bitmap-layer.md
@@ -153,16 +153,39 @@ The color to use for transparent pixels, in `[r, g, b, a]`. Each component is in
 
 The color to tint the bitmap by, in `[r, g, b]`. Each component is in the `[0, 255]` range.
 
-### Callbacks
+## Pixel Picking
 
-From v8.4, `BitmapLayer` provides information on which pixel was picked. Picking callbacks (`onHover`, `onClick`) contain an additional `bitmap` field with the following shape.
+(From v8.4) The [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) passed to callbacks (`onHover`, `onClick`, etc.) provides information on which pixel was picked. It contains an additional `bitmap` field if applicable:
 
-    
-- `pixel` ([number, number])  Integer coordinates into the bitmap
-- `size` ({width: number; height: number})  Size of bitmap in pixels
-- `uv` ([number, number]) Normalized (0-1) floating point coordinates
+- `bitmap`
+  + `pixel` ([number, number])  Integer coordinates into the bitmap
+  + `size` ({width: number; height: number})  Size of bitmap in pixels
+  + `uv` ([number, number]) Normalized (0-1) floating point coordinates
 
-Note that the `bitmap` field can be `null` if the layer is being deselected or the bitmap has not yet loaded.
+Note that the `bitmap` field can be `null` if on mouse leave or if the bitmap has not yet loaded.
+
+The following code reads the picked pixel color from the bitmap when the layer is clicked:
+
+```js
+import {readPixelsToArray} from '@luma.gl/core';
+
+new BitmapLayer({
+  image: './my-image.png',
+  bounds: [-122.45, 37.75, -122.43, 37.78],
+  pickable: true,
+  onClick: ({bitmap, layer}) => {
+    if (bitmap) {
+      const pixelColor = readPixelsToArray(layer.props.image, {
+        sourceX: bitmap.pixel[0],
+        sourceY: bitmap.pixel[1],
+        sourceWidth: 1,
+        sourceHeight: 1
+      })
+      console.log('Color at picked pixel:', pixelColor)
+    }
+  }
+})
+```
 
 ## Source
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,14 @@
 
 This page contains highlights of each deck.gl release. Also check our [vis.gl blog](https://medium.com/vis-gl) for news about new releases and features in deck.gl.
 
+## deck.gl v8.4 (in development)
+
+Release data: TBD
+
+### BitmapLayer
+
+- `BitmapLayer` picking callbacks now provide information on which pixel was picked.
+
 ## deck.gl v8.3
 
 Release Date: Oct 12, 2020

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -19,9 +19,9 @@ const ROOT_URL =
 function getTooltip({tile, bitmap}) {
   let message = tile ? `tile: x: ${tile.x}, y: ${tile.y}, z: ${tile.z}` : '';
   if (bitmap) {
-    message += `\n${bitmap.pixel[0]},${bitmap.pixel[1]} of ${bitmap.size.width}x${
+    message += `\n${bitmap.pixel[0]},${bitmap.pixel[1]} in ${bitmap.size.width}x${
       bitmap.size.height
-    } ${bitmap.texture.id}`;
+    }`;
   }
   return message;
 }

--- a/examples/website/image-tile/app.js
+++ b/examples/website/image-tile/app.js
@@ -16,8 +16,14 @@ const INITIAL_VIEW_STATE = {
 const ROOT_URL =
   'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/image-tiles/moon.image';
 
-function getTooltip({tile}) {
-  return tile && `tile: x: ${tile.x}, y: ${tile.y}, z: ${tile.z}`;
+function getTooltip({tile, bitmap}) {
+  let message = tile ? `tile: x: ${tile.x}, y: ${tile.y}, z: ${tile.z}` : '';
+  if (bitmap) {
+    message += `\n${bitmap.pixel[0]},${bitmap.pixel[1]} of ${bitmap.size.width}x${
+      bitmap.size.height
+    } ${bitmap.texture.id}`;
+  }
+  return message;
 }
 
 export default function App({autoHighlight = true, onTilesLoad}) {

--- a/modules/layers/src/bitmap-layer/bitmap-layer-fragment.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer-fragment.js
@@ -2,8 +2,6 @@
  * Pack the top 12 bits of two normalized floats into 3 8-bit (rgb) values
  * This enables addressing 4096x4096 individual pixels
  *
- * TODO - current implementation only handles u fractions: 4096x256
- *
  * returns vec3 encoded RGB colors
  *  result.r - top 8 bits of u
  *  result.g - top 8 bits of v
@@ -20,7 +18,7 @@ vec3 packUVsIntoRGB(vec2 uv) {
   vec2 uvFraction4bit = floor(uvFraction * 16.);
 
   // Remainder can be encoded in blue channel, encode as 4 bits for pixel coordinates
-  float fractions = uvFraction4bit.x * 16. + uvFraction4bit.y;
+  float fractions = uvFraction4bit.x + uvFraction4bit.y * 16.;
 
   return vec3(uv8bit, fractions) / 255.;
 }

--- a/modules/layers/src/bitmap-layer/bitmap-layer-fragment.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer-fragment.js
@@ -12,17 +12,17 @@
 const packUVsIntoRGB = `
 vec3 packUVsIntoRGB(vec2 uv) {
   // Extract the top 8 bits. We want values to be truncated down so we can add a fraction
-  vec2 uv8bit = floor(uv * 256.) / 256.;
+  vec2 uv8bit = floor(uv * 256.);
 
   // Calculate the normalized remainders of u and v parts that do not fit into 8 bits
   // Scale and clamp to 0-1 range
-  vec2 uvFraction = mod((uv - uv8bit) * 256. * 16., 16.) / 16.0;
+  vec2 uvFraction = fract(uv * 256.);
+  vec2 uvFraction4bit = floor(uvFraction * 16.);
 
   // Remainder can be encoded in blue channel, encode as 4 bits for pixel coordinates
-  // TODO add make v component work without interfering with u
-  float fractions = uvFraction.x / 16.; // + uvFraction.y;
+  float fractions = uvFraction4bit.x * 16. + uvFraction4bit.y;
 
-  return vec3(uv8bit, fractions);
+  return vec3(uv8bit, fractions) / 255.;
 }
 `;
 

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -108,6 +108,34 @@ export default class BitmapLayer extends Layer {
     }
   }
 
+  getPickingInfo({info}) {
+    const uniforms = this.state && this.state.model && this.state.model.uniforms;
+    const {bitmapTexture} = uniforms || {};
+
+    if (!info.color || !bitmapTexture) {
+      info.bitmap = null;
+      return info;
+    }
+
+    const {width, height} = bitmapTexture;
+
+    // Picking color doesn't represent object index in this layer
+    info.index = 0;
+
+    // Calculate uv and pixel in bitmap
+    const uv = unpackUVsFromRGB(info.color);
+    const pixel = [Math.floor(uv[0] * width), Math.floor(uv[1] * height)];
+
+    info.bitmap = {
+      size: {width, height}, // Size of bitmap
+      uv, // Floating point precision in 0-1 range
+      pixel, // Truncated to integer and scaled to pixel size
+      texture: bitmapTexture
+    };
+
+    return info;
+  }
+
   _createMesh() {
     const {bounds} = this.props;
 
@@ -213,3 +241,16 @@ export default class BitmapLayer extends Layer {
 
 BitmapLayer.layerName = 'BitmapLayer';
 BitmapLayer.defaultProps = defaultProps;
+
+/**
+ * Decode uv floats from rgb bytes where b contains 4-bit fractions of uv
+ * @param {number[]} color
+ * @returns {number[]} uvs
+ * https://stackoverflow.com/questions/30242013/glsl-compressing-packing-multiple-0-1-colours-var4-into-a-single-var4-variab
+ */
+function unpackUVsFromRGB(color) {
+  const [u, v, fracUV] = color;
+  const vFrac = (fracUV & 0xf0) / 256;
+  const uFrac = (fracUV & 0x0f) / 16;
+  return [(u + uFrac) / 255, (v + vFrac) / 255];
+}

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -129,8 +129,7 @@ export default class BitmapLayer extends Layer {
     info.bitmap = {
       size: {width, height}, // Size of bitmap
       uv, // Floating point precision in 0-1 range
-      pixel, // Truncated to integer and scaled to pixel size
-      texture: bitmapTexture
+      pixel // Truncated to integer and scaled to pixel size
     };
 
     return info;

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -109,21 +109,21 @@ export default class BitmapLayer extends Layer {
   }
 
   getPickingInfo({info}) {
-    const uniforms = this.state && this.state.model && this.state.model.uniforms;
-    const {bitmapTexture} = uniforms || {};
+    const {image} = this.props;
 
-    if (!info.color || !bitmapTexture) {
+    if (!info.color || !image) {
       info.bitmap = null;
       return info;
     }
 
-    const {width, height} = bitmapTexture;
+    const {width, height} = image;
 
     // Picking color doesn't represent object index in this layer
     info.index = 0;
 
     // Calculate uv and pixel in bitmap
     const uv = unpackUVsFromRGB(info.color);
+
     const pixel = [Math.floor(uv[0] * width), Math.floor(uv[1] * height)];
 
     info.bitmap = {
@@ -249,7 +249,7 @@ BitmapLayer.defaultProps = defaultProps;
  */
 function unpackUVsFromRGB(color) {
   const [u, v, fracUV] = color;
-  const vFrac = (fracUV & 0xf0) / 256;
-  const uFrac = (fracUV & 0x0f) / 16;
-  return [(u + uFrac) / 255, (v + vFrac) / 255];
+  const uFrac = (fracUV & 0xf0) / 256;
+  const vFrac = (fracUV & 0x0f) / 16;
+  return [(u + uFrac) / 256, (v + vFrac) / 256];
 }

--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -249,7 +249,7 @@ BitmapLayer.defaultProps = defaultProps;
  */
 function unpackUVsFromRGB(color) {
   const [u, v, fracUV] = color;
-  const uFrac = (fracUV & 0xf0) / 256;
-  const vFrac = (fracUV & 0x0f) / 16;
+  const vFrac = (fracUV & 0xf0) / 256;
+  const uFrac = (fracUV & 0x0f) / 16;
   return [(u + uFrac) / 256, (v + vFrac) / 256];
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Adds texture coordinates to bitmap layer picking info.
#### Change List
- Adjust picking color in bitmap layer fragment shader
- Decode picking color in BitmapLayer.getPickingInfo callback.
- Added notes to bitmap-layer.md and whats-new.md

Added pixel coordinates to image-tile example (gigapixel moon).

Needs docs etc. @kylebarron assuming you will be able to handle any remaining work?
