### PR TITLE
Core API docs pass

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -2,23 +2,28 @@
 
 `Deck` is a class that takes deck.gl layer instances and viewport parameters, renders those layers as a transparent overlay, and handles events.
 
-If you are using React, you should not use this component directly. Instead you should be rendering the [`DeckGL` React Component](/docs/api-reference/react/deckgl.md).
+If you are using React, you should not use this class directly. Instead you should be rendering the [DeckGL](/docs/api-reference/react/deckgl.md) React component.
 
 
 ## Usage
 
 ```js
 // Basic standalone use
-import {Deck, ScatterplotLayer} from 'deck.gl';
+import {Deck} from '@deck.gl/core';
+import {ScatterplotLayer} from '@deck.gl/layers';
 
-const App = (viewState, data) => (
-  const deck = new Deck({
-    layers: [new ScatterplotLayer({data})]
-  });
-  deck.setProps({viewState});
-);
+const deck = new Deck({
+  initialViewState: {
+    longitude: -122.45,
+    latitude: 37.78,
+    zoom: 12
+  },
+  controller: true,
+  layers: [
+    new ScatterplotLayer({data})
+  ]
+});
 ```
-
 
 ## Constructor
 
@@ -35,21 +40,159 @@ See the [Properties](#properties) section.
 
 ## Properties
 
-##### `width` (Number, required)
+### Initialization Settings
 
-Width of the canvas.
+The following properties are used to initialize a `Deck` instance. Any custom value should always be provided to the `Deck` constructor. Changing them with `setProps` afterwards will have no effect.
 
-##### `height` (Number, required)
+##### `canvas` (HTMLCanvasElement)
 
-Height of the canvas.
+The canvas to render into. Will be auto-created if not supplied.
 
-##### `layers` (Array, required)
+##### `gl` (WebGLContext)
 
-The array of deck.gl layers to be rendered. This array is expected to be an array of newly allocated instances of your deck.gl layers, created with updated properties derived from the current application state.
+WebGL context. Will be auto-created if not supplied.
+
+##### `glOptions` (Object)
+
+Additional options used when creating the WebGLContext. See [WebGL context attributes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext).
+
+##### `id` (String)
+
+* Default: `'deckgl-overlay'`
+
+ID assigned to the canvas that is created by this `Deck` instance, to allow style customization in CSS.
+
+##### `parent` (HTMLElement)
+
+* Default: `document.body`
+
+The container to append the auto-created canvas to.
+
+##### `debug` (Boolean)
+
+* Default: `false`
+
+Flag to enable WebGL debug mode. Also requires an extra luma.gl import:
+
+```js
+import '@luma.gl/debug';
+import {Deck} from '@deck.gl/core';
+
+new Deck({
+  // ...
+  debug: true
+})
+```
+
+Notes:
+
+- Debug mode is slower as it will use synchronous operations to keep track of GPU state.
+
+##### `_typedArrayManagerProps` (Object)
+
+* Default: {}
+
+(Experimental) May contain the following fields:
+  - `overAlloc` (Number) - Default `2`. By default, attributes are allocated twice the memory than they actually need (on both CPU and GPU). Must be larger than `1`.
+  - `poolSize` (Number) - Default `100`. When memory reallocation is needed, old chunks are held on to and recycled. Smaller number uses less CPU memory. Can be any number `>=0`.
+
+The above default settings make data updates faster, at the price of using more memory. If the app does not anticipate frequent data changes, they may be aggressively reduced:
+
+```js
+new Deck({
+  // ...
+  _typedArrayManagerProps: isMobile ? {overAlloc: 1, poolSize: 0} : null
+})
+```
+
+
+### Rendering Configuration
+
+##### `width` (Number|String)
+
+* Default: `'100%'`
+
+Width of the canvas, a number in pixels or a valid CSS string.
+
+##### `height` (Number|String)
+
+* Default: `'100%'`
+
+Height of the canvas, a number in pixels or a valid CSS string.
+
+##### `style` (Object)
+
+Additional CSS styles for the canvas.
+
+##### `useDevicePixels` (Boolean|Number)
+
+* Default: `true`
+
+Controls the resolution of drawing buffer used for rendering.
+
+* `true`: `Device (physical) pixels` resolution is used for rendering, this resolution is defined by `window.devicePixelRatio`. On Retina/HD systems this resolution is usually twice as big as `CSS pixels` resolution.
+* `false`: `CSS pixels` resolution (equal to the canvas size) is used for rendering.
+* `Number` (Experimental): Specified Number is used as a custom ratio (drawing buffer resolution to `CSS pixel` resolution) to determine drawing buffer size, a value less than `one` uses resolution smaller than `CSS pixels`, gives better performance but produces blurry images, a value greater than `one` uses resolution bigger than CSS pixels resolution (canvas size), produces sharp images but at a lower performance.
+
+Note:
+
+* Consider setting to `false` or to a number <=1 if better rendering performance is needed.
+* When it is set to a high Number (like, 4 or more), it is possible to hit the system limit for allocating drawing buffer, such cases will log a warning and fallback to system allowed resolution.
+
+##### `parameters` (Object)
+
+Expects an object with WebGL settings. Before each frame is rendered, this object will be passed to luma.gl's `setParameters` function to reset the WebGL context parameters, e.g. to disable depth testing, change blending modes etc. The default parameters set by `Deck` on initialization are the following:
+
+```js
+{
+  blend: true,
+  blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA],
+  polygonOffsetFill: true,
+  depthTest: true,
+  depthFunc: GL.LEQUAL
+}
+```
+
+Refer to the luma.gl [setParameters](https://luma.gl/docs/api-reference/gltools/parameter-setting) API for documentation on supported parameters and values.
+
+```js
+import GL from '@luma.gl/constants';
+new Deck({
+  // ...
+  parameters: {
+    blendFunc: [GL.ONE, GL.ONE, GL.ONE, GL.ONE],
+    depthTest: false
+  }
+});
+```
+
+Notes:
+
+- Any WebGL `parameters` prop supplied to individual layers will still override the global `parameters` when that layer is rendered.
+- An alternative way to set `parameters`  is to instead define the `onWebGLInitialized` callback (it receives the `gl` context as parameter) and call the luma.gl `setParameters` method inside it.
+
+##### `layers` (Array)
+
+* Default: `[]`
+
+The array of [Layer](/docs/api-reference/core/layer.md) instances to be rendered.
+
+Nested arrays are accepted, as well as falsy values (`null`, `false`, `undefined`). This allows applications to do something like:
+
+```js
+new Deck({
+  // ...
+  layers: dataSource.map((item, index) => item && [
+    new ScatterplotLayer({id: `scatterplot-${index}`, ...}),
+    new PolygonLayer({id: `polygon-${index}`, ...})
+  ])
+});
+// layers is in the shape of [[<layer>, <layer>], null, [<layer>, <layer>], ...]
+```
 
 ##### `layerFilter` (Function)
 
-Default: `null`
+* Default: `null`
 
 If supplied, will be called before a layer is drawn to determine whether it should be rendered. This gives the application an opportunity to filter out layers from the layer list during either rendering or picking. Filtering can be done per viewport or per layer or both. This enables techniques like adding helper layers that work as masks during picking but do not show up during rendering.
 
@@ -66,12 +209,7 @@ new Deck({
 }
 ```
 
-Notes:
-
-- `layerFilter` does not override the visibility defined by the layer's `visible` and `pickable` props.
-- All the lifecycle methods are still triggered even a if a layer is filtered out using this prop.
-
-Arguments:
+Receives arguments:
 
 - `layer` (Layer) - the layer to be drawn
 - `viewport` (Viewport) - the current viewport
@@ -86,58 +224,92 @@ Returns:
 
 `true` if the layer should be drawn.
 
-##### `getCursor` (Function)
+Notes:
 
-A custom callback to retrieve the cursor type. Receives an `interactionState` object and returns a string that is a [CSS cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor).
+- `layerFilter` does not override the visibility if the layer is disabled via `visible: false` or `pickable: false` props.
+- All the lifecycle methods other than `draw` are still triggered even a if a layer is filtered out using this method.
 
-Default: `({isDragging}) => isDragging ? 'grabbing' : 'grab'`
+##### `views` (Object|Array)
 
-Remarks:
+* Default: `new MapView()`
 
-* It is worth noting that when supplying a custom image for the cursor icon, Chrome requires a fallback option to be supplied, otherwise the custom image will not be loaded; e.g. `getCursor={() => 'url(images/custom.png), auto'}`
+A single [`View`](/docs/api-reference/core/view.md) instance, or an array of `View` instances.
 
-##### `views` (Array)
+`View`s represent the "camera(s)" (essentially viewport dimensions and projection matrices) that you look at your data with. deck.gl offers multiple view types for both geospatial and non-geospatial use cases. Read the [Views and Projections](/docs/developer-guide/views.md) guide for the concept and examples.
 
-A single `View`, or an array of [`View`](/docs/api-reference/core/view.md) instances (optionally mixed with [`Viewport`](/docs/api-reference/core/viewport.md) instances, although the latter is deprecated). If not supplied, a single `MapView` will be created. If an empty array is supplied, no `View` will be shown.
-
-Remarks:
-
-* During render and picking, deck.gl will render all the `View`s in the supplied order, this can matter if they overlap.
-* `View`s represent your "camera(s)" (essentially view and projection matrices, together with viewport width and height). By changing the `views` property you change the view of your layers.
 
 ##### `viewState` (Object)
 
-A geospatial `viewState` would typically contain the following fields:
+An object that describes the [view state](/docs/developer-guide/views.md#view-state) for each view in the `views` prop. For example, the default view's view state is described [here](/docs/api-reference/core/map-view.md#view-state):
 
-* `latitude` (Number, optional) - Current latitude - used to define a mercator projection if `viewport` is not supplied.
-* `longitude` (Number, optional) - Current longitude - used to define a mercator projection if `viewport` is not supplied.
-* `zoom` (Number, optional) - Current zoom - used to define a mercator projection if `viewport` is not supplied.
-* `bearing` (Number, optional) - Current bearing - used to define a mercator projection if `viewport` is not supplied.
-* `pitch` (Number, optional) - Current pitch - used to define a mercator projection if `viewport` is not supplied.
+```js
+new Deck({
+  // ...
+  viewState: {
+    longitude: -122.45,
+    latitude: 37.78,
+    zoom: 12,
+    pitch: 30,
+    bearing: 0
+  }
+})
+```
+
+When using multiple views, the `viewState` is a map from each view id to its respective view state object. See [example](/docs/developer-guide/views.md#using-multiple-views-with-view-states).
 
 Transitions between two viewState objects can also be achieved by providing set of fields to `viewState` prop, for more details check [ViewState Transitions](/docs/api-reference/core/view-state-transitions.md)).
 
-#### `initialViewState` (Object)
+Notes:
 
-If `initialViewState` is provided, the `Deck` component will track view state changes from any attached `controller` using internal state, with `initialViewState` as its initial view state.
+- If you supply this prop, you are responsible of managing the changes to the view state upon user interaction. This prop is therefore usually used together with the `onViewStateChange` callback ([example](/docs/developer-guide/interactivity.md#externally-manage-view-state)). For `Deck` to update view states automatically, use the `initialViewState` prop instead.
+
+##### `initialViewState` (Object)
+
+If `initialViewState` is provided, the `Deck` component will track view state changes from any attached `controller` using internal state, with `initialViewState` as its initial view state. This is the easiest way to [control the camera](/docs/developer-guide/interactivity.md).
 
 If the `initialViewState` prop changes, the internally tracked view state will be updated to match the new "initial" view state.
 
 Notes:
 
-* The `props.onViewStateChange` callback will still be called, if provided.
-* If `props.viewState` is supplied by the application, the supplied `viewState` will always be used, "shadowing" the `Deck` component's internal `viewState`.
+* The `onViewStateChange` callback will still be called, if provided.
+* If the `viewState` prop is supplied by the application, the supplied `viewState` will always be used, overriding the `Deck` component's internal view state.
 * In simple applications, use of the `initialViewState` prop can avoid the need to track the view state in the application.
 * One drawback of using `initialViewState` for reactive/functional applications is that the `Deck` component becomes more stateful.
 
+##### `effects` (Array)
+
+The array of effects to be rendered. A lighting effect will be added if an empty array is supplied. Refer to effect's documentation to see details:
+
+* [LightingEffect](/docs/api-reference/core/lighting-effect.md)
+* [PostProcessEffect](/docs/api-reference/core/post-process-effect.md)
+
+##### `_framebuffer` (Object)
+
+(Experimental) Render to a custom frame buffer other than to screen.
+
+##### `_animate` (Boolean)
+
+* Default: `false`
+
+(Experimental) Forces deck.gl to redraw layers every animation frame. Normally deck.gl layers are only redrawn if any change is detected.
+
+
+### Interaction Settings
+
 ##### `controller` (Function | Boolean | Object)
+
+* Default: `null`
 
 Options for viewport interactivity, e.g. pan, rotate and zoom with mouse, touch and keyboard. This is a shorthand for defining interaction with the `views` prop if you are using the default view (i.e. a single `MapView`).
 
 ```js
 new Deck({
-  ...
-  views: [new MapView({controller: true})]
+  // ...
+  views: [
+    new MapView({
+      controller: {touchRotate: true, doubleClickZoom: false}
+    })
+  ]
 })
 ```
 
@@ -145,66 +317,58 @@ is equivalent to:
 
 ```js
 new Deck({
-  ...
+  // ...
   // views: undefined
-  controller: true
+  controller: {touchRotate: true, doubleClickZoom: false}
 })
 ```
 
 `controller` can be one of the following types:
 
 * `null` or `false`: the viewport is not interactive.
-* `true`: initiates the default controller - a [MapController](/docs/api-reference/core/map-controller.md), with default options.
-* `Controller` class (not instance): initiates the provided controller with default options. Must be a subclass of the [MapController](/docs/api-reference/core/map-controller.md).
+* `true`: initiates the default controller of the default view - e.g. a [MapController](/docs/api-reference/core/map-controller.md) if `MapView` is used.
+* `Controller` class (not instance): initiates the provided controller with default options. Must be a subclass of [Controller](/docs/api-reference/core/controller.md).
 * `Object`: controller options. This will be merged with the default controller options.
-  + `controller.type`: the controller class, must be a subclass of the [MapController](/docs/api-reference/core/map-controller.md).
-  + For other options, consult the documentation of [Controller](/docs/api-reference/core/controller.md).
+  + `controller.type`: the controller class, must be a subclass of [Controller](/docs/api-reference/core/controller.md).
+  + Other options supported by the controller type. Consult the documentation of [Controller](/docs/api-reference/core/controller.md#options).
 
-Default `null`.
 
-#### `effects` (Array)
+##### `getCursor` (Function)
 
-The array of effects to be rendered.A lighting effect will be added if an empty array is supplied.Refer to effect's documentation to see details
-* [LightingEffect](/docs/api-reference/core/lighting-effect.md)
+* Default: `({isDragging}) => isDragging ? 'grabbing' : 'grab'`
 
-### Configuration Properties
+A custom callback to retrieve the cursor type.
 
-##### `id` (String, optional)
+Receives arguments:
 
-Canvas ID to allow style customization in CSS.
+- `interactiveState` (Object)
+  + `isDragging` (Boolean) - whether the pointer is down and moving
 
-##### `style` (Object, optional)
+Returns:
 
-CSS styles for the deckgl-canvas.
+A valid [CSS cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) string.
 
-##### `touchAction` (String, optional)
+Remarks:
 
-Allow browser default touch actions. See [hammer.js doc](http://hammerjs.github.io/touch-action/).
+* It is worth noting that when supplying a custom image for the cursor icon, Chrome requires a fallback option to be supplied, otherwise the custom image will not be loaded; e.g. `getCursor={() => 'url(images/custom.png), auto'}`
 
-Default: `none`.
+##### `getTooltip` (Function)
 
-By default, the deck canvas captures all touch interactions. This prop is useful for mobile applications to unblock default scrolling behavior. For example, use the combination `controller: {dragPan: false}` and `touchAction: 'pan-y'` to allow vertical page scroll when dragging over the canvas.
+Callback that takes a hovered-over point and renders a tooltip. If the prop is not specified, the tooltip is always hidden.
 
-##### `pickingRadius` (Number, optional)
-
-Extra pixels around the pointer to include while picking. This is helpful when rendered objects are difficult to target, for example irregularly shaped icons, small moving circles or interaction by touch. Default `0`.
-
-#### `getTooltip` (Function, optional)
-
-Callback that takes a hovered-over point and renders a tooltip. If the prop is not specified, the tooltip is hidden.
-
-Callback arguments:
+Receives arguments:
 
 * `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being hovered.
 
-If the callback returns `null`, the tooltip is hidden, with the CSS `display` property set to `none`.
-If the callback returns a string, that string is rendered in a tooltip with the default CSS styling described below.
-Otherwise, the callback can return an object with the following fields:
+Returns one of the following:
 
-* `text` (String, optional) - Specifies the `innerText` attribute of the tooltip.
-* `html` (String, optional) - Specifies the `innerHTML` attribute of the tooltip. Note that this will override the specified `innerText`.
-* `className` (String, optional) - Class name to attach to the tooltip element. The element has the default class name of `deck-tooltip`.
-* `style` (Object, optional) - An object of CSS styles to apply to the tooltip element, which can override the default styling.
+* `null` - the tooltip is hidden, with the CSS `display` property set to `none`.
+* A string - the string is rendered in a tooltip with the default CSS styling described below.
+* An object with the following fields:
+  + `text` (String, optional) - Specifies the `innerText` attribute of the tooltip.
+  + `html` (String, optional) - Specifies the `innerHTML` attribute of the tooltip. Note that this will override the specified `innerText`.
+  + `className` (String, optional) - Class name to attach to the tooltip element. The element has the default class name of `deck-tooltip`.
+  + `style` (Object, optional) - An object of CSS styles to apply to the tooltip element, which can override the default styling.
 
 By default, the tooltip has the following CSS style:
 
@@ -216,80 +380,43 @@ background-color: #29323c;
 padding: 10px;
 ```
 
-##### `useDevicePixels` (Boolean|Number, optional)
+##### `pickingRadius` (Number)
 
-Controls the resolution of drawing buffer used for rendering.
-
-* `true`: `Device (physical) pixels` resolution is used for rendering, this resolution is defined by `window.devicePixelRatio`. On Retina/HD systems this resolution is usually twice as big as `CSS pixels` resolution.
-* `false`: `CSS pixels` resolution (equal to the canvas size) is used for rendering.
-* `Number` (Experimental): Specified Number is used as a custom ratio (drawing buffer resolution to `CSS pixel` resolution) to determine drawing buffer size, a value less than `one` uses resolution smaller than `CSS pixels`, gives better performance but produces blurry images, a value greater than `one` uses resolution bigger than CSS pixels resolution (canvas size), produces sharp images but at a lower performance.
-
-Default value is `true`.
-
-Note:
-
-* Consider setting to `false` or to a Number less than `one` if better rendering performance is needed.
-
-* When it is set to a high Number (like, 4 or more), it is possible to hit the system limit for allocating drawing buffer, such cases will log a warning and fallback to system allowed resolution.
-
-##### `gl` (Object, optional)
-
-gl context, will be autocreated if not supplied.
-
-##### `glOptions` (Object, optional)
-
-Additional options used when creating the WebGLContext. See [WebGL context attributes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext).
-
-##### `_framebuffer` (Object, optional)
-
-(Experimental) Render to a custom frame buffer other than to screen.
-
-##### `parameters` (Object, optional)
-
-Expects an object with WebGL settings. This object will be passed to luma.gl's `setParameters` function to configure the WebGL context, e.g. to disable depth testing, change blending modes etc.
-
-The `parameters` will be set before each frame is rendered. Naturally, any WebGL `parameters` prop supplied to individual layers will still override global parameters for that layer.
-
-To get access to static parameter values, applications can `import GL from 'luma.gl'`. Please refer to the luma.gl [setParameters](https://luma.gl/docs/api-reference/gltools/parameter-setting) API for documentation on supported parameters and values.
-
-An alternative way to set `parameters`  is to instead define the `onWebGLInitialized` callback (it receives the `gl` context as parameter) and call the luma.gl `setParameters` method inside it.
+Extra pixels around the pointer to include while picking. This is helpful when rendered objects are difficult to target, for example irregularly shaped icons, small moving circles or interaction by touch. Default `0`.
 
 
-##### `debug` (Boolean, optional)
+##### `touchAction` (String)
 
-Flag to enable WebGL debug mode.
+* Default: `none`.
 
-Default value is `false`.
+Allow browser default touch actions. See [hammer.js documentation](http://hammerjs.github.io/touch-action/).
 
-Notes:
+By default, the deck canvas captures all touch interactions. This prop is useful for mobile applications to unblock default scrolling behavior. For example, use the combination `controller: {dragPan: false}` and `touchAction: 'pan-y'` to allow vertical page scroll when dragging over the canvas.
 
-* debug mode is slower as it will use synchronous operations to keep track of GPU state.
-* Enabling debug mode also requires an extra luma.gl import:
+##### `_pickable` (Boolean)
 
-```js
-import '@luma.gl/debug'
-```
+* Default: `true`
 
-##### `_animate` (Experimental)
-
-Forces deck.gl to redraw layers every animation frame. Normally deck.gl layers are only redrawn if any change is detected.
+(Experimental) If set to `false`, force disables all picking features, disregarding the `pickable` prop set in any layer.
 
 
 ### Event Callbacks
 
-##### `onWebGLInitialized` (Function, optional)
+##### `onWebGLInitialized` (Function)
 
 Called once the WebGL context has been initiated.
 
-Callback arguments:
+Receives arguments:
 
 * `gl` - the WebGL context.
 
 ##### `onViewStateChange` (Function)
 
-The `onViewStateChange` callback is fired when the user has interacted with the deck.gl canvas, e.g. using mouse, touch or keyboard.
+Called when the user has interacted with the deck.gl canvas, e.g. using mouse, touch or keyboard.
 
 `onViewStateChange({viewState, interactionState, oldViewState})`
+
+Receives arguments:
 
 * `viewState` - An updated [view state](/docs/developer-guide/views.md) object.
 * `interactionState` - Describes the interaction that invoked the view state change. May include the following fields:
@@ -302,123 +429,129 @@ The `onViewStateChange` callback is fired when the user has interacted with the 
 
 Returns:
 
-* The application can return an updated view state. If a view state is returned, it will be used instead of the passed in `viewState` to update the application's internal view state (see `initialViewState`).
+A view state object that is used to update `Deck`'s internally tracked view state (see `initialViewState`). This can be used to intercept and modify the view state before the camera updates, see [add constraints to view state example](/docs/developer-guide/interactivity.md#add-constraints-to-view-state).
 
-##### `onHover` (Function, optional)
+If no value is returned, it's equivalent to `(viewState) => viewState`.
+
+##### `onHover` (Function)
 
 Called when the pointer moves over the canvas.
 
-Callback arguments:
+Receives arguments:
 
 * `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being hovered.
 * `event` - the original gesture event
 
-##### `onClick` (Function, optional)
+##### `onClick` (Function)
 
 Called when clicking on the canvas.
 
-Callback arguments:
+Receives arguments:
 
 * `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being clicked.
 * `event` - the original gesture event
 
-##### `onDragStart` (Function, optional)
+##### `onDragStart` (Function)
 
 Called when the user starts dragging on the canvas.
 
-Callback arguments:
+Receives arguments:
 
 * `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being dragged.
 * `event` - the original gesture event
 
-##### `onDrag` (Function, optional)
+##### `onDrag` (Function)
 
 Called when dragging the canvas.
 
-Callback arguments:
+Receives arguments:
 
 * `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being dragged.
 * `event` - the original gesture event
 
-##### `onDragEnd` (Function, optional)
+##### `onDragEnd` (Function)
 
 Called when the user releases from dragging the canvas.
 
-Callback arguments:
+Receives arguments:
 
 * `info` - the [picking info](/docs/developer-guide/interactivity.md#the-picking-info-object) describing the object being dragged.
 * `event` - the original gesture event
 
 
-##### `onLoad` (Function, optional)
+##### `onLoad` (Function)
 
 Called once after gl context and Deck components (`ViewManager`, `LayerManager`, etc) are created. It is safe to trigger viewport transitions after this event.
 
 
-##### `onResize` (Function, optional)
+##### `onResize` (Function)
 
 Called when the canvas resizes.
 
-Callback arguments:
+Receives arguments:
 
 * `size`
   - `width` (Number) - the new width of the deck canvas, in client pixels
   - `height` (Number) - the new height of the deck canvas, in client pixels
 
 
-##### `onBeforeRender` (Function, optional)
+##### `onBeforeRender` (Function)
 
 Called just before the canvas rerenders.
 
-Callback arguments:
+Receives arguments:
 
 * `gl` - the WebGL context.
 
 
-##### `onAfterRender` (Function, optional)
+##### `onAfterRender` (Function)
 
 Called right after the canvas rerenders.
 
-Callback arguments:
+Receives arguments:
 
 * `gl` - the WebGL context.
 
 
-
-##### `onError` (Function, optional)
+##### `onError` (Function)
 
 Called if deck.gl encounters an error. By default, deck logs the error to console and attempt to continue rendering the rest of the scene.
 
-Callback arguments:
+Receives arguments:
 
 * `error` ([Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error))
 * `source` - the source of the error, likely a Layer instance
 
 
-##### `_onMetrics` (Function, optional) **Experimental**
+##### `_onMetrics` (Function)
 
-Called once every second with performance metrics.
+(Experimental) Called once every second with performance metrics.
 
-Callback argument is an object with fields specified [here](#metrics).
+Receives arguments:
+
+- `metrics` - an object with fields specified [here](#metrics).
+
 
 ## Methods
 
 ##### `finalize`
 
-Frees resources associated with this object immediately (rather than waiting for garbage collection).
+Frees all resources associated with this `Deck` instance.
 
 `deck.finalize()`
 
 
 ##### `setProps`
 
-Updates properties.
+Updates (partial) properties.
 
 ```js
 deck.setProps({...});
 ```
 
-See the Properties section on this page for more detail on which props can be set.
+Parameters:
+
+* One or more properties to update, as described in the "Properties" section on this page.
 
 ##### `redraw`
 
@@ -427,8 +560,10 @@ Attempt to draw immediately, rather than waiting for the next draw cycle. By def
 Redrawing frequently outside of rAF may cause performance problems. Only use this method if the render cycle must be managed manually.
 
 ```js
-deck.redraw(force);
+deck.redraw(true);
 ```
+
+Parameters:
 
 * `force` (Boolean) - if `false`, only redraw if necessary (e.g. changes have been made to views or layers). If `true`, skip the check. Default `false`.
 
@@ -440,6 +575,8 @@ Get the closest pickable and visible object at the given screen coordinate.
 ```js
 deck.pickObject({x, y, radius, layerIds})
 ```
+
+Parameters:
 
 * `x` (Number) - x position in pixels
 * `y` (Number) - y position in pixels
@@ -459,6 +596,8 @@ Performs deep picking. Finds all close pickable and visible object at the given 
 ```js
 deck.pickMultipleObjects({x, y, radius, layerIds, depth})
 ```
+
+Parameters:
 
 * `x` (Number) - x position in pixels
 * `y` (Number) - y position in pixels
@@ -504,28 +643,24 @@ Notes:
 
 ## Member Variables
 
-#### metrics
+##### `metrics`
 
 A map of various performance statistics for the last 60 frames of rendering. Metrics gathered in deck.gl are the following:
-- 'fps': average number of frames rendered per second
-- 'updateAttributesTime': time spent updating layer attributes
-- 'setPropsTime': time spent setting deck properties
-- 'framesRedrawn': number of times the scene was rendered
-- 'pickTime': total time spent on picking operations
-- 'pickCount': number of times a pick operation was performed
-- 'gpuTime': total time spent on GPU processing
-- 'gpuTimePerFrame': average time spent on GPU processing per frame
-- 'cpuTime': total time spent on CPU processing
-- 'cpuTimePerFrame': average time spent on CPU processing per frame
-- 'bufferMemory': total GPU memory allocated for buffers
-- 'textureMemory': total GPU memory allocated for textures
-- 'renderbufferMemory': total GPU memory allocated for renderbuffers
-- 'gpuMemory': total allocated GPU memory
 
-
-## Remarks
-
-* Since deck.gl is based on WebGL and uses a single WebGL context, it can only render into a single canvas. Thus all its `View`s will render into the same canvas (unless you use multiple DeckGL instances, but that can have significant resource and performance impact).
+- `fps` - average number of frames rendered per second
+- `updateAttributesTime` - time spent updating layer attributes
+- `setPropsTime` - time spent setting deck properties
+- `framesRedrawn` - number of times the scene was rendered
+- `pickTime` - total time spent on picking operations
+- `pickCount` - number of times a pick operation was performed
+- `gpuTime` - total time spent on GPU processing
+- `gpuTimePerFrame` - average time spent on GPU processing per frame
+- `cpuTime` - total time spent on CPU processing
+- `cpuTimePerFrame` - average time spent on CPU processing per frame
+- `bufferMemory` - total GPU memory allocated for buffers
+- `textureMemory` - total GPU memory allocated for textures
+- `renderbufferMemory` - total GPU memory allocated for renderbuffers
+- `gpuMemory` - total allocated GPU memory
 
 
 ## Source

--- a/docs/api-reference/core/first-person-view.md
+++ b/docs/api-reference/core/first-person-view.md
@@ -19,13 +19,13 @@ new FirstPersonView({id, ...});
 
 To render, a `FirstPersonView` needs to be combined with a `viewState` object with the following parameters:
 
-- `longitude` (`Number`, optional) - longitude of the camera
-- `latitude` (`Number`, optional) - latitude of the camera
-* `position` (`Number[3]`, optional) - meter offsets of the camera from the lng-lat anchor point. Default `[0, 0, 0]`.
-* `bearing` (`Number`, optional) - bearing angle in degrees. Default `0` (north).
-* `pitch` (`Number`, optional) - pitch angle in degrees. Default `0` (horizontal).
-- `maxPitch` (`Number`, optional) - max pitch angle. Default `90` (down).
-- `minPitch` (`Number`, optional) - min pitch angle. Default `-90` (up).
+- `longitude` (Number, optional) - longitude of the camera
+- `latitude` (Number, optional) - latitude of the camera
+* `position` (Number[3], optional) - meter offsets of the camera from the lng-lat anchor point. Default `[0, 0, 0]`.
+* `bearing` (Number, optional) - bearing angle in degrees. Default `0` (north).
+* `pitch` (Number, optional) - pitch angle in degrees. Default `0` (horizontal).
+- `maxPitch` (Number, optional) - max pitch angle. Default `90` (down).
+- `minPitch` (Number, optional) - min pitch angle. Default `-90` (up).
 
 
 ## FirstPersonController

--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -32,18 +32,18 @@ const view = new GlobeView({id, ...});
 
 `GlobeView` takes the same parameters as the [View](/docs/api-reference/core/view.md) superclass constructor, plus the following:
 
-- `resolution` (`Number`, optional) - the resolution at which to turn flat features into 3D meshes, in degrees. Smaller numbers will generate more detailed mesh. Default `10`.
+- `resolution` (Number, optional) - the resolution at which to turn flat features into 3D meshes, in degrees. Smaller numbers will generate more detailed mesh. Default `10`.
 
 
 ## View State
 
 To render, `GlobeView` needs to be used together with a `viewState` with the following parameters:
 
-- `longitude` (`Number`) - longitude at the viewport center
-- `latitude` (`Number`) - latitude at the viewport center
-- `zoom` (`Number`) - zoom level
-- `maxZoom` (`Number`, optional) - max zoom level. Default `20`.
-- `minZoom` (`Number`, optional) - min zoom level. Default `0`.
+- `longitude` (Number) - longitude at the viewport center
+- `latitude` (Number) - latitude at the viewport center
+- `zoom` (Number) - zoom level
+- `maxZoom` (Number, optional) - max zoom level. Default `20`.
+- `minZoom` (Number, optional) - min zoom level. Default `0`.
 
 Additional projection matrix arguments:
 

--- a/docs/api-reference/core/map-view.md
+++ b/docs/api-reference/core/map-view.md
@@ -13,21 +13,24 @@ const view = new MapView({id, ...});
 
 `MapView` takes the same parameters as the [View](/docs/api-reference/core/view.md) superclass constructor, plus the following:
 
-- `repeat` (`Boolean`) - Whether to render multiple copies of the map at low zoom levels. Default `false`.
+- `repeat` (Boolean, optional) - Whether to render multiple copies of the map at low zoom levels. Default `false`.
+- `nearZMultiplier` (Number, optional) - Scaler for the near plane, 1 unit equals to the height of the viewport. Default to `0.1`. Overwrites the `near` parameter.
+- `farZMultiplier` (Number, optional) - Scaler for the far plane, 1 unit equals to the distance from the camera to the top edge of the screen. Default to `1.01`. Overwrites the `far` parameter.
+
 
 ## View State
 
 To render, `MapView` needs to be used together with a `viewState` with the following parameters:
 
-- `longitude` (`Number`) - longitude at the map center
-- `latitude` (`Number`) - latitude at the map center
-- `zoom` (`Number`) - zoom level
-- `pitch` (`Number`, optional) - pitch angle in degrees. Default `0` (top-down).
-- `bearing` (`Number`, optional) - bearing angle in degrees. Default `0` (north).
-- `maxZoom` (`Number`, optional) - max zoom level. Default `20`.
-- `minZoom` (`Number`, optional) - min zoom level. Default `0`.
-- `maxPitch` (`Number`, optional) - max pitch angle. Default `60`.
-- `minPitch` (`Number`, optional) - min pitch angle. Default `0`.
+- `longitude` (Number) - longitude at the map center
+- `latitude` (Number) - latitude at the map center
+- `zoom` (Number) - zoom level
+- `pitch` (Number, optional) - pitch angle in degrees. Default `0` (top-down).
+- `bearing` (Number, optional) - bearing angle in degrees. Default `0` (north).
+- `maxZoom` (Number, optional) - max zoom level. Default `20`.
+- `minZoom` (Number, optional) - min zoom level. Default `0`.
+- `maxPitch` (Number, optional) - max pitch angle. Default `60`.
+- `minPitch` (Number, optional) - min pitch angle. Default `0`.
 
 The default controller of a `MapView` is [MapController](/docs/api-reference/core/map-controller.md).
 

--- a/docs/api-reference/core/orbit-view.md
+++ b/docs/api-reference/core/orbit-view.md
@@ -21,14 +21,14 @@ const view = new OrbitView({id, ...});
 
 To render, `OrbitView` needs to be used together with a `viewState` with the following parameters:
 
-* `target` (`Number[3]`) - The world position at the center of the viewport. Default `[0, 0, 0]`.
-* `rotationOrbit` (`Number`, optional) - Rotating angle around orbit axis. Default `0`.
-* `rotationX` (`Number`, optional) - Rotating angle around X axis. Default `0`.
-* `zoom` (`Number`, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. Default `0`.
-* `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `-Infinity`.
-* `maxZoom` (`Number`, optional) - The max zoom level of the viewport. Default `Infinity`.
-* `minRotationX` (`Number`, optional) - The min rotating angle around X axis. Default `-90`.
-* `maxRotationX` (`Number`, optional) - The max rotating angle around X axis. Default `90`.
+* `target` (Number[3], optional) - The world position at the center of the viewport. Default `[0, 0, 0]`.
+* `rotationOrbit` (Number, optional) - Rotating angle around orbit axis. Default `0`.
+* `rotationX` (Number, optional) - Rotating angle around X axis. Default `0`.
+* `zoom` (Number, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. Default `0`.
+* `minZoom` (Number, optional) - The min zoom level of the viewport. Default `-Infinity`.
+* `maxZoom` (Number, optional) - The max zoom level of the viewport. Default `Infinity`.
+* `minRotationX` (Number, optional) - The min rotating angle around X axis. Default `-90`.
+* `maxRotationX` (Number, optional) - The max rotating angle around X axis. Default `90`.
 
 
 ## OrbitController

--- a/docs/api-reference/core/orthographic-view.md
+++ b/docs/api-reference/core/orthographic-view.md
@@ -21,10 +21,10 @@ const view = new OrthographicView({id, ...});
 
 To render, `OrthographicView` needs to be used together with a `viewState` with the following parameters:
 
-* `target` (`Number[3]`, optional) - The world position at the center of the viewport. Default `[0, 0, 0]`.
-* `zoom` (`Number`, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. Default `0`.
-* `minZoom` (`Number`, optional) - The min zoom level of the viewport. Default `-Infinity`.
-* `maxZoom` (`Number`, optional) - The max zoom level of the viewport. Default `Infinity`.
+* `target` (Number[3], optional) - The world position at the center of the viewport. Default `[0, 0, 0]`.
+* `zoom` (Number, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. Default `0`.
+* `minZoom` (Number, optional) - The min zoom level of the viewport. Default `-Infinity`.
+* `maxZoom` (Number, optional) - The max zoom level of the viewport. Default `Infinity`.
 
 
 ## OrthographicController

--- a/docs/api-reference/react/deckgl.md
+++ b/docs/api-reference/react/deckgl.md
@@ -4,7 +4,7 @@
 
 Make sure to read the [Using deck.gl with React](/docs/get-started/using-with-react.md) article.
 
-The `DeckGL` class is a React wrapper of the `Deck` JavaScript class which exposes essentially the same props. The `Deck` class should not be used directly in React applications.
+The `DeckGL` class is a React wrapper of the [Deck](/docs/api-reference/core/deck.md) JavaScript class which exposes essentially the same props. The `Deck` class should not be used directly in React applications.
 
 
 ## Usage

--- a/docs/developer-guide/tips-and-tricks.md
+++ b/docs/developer-guide/tips-and-tricks.md
@@ -59,22 +59,15 @@ If this is an issue, set the `isolation` CSS prop on the `DeckGL` parent element
 
 The `Deck` class supports the following experimental props to aggressively reduce memory usage on memory-restricted devices:
 
-##### `_pickable` (Boolean)
+- [_pickable](/docs/api-reference/core/deck.md#_pickable)
+- [_typedArrayManagerProps](/docs/api-reference/core/deck.md#_typedArrayManagerProps)
 
-- Default `true`
-
-If set to `false`, force disables all picking features (overrides `layer.props.pickable`).
-
-##### `_typedArrayManagerProps` (Object)
-
-- `overAlloc` (Number) - Default `2`. By default, attributes are allocated twice the memory than they actually need (on both CPU and GPU). Must be larger than `1`.
-- `poolSize` (Number) - Default `100`. When memory reallocation is needed, old chunks are held on to and recycled. Smaller number uses less CPU memory. Can be any number `>=0`.
-
-The above default settings make data updates faster, at the price of using more memory. If the app does not anticipate frequent data changes, they may be aggressively reduced:
+The app can sacrefice certain features and/or runtime performance in exchange for a smaller memory footprint:
 
 ```js
 new Deck({
-  ...
+  // ...
+  _pickable: false,
   _typedArrayManagerProps: isMobile ? {overAlloc: 1, poolSize: 0} : null
 })
 ```


### PR DESCRIPTION
#### Change List

- Update outdated content in the `Deck` class doc (e.g. geospatial-only references), add documentation
for missing props
- Consistent formatting