### PR TITLE
BUG FIX: pydeck api_keys 

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -108,7 +108,7 @@ class Deck(JSONMixin):
         for provider in BaseMapProvider:
             attr_name = f"{provider.value}_key"
             provider_env_var = f"{provider.name}_API_KEY"
-            attr_value = api_keys.get(provider) or os.getenv(provider_env_var)
+            attr_value = api_keys.get(provider.value) or os.getenv(provider_env_var)
             setattr(self, attr_name, attr_value)
             setattr(self.deck_widget, attr_name, attr_value)
 


### PR DESCRIPTION
Resolves #5474

api_keys dictionary expects keys of either mapbox, google_map or carto, which are accessed via provider.value. 


