### PR TITLE
Set default of MVTLayer binary to true

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -19,6 +19,7 @@ The module entry point is now only lightly transpiled for the most commonly used
 - `GeoJsonLayer`'s `lineJointRounded` prop now only controls line joints. To use rounded line caps, set `lineCapRounded` to `true`.
 - Dashed lines via `PathStyleExtension` now draw rounded dash caps if `capRounded` is `true`.
 - `@deck.gl/geo-layers` now requires `@deck.gl/extensions`, due to `ClipExtension` dependency.
+- `MVTLayer`'s `binary` prop is now set to `true` by default.
 
 ### onError Callback
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,31 @@
 
 This page contains highlights of each deck.gl release. Also check our [vis.gl blog](https://medium.com/vis-gl) for news about new releases and features in deck.gl.
 
+## deck.gl v8.5 (In development)
+
+### MVT Layer
+
+#### Binary mode
+
+The `binary` prop of `MVTLayer` is set to `true` by default.
+
+#### Direct binary parsing
+
+Binary output is now 2-3X faster for large datasets thanks to parsing directly from PBF to binary, rather than going through GeoJSON as an intermediate representation. Speed comparison on some example data sets (MVT tiles parsed per second):
+
+|                    | Via GeoJSON | Direct | Speed increase |
+| ------------------ | ----------- | ------ | -------------- |
+| Block groups       | 2.86/s      | 5.57/s | 1.94X          |
+| Census layer       | 6.09/s      | 11.9/s | 1.95X          |
+| Counties Layer     | 72.5/s      | 141/s  | 1.94X          |
+| Usa Zip Code Layer | 8.45/s      | 20.3/s | 2.4X           |
+
+_Benchmarks ran using scripts on a 2012 MacBook Pro, 2.3 GHz Intel Core i7, 8 GB, measuring parsing time of MVTLoader only (network time and rendering is not included)_
+
+#### Polygon triangulation in worker
+
+The MVTLoader now peforms the triangulation of polygons in a worker, speeding up loading of polygon geometries and easing the work on the main thread.
+
 ## deck.gl v8.4
 
 Release date: Jan 31, 2021

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -6,13 +6,9 @@ This page contains highlights of each deck.gl release. Also check our [vis.gl bl
 
 ### MVT Layer
 
-#### Binary mode
-
-The `binary` prop of `MVTLayer` is set to `true` by default.
-
 #### Direct binary parsing
 
-Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles being parsed directly into binary attributes rather than GeoJSON, and additional work being performed on worker threads. Speed comparison on some example data sets (MVT tiles parsed per second):
+Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles being parsed directly into binary attributes rather than GeoJSON, and additional work (including [triangulation](https://github.com/visgl/loaders.gl/blob/master/docs/whats-new.md#v30-in-development))being performed on worker threads. Speed comparison on some example data sets (MVT tiles parsed per second):
 
 |  Data set                 | `binary: false` | `binary: true` | Speed increase |
 | ------------------ | ----------- | ------ | -------------- |
@@ -22,10 +18,6 @@ Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles bein
 | Usa Zip Code Layer | 8.45/s      | 20.3/s | 2.4x           |
 
 _Benchmarks ran using scripts on a 2012 MacBook Pro, 2.3 GHz Intel Core i7, 8 GB, measuring parsing time of MVTLoader only (network time and rendering is not included)_
-
-#### Polygon triangulation in worker
-
-The MVTLoader now peforms the triangulation of polygons in a worker, speeding up loading of polygon geometries and easing the work on the main thread.
 
 ## deck.gl v8.4
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -14,12 +14,12 @@ The `binary` prop of `MVTLayer` is set to `true` by default.
 
 Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles being parsed directly into binary attributes rather than GeoJSON, and additional work being performed on worker threads. Speed comparison on some example data sets (MVT tiles parsed per second):
 
-|                    | Via GeoJSON | Direct | Speed increase |
+|  Data set                 | `binary: false` | `binary: true` | Speed increase |
 | ------------------ | ----------- | ------ | -------------- |
-| Block groups       | 2.86/s      | 5.57/s | 1.94X          |
-| Census layer       | 6.09/s      | 11.9/s | 1.95X          |
-| Counties Layer     | 72.5/s      | 141/s  | 1.94X          |
-| Usa Zip Code Layer | 8.45/s      | 20.3/s | 2.4X           |
+| Block groups       | 2.86/s      | 5.57/s | 1.94x          |
+| Census layer       | 6.09/s      | 11.9/s | 1.95x          |
+| Counties Layer     | 72.5/s      | 141/s  | 1.94x          |
+| Usa Zip Code Layer | 8.45/s      | 20.3/s | 2.4x           |
 
 _Benchmarks ran using scripts on a 2012 MacBook Pro, 2.3 GHz Intel Core i7, 8 GB, measuring parsing time of MVTLoader only (network time and rendering is not included)_
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -15,7 +15,7 @@ Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles bein
 | Block groups       | 2.86/s      | 5.57/s | 1.94x          |
 | Census layer       | 6.09/s      | 11.9/s | 1.95x          |
 | Counties Layer     | 72.5/s      | 141/s  | 1.94x          |
-| Usa Zip Code Layer | 8.45/s      | 20.3/s | 2.4x           |
+| USA Zip Code Layer | 8.45/s      | 20.3/s | 2.4x           |
 
 _Benchmarks ran using scripts on a 2012 MacBook Pro, 2.3 GHz Intel Core i7, 8 GB, measuring parsing time of MVTLoader only (network time and rendering is not included)_
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -8,7 +8,7 @@ This page contains highlights of each deck.gl release. Also check our [vis.gl bl
 
 #### Direct binary parsing
 
-Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles being parsed directly into binary attributes rather than GeoJSON, and additional work (including [triangulation](https://github.com/visgl/loaders.gl/blob/master/docs/whats-new.md#v30-in-development))being performed on worker threads. Speed comparison on some example data sets (MVT tiles parsed per second):
+Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles being parsed directly into binary attributes rather than GeoJSON, and additional work (including [triangulation](https://github.com/visgl/loaders.gl/blob/master/docs/whats-new.md#v30-in-development)) being performed on worker threads. Speed comparison on some example data sets (MVT tiles parsed per second):
 
 |  Data set                 | `binary: false` | `binary: true` | Speed increase |
 | ------------------ | ----------- | ------ | -------------- |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,8 +12,8 @@ Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles bein
 
 |  Data set                 | `binary: false` | `binary: true` | Speed increase |
 | ------------------ | ----------- | ------ | -------------- |
-| Block groups       | 2.86/s      | 5.57/s | 1.94x          |
-| Census layer       | 6.09/s      | 11.9/s | 1.95x          |
+| Block Groups       | 2.86/s      | 5.57/s | 1.94x          |
+| Census Layer       | 6.09/s      | 11.9/s | 1.95x          |
 | Counties Layer     | 72.5/s      | 141/s  | 1.94x          |
 | USA Zip Code Layer | 8.45/s      | 20.3/s | 2.4x           |
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,7 +12,7 @@ The `binary` prop of `MVTLayer` is set to `true` by default.
 
 #### Direct binary parsing
 
-Binary output is now 2-3X faster for large datasets thanks to parsing directly from PBF to binary, rather than going through GeoJSON as an intermediate representation. Speed comparison on some example data sets (MVT tiles parsed per second):
+Mapbox Vector Tiles parsing throughput is now 2-3x faster, due to MVT tiles being parsed directly into binary attributes rather than GeoJSON, and additional work being performed on worker threads. Speed comparison on some example data sets (MVT tiles parsed per second):
 
 |                    | Via GeoJSON | Direct | Speed increase |
 | ------------------ | ----------- | ------ | -------------- |

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -16,7 +16,7 @@ const defaultProps = {
   uniqueIdProperty: {type: 'string', value: ''},
   highlightedFeatureId: null,
   loaders: [MVTLoader],
-  binary: false
+  binary: true
 };
 
 async function fetchTileJSON(url) {


### PR DESCRIPTION
In v8.5 we would like to change the default of the `binary` prop in the `MVTLayer` to `true` as this code path is much faster and offers a smoother experience to the user