### PR TITLE
Add onError to Layer props

### DIFF
--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -129,6 +129,15 @@ Remarks:
 Add additional functionalities to this layer. See the [list of available extensions](/docs/api-reference/extensions/overview.md).
 
 
+##### `onError` (Function, optional)
+
+Called when this layer encounters an error, with the following arguments:
+
+- `error` - a JavaScript `Error` object.
+
+If this callback is supplied and returns `true`, the error is marked as handled and will not bubble up to the [`onError`](/docs/api-reference/react/deckgl.md#onerror) callback of the `Deck` instance.
+
+
 ### Interaction Properties
 
 Layers can be interacted with using these properties.
@@ -561,6 +570,10 @@ Used to update the layers [`state`](/docs/api-reference/core/layer.md#state) obj
 ##### `setModuleParameters`
 
 Used to update the settings of shader modules.
+
+##### `throw`
+
+Send an `Error` object to the error handling pipeline.
 
 ### Layer Lifecycle Methods
 

--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -571,9 +571,14 @@ Used to update the layers [`state`](/docs/api-reference/core/layer.md#state) obj
 
 Used to update the settings of shader modules.
 
-##### `throw`
+##### `raiseError`
 
-Send an `Error` object to the error handling pipeline.
+Used to propagate errors thrown in layers to the deck.gl error handling system. This prevents rendering from being interrupted by exceptions in layers.
+
+`raiseError(error, message)`
+
+- `error` (Error) - a JavaScript Error object
+- `message` (String, optional) - additional contextual description to amend the error message with
 
 ### Layer Lifecycle Methods
 

--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -44,16 +44,11 @@ export default class DeckPicker {
       layerId: null,
       info: null
     };
-    this._onError = null;
   }
 
   setProps(props) {
     if ('layerFilter' in props) {
       this.layerFilter = props.layerFilter;
-    }
-
-    if ('onError' in props) {
-      this._onError = props.onError;
     }
 
     if ('_pickable' in props) {
@@ -379,7 +374,6 @@ export default class DeckPicker {
     this.pickLayersPass.render({
       layers,
       layerFilter: this.layerFilter,
-      onError: this._onError,
       views,
       viewports,
       onViewportActive,

--- a/modules/core/src/lib/deck-renderer.js
+++ b/modules/core/src/lib/deck-renderer.js
@@ -16,7 +16,6 @@ export default class DeckRenderer {
     this._needsRedraw = 'Initial render';
     this.renderBuffers = [];
     this.lastPostProcessEffect = null;
-    this._onError = null;
   }
 
   setProps(props) {
@@ -28,10 +27,6 @@ export default class DeckRenderer {
     if ('drawPickingColors' in props && this.drawPickingColors !== props.drawPickingColors) {
       this.drawPickingColors = props.drawPickingColors;
       this._needsRedraw = 'drawPickingColors changed';
-    }
-
-    if ('onError' in props) {
-      this._onError = props.onError;
     }
   }
 
@@ -51,7 +46,6 @@ export default class DeckRenderer {
     const layerPass = this.drawPickingColors ? this.pickLayersPass : this.drawLayersPass;
 
     opts.layerFilter = this.layerFilter;
-    opts.onError = this._onError;
     opts.effects = opts.effects || [];
     opts.target = opts.target || Framebuffer.getDefaultFramebuffer(this.gl);
 

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -88,7 +88,6 @@ export default class LayerManager {
     this._needsRedraw = 'Initial render';
     this._needsUpdate = false;
     this._debug = false;
-    this._onError = null;
 
     this.activateViewport = this.activateViewport.bind(this);
 
@@ -167,7 +166,7 @@ export default class LayerManager {
     }
 
     if ('onError' in props) {
-      this._onError = props.onError;
+      this.context.onError = props.onError;
     }
   }
 
@@ -218,7 +217,7 @@ export default class LayerManager {
 
   _handleError(stage, error, layer) {
     error.message = `${stage} of ${layerName(layer)}: ${error.message}`;
-    this._onError?.(error, layer);
+    layer.throw(error);
   }
 
   // Match all layers, checking for caught errors

--- a/modules/core/src/lib/layer-manager.js
+++ b/modules/core/src/lib/layer-manager.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import {Timeline} from '@luma.gl/core';
-import Layer from './layer';
 import {LIFECYCLE} from '../lifecycle/constants';
 import log from '../utils/log';
 import debug from '../debug';
@@ -51,8 +50,6 @@ const INITIAL_CONTEXT = Object.seal({
 
   userData: {} // Place for any custom app `context`
 });
-
-const layerName = layer => (layer instanceof Layer ? `${layer}` : !layer ? 'null' : 'invalid');
 
 export default class LayerManager {
   // eslint-disable-next-line
@@ -216,8 +213,7 @@ export default class LayerManager {
   }
 
   _handleError(stage, error, layer) {
-    error.message = `${stage} of ${layerName(layer)}: ${error.message}`;
-    layer.throw(error);
+    layer.raiseError(error, `${stage} of ${layer}`);
   }
 
   // Match all layers, checking for caught errors
@@ -228,7 +224,7 @@ export default class LayerManager {
     const oldLayerMap = {};
     for (const oldLayer of oldLayers) {
       if (oldLayerMap[oldLayer.id]) {
-        log.warn(`Multiple old layers with same id ${layerName(oldLayer)}`)();
+        log.warn(`Multiple old layers with same id ${oldLayer.id}`)();
       } else {
         oldLayerMap[oldLayer.id] = oldLayer;
       }
@@ -265,7 +261,7 @@ export default class LayerManager {
       const oldLayer = oldLayerMap[newLayer.id];
       if (oldLayer === null) {
         // null, rather than undefined, means this id was originally there
-        log.warn(`Multiple new layers with same id ${layerName(newLayer)}`)();
+        log.warn(`Multiple new layers with same id ${newLayer.id}`)();
       }
       // Remove the old layer from candidates, as it has been matched with this layer
       oldLayerMap[newLayer.id] = null;
@@ -343,7 +339,7 @@ export default class LayerManager {
 
   // Finalizes a single layer
   _finalizeLayer(layer) {
-    this._needsRedraw = this._needsRedraw || `finalized ${layerName(layer)}`;
+    this._needsRedraw = this._needsRedraw || `finalized ${layer}`;
 
     layer.lifecycle = LIFECYCLE.AWAITING_FINALIZATION;
 

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -65,6 +65,7 @@ const defaultProps = {
   _dataDiff: {type: 'function', value: data => data && data.__diff, compare: false, optional: true},
   dataTransform: {type: 'function', value: null, compare: false, optional: true},
   onDataLoad: {type: 'function', value: null, compare: false, optional: true},
+  onError: {type: 'function', value: null, compare: false, optional: true},
   fetch: {
     type: 'function',
     value: (url, {propName, layer}) => {
@@ -134,6 +135,12 @@ export default class Layer extends Component {
   toString() {
     const className = this.constructor.layerName || this.constructor.name;
     return `${className}({id: '${this.props.id}'})`;
+  }
+
+  throw(error) {
+    if (!this.props.onError?.(error)) {
+      this.context?.onError?.(error, this);
+    }
   }
 
   // Public API

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -137,7 +137,10 @@ export default class Layer extends Component {
     return `${className}({id: '${this.props.id}'})`;
   }
 
-  throw(error) {
+  raiseError(error, message) {
+    if (message) {
+      error.message = `${message}: ${error.message}`;
+    }
     if (!this.props.onError?.(error)) {
       this.context?.onError?.(error, this);
     }

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -141,7 +141,7 @@ export default class ComponentState {
 
     // interpret value string as url and start a new load tracked by a promise
     if (typeof value === 'string') {
-      const fetch = this.layer && this.layer.props.fetch;
+      const fetch = this.layer?.props.fetch;
       const url = value;
       if (fetch) {
         value = fetch(url, {propName, layer: this.layer});
@@ -215,10 +215,8 @@ export default class ComponentState {
         }
       })
       .catch(error => {
-        if (this.layer) {
-          error.message = `loading ${propName} of ${this.layer}: ${error.message}`;
-          this.layer.throw(error);
-        }
+        error.message = `loading ${propName} of ${this.layer}: ${error.message}`;
+        this.layer?.throw(error);
       });
   }
 
@@ -252,7 +250,7 @@ export default class ComponentState {
       this._setAsyncPropValue(propName, data, loadCount);
     }
 
-    const onDataLoad = this.layer && this.layer.props.onDataLoad;
+    const onDataLoad = this.layer?.props.onDataLoad;
     if (onDataLoad) {
       onDataLoad(data, {propName, layer: this.layer});
     }

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import log from '../utils/log';
 import {isAsyncIterable} from '../utils/iterable-utils';
 import {PROP_SYMBOLS} from './constants';
 const {ASYNC_ORIGINAL, ASYNC_RESOLVED, ASYNC_DEFAULTS} = PROP_SYMBOLS;
@@ -210,12 +209,17 @@ export default class ComponentState {
         data = this._postProcessValue(asyncProp, data);
         this._setAsyncPropValue(propName, data, loadCount);
 
-        const onDataLoad = this.layer && this.layer.props.onDataLoad;
+        const onDataLoad = this.layer?.props.onDataLoad;
         if (propName === 'data' && onDataLoad) {
           onDataLoad(data, {propName, layer: this.layer});
         }
       })
-      .catch(error => log.error(error)());
+      .catch(error => {
+        if (this.layer) {
+          error.message = `loading ${propName} of ${this.layer}: ${error.message}`;
+          this.layer.throw(error);
+        }
+      });
   }
 
   async _resolveAsyncIterable(propName, iterable) {

--- a/modules/core/src/lifecycle/component-state.js
+++ b/modules/core/src/lifecycle/component-state.js
@@ -215,8 +215,7 @@ export default class ComponentState {
         }
       })
       .catch(error => {
-        error.message = `loading ${propName} of ${this.layer}: ${error.message}`;
-        this.layer?.throw(error);
+        this.layer?.raiseError(error, `loading ${propName} of ${this.layer}`);
       });
   }
 

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -141,8 +141,7 @@ export default class LayersPass extends Pass {
             parameters: layerParameters
           });
         } catch (err) {
-          err.message = `drawing ${layer} to ${pass}: ${err.message}`;
-          layer.throw(err);
+          layer.raiseError(err, `drawing ${layer} to ${pass}`);
         }
       }
     }

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -86,7 +86,7 @@ export default class LayersPass extends Pass {
   // TODO - when picking we could completely skip rendering viewports that dont
   // intersect with the picking rect
   /* eslint-disable max-depth, max-statements */
-  _drawLayersInViewport(gl, {layers, pass, onError, viewport, view}, drawLayerParams) {
+  _drawLayersInViewport(gl, {layers, pass, viewport, view}, drawLayerParams) {
     const glViewport = getGLViewport(gl, {viewport});
 
     if (view && view.props.clear) {
@@ -142,7 +142,7 @@ export default class LayersPass extends Pass {
           });
         } catch (err) {
           err.message = `drawing ${layer} to ${pass}: ${err.message}`;
-          onError?.(err, layer);
+          layer.throw(err);
         }
       }
     }

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -33,7 +33,7 @@ const defaultProps = {
   // Image url that encodes height data
   elevationData: urlType,
   // Image url to use as texture
-  texture: urlType,
+  texture: {...urlType, optional: true},
   // Martini error tolerance in meters, smaller number -> more detailed mesh
   meshMaxError: {type: 'number', value: 4.0},
   // Bounding box of the terrain image, [minX, minY, maxX, maxY] in world coordinates

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -5,8 +5,9 @@ const DEFAULT_EXTENT = [-Infinity, -Infinity, Infinity, Infinity];
 
 export const urlType = {
   type: 'url',
-  value: '',
-  validate: value =>
+  value: null,
+  validate: (value, propType) =>
+    (propType.optional && value === null) ||
     typeof value === 'string' ||
     (Array.isArray(value) && value.every(url => typeof url === 'string')),
   equals: (value1, value2) => {

--- a/test/modules/geo-layers/tile-layer/utils.spec.js
+++ b/test/modules/geo-layers/tile-layer/utils.spec.js
@@ -412,11 +412,17 @@ test('tileToBoundingBox#Infovis', t => {
 });
 
 test('urlType', t => {
-  t.ok(urlType.validate(urlType.value), 'default value is validated');
-  t.ok(urlType.validate('https://server.com/{z}/{x}/{y}.png'), 'string is validated');
-  t.ok(urlType.validate(['https://server.com/{z}/{x}/{y}.png']), 'array of string is validated');
-  t.notOk(urlType.validate(null), 'is not valid');
-  t.notOk(urlType.validate(['https://server.com/{z}/{x}/{y}.png', null]), 'is not valid');
+  t.ok(urlType.validate('https://server.com/{z}/{x}/{y}.png', urlType), 'string is validated');
+  t.ok(
+    urlType.validate(['https://server.com/{z}/{x}/{y}.png'], urlType),
+    'array of string is validated'
+  );
+  t.notOk(urlType.validate(urlType.value, urlType), 'unspecified value is not valid');
+  t.ok(
+    urlType.validate(urlType.value, {...urlType, optional: true}),
+    'unspecified value is valid if optional:true'
+  );
+  t.notOk(urlType.validate(['https://server.com/{z}/{x}/{y}.png', null], urlType), 'is not valid');
 
   t.ok(urlType.equals('', ''), 'should be equal');
   t.ok(


### PR DESCRIPTION
Revamps the error handling system

#### Change List
- Simplify the propagation of the `onError` prop across core classes. Consolidate lifecycle error handling to use layer context.
- Add an `onError` callback to base `Layer` props. Related but not limited to use case discussed in #5647 
- Documentation