### PR TITLE
Fix HeatmapLayer update racing condition

### DIFF
--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -107,7 +107,7 @@ export default class HeatmapLayer extends AggregationLayer {
     return changeFlags.somethingChanged;
   }
 
-  /* eslint-disable complexity */
+  /* eslint-disable max-statements,complexity */
   updateState(opts) {
     if (!this.state.supported) {
       return;
@@ -122,8 +122,11 @@ export default class HeatmapLayer extends AggregationLayer {
     }
 
     if (changeFlags.dataChanged || changeFlags.boundsChanged) {
+      // Update weight map immediately
+      clearTimeout(this.state.updateTimer);
       this.setState({isWeightMapDirty: true});
     } else if (changeFlags.viewportZoomChanged) {
+      // Update weight map when zoom stops
       this._debouncedUpdateWeightmap();
     }
 
@@ -148,9 +151,13 @@ export default class HeatmapLayer extends AggregationLayer {
       this.setState({colorDomain});
     }
 
+    if (this.state.isWeightMapDirty) {
+      this._updateWeightmap();
+    }
+
     this.setState({zoom: opts.context.viewport.zoom});
   }
-  /* eslint-enable complexity */
+  /* eslint-enable max-statements,complexity */
 
   renderLayers() {
     if (!this.state.supported) {
@@ -178,11 +185,6 @@ export default class HeatmapLayer extends AggregationLayer {
           attributes: {
             positions: triPositionBuffer,
             texCoords: triTexCoordBuffer
-          }
-        },
-        onRedraw: () => {
-          if (this.state.isWeightMapDirty) {
-            this._updateWeightmap();
           }
         },
         vertexCount: 4,

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -24,12 +24,6 @@ import {Layer, project32} from '@deck.gl/core';
 import vs from './triangle-layer-vertex.glsl';
 import fs from './triangle-layer-fragment.glsl';
 
-const defaultProps = {
-  count: 0, // number of triangles to be rendered
-  texture: null,
-  onRedraw: {type: 'function', value: null, compare: false}
-};
-
 export default class TriangleLayer extends Layer {
   getShaders() {
     return {vs, fs, modules: [project32]};
@@ -91,4 +85,3 @@ export default class TriangleLayer extends Layer {
 }
 
 TriangleLayer.layerName = 'TriangleLayer';
-TriangleLayer.defaultProps = defaultProps;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.js
@@ -72,13 +72,8 @@ export default class TriangleLayer extends Layer {
       intensity,
       threshold,
       aggregationMode,
-      colorDomain,
-      onRedraw
+      colorDomain
     } = this.props;
-
-    if (onRedraw) {
-      onRedraw();
-    }
 
     model
       .setUniforms({


### PR DESCRIPTION
#### Background

This PR fixes a rare racing condition where the viewport during `heatmapLayer.renderLayers` is different from the viewport during `triangleLayer.draw`. It removes an old hack that was intended to avoid texture update when the layer is invisible. As of the current release, `heatmapLayer.updateState` and `heatmapLayer.renderLayers` are no longer triggered on viewport change when the layer is invisible.

#### Change List
- Remove `onRedraw` hack, update weight texture in `updateState`
