### PR TITLE
Update styling of embedded codepen demos in docs

### DIFF
--- a/docs/api-reference/core/lighting-effect.md
+++ b/docs/api-reference/core/lighting-effect.md
@@ -2,10 +2,13 @@
 
 The `LightingEffect` applies ambient, point and directional lighting to layers which support material property.
 
-<iframe height="450" style="width: 100%;" scrolling="no" title="deck.gl LightingEffect Demo" src="https://codepen.io/vis-gl/embed/ZZwrZz/?height=450&theme-id=light&default-tab=result" frameborder="no" allowtransparency="true" allowfullscreen="true">
-  See the Pen <a href='https://codepen.io/vis-gl/pen/ZZwrZz/'>deck.gl LightingEffect Demo</a> by vis.gl
-  (<a href='https://codepen.io/vis-gl'>@vis-gl</a>) on <a href='https://codepen.io'>CodePen</a>.
-</iframe>
+<div style="position:relative;height:450px"></div>
+<div style="position:absolute;transform:translateY(-450px);padding-left:inherit;padding-right:inherit;left:0;right:0">
+  <iframe height="450" width="100%" scrolling="no" title="deck.gl LightingEffect Demo" src="https://codepen.io/vis-gl/embed/ZZwrZz/?height=450&theme-id=light&default-tab=result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+    See the Pen <a href='https://codepen.io/vis-gl/pen/ZZwrZz/'>deck.gl LightingEffect Demo</a> by vis.gl
+    (<a href='https://codepen.io/vis-gl'>@vis-gl</a>) on <a href='https://codepen.io'>CodePen</a>.
+  </iframe>
+</div>
 
 ## Constructor
 

--- a/docs/api-reference/core/post-process-effect.md
+++ b/docs/api-reference/core/post-process-effect.md
@@ -2,10 +2,13 @@
 
 The `PostProcessEffect` applies screen space pixel manipulation effects to deck.gl layers.
 
-<iframe height="450" style="width: 100%;" scrolling="no" title="deck.gl PostProcessEffect Demo" src="https://codepen.io/vis-gl/embed/YbRGvv/?height=450&theme-id=light&default-tab=result" frameborder="no" allowtransparency="true" allowfullscreen="true">
-  See the Pen <a href='https://codepen.io/vis-gl/pen/YbRGvv/'>deck.gl PostProcessEffect Demo</a> by vis.gl
-  (<a href='https://codepen.io/vis-gl'>@vis-gl</a>) on <a href='https://codepen.io'>CodePen</a>.
-</iframe>
+<div style="position:relative;height:450px"></div>
+<div style="position:absolute;transform:translateY(-450px);padding-left:inherit;padding-right:inherit;left:0;right:0">
+  <iframe height="450" width="100%" scrolling="no" title="deck.gl PostProcessEffect Demo" src="https://codepen.io/vis-gl/embed/YbRGvv/?height=450&theme-id=light&default-tab=result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+    See the Pen <a href='https://codepen.io/vis-gl/pen/YbRGvv/'>deck.gl PostProcessEffect Demo</a> by vis.gl
+    (<a href='https://codepen.io/vis-gl'>@vis-gl</a>) on <a href='https://codepen.io'>CodePen</a>.
+  </iframe>
+</div>
 
 ## Constructor
 


### PR DESCRIPTION
Allow the iFrame to stretch outside of the page width of the markdown.

Before:

![Screen Shot 2021-02-01 at 2 06 44 PM](https://user-images.githubusercontent.com/2059298/106524315-3eb7bc00-6497-11eb-879e-3b6b8daa1ceb.png)

After:

![Screen Shot 2021-02-01 at 2 06 16 PM](https://user-images.githubusercontent.com/2059298/106524321-424b4300-6497-11eb-9ddb-ff6cee730f35.png)
