### PR TITLE
MVT: fix picking non-binary

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -164,7 +164,11 @@ export default class MVTLayer extends TileLayer {
 
     if (info.object) {
       if (!isWGS84 && info.object) {
-        info.object = transformTileCoordsToWGS84(info.object, info.tile, this.context.viewport);
+        info.object = transformTileCoordsToWGS84(
+          info.object,
+          info.tile.bbox,
+          this.context.viewport
+        );
       }
     } else if (this.props.binary && info.index !== -1) {
       // get the feature from the binary at the given index.

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -162,14 +162,8 @@ export default class MVTLayer extends TileLayer {
 
     const isWGS84 = this.context.viewport.resolution;
 
-    if (info.object) {
-      if (!isWGS84 && info.object) {
-        info.object = transformTileCoordsToWGS84(
-          info.object,
-          info.tile.bbox,
-          this.context.viewport
-        );
-      }
+    if (info.object && !isWGS84) {
+      info.object = transformTileCoordsToWGS84(info.object, info.tile.bbox, this.context.viewport);
     } else if (this.props.binary && info.index !== -1) {
       // get the feature from the binary at the given index.
       const {data} = params.sourceLayer.props;


### PR DESCRIPTION
Picking info was launching an exception when trying to transform to WGS84.