### PR TITLE
Controller inertia (2/3): maintain correct interaction state in controller

### DIFF
--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -10,9 +10,9 @@ export const TRANSITION_EVENTS = {
 };
 
 const DEFAULT_PROPS = {
-  transitionDuration: 0,
+  // transitionDuration: 0,
   transitionEasing: t => t,
-  transitionInterpolator: new LinearInterpolator(),
+  // transitionInterpolator: new LinearInterpolator(),
   transitionInterruption: TRANSITION_EVENTS.BREAK,
   onTransitionStart: noop,
   onTransitionInterrupt: noop,
@@ -187,5 +187,3 @@ export default class TransitionManager {
     });
   }
 }
-
-TransitionManager.defaultProps = DEFAULT_PROPS;

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -26,7 +26,8 @@ export default class TransitionManager {
     this.propsInTransition = null;
     this.transition = new Transition(props.timeline);
 
-    this.onViewStateChange = props.onViewStateChange;
+    this.onViewStateChange = props.onViewStateChange || noop;
+    this.onStateChange = props.onStateChange || noop;
 
     this._onTransitionUpdate = this._onTransitionUpdate.bind(this);
   }
@@ -144,12 +145,23 @@ export default class TransitionManager {
       onInterrupt: this._onTransitionEnd(endProps.onTransitionInterrupt),
       onEnd: this._onTransitionEnd(endProps.onTransitionEnd)
     });
+
+    this.onStateChange({inTransition: true});
+
     this.updateTransition();
   }
 
   _onTransitionEnd(callback) {
     return transition => {
       this.propsInTransition = null;
+
+      this.onStateChange({
+        inTransition: false,
+        isZooming: false,
+        isPanning: false,
+        isRotating: false
+      });
+
       callback(transition);
     };
   }
@@ -169,13 +181,10 @@ export default class TransitionManager {
       Object.assign({}, this.props, viewport)
     ).getViewportProps();
 
-    if (this.onViewStateChange) {
-      this.onViewStateChange({
-        viewState: this.propsInTransition,
-        interactionState: {inTransition: true},
-        oldViewState: this.props
-      });
-    }
+    this.onViewStateChange({
+      viewState: this.propsInTransition,
+      oldViewState: this.props
+    });
   }
 }
 

--- a/modules/core/src/controllers/transition-manager.js
+++ b/modules/core/src/controllers/transition-manager.js
@@ -1,4 +1,3 @@
-import LinearInterpolator from '../transitions/linear-interpolator';
 import Transition from '../transitions/transition';
 
 const noop = () => {};
