### PR TITLE
PathStyleExtension: allow picking gaps between solid lines

### DIFF
--- a/docs/api-reference/extensions/path-style-extension.md
+++ b/docs/api-reference/extensions/path-style-extension.md
@@ -23,6 +23,7 @@ const layer = new PolygonLayer({
   ...
   getDashArray: [3, 2],
   dashJustified: true,
+  dashGapPickable: true,
   extensions: [new PathStyleExtension({dash: true})]
 });
 ```
@@ -97,6 +98,13 @@ The offset to draw each path with, relative to the width of the path. Negative o
 
 * If a number is provided, it is used as the offset for all paths.
 * If a function is provided, it is called on each path to retrieve its offset.
+
+
+##### `dashGapPickable` (Boolean, optional)
+
+* Default `false`
+
+Only effective if `getDashArray` is specified. If `true`, gaps between solid strokes are pickable. If `false`, only the solid strokes are pickable. 
 
 ## Remarks
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -135,6 +135,7 @@ const GeoJsonLayerExample = {
     lineWidthMinPixels: 1,
     pickable: true,
     dashJustified: true,
+    dashGapPickable: true,
     extensions: [new PathStyleExtension({dash: true})]
   }
 };

--- a/modules/extensions/src/path-style/path-style.js
+++ b/modules/extensions/src/path-style/path-style.js
@@ -25,7 +25,8 @@ import {dist} from 'gl-matrix/vec3';
 const defaultProps = {
   getDashArray: {type: 'accessor', value: [0, 0]},
   getOffset: {type: 'accessor', value: 0},
-  dashJustified: false
+  dashJustified: false,
+  dashGapPickable: false
 };
 
 export default class PathStyleExtension extends LayerExtension {
@@ -93,6 +94,7 @@ export default class PathStyleExtension extends LayerExtension {
 
     if (extension.opts.dash) {
       uniforms.dashAlignMode = this.props.dashJustified ? 1 : 0;
+      uniforms.dashGapPickable = Boolean(this.props.dashGapPickable);
     }
 
     this.state.model.setUniforms(uniforms);

--- a/modules/extensions/src/path-style/shaders.glsl.js
+++ b/modules/extensions/src/path-style/shaders.glsl.js
@@ -14,12 +14,8 @@ vDashOffset = instanceDashOffsets / width.x;
 
     'fs:#decl': `
 uniform float dashAlignMode;
-<<<<<<< HEAD
 uniform float capType;
-uniform bool allowPickGap;
-=======
 uniform bool dashGapPickable;
->>>>>>> b49ee2ccc... address comments
 varying vec2 vDashArray;
 varying float vDashOffset;
 
@@ -55,7 +51,7 @@ float round(float x) {
 
     if (gapLength > 0.0 && unitOffset > solidLength) {
       if (capType <= 0.5) {
-        if (!(allowPickGap && picking_uActive)) {
+        if (!(dashGapPickable && picking_uActive)) {
           discard;
         }
       } else {
@@ -65,7 +61,7 @@ float round(float x) {
           vPathPosition.x
         ));
         if (distToEnd > 1.0) {
-          if (!(allowPickGap && picking_uActive)) {
+          if (!(dashGapPickable && picking_uActive)) {
             discard;
           }
         }

--- a/modules/extensions/src/path-style/shaders.glsl.js
+++ b/modules/extensions/src/path-style/shaders.glsl.js
@@ -14,7 +14,12 @@ vDashOffset = instanceDashOffsets / width.x;
 
     'fs:#decl': `
 uniform float dashAlignMode;
+<<<<<<< HEAD
 uniform float capType;
+uniform bool allowPickGap;
+=======
+uniform bool dashGapPickable;
+>>>>>>> b49ee2ccc... address comments
 varying vec2 vDashArray;
 varying float vDashOffset;
 
@@ -50,7 +55,9 @@ float round(float x) {
 
     if (gapLength > 0.0 && unitOffset > solidLength) {
       if (capType <= 0.5) {
-        discard;
+        if (!(allowPickGap && picking_uActive)) {
+          discard;
+        }
       } else {
         // caps are rounded, test the distance to solid ends
         float distToEnd = length(vec2(
@@ -58,7 +65,9 @@ float round(float x) {
           vPathPosition.x
         ));
         if (distToEnd > 1.0) {
-          discard;
+          if (!(allowPickGap && picking_uActive)) {
+            discard;
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- There is a use case to pick dash line either interacts with gap or the solid strokes

<!-- For all the PRs -->
#### Change List
- PathStyleExtension: add an option `allowPickGap`, which allows picking on the gap of dash lines
