### PR TITLE
Tiles content in WGS84 for MVTLayer

### DIFF
--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -161,6 +161,30 @@ new MVTLayer({
 })
 ```
 
+##### `onViewportLoad` (Function, optional)
+
+`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. An array of loaded [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances are passed as argument to this function.
+
+A new getter `dataInWGS84` is added for the tile instance to retrieve the tile content in world coordinates (WGS84).
+
+- Default: `data => null`
+
+```javascript
+const onViewportLoad = tiles => {
+  tiles.forEach(tile => {
+    // data in local coordinates
+    const dataInLocalCoords = tile.data;
+    // data in world coordinates (WGS84)
+    const dataInWGS84 = tile.dataInWGS84;
+  });
+};
+new MVTLayer({
+  id: "..."
+  data: "..."
+  onViewportLoad
+})
+```
+
 ## Source
 
 [modules/geo-layers/src/mvt-layer/mvt-layer.js](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/mvt-layer/mvt-layer.js)

--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -163,9 +163,11 @@ new MVTLayer({
 
 ## Tile
 
-A new getter `dataInWGS84` is added to the [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances used on this layer. It allows to retrieve the tile content in world coordinates (WGS84).
+Aside from all members of the [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) class, tile instances from the `MVTLayer` also include the following fields:
 
-- Default: `data => null`
+##### `dataInWGS84` (Array)
+
+A list of features in world coordinates (WGS84).
 
 Usage example:
 
@@ -182,6 +184,7 @@ new MVTLayer({
   onViewportLoad
 })
 ```
+
 ## Source
 
 [modules/geo-layers/src/mvt-layer/mvt-layer.js](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/mvt-layer/mvt-layer.js)

--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -161,19 +161,17 @@ new MVTLayer({
 })
 ```
 
-##### `onViewportLoad` (Function, optional)
+## Tile
 
-`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. An array of loaded [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances are passed as argument to this function.
-
-A new getter `dataInWGS84` is added for the tile instance to retrieve the tile content in world coordinates (WGS84).
+A new getter `dataInWGS84` is added to the [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances used on this layer. It allows to retrieve the tile content in world coordinates (WGS84).
 
 - Default: `data => null`
+
+Usage example:
 
 ```javascript
 const onViewportLoad = tiles => {
   tiles.forEach(tile => {
-    // data in local coordinates
-    const dataInLocalCoords = tile.data;
     // data in world coordinates (WGS84)
     const dataInWGS84 = tile.dataInWGS84;
   });
@@ -184,7 +182,6 @@ new MVTLayer({
   onViewportLoad
 })
 ```
-
 ## Source
 
 [modules/geo-layers/src/mvt-layer/mvt-layer.js](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/mvt-layer/mvt-layer.js)

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -233,7 +233,11 @@ Affects both rendering and tile fetching to produce a transformed tile layer.  N
 
 ##### `onViewportLoad` (Function, optional)
 
+<<<<<<< HEAD
 `onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. An array of loaded [Tile](#tile) instances are passed as argument to this function
+=======
+`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content for each visible tile is passed as an array of tile objects to this callback function. Check the [Tile](#tile) class for more info.
+>>>>>>> Doc typo
 
 
 - Default: `data => null`

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -233,11 +233,7 @@ Affects both rendering and tile fetching to produce a transformed tile layer.  N
 
 ##### `onViewportLoad` (Function, optional)
 
-<<<<<<< HEAD
 `onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. An array of loaded [Tile](#tile) instances are passed as argument to this function
-=======
-`onViewportLoad` is a function that is called when all tiles in the current viewport are loaded. The loaded content for each visible tile is passed as an array of tile objects to this callback function. Check the [Tile](#tile) class for more info.
->>>>>>> Doc typo
 
 
 - Default: `data => null`
@@ -284,18 +280,6 @@ Properties:
 - `z` (Number) - z index of the tile
 - `bbox` (Object) - bounding box of the tile. When used with a geospatial view, `bbox` is in the shape of `{west: <longitude>, north: <latitude>, east: <longitude>, south: <latitude>}`. When used with a non-geospatial view, `bbox` is in the shape of `{left, top, right, bottom}`.
 - `data` (Array) - tiles content as returned by `getTileData`. 
-
-## Tile
-
-Class to hold the reading of a single tile
-
-Properties:
-
-- `x` (Number) - x index of the tile
-- `y` (Number) - y index of the tile
-- `z` (Number) - z index of the tile
-- `data` (Array) - tiles content as returned by `getTileData`. 
-
 ## Source
 
 [modules/geo-layers/src/tile-layer](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/tile-layer)

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -280,6 +280,7 @@ Properties:
 - `z` (Number) - z index of the tile
 - `bbox` (Object) - bounding box of the tile. When used with a geospatial view, `bbox` is in the shape of `{west: <longitude>, north: <latitude>, east: <longitude>, south: <latitude>}`. When used with a non-geospatial view, `bbox` is in the shape of `{left, top, right, bottom}`.
 - `data` (Array) - tiles content as returned by `getTileData`. 
+
 ## Source
 
 [modules/geo-layers/src/tile-layer](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/tile-layer)

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -281,6 +281,17 @@ Properties:
 - `bbox` (Object) - bounding box of the tile. When used with a geospatial view, `bbox` is in the shape of `{west: <longitude>, north: <latitude>, east: <longitude>, south: <latitude>}`. When used with a non-geospatial view, `bbox` is in the shape of `{left, top, right, bottom}`.
 - `data` (Array) - tiles content as returned by `getTileData`. 
 
+## Tile
+
+Class to hold the reading of a single tile
+
+Properties:
+
+- `x` (Number) - x index of the tile
+- `y` (Number) - y index of the tile
+- `z` (Number) - z index of the tile
+- `data` (Array) - tiles content as returned by `getTileData`. 
+
 ## Source
 
 [modules/geo-layers/src/tile-layer](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/tile-layer)

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -243,14 +243,13 @@ export default class MVTLayer extends TileLayer {
               tile.contentWGS84 = tile.content.map(feature =>
                 transformTileCoordsToWGS84(feature, tile.bbox, this.context.viewport)
               );
-            }            
+            }
             return tile.contentWGS84;
           }
         });
       }
     });
   }