@@ -10,9 +9,7 @@ export const TRANSITION_EVENTS = {
 };
 
 const DEFAULT_PROPS = {
-  // transitionDuration: 0,
   transitionEasing: t => t,
-  // transitionInterpolator: new LinearInterpolator(),
   transitionInterruption: TRANSITION_EVENTS.BREAK,
   onTransitionStart: noop,
   onTransitionInterrupt: noop,

--- a/test/modules/core/controllers/controllers.spec.js
+++ b/test/modules/core/controllers/controllers.spec.js
@@ -9,8 +9,8 @@ import {
 
 import testController from './test-controller';
 
-test('MapController', t => {
-  testController(t, MapView, {
+test('MapController', async t => {
+  await testController(t, MapView, {
     longitude: -122.45,
     latitude: 37.78,
     zoom: 10,
@@ -21,8 +21,8 @@ test('MapController', t => {
   t.end();
 });
 
-test('GlobeController', t => {
-  testController(
+test('GlobeController', async t => {
+  await testController(
     t,
     GlobeView,
     {
@@ -37,8 +37,8 @@ test('GlobeController', t => {
   t.end();
 });
 
-test('OrbitController', t => {
-  testController(t, OrbitView, {
+test('OrbitController', async t => {
+  await testController(t, OrbitView, {
     orbitAxis: 'Y',
     rotationX: 30,
     rotationOrbit: -45,
@@ -49,8 +49,8 @@ test('OrbitController', t => {
   t.end();
 });
 
-test('OrthographicController', t => {
-  testController(
+test('OrthographicController', async t => {
+  await testController(
     t,
     OrthographicView,
     {
@@ -64,8 +64,8 @@ test('OrthographicController', t => {
   t.end();
 });
 
-test('FirstPersonController', t => {
-  testController(
+test('FirstPersonController', async t => {
+  await testController(
     t,
     FirstPersonView,
     {

--- a/test/modules/core/controllers/test-controller.js
+++ b/test/modules/core/controllers/test-controller.js
@@ -222,9 +222,8 @@ export default function testController(t, ViewClass, defaultProps, blackList = [
     controller.setProps(
       Object.assign(
         {
-          onViewStateChange: ({viewState}) => {
+          onViewStateChange: () => {
             onViewStateChangeCalled++;
-            controller.setProps(Object.assign({}, defaultProps, testCase.props, viewState));
           },
           onStateChange: state => {
             for (const key in state) {

--- a/test/modules/core/lib/transition-manager.spec.js
+++ b/test/modules/core/lib/transition-manager.spec.js
@@ -1,9 +1,9 @@
 import test from 'tape-catch';
 import TransitionManager from '@deck.gl/core/controllers/transition-manager';
-import FlyToInterpolator from '@deck.gl/core/transitions/viewport-fly-to-interpolator.js';
 import {MapState} from '@deck.gl/core/controllers/map-controller';
 import {Timeline} from '@luma.gl/core';
 import {config} from 'math.gl';
+import {LinearInterpolator, FlyToInterpolator} from '@deck.gl/core';
 
 /* global global, setTimeout, clearTimeout */
 // backfill requestAnimationFrame on Node
@@ -24,6 +24,7 @@ const TEST_CASES = [
       zoom: 12,
       pitch: 0,
       bearing: 0,
+      transitionInterpolator: new LinearInterpolator(),
       transitionDuration: 200
     },
     input: [
@@ -36,6 +37,7 @@ const TEST_CASES = [
         zoom: 12,
         pitch: 0,
         bearing: 0,
+        transitionInterpolator: new LinearInterpolator(),
         transitionDuration: 200
       },
       // no valid prop change
@@ -47,6 +49,7 @@ const TEST_CASES = [
         zoom: 12,
         pitch: 0,
         bearing: 0,
+        transitionInterpolator: new LinearInterpolator(),
         transitionDuration: 'auto'
       },
       // transitionDuration is 0
@@ -76,6 +79,7 @@ const TEST_CASES = [
       zoom: 12,
       pitch: 60,
       bearing: 0,
+      transitionInterpolator: new LinearInterpolator(),
       transitionDuration: 200
     },
     input: [
@@ -88,6 +92,7 @@ const TEST_CASES = [
         zoom: 12,
         pitch: 0,
         bearing: 0,
+        transitionInterpolator: new LinearInterpolator(),
         transitionDuration: 200
       },
       // viewport change interrupting transition
@@ -99,6 +104,7 @@ const TEST_CASES = [
         zoom: 12,
         pitch: 0,
         bearing: 0,
+        transitionInterpolator: new LinearInterpolator(),
         transitionDuration: 200
       },
       // viewport change interrupting transition - 'auto'
@@ -128,7 +134,7 @@ test('TransitionManager#constructor', t => {
 
 test('TransitionManager#processViewStateChange', t => {
   const timeline = new Timeline();
-  const mergeProps = props => Object.assign({timeline}, TransitionManager.defaultProps, props);
+  const mergeProps = props => Object.assign({timeline}, props);
 
   TEST_CASES.forEach(testCase => {
     const transitionManager = new TransitionManager(MapState, mergeProps(testCase.initialProps));
@@ -158,7 +164,7 @@ test('TransitionManager#callbacks', t => {
   let viewport;
   let transitionProps;
 
-  const {transitionInterpolator} = TransitionManager.defaultProps;
+  const transitionInterpolator = new LinearInterpolator();
 
   const callbacks = {
     onTransitionStart: () => {
@@ -184,7 +190,7 @@ test('TransitionManager#callbacks', t => {
   };
 
   const mergeProps = props =>
-    Object.assign({timeline}, TransitionManager.defaultProps, callbacks, props);
+    Object.assign({timeline}, callbacks, props);
 
   const transitionManager = new TransitionManager(MapState, mergeProps(testCase.initialProps));
 
@@ -213,7 +219,7 @@ test('TransitionManager#callbacks', t => {
 
 test('TransitionManager#auto#duration', t => {
   const timeline = new Timeline();
-  const mergeProps = props => Object.assign({timeline}, TransitionManager.defaultProps, props);
+  const mergeProps = props => Object.assign({timeline}, props);
   const initialProps = {
     width: 100,
     height: 100,
@@ -221,8 +227,7 @@ test('TransitionManager#auto#duration', t => {
     latitude: 37.78,
     zoom: 12,
     pitch: 0,
-    bearing: 0,
-    transitionDuration: 200
+    bearing: 0
   };
   const transitionManager = new TransitionManager(MapState, mergeProps(initialProps));
   transitionManager.processViewStateChange(

--- a/test/modules/core/lib/transition-manager.spec.js
+++ b/test/modules/core/lib/transition-manager.spec.js
@@ -189,8 +189,7 @@ test('TransitionManager#callbacks', t => {
     }
   };
 
-  const mergeProps = props =>
-    Object.assign({timeline}, callbacks, props);
+  const mergeProps = props => Object.assign({timeline}, callbacks, props);
 
   const transitionManager = new TransitionManager(MapState, mergeProps(testCase.initialProps));
 


### PR DESCRIPTION
For #5089 

#### Change List
- Separate interaction state (user facing) from controller internal states
- Reroute `TransitionManager`'s `onViewStateChange` call through the controller
- Tests
