### PR TITLE
Remove 3rd party modules from @deck.gl/jupyter-widget

### DIFF
--- a/modules/jupyter-widget/src/deck-bundle.js
+++ b/modules/jupyter-widget/src/deck-bundle.js
@@ -11,7 +11,6 @@ Object.assign(
   require('@deck.gl/geo-layers'),
   require('@deck.gl/mesh-layers'),
   require('@deck.gl/google-maps'),
-  require('@deck.gl/carto'),
   require('@deck.gl/json')
 );
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #5063. Reverts inclusion of @deck.gl/carto in the core pydeck JS bundle.
<!-- For other PRs without open issue -->
#### Background

We need a way of handling 3rd party/vendor-specific modules in pydeck that does not include that vendor's integration by default–much like how `@deck.gl/core` and `@deck.gl/carto` are separate modules there should be a `pydeck` core and `pydeck_carto`.
<!-- For all the PRs -->
#### Change List
- Remove Carto module from standalone bundle
