### PR TITLE
Fix docs links

### DIFF
--- a/docs/api-reference/layers/geojson-layer.md
+++ b/docs/api-reference/layers/geojson-layer.md
@@ -272,10 +272,10 @@ Note: This accessor is only called for `Polygon` and `MultiPolygon` features.
 
 The GeoJsonLayer renders the following sublayers:
 
-* `polygons-fill` - a [SolidPolygonLayer](/docs/api-reference/geo-layers/solid-polygon-layer.md) rendering all the `Polygon` and `MultiPolygon` features.
-* `polygons-stroke` - a [PathLayer](/docs/api-reference/geo-layers/path-layer.md) rendering the outline of all the `Polygon` and `MultiPolygon` features. Only rendered if `stroked: true` and `extruded: false`.
-* `linestrings` - a [PathLayer](/docs/api-reference/geo-layers/path-layer.md) rendering all the `LineString` and `MultiLineString` features.
-* `points` - a [ScatterplotLayer](/docs/api-reference/geo-layers/scatterplot-layer.md) rendering all the `Point` and `MultiPoint` features.
+* `polygons-fill` - a [SolidPolygonLayer](/docs/api-reference/layers/solid-polygon-layer.md) rendering all the `Polygon` and `MultiPolygon` features.
+* `polygons-stroke` - a [PathLayer](/docs/api-reference/layers/path-layer.md) rendering the outline of all the `Polygon` and `MultiPolygon` features. Only rendered if `stroked: true` and `extruded: false`.
+* `linestrings` - a [PathLayer](/docs/api-reference/layers/path-layer.md) rendering all the `LineString` and `MultiLineString` features.
+* `points` - a [ScatterplotLayer](/docs/api-reference/layers/scatterplot-layer.md) rendering all the `Point` and `MultiPoint` features.
 
 
 ## Remarks

--- a/docs/api-reference/layers/grid-cell-layer.md
+++ b/docs/api-reference/layers/grid-cell-layer.md
@@ -11,7 +11,7 @@ import {GridCellLayerDemo} from 'website-components/doc-demos/layers';
 > This is the primitive layer rendered by [CPUGridLayer](/docs/api-reference/aggregation-layers/cpu-grid-layer.md) after aggregation. Unlike the CPUGridLayer, it renders one column for each data object.
 
 The GridCellLayer can render a grid-based heatmap.
-It is a variation of the [ColumnLayer](/docs/api-reference/geo-layers/column-layer.md).
+It is a variation of the [ColumnLayer](/docs/api-reference/layers/column-layer.md).
 It takes the constant width / height of all cells and top-left coordinate of
 each cell. The grid cells can be given a height using the `getElevation` accessor.
 

--- a/docs/api-reference/layers/polygon-layer.md
+++ b/docs/api-reference/layers/polygon-layer.md
@@ -282,8 +282,8 @@ Only applies if `extruded: true`.
 
 The PolygonLayer renders the following sublayers:
 
-* `fill` - a [SolidPolygonLayer](/docs/api-reference/geo-layers/solid-polygon-layer.md) rendering the surface of all polygons.
-* `stroke` - a [PathLayer](/docs/api-reference/geo-layers/path-layer.md) rendering the outline of all polygons. Only rendered if `stroked: true` and `extruded: false`.
+* `fill` - a [SolidPolygonLayer](/docs/api-reference/layers/solid-polygon-layer.md) rendering the surface of all polygons.
+* `stroke` - a [PathLayer](/docs/api-reference/layers/path-layer.md) rendering the outline of all polygons. Only rendered if `stroked: true` and `extruded: false`.
 
 
 ## Remarks

--- a/docs/api-reference/layers/solid-polygon-layer.md
+++ b/docs/api-reference/layers/solid-polygon-layer.md
@@ -236,7 +236,7 @@ new SolidPolygonLayer({
 ## Remarks
 
 * This layer only renders filled polygons. If you need to render polygon
-  outlines, use the [`PathLayer`](/docs/api-reference/geo-layers/path-layer.md)
+  outlines, use the [`PathLayer`](/docs/api-reference/layers/path-layer.md)
 * Polygons are always closed, i.e. there is an implicit line segment between
   the first and last vertices, when those vertices are not equal.
 * The specification of complex polygons intentionally follows the GeoJson

--- a/docs/api-reference/layers/text-layer.md
+++ b/docs/api-reference/layers/text-layer.md
@@ -4,7 +4,7 @@ import {TextLayerDemo} from 'website-components/doc-demos/layers';
 
 # TextLayer
 
-The text layer renders text labels on the map using texture mapping. This Layer is extended based on [Icon Layer](/docs/api-reference/geo-layers/icon-layer.md) and wrapped using [Composite Layer](/docs/api-reference/core/composite-layer.md).
+The text layer renders text labels on the map using texture mapping. This Layer is extended based on [Icon Layer](/docs/api-reference/layers/icon-layer.md) and wrapped using [Composite Layer](/docs/api-reference/core/composite-layer.md).
 
 Auto pack required `characterSet` into a shared texture `fontAtlas`.
 

--- a/docs/api-reference/mapbox/mapbox-layer.md
+++ b/docs/api-reference/mapbox/mapbox-layer.md
@@ -102,7 +102,7 @@ Parameters:
   + `props.id` (String) - an unique id is required for each layer.
   + `props.deck` (`Deck`, optional) - a `Deck` instance that controls the rendering of this layer. If provided, the layer will be looked up from its layer stack by `id` at render time, and all other props are ignored.
   + `props.type` (`Layer`, optional) - a class that extends deck.gl's base `Layer` class. Required if `deck` is not provided.
-  + Optional: any other prop needed by this type of layer. See deck.gl's [layer catalog](/docs/api-reference/geo-layers/README.md) for documentations and examples on how to create layers.
+  + Optional: any other prop needed by this type of layer. See deck.gl's [layer catalog](/docs/api-reference/layers/README.md) for documentation and examples on how to create layers.
 
 
 ## Methods


### PR DESCRIPTION
#### Change list

- Fix links in API reference docs. Several links pointed to the `geo-layers` dir when they should've been pointed to the `layers` dir.