### PR TITLE
Add prop to specify winding direction in SolidPolygonLayer

### DIFF
--- a/docs/api-reference/layers/polygon-layer.md
+++ b/docs/api-reference/layers/polygon-layer.md
@@ -188,7 +188,20 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 If `false`, will skip normalizing the coordinates returned by `getPolygon`. Disabling normalization improves performance during data update, but makes the layer prone to error in case the data is malformed. It is only recommended when you use this layer with preprocessed static data or validation on the backend.
 
-When normalization is disabled, polygons must be specified in the format of flat array or `{positions, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical) and must contain at least 3 vertices. See `getPolygon` below for details.
+When normalization is disabled, polygons must be specified in the format of flat array or `{positions, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical). The winding order of rings must be consistent with that defined by `_windingOrder`. See `getPolygon` below for details.
+
+##### `_windingOrder` (String, optional)
+
+* Default: `'CW'`
+
+> Note: This prop is experimental
+
+This prop is only effective with `_normalize: false`. It specifies the winding order of rings in the polygon data, one of:
+
+- `'CW'`: outer-ring is clockwise, and holes are counter-clockwise
+- `'CCW'`: outer-ring is counter-clockwise, and holes are clockwise
+
+The proper value depends on the source of your data. Most geometry formats [enforce a specific winding order](https://gis.stackexchange.com/a/147971). Incorrectly set winding order will cause  an extruded polygon's surfaces to be flipped, affecting culling and the lighting effect.
 
 
 ### Data Accessors

--- a/docs/api-reference/layers/solid-polygon-layer.md
+++ b/docs/api-reference/layers/solid-polygon-layer.md
@@ -119,7 +119,21 @@ Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-
 
 If `false`, will skip normalizing the coordinates returned by `getPolygon`. Disabling normalization improves performance during data update, but makes the layer prone to error in case the data is malformed. It is only recommended when you use this layer with preprocessed static data or validation on the backend.
 
-When normalization is disabled, polygons must be specified in the format of flat array or `{positions, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical). See `getPolygon` below for details.
+When normalization is disabled, polygons must be specified in the format of flat array or `{positions, holeIndices}`. Rings must be closed (i.e. the first and last vertices must be identical). The winding order of rings must be consistent with that defined by `_windingOrder`. See `getPolygon` below for details.
+
+##### `_windingOrder` (String, optional)
+
+* Default: `'CW'`
+
+> Note: This prop is experimental
+
+This prop is only effective with `_normalize: false`. It specifies the winding order of rings in the polygon data, one of:
+
+- `'CW'`: outer-ring is clockwise, and holes are counter-clockwise
+- `'CCW'`: outer-ring is counter-clockwise, and holes are clockwise
+
+The proper value depends on the source of your data. Most geometry formats [enforce a specific winding order](https://gis.stackexchange.com/a/147971). Incorrectly set winding order will cause an extruded polygon's surfaces to be flipped, affecting culling and the lighting effect.
+
 
 ### Data Accessors
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -26,7 +26,7 @@ A legacy field `pickingInfo.lngLat` has been removed. Use `pickingInfo.coordinat
 
 - `MVTLayer`'s `onHover` and `onClick` callbacks now yield the `info.object` feature coordinates in WGS84 standard.
 - `ScenegraphLayer` now has built-in support for `GLTFLoader`. It's no longer necessary to call `registerLoaders` before using it.
-- `SolidPolygonLayer`'s polygonTesselator enforces winding order for outer polygons and holes (Potentially breaking visual change). Make sure to use correct culling settings.
+- `SolidPolygonLayer` now enforces the winding order for outer polygons and holes. This ensures the correct orientation of an extruded polygon's surfaces, and therefore consistent culling and lighting effect results. This may change the visual outcome of your layers if the winding order was wrongly deduced in the previous versions.
 - `TileLayer` `onViewportLoad` receives as argument an array of loaded [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances. At previous version the argument was an array of tile content.
 
 ## Upgrading from deck.gl v8.2 to v8.3

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -26,7 +26,7 @@ A legacy field `pickingInfo.lngLat` has been removed. Use `pickingInfo.coordinat
 
 - `MVTLayer`'s `onHover` and `onClick` callbacks now yield the `info.object` feature coordinates in WGS84 standard.
 - `ScenegraphLayer` now has built-in support for `GLTFLoader`. It's no longer necessary to call `registerLoaders` before using it.
-- `SolidPolygonLayer` now enforces the winding order for outer polygons and holes. This ensures the correct orientation of an extruded polygon's surfaces, and therefore consistent culling and lighting effect results. This may change the visual outcome of your layers if the winding order was wrongly deduced in the previous versions.
+- `SolidPolygonLayer` now enforces the winding order for outer polygons and holes. This ensures the correct orientation of an extruded polygon's surfaces, and therefore consistent culling and lighting effect results. This may change the visual outcome of your layers if the winding order was wrongly deduced in the previous versions. When using this layer with `_normalize: false`, a new prop `_windingOrder` can be used to specify the winding order used by your polygon data.
 - `TileLayer` `onViewportLoad` receives as argument an array of loaded [Tile](/docs/api-reference/geo-layers/tile-layer.md#tile) instances. At previous version the argument was an array of tile content.
 
 ## Upgrading from deck.gl v8.2 to v8.3

--- a/modules/layers/src/polygon-layer/polygon-layer.js
+++ b/modules/layers/src/polygon-layer/polygon-layer.js
@@ -34,6 +34,7 @@ const defaultProps = {
   elevationScale: 1,
   wireframe: false,
   _normalize: true,
+  _windingOrder: 'CW',
 
   lineWidthUnits: 'meters',
   lineWidthScale: 1,
@@ -134,6 +135,7 @@ export default class PolygonLayer extends CompositeLayer {
       extruded,
       wireframe,
       _normalize,
+      _windingOrder,
       elevationScale,
       transitions,
       positionFormat
@@ -179,6 +181,7 @@ export default class PolygonLayer extends CompositeLayer {
           filled,
           wireframe,
           _normalize,
+          _windingOrder,
 
           getElevation,
           getFillColor,

--- a/modules/layers/src/solid-polygon-layer/polygon.js
+++ b/modules/layers/src/solid-polygon-layer/polygon.js
@@ -113,6 +113,7 @@ function copyNestedRing(target, targetStartIndex, simplePolygon, size, windingDi
 
   windingOptions.start = targetStartIndex;
   windingOptions.end = targetIndex;
+  windingOptions.size = size;
   modifyPolygonWindingDirection(target, windingDirection, windingOptions);
 
   return targetIndex;
@@ -157,6 +158,7 @@ function copyFlatRing(
 
   windingOptions.start = targetStartIndex;
   windingOptions.end = targetIndex;
+  windingOptions.size = size;
   modifyPolygonWindingDirection(target, windingDirection, windingOptions);
 
   return targetIndex;
@@ -176,7 +178,6 @@ export function normalize(polygon, positionSize) {
 
   const positions = [];
   const holeIndices = [];
-  windingOptions.size = positionSize;
 
   if (polygon.positions) {
     // complex flat

--- a/modules/layers/src/solid-polygon-layer/polygon.js
+++ b/modules/layers/src/solid-polygon-layer/polygon.js
@@ -25,6 +25,10 @@ import {modifyPolygonWindingDirection, WINDING} from '@math.gl/polygon';
 const OUTER_POLYGON_WINDING = WINDING.CLOCKWISE;
 const HOLE_POLYGON_WINDING = WINDING.COUNTER_CLOCKWISE;
 
+const windingOptions = {
+  isClosed: true
+};
+
 // 4 data formats are supported:
 // Simple Polygon: an array of points
 // Complex Polygon: an array of array of points (array of rings)
@@ -107,14 +111,9 @@ function copyNestedRing(target, targetStartIndex, simplePolygon, size, windingDi
     }
   }
 
-  if (windingDirection) {
-    modifyPolygonWindingDirection(target, windingDirection, {
-      start: targetStartIndex,
-      end: targetIndex,
-      size,
-      isClosed: true
-    });
-  }
+  windingOptions.start = targetStartIndex;
+  windingOptions.end = targetIndex;
+  modifyPolygonWindingDirection(target, windingDirection, windingOptions);
 
   return targetIndex;
 }
@@ -156,14 +155,9 @@ function copyFlatRing(
     }
   }
 
-  if (windingDirection) {
-    modifyPolygonWindingDirection(target, windingDirection, {
-      start: targetStartIndex,
-      end: targetIndex,
-      size,
-      isClosed: true
-    });
-  }
+  windingOptions.start = targetStartIndex;
+  windingOptions.end = targetIndex;
+  modifyPolygonWindingDirection(target, windingDirection, windingOptions);
 
   return targetIndex;
 }
@@ -182,6 +176,7 @@ export function normalize(polygon, positionSize) {
 
   const positions = [];
   const holeIndices = [];
+  windingOptions.size = positionSize;
 
   if (polygon.positions) {
     // complex flat

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
@@ -39,14 +39,21 @@ ${main}
 void main(void) {
   PolygonProps props;
 
-  props.positions = instancePositions;
-  props.positions64Low = instancePositions64Low;
+  #if RING_WINDING_ORDER == 1
+    props.positions = instancePositions;
+    props.positions64Low = instancePositions64Low;
+    props.nextPositions = nextPositions;
+    props.nextPositions64Low = nextPositions64Low;
+  #else
+    props.positions = nextPositions;
+    props.positions64Low = nextPositions64Low;
+    props.nextPositions = instancePositions;
+    props.nextPositions64Low = instancePositions64Low;
+  #endif
   props.elevations = instanceElevations;
   props.fillColors = instanceFillColors;
   props.lineColors = instanceLineColors;
   props.pickingColors = instancePickingColors;
-  props.nextPositions = nextPositions;
-  props.nextPositions64Low = nextPositions64Low;
 
   calculatePosition(props);
 }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.js
@@ -39,7 +39,7 @@ ${main}
 void main(void) {
   PolygonProps props;
 
-  #if RING_WINDING_ORDER == 1
+  #if RING_WINDING_ORDER_CW == 1
     props.positions = instancePositions;
     props.positions64Low = instancePositions64Low;
     props.nextPositions = nextPositions;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -67,7 +67,7 @@ export default class SolidPolygonLayer extends Layer {
       vs: type === 'top' ? vsTop : vsSide,
       fs,
       defines: {
-        RING_WINDING_ORDER: !this.props._normalize && this.props._windingOrder === 'CCW' ? -1 : 1
+        RING_WINDING_ORDER_CW: !this.props._normalize && this.props._windingOrder === 'CCW' ? 0 : 1
       },
       modules: [project32, gouraudLighting, picking]
     });

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.js
@@ -38,6 +38,7 @@ const defaultProps = {
   // Whether to draw a GL.LINES wireframe of the polygon
   wireframe: false,
   _normalize: true,
+  _windingOrder: 'CW',
 
   // elevation multiplier
   elevationScale: {type: 'number', min: 0, value: 1},
@@ -65,7 +66,9 @@ export default class SolidPolygonLayer extends Layer {
     return super.getShaders({
       vs: type === 'top' ? vsTop : vsSide,
       fs,
-      defines: {},
+      defines: {
+        RING_WINDING_ORDER: !this.props._normalize && this.props._windingOrder === 'CCW' ? -1 : 1
+      },
       modules: [project32, gouraudLighting, picking]
     });
   }

--- a/test/bench/tesselation.bench.js
+++ b/test/bench/tesselation.bench.js
@@ -1,6 +1,7 @@
 import * as data from 'deck.gl-test/data';
 
 import PolygonTesselator from '@deck.gl/layers/solid-polygon-layer/polygon-tesselator';
+import {normalize} from '@deck.gl/layers/solid-polygon-layer/polygon';
 
 const polygons = data.choropleths.features.map(f => f.geometry.coordinates);
 
@@ -23,5 +24,10 @@ export default function tesselationBench(suite) {
         fp64: true,
         positionFormat: 'XYZ'
       });
+    })
+    .add('polygonTesselator.normalizeGeometry', () => {
+      for (const polygon of polygons) {
+        normalize(polygon, 3);
+      }
     });
 }


### PR DESCRIPTION
Follow up of #5223 

This PR allows binary users to specify the winding order of their polygon data if they choose to skip normalization.

I also considered using this prop to control the default winding order during normalization but decided against it for now. Benchmark shows that perf difference is ~10% when using one vs another. I've noticed that GeoJSONs converted from Shapefiles using GDAL do not conform to the right-hand rule, so it's hard to determine what's the best order to use simply based on the file format. It might introduce more confusion than benefit if we ask the user to explicitly pick one.

#### Change List
- Add `_windingOrder` prop to `PolygonLayer` and `SolidPolygonLayer`
- A benchmark test for polygon normalization
- Docs
- Upgrade guide
