### PR TITLE
Fix BitmapLayer crash during multi-depth picking

### DIFF
--- a/modules/layers/src/bitmap-layer/bitmap-layer.js
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.js
@@ -133,6 +133,15 @@ export default class BitmapLayer extends Layer {
     return info;
   }
 
+  // Override base Layer multi-depth picking logic
+  disablePickingIndex() {
+    this.setState({disablePicking: true});
+  }
+
+  restorePickingColors() {
+    this.setState({disablePicking: false});
+  }
+
   _updateAutoHighlight(info) {
     super._updateAutoHighlight({
       ...info,
@@ -186,9 +195,13 @@ export default class BitmapLayer extends Layer {
   }
 
   draw(opts) {
-    const {uniforms} = opts;
-    const {model, coordinateConversion, bounds} = this.state;
+    const {uniforms, moduleParameters} = opts;
+    const {model, coordinateConversion, bounds, disablePicking} = this.state;
     const {image, desaturate, transparentColor, tintColor} = this.props;
+
+    if (moduleParameters.pickingActive && disablePicking) {
+      return;
+    }
 
     // // TODO fix zFighting
     // Render the image


### PR DESCRIPTION
For #5576 

The `BitmapLayer` does not have a `pickingColors`/`instancePickingColors` attribute, which is required by the base `Layer` multi-picking logic.

#### Change List
- Skip drawing in multi-picking after the layer is picked
