### PR TITLE
Fix TileLayer fetch options

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -28,7 +28,11 @@ const defaultProps = {
   fetch: {
     type: 'function',
     value: (url, {layer, signal}) => {
-      const loadOptions = {signal, ...(layer.getLoadOptions() || {})};
+      const loadOptions = {...layer.getLoadOptions()};
+      loadOptions.fetch = {
+        ...loadOptions.fetch,
+        signal
+      };
 
       return load(url, loadOptions);
     },


### PR DESCRIPTION
#### Change List
- Remove `Top level loader option 'signal' deprecated` warning
- Make sure that tiles can still be aborted when the user passes `loadOptions.fetch`
