### PR TITLE
Pass isHovering to getCursor

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -343,6 +343,7 @@ Receives arguments:
 
 - `interactiveState` (Object)
   + `isDragging` (Boolean) - whether the pointer is down and moving
+  + `isHovering` (Boolean) - whether the pointer is over a pickable object
 
 Returns:
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -162,6 +162,7 @@ export default class Deck {
 
     this.viewState = null; // Internal view state if no callback is supplied
     this.interactiveState = {
+      isHovering: false, // Whether the cursor is over a pickable object
       isDragging: false // Whether the cursor is down
     };
 
@@ -562,6 +563,7 @@ export default class Deck {
     if (_pickRequest.event) {
       // Perform picking
       const {result, emptyInfo} = this._pick('pickObject', 'pickObject Time', _pickRequest);
+      this.interactiveState.isHovering = result.length > 0;
 
       // There are 4 possible scenarios:
       // result is [outInfo, pickedInfo] (moved from one pickable layer to another)


### PR DESCRIPTION
For #4548, make it easier to customize cursor

#### Change List
- Pass `isHovering` to `getCursor`
