### PR TITLE
Fix OrbitView and OrthographicView custom prop handling

### DIFF
--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -39,15 +39,8 @@ function getViewMatrix({height, fovy, orbitAxis, rotationX, rotationOrbit, zoom}
 class OrbitViewport extends Viewport {
   constructor(props) {
     const {
-      id,
-      x,
-      y,
-      width,
       height,
-
       fovy = 50, // From eye position to lookAt
-      near,
-      far,
       orbitAxis = 'Z', // Orbit axis with 360 degrees rotating freedom, can only be 'Y' or 'Z'
       target = [0, 0, 0], // Which point is camera looking at, default origin
 
@@ -58,7 +51,7 @@ class OrbitViewport extends Viewport {
     } = props;
 
     super({
-      id,
+      ...props,
       viewMatrix: getViewMatrix({
         height,
         fovy,
@@ -68,13 +61,7 @@ class OrbitViewport extends Viewport {
         zoom
       }),
       fovy,
-      near,
-      far,
-      x,
-      y,
       position: target,
-      width,
-      height,
       zoom
     });
   }

--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -22,25 +22,19 @@ function getProjectionMatrix({width, height, near, far}) {
 }
 
 class OrthographicViewport extends Viewport {
-  constructor({
-    id,
-    x,
-    y,
-    width,
-    height,
-    near = 0.1,
-    far = 1000,
-    zoom = 0,
-    target = [0, 0, 0],
-    flipY = true
-  }) {
-    const scale = Math.pow(2, zoom);
-    super({
-      id,
-      x,
-      y,
+  constructor(props) {
+    const {
       width,
       height,
+      near = 0.1,
+      far = 1000,
+      zoom = 0,
+      target = [0, 0, 0],
+      flipY = true
+    } = props;
+    const scale = Math.pow(2, zoom);
+    super({
+      ...props,
       position: target,
       viewMatrix: viewMatrix.clone().scale([scale, scale * (flipY ? -1 : 1), scale]),
       projectionMatrix: getProjectionMatrix({width, height, near, far}),


### PR DESCRIPTION
#### Background

`OrbitView` and `OrthographicView` do not conform with documentation ("takes the same parameters as the `View` constructor") because they are selectively passing user props to the `Viewport` constructor. This blocks user from using their own `orthographic` or `projectionMatrix` settings.

#### Change List
- Merge props when constructing `OrbitViewport` and `OrthographicViewport`
