### PR TITLE
Bump loaders.gl to 2.3.13

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -9,8 +9,8 @@
     "start-local-production": "webpack-dev-server --env.local --env.production --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/ply": "^2.3.9",
-    "@loaders.gl/gltf": "^2.3.9",
+    "@loaders.gl/ply": "^2.3.13",
+    "@loaders.gl/gltf": "^2.3.13",
     "@luma.gl/experimental": "^8.3.1",
     "@luma.gl/debug": "^8.3.1",
     "colorbrewer": "^1.0.0",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -8,11 +8,11 @@
     "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.local --env.production=true"
   },
   "dependencies": {
-    "@loaders.gl/3d-tiles": "^2.3.9",
-    "@loaders.gl/core": "^2.3.9",
-    "@loaders.gl/csv": "^2.3.9",
-    "@loaders.gl/draco": "^2.3.9",
-    "@loaders.gl/gltf": "^2.3.9",
+    "@loaders.gl/3d-tiles": "^2.3.13",
+    "@loaders.gl/core": "^2.3.13",
+    "@loaders.gl/csv": "^2.3.13",
+    "@loaders.gl/draco": "^2.3.13",
+    "@loaders.gl/gltf": "^2.3.13",
     "@luma.gl/constants": "^8.3.1",
     "brace": "^0.11.1",
     "deck.gl": "^8.3.0",

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "@loaders.gl/3d-tiles": "^2.3.9",
+    "@loaders.gl/3d-tiles": "^2.3.13",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/globe/package.json
+++ b/examples/website/globe/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/csv": "^2.3.9",
+    "@loaders.gl/csv": "^2.3.13",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "deck.gl": "^8.4.0",

--- a/examples/website/i3s/package.json
+++ b/examples/website/i3s/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/i3s": "^2.3.9",
+    "@loaders.gl/i3s": "^2.3.13",
     "deck.gl": "^8.4.0"
   },
   "devDependencies": {

--- a/examples/website/mesh/package.json
+++ b/examples/website/mesh/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/obj": "^2.3.9",
+    "@loaders.gl/obj": "^2.3.13",
     "deck.gl": "^8.4.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/examples/website/point-cloud/package.json
+++ b/examples/website/point-cloud/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/las": "^2.3.9",
+    "@loaders.gl/las": "^2.3.13",
     "deck.gl": "^8.4.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"

--- a/examples/website/radio/package.json
+++ b/examples/website/radio/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/csv": "^2.3.9",
+    "@loaders.gl/csv": "^2.3.13",
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "d3-scale": "^2.0.0",

--- a/examples/website/safegraph/package.json
+++ b/examples/website/safegraph/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/csv": "^2.3.9",
+    "@loaders.gl/csv": "^2.3.13",
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.4.0",
     "mapbox-gl": "^1.0.0"

--- a/examples/website/scenegraph/package.json
+++ b/examples/website/scenegraph/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "@loaders.gl/gltf": "^2.3.9",
+    "@loaders.gl/gltf": "^2.3.13",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -32,9 +32,9 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/loader-utils": "^2.3.9",
-    "@loaders.gl/mvt": "^2.3.9",
-    "@loaders.gl/tiles": "^2.3.9",
+    "@loaders.gl/loader-utils": "^2.3.13",
+    "@loaders.gl/mvt": "^2.3.13",
+    "@loaders.gl/tiles": "^2.3.13",
     "@math.gl/web-mercator": "^3.4.2",
     "cartocolor": "^4.0.2",
     "d3-scale": "^3.2.3"

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -32,8 +32,8 @@
     "prepublishOnly": "npm run build-debugger && npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/core": "^2.3.9",
-    "@loaders.gl/images": "^2.3.9",
+    "@loaders.gl/core": "^2.3.13",
+    "@loaders.gl/images": "^2.3.13",
     "@luma.gl/core": "^8.4.1",
     "@math.gl/web-mercator": "^3.4.2",
     "gl-matrix": "^3.0.0",

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -30,12 +30,12 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/3d-tiles": "^2.3.9",
-    "@loaders.gl/gis": "^2.3.9",
-    "@loaders.gl/loader-utils": "^2.3.9",
-    "@loaders.gl/mvt": "^2.3.9",
-    "@loaders.gl/terrain": "^2.3.9",
-    "@loaders.gl/tiles": "^2.3.9",
+    "@loaders.gl/3d-tiles": "^2.3.13",
+    "@loaders.gl/gis": "^2.3.13",
+    "@loaders.gl/loader-utils": "^2.3.13",
+    "@loaders.gl/mvt": "^2.3.13",
+    "@loaders.gl/terrain": "^2.3.13",
+    "@loaders.gl/tiles": "^2.3.13",
     "@math.gl/culling": "^3.4.2",
     "@math.gl/web-mercator": "^3.4.2",
     "h3-js": "^3.6.0",

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -37,9 +37,9 @@
     "@deck.gl/layers": "8.4.9",
     "@deck.gl/mesh-layers": "8.4.9",
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3",
-    "@loaders.gl/3d-tiles": "^2.3.9",
-    "@loaders.gl/core": "^2.3.9",
-    "@loaders.gl/csv": "^2.3.9",
+    "@loaders.gl/3d-tiles": "^2.3.13",
+    "@loaders.gl/core": "^2.3.13",
+    "@loaders.gl/csv": "^2.3.13",
     "@luma.gl/constants": "^8.4.1",
     "mapbox-gl": "^1.2.1"
   },

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/images": "^2.3.9",
+    "@loaders.gl/images": "^2.3.13",
     "@mapbox/tiny-sdf": "^1.1.0",
     "@math.gl/polygon": "^3.4.2",
     "earcut": "^2.0.6"

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -33,7 +33,7 @@
     "@deck.gl/core": "^8.0.0"
   },
   "dependencies": {
-    "@loaders.gl/gltf": "^2.3.9",
+    "@loaders.gl/gltf": "^2.3.13",
     "@luma.gl/experimental": "^8.4.1",
     "@luma.gl/shadertools": "^8.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "jsdom": false
   },
   "devDependencies": {
-    "@loaders.gl/csv": "^2.3.9",
-    "@loaders.gl/polyfills": "^2.3.9",
+    "@loaders.gl/csv": "^2.3.13",
+    "@loaders.gl/polyfills": "^2.3.13",
     "@luma.gl/test-utils": "^8.4.1",
     "@probe.gl/bench": "^3.2.1",
     "@probe.gl/test-utils": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,104 +1767,104 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@loaders.gl/3d-tiles@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/3d-tiles/-/3d-tiles-2.3.11.tgz#ef4cac6b56f9550ff455adbaf4e03e995877bbff"
-  integrity sha512-EISLGrnEvmF2n19L4ac/wNXWR/mHNcRjxiAu9fmfl6EAwBEb6HM2Pvo/VodWwHHkj+YJQrx4RoMFpDHBswyJ2A==
+"@loaders.gl/3d-tiles@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/3d-tiles/-/3d-tiles-2.3.13.tgz#7b304423d42e76ecc4e7ee4339174a29f2c364ae"
+  integrity sha512-WccDTlv/AJo5GJFEa6MIjk1H0294hTs8zhmEDq5mmdQ4B7la+4aWKmIfJmgCcIv8vWUkzQIuRIHTgxi0ShmUTw==
   dependencies:
-    "@loaders.gl/core" "2.3.11"
-    "@loaders.gl/draco" "2.3.11"
-    "@loaders.gl/gltf" "2.3.11"
-    "@loaders.gl/loader-utils" "2.3.11"
-    "@loaders.gl/math" "2.3.11"
-    "@loaders.gl/tiles" "2.3.11"
+    "@loaders.gl/core" "2.3.13"
+    "@loaders.gl/draco" "2.3.13"
+    "@loaders.gl/gltf" "2.3.13"
+    "@loaders.gl/loader-utils" "2.3.13"
+    "@loaders.gl/math" "2.3.13"
+    "@loaders.gl/tiles" "2.3.13"
     "@math.gl/core" "^3.3.0"
     "@math.gl/geospatial" "^3.3.0"
     "@probe.gl/stats" "^3.3.0"
 
-"@loaders.gl/core@2.3.11", "@loaders.gl/core@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.3.11.tgz#231c335f4123f645d4ae369a225f2cddf061135e"
-  integrity sha512-3lmoLy/JiSZQV7oTFcfNrYYonXghEBeEJFK0DHa/AinWVw7Ikz/MK2r3Z4MXElE/tnXPYN/AeLqkfDdwG8Nk1g==
+"@loaders.gl/core@2.3.13", "@loaders.gl/core@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.3.13.tgz#093fe965cfab0a72c902a63d461282ae1ed55dc2"
+  integrity sha512-Hjm8eJjS/OUnaHrOSgXtE+qDg5V4Do0jIpp2u0Dv3CMxPrtd2TpwkDfAyZWmmbZew9rzqPoAVMINejS/ItWUeg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/loader-utils" "2.3.13"
 
-"@loaders.gl/csv@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/csv/-/csv-2.3.11.tgz#56b3b7a3849c00b098650852f5cb0fb26ddd9ae8"
-  integrity sha512-x5yAMl8QYawy+CarULtsIwcJUXOz6jQEXDgTvroIPnxyn67IosJRI/8/9MX7R/D2NYIgMpoV2m8Yz32VurJzSA==
+"@loaders.gl/csv@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/csv/-/csv-2.3.13.tgz#9150e71b23c26d2b6b660028a819d876c2a349c1"
+  integrity sha512-sTOw/BTa7bTqpaugF/edWSb5Uq5Ztp/2MVcrK7PMgFP+W5I1mV6BTObxBw083SOCNlnGvuLH7GlYzrBmE8QMwQ==
   dependencies:
-    "@loaders.gl/loader-utils" "2.3.11"
-    "@loaders.gl/tables" "2.3.11"
+    "@loaders.gl/loader-utils" "2.3.13"
+    "@loaders.gl/tables" "2.3.13"
 
-"@loaders.gl/draco@2.3.11":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-2.3.11.tgz#6c9733502515599704de15accc0c82e8fe6ea19c"
-  integrity sha512-MllCmZO3hP9MYNfSAFn83jrD/QbMt5IMftSMf1HArzYDt/yWkPp3VXayV5WjTyoZby8AJYweE8GhPqWIa869fQ==
+"@loaders.gl/draco@2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-2.3.13.tgz#fcc08c0a3b438e3d7ed099dbafc1f83205b5f41b"
+  integrity sha512-rePkoM/xpvNyjO2vvBRQ39Aa3tCpBFCWf/jheka4bFXnLJzy8X7ZGNXojZEsrdT0lAiHM+QrCeAWvtyDEujURA==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/loader-utils" "2.3.13"
     draco3d "^1.3.6"
 
-"@loaders.gl/gis@2.3.11", "@loaders.gl/gis@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-2.3.11.tgz#02da934e09da1dc5e8925adf76c2f6311bc87fcf"
-  integrity sha512-MdJ7/nISfi/VQGZtbE+zDIvTMhENOduSU8V7YCbvM2gZqn2eRqWq7hbH9bPxxS8EnhXeKaF2Vp8cw4VR/YOutQ==
+"@loaders.gl/gis@2.3.13", "@loaders.gl/gis@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-2.3.13.tgz#b80cda7e8f709efd0a5a9badf7daf9c68b6b0409"
+  integrity sha512-i+hot7QeW53GhRwnvF5H65lsZYv4/ESbFuGtNy5TKivPaTIqn1oIFtLOku9Ntw5xTfky9qNNlbMPcsDMoniavQ==
   dependencies:
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/loader-utils" "2.3.13"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
-"@loaders.gl/gltf@2.3.11", "@loaders.gl/gltf@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-2.3.11.tgz#fa718fb82c1bb0070733d04069e0012814eae649"
-  integrity sha512-IMLJMie4Pc20AxnwTw5dXJRrszxSldTgPO2HfSf9ZSxYELF+B1yjec5rDGON0HZ+nMN3rCK/4Z2r/gf7w3Qbpg==
+"@loaders.gl/gltf@2.3.13", "@loaders.gl/gltf@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-2.3.13.tgz#4207ee05232b089a9cafa0254cae6812f7ac351b"
+  integrity sha512-V/GUMe1Gm8cEfKnp899l0Nu6rKycEbLidO9WYhlwbB5avcwrxltWRqoWvQKFKNCqJyH5neJbl8vDmaaeeELD3w==
   dependencies:
-    "@loaders.gl/core" "2.3.11"
-    "@loaders.gl/draco" "2.3.11"
-    "@loaders.gl/images" "2.3.11"
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/core" "2.3.13"
+    "@loaders.gl/draco" "2.3.13"
+    "@loaders.gl/images" "2.3.13"
+    "@loaders.gl/loader-utils" "2.3.13"
 
-"@loaders.gl/images@2.3.11", "@loaders.gl/images@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.3.11.tgz#3bfca6124de071d4545a81fb502d1180d84a8801"
-  integrity sha512-Kb2lQZQgOTh/DMbWQmkMfsilyQamSJqDTZDoJKbXM6x3P+O9cLuMZXE6KQrq80z5Ax1BcC7nGcn+hNq5904ADA==
+"@loaders.gl/images@2.3.13", "@loaders.gl/images@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-2.3.13.tgz#3b827cf1e8d31c8f1adf85136c7fd53c08dbb0a8"
+  integrity sha512-BBgLf17udhRnYwvsObAOM7jEeLBaeU3di1NyLhpTMa7WbG3jAnDlmy1BRue8wYfgVpWnmk18YubZtX6vCRrJnA==
   dependencies:
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/loader-utils" "2.3.13"
 
-"@loaders.gl/loader-utils@2.3.11", "@loaders.gl/loader-utils@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.3.11.tgz#1f7e8db6f464daacfdc39c0ed6872f232da67423"
-  integrity sha512-PE9dhBdw/GuH7ZHrVkhy9wdCTXJ7/nvMhMjL91E0bJ206TvPO+vGDMtIu9QFqt254PE5oU35MJS5bbB/Bgs5kQ==
+"@loaders.gl/loader-utils@2.3.13", "@loaders.gl/loader-utils@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-2.3.13.tgz#5cf6403b1c19b2fe5abacbd89e6252b8ca50db96"
+  integrity sha512-vXzH5CWG8pWjUEb7hUr6CM4ERj4NVRpA60OxvVv/OaZZ7hNN63+9/tSUA5IXD9QArWPWrFBnKnvE+5gg4WNqTg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@probe.gl/stats" "^3.3.0"
 
-"@loaders.gl/math@2.3.11":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/math/-/math-2.3.11.tgz#ebd7a0c4c0e13fee0717ad9dc156390a479841f8"
-  integrity sha512-UkDsnixFMpvgNqgj0dvYj/dpeTmiknHL7Q9NtB9IhFEQ21hHlwvcx1iRWAAgOAyooYACmkI45A/JdMv0XnKeGw==
+"@loaders.gl/math@2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/math/-/math-2.3.13.tgz#500173a7b2202ca09ee07e68f617ec45e8f3bfd9"
+  integrity sha512-ewlpk+5NR+DWSDx7OIptcd+KaPRmwgOlSg/54p+pjw1oO0rqs7y8tv7s+KfYJX66rN7i9MiBaJ0JwfC0lrB09A==
   dependencies:
-    "@loaders.gl/images" "2.3.11"
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/images" "2.3.13"
+    "@loaders.gl/loader-utils" "2.3.13"
     "@math.gl/core" "^3.3.0"
 
-"@loaders.gl/mvt@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/mvt/-/mvt-2.3.11.tgz#dee25062e55f232942a2060c2d569bc9e39e9711"
-  integrity sha512-2T6aA8g8schuAHKqFTE0Cba3K4siWy510gorXurdbExG132wD+zGltZnF3w7GaZ+ijx/j3LYHtHrG/d0j7OeLw==
+"@loaders.gl/mvt@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/mvt/-/mvt-2.3.13.tgz#87cf43f017446f5c996f13c874b6d6b601498c72"
+  integrity sha512-Zi1Gc6XzxTY05tVbxMITvy6zUiBhMpMWvhPkaCcOfktblDMnhQTkIb9fVnhv7ioe4hId4rvuXDIUXhtrBTJEKQ==
   dependencies:
-    "@loaders.gl/gis" "2.3.11"
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/gis" "2.3.13"
+    "@loaders.gl/loader-utils" "2.3.13"
     "@mapbox/point-geometry" "~0.1.0"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
-"@loaders.gl/polyfills@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-2.3.11.tgz#ac9b8172ef00667b7bb9191e05a4039920aa7193"
-  integrity sha512-uJEs1dcWFSrm+2FW+woRlL8HPgRtqQVTOa97ZuqbnzB+HUxW0QfuQZB8G9Cm7F6SWr3u+tISu1x5YjHwVNpaZg==
+"@loaders.gl/polyfills@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-2.3.13.tgz#dccd63e4fffecb89cac06dc594673c8c3dfe90f6"
+  integrity sha512-kb8EpuEO3HALvZqP9AirPV+mRJ4+24yP+xZuDvX7TaFZ21dWQ1O4dwjJLYenR1SlBsNAdZ4cYyN+59EiCiPjfw==
   dependencies:
     "@babel/runtime" "^7.3.1"
     get-pixels "^3.3.2"
@@ -1874,31 +1874,31 @@
     through "^2.3.8"
     web-streams-polyfill "^3.0.0"
 
-"@loaders.gl/tables@2.3.11":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.3.11.tgz#e2ae93a4941354fad57f498942aaa0541138e5a5"
-  integrity sha512-DRNYKr/gaHHA8KmE+Tbgp3KdaRB2qA0yck+J9Yeoq6TpiQphYspYbQV6OCGswdY2HhJJDh7DFXwsfE+5zzsuUQ==
+"@loaders.gl/tables@2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-2.3.13.tgz#df30cbb02110e4857e2f3e2a07b64fcf8e0e5b78"
+  integrity sha512-NHEEUJ/08d3QjMl71CL8MDFUdbKclsjbAVVl9Hiud47qsS7eWwU5g7bayEW0dSawMhZVu+dbbpOyziv/QgDizw==
   dependencies:
-    "@loaders.gl/core" "2.3.11"
+    "@loaders.gl/core" "2.3.13"
     d3-dsv "^1.2.0"
 
-"@loaders.gl/terrain@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/terrain/-/terrain-2.3.11.tgz#d9a1c6497932303b6e68b7247be9b3dc41921e03"
-  integrity sha512-PiK9aXbt4W/c/ufT5mms0HuZmcPvVIDNEqSKKgkQE2kRAFgUOoYBS1XHGFUn5/iS/aWD6K7uOBOk3B6Og8GwPA==
+"@loaders.gl/terrain@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/terrain/-/terrain-2.3.13.tgz#84f9d332f05fbd453caed3a9c9b8c9d6caaf2c4a"
+  integrity sha512-sZi/CMcNxKbcv7F8pk0PLX5P0o11Sy8DzOk4MB0mRe4XM1ITeiaXf8L6JZkOC3HBdBOzNlId6N3f32fK9OHPnw==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "2.3.11"
+    "@loaders.gl/loader-utils" "2.3.13"
     "@mapbox/martini" "^0.2.0"
 
-"@loaders.gl/tiles@2.3.11", "@loaders.gl/tiles@^2.3.9":
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tiles/-/tiles-2.3.11.tgz#db790e3c42b2571020b2b8becc031a54df2c1cfd"
-  integrity sha512-OOR7eLWzUy+nLDmKkkrIJjXzXXCzcPWfWvOOsODmPQKrNLBqq3CE4taC0PFj4ABYdkDZmojoLky1Kw8W6sqHig==
+"@loaders.gl/tiles@2.3.13", "@loaders.gl/tiles@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/tiles/-/tiles-2.3.13.tgz#470f5f46d35699ad7063445d1ba142e3ce4dabf0"
+  integrity sha512-3ZSlMgcPTo5lCnvKw/is5dvTayzvX+wi6n1u4lEe4gt8Ml9KYp/e45hOqp6qXR6SckO2+ohBXOzQP2e8ZhRxXQ==
   dependencies:
-    "@loaders.gl/core" "2.3.11"
-    "@loaders.gl/loader-utils" "2.3.11"
-    "@loaders.gl/math" "2.3.11"
+    "@loaders.gl/core" "2.3.13"
+    "@loaders.gl/loader-utils" "2.3.13"
+    "@loaders.gl/math" "2.3.13"
     "@math.gl/core" "^3.3.0"
     "@math.gl/culling" "^3.3.0"
     "@math.gl/geospatial" "^3.3.0"


### PR DESCRIPTION
Bump loaders.gl to 2.3.13 to fix MVT binary with empty tiles: https://github.com/visgl/deck.gl/issues/5534