### PR TITLE
[feat] WebGL context lost handling > pass to listeners of onError

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -175,7 +175,6 @@ export default class Deck {
     this._onPointerDown = this._onPointerDown.bind(this);
     this._onPointerMove = this._onPointerMove.bind(this);
     this._pickAndCallback = this._pickAndCallback.bind(this);
-    this._onRendererInitialized = this._onRendererInitialized.bind(this);
     this._onRenderFrame = this._onRenderFrame.bind(this);
     this._onViewStateChange = this._onViewStateChange.bind(this);
     this._onInteractionStateChange = this._onInteractionStateChange.bind(this);
@@ -505,7 +504,7 @@ export default class Deck {
           // eslint-disable-next-line
           onContextLost: event => this.props.onError(event)
         }),
-      onInitialize: this._onRendererInitialized,
+      onInitialize: ({gl}) => this._setGLContext(gl),
       onRender: this._onRenderFrame,
       onBeforeRender: props.onBeforeRender,
       onAfterRender: props.onAfterRender,
@@ -710,10 +709,6 @@ export default class Deck {
   }
 
   // Callbacks
-
-  _onRendererInitialized({gl}) {
-    this._setGLContext(gl);
-  }
 
   _onRenderFrame(animationProps) {
     this._getFrameStats();

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -133,7 +133,7 @@ const defaultProps = {
   onBeforeRender: noop,
   onAfterRender: noop,
   onLoad: noop,
-  onError: null,
+  onError: (error, ...args) => log.error(...args, error)(),
   _onMetrics: null,
 
   getCursor,
@@ -496,7 +496,15 @@ export default class Deck {
       autoResizeDrawingBuffer,
       autoResizeViewport: false,
       gl,
-      onCreateContext: opts => createGLContext({...glOptions, ...opts, canvas: this.canvas, debug}),
+      onCreateContext: options =>
+        createGLContext({
+          ...glOptions,
+          ...options,
+          canvas: this.canvas,
+          debug,
+          // eslint-disable-next-line
+          onContextLost: event => this.props.onError(event)
+        }),
       onInitialize: this._onRendererInitialized,
       onRender: this._onRenderFrame,
       onBeforeRender: props.onBeforeRender,

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -501,9 +501,9 @@ export default class Deck {
           ...options,
           canvas: this.canvas,
           debug,
-          // eslint-disable-next-line
           onContextLost: event => this.props.onError(event)
         }),
+      // eslint-disable-next-line no-shadow
       onInitialize: ({gl}) => this._setGLContext(gl),
       onRender: this._onRenderFrame,
       onBeforeRender: props.onBeforeRender,


### PR DESCRIPTION
For #5398

#### Change List
- _onWebGLContextLost callbacks passed to Luma and registered 
- deck.onError is triggered by _onWebGLContextLost