### PR TITLE
Fix link in heatmap-layer.md

### DIFF
--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -5,7 +5,7 @@ import {HeatmapLayerDemo} from 'website-components/doc-demos/aggregation-layers'
 
 # HeatmapLayer
 
-`HeatmapLayer` can be used to visualize spatial distribution of data. It internally implements [Gaussian Kernel Density Estimation](https://en.wikipedia.org/wiki/Kernel_(statistics%29#Kernel_functions_in_common_use) to render heatmaps. Note that this layer does not support all platforms; see "limitations" section below.
+`HeatmapLayer` can be used to visualize spatial distribution of data. It internally implements [Gaussian Kernel Density Estimation](https://en.wikipedia.org/wiki/Kernel_(statistics%29#Kernel_functions_in_common_use)) to render heatmaps. Note that this layer does not support all platforms; see "limitations" section below.
 
 ```js
 import DeckGL from '@deck.gl/react';


### PR DESCRIPTION
Link is currently incorrectly rendered because of a missing closing `)` 
![image](https://user-images.githubusercontent.com/15164633/113637604-3d8b4280-9632-11eb-8d3d-362e04e63bc6.png)
