### PR TITLE
Clear tooltip when viewport changes

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -735,6 +735,11 @@ export default class Deck {
 
     this._updateCursor();
 
+    // If view state has changed, clear tooltip
+    if (this.tooltip.isVisible && this.viewManager.needsRedraw()) {
+      this.tooltip.setTooltip(null);
+    }
+
     // Update layers if needed (e.g. some async prop has loaded)
     // Note: This can trigger a redraw
     this.layerManager.updateLayers();

--- a/modules/core/src/lib/tooltip.js
+++ b/modules/core/src/lib/tooltip.js
@@ -41,6 +41,8 @@ export default class Tooltip {
       Object.assign(this.el.style, defaultStyle);
       canvasParent.appendChild(this.el);
     }
+
+    this.isVisible = false;
   }
 
   setTooltip(displayInfo, x, y) {
@@ -49,6 +51,7 @@ export default class Tooltip {
     if (typeof displayInfo === 'string') {
       el.innerText = displayInfo;
     } else if (!displayInfo) {
+      this.isVisible = false;
       el.style.display = 'none';
       return;
     } else {
@@ -63,6 +66,7 @@ export default class Tooltip {
       }
       Object.assign(el.style, displayInfo.style);
     }
+    this.isVisible = true;
     el.style.display = 'block';
     el.style.transform = `translate(${x}px, ${y}px)`;
   }


### PR DESCRIPTION
For #5260

Before:

![tooltip-before](https://user-images.githubusercontent.com/2059298/108608627-18da5480-737d-11eb-9fc0-531315bf82ab.gif)

After:

![tooltip-after](https://user-images.githubusercontent.com/2059298/108608620-0e1fbf80-737d-11eb-9d35-b6fbc5c820fd.gif)

#### Change List
- Clear tooltip if the viewport moves
