### PR TITLE
Update TerrainLayer props passed to TileLayer

### DIFF
--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -203,7 +203,14 @@ export default class TerrainLayer extends CompositeLayer {
       maxZoom,
       minZoom,
       extent,
-      maxRequests
+      maxRequests,
+      onTileLoad,
+      onTileUnload,
+      onTileError,
+      maxCacheSize,
+      maxCacheByteSize,
+      refinementStrategy,
+      fetch
     } = this.props;
 
     if (this.state.isTiled) {
@@ -231,7 +238,14 @@ export default class TerrainLayer extends CompositeLayer {
           maxZoom,
           minZoom,
           extent,
-          maxRequests
+          maxRequests,
+          onTileLoad,
+          onTileUnload,
+          onTileError,
+          maxCacheSize,
+          maxCacheByteSize,
+          refinementStrategy,
+          fetch
         }
       );
     }


### PR DESCRIPTION
For #5686

#### Change List

- Update props that `TerrainLayer` passes to `TileLayer`. The `TileLayer`'s `defaultProps` are seeded as the `TerrainLayer`'s `defaultProps`, so this updates to include all `TileLayer` props.