-
 }
 
 function getFeatureUniqueId(feature, uniqueIdProperty) {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -238,7 +238,7 @@ export default class MVTLayer extends TileLayer {
         // eslint-disable-next-line accessor-pairs
         Object.defineProperty(tile, propName, {
           get: () => {
-            if (!tile.contentWGS84) {
+            if (tile.contentWGS84 === undefined) {
               // Create a cache to transform only once
               tile.contentWGS84 = tile.content.map(feature =>
                 transformTileCoordsToWGS84(feature, tile.bbox, this.context.viewport)

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -238,13 +238,18 @@ export default class MVTLayer extends TileLayer {
         // eslint-disable-next-line accessor-pairs
         Object.defineProperty(tile, propName, {
           get: () => {
-            if (tile.contentWGS84 === undefined) {
+            // Still loading or encountered an error
+            if (!tile.content) {
+              return null;
+            }
+
+            if (tile._contentWGS84 === undefined) {
               // Create a cache to transform only once
-              tile.contentWGS84 = tile.content.map(feature =>
+              tile._contentWGS84 = tile.content.map(feature =>
                 transformTileCoordsToWGS84(feature, tile.bbox, this.context.viewport)
               );
             }
-            return tile.contentWGS84;
+            return tile._contentWGS84;
           }
         });
       }

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -267,7 +267,7 @@ test('TileJSON', async t => {
   _global.fetch = fetch;
 });
 
-test.only('MVT dataInWGS84', async t => {
+test('MVT dataInWGS84', async t => {
   class TestMVTLayer extends MVTLayer {
     getTileData() {
       return geoJSONData;


### PR DESCRIPTION
#### Background
MVTLayer users receive the tiles content at `onViewportLoad` in local coordinates. This PR add a new getter `dataInWGS84` to return the tiles transformed in WGS84

Usage example:
```javascript
const onViewportLoad = tiles => {
  tiles.forEach(tile => {
    // data in local coordinates
    const dataInLocalCoords = tile.data;
    // data in world coordinates (WGS84)
    const dataInWGS84 = tile.dataInWGS84;
  });
};
new MVTLayer({
  id: "..."
  data: "..."
  onViewportLoad
})
```
#### Change List

- [x] Add `onViewportLoad` at MVTLayer doc to explain the getter and the usage.
- [x] Modify MVTLayer to dynamically add the getter to the visible tiles at updateState
- [x] Tests
