### PR TITLE
Make sure layer context is reset even if a layer throws during update

### DIFF
--- a/test/modules/core/lib/layer-manager.spec.js
+++ b/test/modules/core/lib/layer-manager.spec.js
@@ -207,9 +207,8 @@ test('LayerManager#error handling', t => {
     new BadLayer({id: 'crash-on-update', throw: true})
   ]);
 
-  t.is(errorArgs.length, 3, 'onError is called');
-  t.is(errorArgs[1].layer.id, 'crash-on-init', 'onError is called with correct args');
-  t.is(errorArgs[2].layer.id, 'crash-on-update', 'onError is called with correct args');
+  t.is(errorArgs.length, 2, 'onError is called');
+  t.is(errorArgs[1].layer.id, 'crash-on-update', 'onError is called with correct args');
 
   t.end();
 });


### PR DESCRIPTION
#### Background

This fixes the issue where a failed layer tries to update repeatedly on every render cycle.

#### Change List
- Reset the change flags and temporarily overwritten context when a layer's `updateState`/`draw` errors out
- Unit test
