### PR TITLE
fix(core): Fix layer manager error handling

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -133,7 +133,8 @@ const defaultProps = {
   onBeforeRender: noop,
   onAfterRender: noop,
   onLoad: noop,
-  onError: (error, ...args) => log.error(...args, error)(),
+  /** @type {(error: Error, source: string) => any} */
+  onError: (error, source) => log.error(`${error}`, source)(),
   _onMetrics: null,
 
   getCursor,
@@ -501,7 +502,7 @@ export default class Deck {
           ...options,
           canvas: this.canvas,
           debug,
-          onContextLost: event => this.props.onError(event)
+          onContextLost: event => this.props.onError(event, null)
         }),
       // eslint-disable-next-line no-shadow
       onInitialize: ({gl}) => this._setGLContext(gl),

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -88,7 +88,9 @@ export default class LayerManager {
     this._needsRedraw = 'Initial render';
     this._needsUpdate = false;
     this._debug = false;
-    this._onError = null;
+    /** @type {(error: Error, source: string) => any} */
+    // eslint-disable-next-line handle-callback-err
+    this._onError = (error, source) => {};
 
     this.activateViewport = this.activateViewport.bind(this);
 
@@ -217,11 +219,8 @@ export default class LayerManager {
   }
 
   _handleError(stage, error, layer) {
-    if (this._onError) {
-      this._onError(error, layer);
-    } else {
-      log.error(`error during ${stage} of ${layerName(layer)}`, error)();
-    }
+    const message = `${error} during ${stage} of ${layerName(layer)}`;
+    this._onError(new Error(message), layer);
   }
 
   // Match all layers, checking for caught errors


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
#### Background
- layer manager error handling was behaving differently when no handler was set, using parameters not propagated to error handler.
#### Change List
- ensure handling doesn't depend on whether handler is set.
