### PR TITLE
Restore default transitionInterpolator

### DIFF
--- a/modules/core/src/controllers/controller.js
+++ b/modules/core/src/controllers/controller.js
@@ -191,6 +191,11 @@ export default class Controller {
       this.toggleEvents(this._customEvents, true);
     }
 
+    if (!('transitionInterpolator' in props)) {
+      // Add default transition interpolator
+      props.transitionInterpolator = this._getTransitionProps().transitionInterpolator;
+    }
+
     this.transitionManager.processViewStateChange(props);
 
     let {inertia} = props;

--- a/modules/core/src/controllers/first-person-controller.js
+++ b/modules/core/src/controllers/first-person-controller.js
@@ -1,6 +1,8 @@
 import Controller from './controller';
 import ViewState from './view-state';
 import {mod} from '../utils/math-utils';
+import LinearInterpolator from '../transitions/linear-interpolator';
+import {TRANSITION_EVENTS} from './transition-manager';
 
 import {Vector3, _SphericalCoordinates as SphericalCoordinates, clamp} from 'math.gl';
 
@@ -11,6 +13,13 @@ const DEFAULT_STATE = {
   bearing: 0,
   maxPitch: 90,
   minPitch: -90
+};
+
+const LINEAR_TRANSITION_PROPS = {
+  transitionDuration: 300,
+  transitionEasing: t => t,
+  transitionInterpolator: new LinearInterpolator(['position', 'pitch', 'bearing']),
+  transitionInterruption: TRANSITION_EVENTS.BREAK
 };
 
 class FirstPersonState extends ViewState {
@@ -292,5 +301,10 @@ class FirstPersonState extends ViewState {
 export default class FirstPersonController extends Controller {
   constructor(props) {
     super(FirstPersonState, props);
+  }
+
+  _getTransitionProps() {
+    // Enables Transitions on double-tap and key-down events.
+    return LINEAR_TRANSITION_PROPS;
   }
 }

--- a/test/modules/core/controllers/controllers.spec.js
+++ b/test/modules/core/controllers/controllers.spec.js
@@ -85,6 +85,7 @@ test('FirstPersonController', async t => {
       longitude: -122.45,
       latitude: 37.78,
       pitch: 15,
+      bearing: 0,
       position: [0, 0, 2]
     },
     // FirstPersonController does not pan


### PR DESCRIPTION
For #5458

`transitionInterpolator` was removed from `TransitionManager.defaultProps` by #5371 because the default only worked with `MapView`.

#### Change List
- restores default `transitionInterpolator` based on which controller is in use.

