### PR TITLE
Update jupyter-widget bundle config

### DIFF
--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -24,9 +24,9 @@
   "sideEffects": false,
   "scripts": {
     "watch": "webpack --watch",
-    "build": "webpack",
+    "build": "webpack -p",
     "build:labextension": "npm pack",
-    "prepublishOnly": "webpack"
+    "prepublishOnly": "webpack -p"
   },
   "dependencies": {
     "@deck.gl/aggregation-layers": "8.5.0-alpha.3",

--- a/modules/jupyter-widget/webpack.config.js
+++ b/modules/jupyter-widget/webpack.config.js
@@ -18,12 +18,19 @@ const rules = [
     include: /src/,
     options: {
       babelrc: false,
-      presets: [['@babel/preset-env', {forceAllTransforms: true}]],
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: ['>0.2%', 'not ie 11', 'not dead', 'not chrome 49']
+          }
+        ]
+      ],
       // all of the helpers will reference the module @babel/runtime to avoid duplication
       // across the compiled output.
       plugins: [
         '@babel/transform-runtime',
-        // 'inline-webgl-constants',
+        'inline-webgl-constants',
         ['remove-glsl-comments', {patterns: ['**/*.glsl.js']}]
       ]
     }


### PR DESCRIPTION
We do not have to do a full transpile of the source. Jupyter Notebook's browser requirement: https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility

#### Change List
- Specify babel targets
- Uncomment `inline-webgl-constants` plugin (fixed by #5517)
