### PR TITLE
Fix MVTLayer loaders prop propagation

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -15,7 +15,7 @@ const WORLD_SIZE = 512;
 const defaultProps = {
   uniqueIdProperty: {type: 'string', value: ''},
   highlightedFeatureId: null,
-  loaders: MVTLoader,
+  loaders: [MVTLoader],
   binary: false
 };
 

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -56,7 +56,7 @@ const defaultProps = {
   wireframe: false,
   material: true,
 
-  loaders: TerrainLoader
+  loaders: [TerrainLoader]
 };
 
 // Turns array of templates into a single string to work around shallow change


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/5453

When calling `load` with a non-array `loaders` argument it blocks the usage of other registered loaders.

#### Change List
- Make all `loaders` prop defaults arrays.
