### PR TITLE
Force using a single loader for MVT data

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -110,7 +110,7 @@ export default class MVTLayer extends TileLayer {
       },
       gis: this.props.binary ? {format: 'binary'} : {}
     };
-    return load(url, this.props.loaders, options);
+    return load(url, this.props.loaders[0], options);
   }
 
   renderSubLayers(props) {


### PR DESCRIPTION
Workaround for unrecognized/empty response from the tile server

#### Change List
- Force using a single loader to parse MVT data
