### PR TITLE
Avoid silencing errors by default in CartoLayer

### DIFF
--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -88,9 +88,9 @@ Receives arguments:
 
 ##### `onDataError` (Function, optional)
 
-`onDataError` is called when the request to the CARTO tiler failed.
+`onDataError` is called when the request to the CARTO tiler failed. By default the Error is thrown.
 
-- Default: `console.error`
+- Default: `null`
 
 Receives arguments:
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -115,9 +115,9 @@ Receives arguments:
 
 ##### `onDataError` (Function, optional)
 
-`onDataError` is called when the request to the CARTO tiler failed.
+`onDataError` is called when the request to the CARTO tiler failed. By default the Error is thrown.
 
-* Default: `console.error`
+* Default: `null`
 
 Receives arguments:
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -6,8 +6,7 @@ const defaultProps = {
   data: null,
   credentials: null,
   onDataLoad: {type: 'function', value: tilejson => {}, compare: false},
-  // eslint-disable-next-line
-  onDataError: {type: 'function', value: err => console.error(err), compare: false}
+  onDataError: {type: 'function', value: null, compare: false}
 };
 
 export default class CartoLayer extends CompositeLayer {
@@ -34,7 +33,11 @@ export default class CartoLayer extends CompositeLayer {
       this.setState({tilejson});
       this.props.onDataLoad(tilejson);
     } catch (err) {
-      this.props.onDataError(err);
+      if (this.props.onDataError) {
+        this.props.onDataError(err);
+      } else {
+        throw err;
+      }
     }
   }
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -6,7 +6,7 @@ const defaultProps = {
   data: null,
   credentials: null,
   onDataLoad: {type: 'function', value: tilejson => {}, compare: false},
-  onDataError: {type: 'function', value: null, compare: false}
+  onDataError: {type: 'function', value: null, compare: false, optional: true}
 };
 
 export default class CartoLayer extends CompositeLayer {


### PR DESCRIPTION
By default errors from `_updateData` in CartoLayers were caught and output to the error log, now the errors will be uncaught by default to help with tests and debugging.
