### PR TITLE
Return tile objects at OnViewportLoad instead of data

### DIFF
--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -233,7 +233,8 @@ Affects both rendering and tile fetching to produce a transformed tile layer.  N
 
 ##### `onViewportLoad` (Function, optional)
 
-`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content (as returned by `getTileData`) for each visible tile is passed as an array to this callback function.
+`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content or each visible tile is passed as an array of tile objects to this callback function. Check the [Tile](#tile) class for more info.
+
 
 - Default: `data => null`
 
@@ -268,6 +269,19 @@ Receives arguments:
 
 - `tile` (Object) - the tile that has been cleared from cache.
 
+## Tile
+
+Class to hold the reading of a single tile
+
+Properties:
+
+- `x` (Number) - x index of the tile
+- `y` (Number) - y index of the tile
+- `z` (Number) - z index of the tile
+- `data` (Array) - tiles content as returned by `getTileData`. 
+
 ## Source
 
 [modules/geo-layers/src/tile-layer](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/tile-layer)
+
+

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -233,7 +233,7 @@ Affects both rendering and tile fetching to produce a transformed tile layer.  N
 
 ##### `onViewportLoad` (Function, optional)
 
-`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content for each visible tile is passed as an array of tile objects to this callback function. Check the [Tile](#tile) class for more info.
+`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. An array of loaded [Tile](#tile) instances are passed as argument to this function
 
 
 - Default: `data => null`
@@ -247,7 +247,7 @@ Affects both rendering and tile fetching to produce a transformed tile layer.  N
 
 Receives arguments:
 
-- `tile` (Object) - the tile that has been loaded.
+- `tile` (Object) - the [tile](#tile) that has been loaded.
 
 ##### `onTileError` (Function, optional)
 
@@ -267,7 +267,7 @@ Receives arguments:
 
 Receives arguments:
 
-- `tile` (Object) - the tile that has been cleared from cache.
+- `tile` (Object) - the [tile](#tile) that has been cleared from cache.
 
 ## Tile
 
@@ -278,6 +278,7 @@ Properties:
 - `x` (Number) - x index of the tile
 - `y` (Number) - y index of the tile
 - `z` (Number) - z index of the tile
+- `bbox` (Object) - tile boundaries in WGS84
 - `data` (Array) - tiles content as returned by `getTileData`. 
 
 ## Source

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -233,7 +233,7 @@ Affects both rendering and tile fetching to produce a transformed tile layer.  N
 
 ##### `onViewportLoad` (Function, optional)
 
-`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content or each visible tile is passed as an array of tile objects to this callback function. Check the [Tile](#tile) class for more info.
+`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content for each visible tile is passed as an array of tile objects to this callback function. Check the [Tile](#tile) class for more info.
 
 
 - Default: `data => null`

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -278,7 +278,7 @@ Properties:
 - `x` (Number) - x index of the tile
 - `y` (Number) - y index of the tile
 - `z` (Number) - z index of the tile
-- `bbox` (Object) - tile boundaries in WGS84
+- `bbox` (Object) - bounding box of the tile. When used with a geospatial view, `bbox` is in the shape of `{west: <longitude>, north: <latitude>, east: <longitude>, south: <latitude>}`. When used with a non-geospatial view, `bbox` is in the shape of `{left, top, right, bottom}`.
 - `data` (Array) - tiles content as returned by `getTileData`. 
 
 ## Source

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -27,6 +27,8 @@ A legacy field `pickingInfo.lngLat` has been removed. Use `pickingInfo.coordinat
 - `MVTLayer`'s `onHover` and `onClick` callbacks now yield the `info.object` feature coordinates in WGS84 standard.
 - `ScenegraphLayer` now has built-in support for `GLTFLoader`. It's no longer necessary to call `registerLoaders` before using it.
 
+- `TileLayer` `onViewportLoad` receives as argument an array of loaded [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances. At previous version the argument was an array of tile content.
+
 
 ## Upgrading from deck.gl v8.2 to v8.3
 

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -137,7 +137,7 @@ export default class TileLayer extends CompositeLayer {
     const {onViewportLoad} = this.props;
 
     if (onViewportLoad) {
-      onViewportLoad(tileset.selectedTiles.map(tile => tile.data));
+      onViewportLoad(tileset.selectedTiles);
     }
   }
 


### PR DESCRIPTION

#### Background
The callback at TileLayer doesn't return the x,y,z of the tile and it's quite difficult to work only with the tile data. For example, if the user wants to transform to WGS84 we need to also provide the reference tile together with the data.

This is a small breaking change that we need to notify in the release.

#### Change List
- Return an array of tile objects at onViewportLoad instead of the content of the file.
- Updated TileLayer doc. I've included a section for the Tile class.

