### PR TITLE
Expose Tileset2D instance

### DIFF
--- a/modules/geo-layers/src/index.js
+++ b/modules/geo-layers/src/index.js
@@ -22,6 +22,7 @@
 export {default as GreatCircleLayer} from './great-circle-layer/great-circle-layer';
 export {default as S2Layer} from './s2-layer/s2-layer';
 export {default as TileLayer} from './tile-layer/tile-layer';
+export {default as Tileset2D} from './tile-layer/tileset-2d';
 export {default as TripsLayer} from './trips-layer/trips-layer';
 export {default as H3ClusterLayer} from './h3-layers/h3-cluster-layer';
 export {default as H3HexagonLayer} from './h3-layers/h3-hexagon-layer';

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -34,7 +34,8 @@ const defaultProps = {
     },
     compare: false
   },
-  maxRequests: 6
+  maxRequests: 6,
+  Tileset2D
 };
 
 export default class TileLayer extends CompositeLayer {
@@ -85,7 +86,7 @@ export default class TileLayer extends CompositeLayer {
         extent,
         maxRequests
       } = props;
-      tileset = new Tileset2D({
+      tileset = new props.Tileset2D({
         getTileData: this.getTileData.bind(this),
         maxCacheSize,
         maxCacheByteSize,


### PR DESCRIPTION
#### Background

There's a lot of great tile selection logic in the `TileLayer`. However it's very much tied to the Web Mercator projection and OSM indexing system. There are use cases for displaying tiled data that isn't in the OSM tiling system. For example, if one wished to display tiled data in the `GlobeView`, a "global geodetic" tiling system might be more appropriate, where there are two base tiles for each hemisphere, then a quadtree within each, and where each tile is in the WGS84 projection.

I don't think it should necessarily be deck.gl's job to support other tiling systems, but I think it should be easier for an end user to extend the `TileLayer`'s functionality.

This is a very basic PR to expose the `Tileset2D` class, and is intended to start further discussion. 

- Does it make sense to set `Tileset2D` as a layer prop? I'm not aware of any other circumstances where a class is a prop. Should it be tied to the `TileLayer` class instead, so that a user who wishes to change the `Tileset2D` would subclass the `TileLayer` and swap out the `tileset` attribute?

#### Change List

- Expose `Tileset2D` from `@deck.gl/geo-layers`
- Add `Tileset2D` as prop to `TileLayer`.
