### PR TITLE
Abort Ongoing Requests when TileLayer is Destroyed

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -45,6 +45,13 @@ export default class TileLayer extends CompositeLayer {
     };
   }
 
+  finalizeState() {
+    const {tileset} = this.state;
+    if (tileset) {
+      tileset.finalize();
+    }
+  }
+
   get isLoaded() {
     const {tileset} = this.state;
     return tileset.selectedTiles.every(

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -238,6 +238,45 @@ test('TileLayer#AbortRequestsOnUpdateTrigger', async t => {
   t.end();
 });
 
+test('TileLayer#AbortRequestsOnNewLayer', async t => {
+  const testViewport = new WebMercatorViewport({
+    width: 1200,
+    height: 400,
+    longitude: 0,
+    latitude: 0,
+    zoom: 1,
+    repeat: true
+  });
+  let tileset;
+
+  const testCases = [
+    {
+      props: {
+        getTileData: () => sleep(10)
+      },
+      onAfterUpdate: ({layer}) => {
+        tileset = layer.state.tileset;
+      }
+    },
+    {
+      props: {
+        id: 'new-layer'
+      },
+      onAfterUpdate: () => {
+        t.is(
+          tileset._tiles.map(tile => tile._isCancelled).length,
+          4,
+          'all tiles from discarded layer should be cancelled'
+        );
+      }
+    }
+  ];
+
+  testLayer({Layer: TileLayer, viewport: testViewport, testCases, onError: t.notOk});
+
+  t.end();
+});
+
 function sleep(ms) {
   return new Promise(resolve => {
     /* global setTimeout */


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Following up #5297, I think this is a reasonable extension of that work (which totally works exactly as expected).  I can totally close this if this is not something we are interested in @Pessimistress @chrisgervang @kylebarron - sorry for the multiple PR's, the use-cases were slightly different so I didn't notice this one when testing the fix for #5297 
<!-- For other PRs without open issue -->
#### Background
I think `updateTriggers` and `finalizeState` have similar use cases in this case and the docs for deck.gl do state that `finalizeState` is for [releasing resources](https://deck.gl/docs/api-reference/core/layer#finalizestate)
<!-- For all the PRs -->
#### Change List
- add a `finalizeState` method to `TileLayer` for aborting ongoing requests
