### PR TITLE
Force OrbitView/OrthographicView to create non-geospatial viewports

### DIFF
--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -52,6 +52,9 @@ class OrbitViewport extends Viewport {
 
     super({
       ...props,
+      // in case viewState contains longitude/latitude values,
+      // make sure that the base Viewport class does not treat this as a geospatial viewport
+      longitude: null,
       viewMatrix: getViewMatrix({
         height,
         fovy,

--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -35,6 +35,9 @@ class OrthographicViewport extends Viewport {
     const scale = Math.pow(2, zoom);
     super({
       ...props,
+      // in case viewState contains longitude/latitude values,
+      // make sure that the base Viewport class does not treat this as a geospatial viewport
+      longitude: null,
       position: target,
       viewMatrix: viewMatrix.clone().scale([scale, scale * (flipY ? -1 : 1), scale]),
       projectionMatrix: getProjectionMatrix({width, height, near, far}),


### PR DESCRIPTION
For #5522

#### Change List
- `OrbitView`/`OrthographicView` should not pass `longitude`/`latitude` to the base `Viewport` constructor
