### PR TITLE
Remove onViewportChange callback at MVT layer

### DIFF
--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -148,9 +148,9 @@ Returns:
 
 Remarks:
 
-- As it's an expensive operation, it is not recommended to call `getRenderedFeatures` every time `onViewStateChange` is executed, use a debounce function instead. 
+- As it's an expensive operation, it's not recommended to call `getRenderedFeatures` every time `onViewStateChange` is executed, use a debounce function instead. 
 
-- In most of the cases you probably want to use it attached to `onViewStateChange` and `onViewportLoad`
+- In most of the cases you probably want to use it attached to `onViewStateChange` and `onViewportLoad`.
 
 ## Tile
 

--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -128,38 +128,29 @@ Receives arguments:
 
 tileJSON (Object) - the tileJSON fetched
 
-##### `onViewportChange` (Function, optional)
+## Methods
 
-`onViewportChange` called when the viewport changes or all tiles in the current viewport have been loaded. A function (`getRenderedFeatures`) to calculate the features rendered in the current viewport is passed as a JSON to this callback function.
+#### getRenderedFeatures` (Function)
 
+Get the rendered features in the current viewport.
 
-Receives arguments:
+If a `uniqueIdProperty` is provided only unique properties are returned.
 
-* `getRenderedFeatures` (Function)
+Requires `pickable` prop to be true.
 
-  + maxFeatures: Optional. Max number of features to retrieve when getRenderedFeatures is called. Default to `null`.
+Parameters:
 
-  Requires `pickable` to be true.
+- `maxFeatures` (Number, optional): Max number of features to retrieve when getRenderedFeatures is called. Default to `null`.
 
-  It is not recommended to call `getRenderedFeatures` every time `onViewportChange` is executed, instead, use a debounce function.
+Returns:
 
-  If a `uniqueIdProperty` is provided only unique properties are returned.
+- An array with geometries in GeoJSON format.
 
-* `viewport` (Object). A instance of the current [`Viewport`](/docs/api-reference/core/viewport.md).
+Remarks:
 
-```javascript
-const onViewportChange =  e => {
-  const features = e.getRenderedFeatures();
-};
+- As it's an expensive operation, it is not recommended to call `getRenderedFeatures` every time `onViewStateChange` is executed, use a debounce function instead. 
 
-new MVTLayer({
-  id: "..."
-  data: "..."
-  pickable: true
-  onViewportChange: debounce(onViewportChange, 500)
-  uniqueIdProperty: 'geoid'
-})
-```
+- In most of the cases you probably want to use it attached to `onViewStateChange` and `onViewportLoad`
 
 ## Tile
 

--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -130,7 +130,7 @@ tileJSON (Object) - the tileJSON fetched
 
 ## Methods
 
-#### getRenderedFeatures` (Function)
+#### `getRenderedFeatures` (Function)
 
 Get the rendered features in the current viewport.
 
@@ -149,7 +149,6 @@ Returns:
 Remarks:
 
 - As it's an expensive operation, it's not recommended to call `getRenderedFeatures` every time `onViewStateChange` is executed, use a debounce function instead. 
-
 - In most of the cases you probably want to use it attached to `onViewStateChange` and `onViewportLoad`.
 
 ## Tile

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -13,7 +13,6 @@ const WORLD_SIZE = 512;
 const defaultProps = {
   uniqueIdProperty: {type: 'string', value: ''},
   highlightedFeatureId: null,
-  onViewportChange: {type: 'function', optional: true, value: null, compare: false},
   loaders: MVTLoader
 };
 
@@ -46,10 +45,6 @@ export default class MVTLayer extends TileLayer {
     if (this.state.data) {
       super.updateState({props, oldProps, context, changeFlags});
       this._setWGS84PropertyForTiles();
-      const {tileset} = this.state;
-      if (changeFlags.viewportChanged && tileset.isLoaded) {
-        this._onViewportChange();
-      }
     }
   }
 
@@ -216,17 +211,6 @@ export default class MVTLayer extends TileLayer {
     }
 
     return renderedFeatures;
-  }
-
-  _onViewportChange() {
-    const {onViewportChange} = this.props;
-    if (onViewportChange) {
-      const {viewport} = this.context;
-      onViewportChange({
-        getRenderedFeatures: this.getRenderedFeatures.bind(this),
-        viewport
-      });
-    }
   }
 
   _setWGS84PropertyForTiles() {


### PR DESCRIPTION
`onViewportChange` is only available for MVTLayer and it can be replaced by listening to `onViewStateChange` and `onViewportLoad`.





