### PR TITLE
Pass through loadOptions and AbortSignal to MVTLayer & TerrainLayer

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -97,20 +97,23 @@ export default class MVTLayer extends TileLayer {
       return Promise.reject('Invalid URL');
     }
     let options = this.getLoadOptions();
+    const {binary, fetch} = this.props;
+    const {signal, x, y, z} = tile;
+    const loaders = this.props.loaders[0];
     options = {
       ...options,
       mvt: {
         ...(options && options.mvt),
         coordinates: this.context.viewport.resolution ? 'wgs84' : 'local',
-        tileIndex: {x: tile.x, y: tile.y, z: tile.z}
+        tileIndex: {x, y, z}
         // Local worker debug
         // workerUrl: `modules/mvt/dist/mvt-loader.worker.js`
         // Set worker to null to skip web workers
         // workerUrl: null
       },
-      gis: this.props.binary ? {format: 'binary'} : {}
+      gis: binary ? {format: 'binary'} : {}
     };
-    return load(url, this.props.loaders[0], options);
+    return fetch(url, {layer: this, loaders, options, signal});
   }
 
   renderSubLayers(props) {

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -143,7 +143,7 @@ export default class TerrainLayer extends CompositeLayer {
     });
     const surface = textureUrl
       ? // If surface image fails to load, the tile should still be displayed
-        load(textureUrl).catch(_ => null)
+        load(textureUrl, {fetch: {signal}}).catch(_ => null)
       : Promise.resolve(null);
 
     return Promise.all([terrain, surface]);

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -98,11 +98,14 @@ export default class TerrainLayer extends CompositeLayer {
     }
   }
 
-  loadTerrain({elevationData, bounds, elevationDecoder, meshMaxError, workerUrl}) {
+  loadTerrain({elevationData, bounds, elevationDecoder, meshMaxError, signal, workerUrl}) {
     if (!elevationData) {
       return null;
     }
     const options = {
+      fetch: {
+        signal
+      },
       terrain: {
         bounds,
         meshMaxError,
@@ -120,7 +123,7 @@ export default class TerrainLayer extends CompositeLayer {
     const dataUrl = getURLFromTemplate(elevationData, tile);
     const textureUrl = getURLFromTemplate(texture, tile);
 
-    const {bbox, z} = tile;
+    const {bbox, signal, z} = tile;
     const viewport = new WebMercatorViewport({
       longitude: (bbox.west + bbox.east) / 2,
       latitude: (bbox.north + bbox.south) / 2,
@@ -135,6 +138,7 @@ export default class TerrainLayer extends CompositeLayer {
       bounds,
       elevationDecoder,
       meshMaxError,
+      signal,
       workerUrl
     });
     const surface = textureUrl

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -99,11 +99,14 @@ export default class TerrainLayer extends CompositeLayer {
   }
 
   loadTerrain({elevationData, bounds, elevationDecoder, meshMaxError, signal, workerUrl}) {
+    const loadOptions = this.getLoadOptions();
     if (!elevationData) {
       return null;
     }
     const options = {
+      ...loadOptions,
       fetch: {
+        ...loadOptions.fetch,
         signal
       },
       terrain: {
@@ -119,7 +122,7 @@ export default class TerrainLayer extends CompositeLayer {
   }
 
   getTiledTerrainData(tile) {
-    const {elevationData, texture, elevationDecoder, meshMaxError, workerUrl} = this.props;
+    const {elevationData, fetch, texture, elevationDecoder, meshMaxError, workerUrl} = this.props;
     const dataUrl = getURLFromTemplate(elevationData, tile);
     const textureUrl = getURLFromTemplate(texture, tile);
 
@@ -143,7 +146,7 @@ export default class TerrainLayer extends CompositeLayer {
     });
     const surface = textureUrl
       ? // If surface image fails to load, the tile should still be displayed
-        load(textureUrl, {fetch: {signal}}).catch(_ => null)
+        fetch(textureUrl, {layer: this, signal}).catch(_ => null)
       : Promise.resolve(null);
 
     return Promise.all([terrain, surface]);

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -106,7 +106,7 @@ export default class TerrainLayer extends CompositeLayer {
     const options = {
       ...loadOptions,
       fetch: {
-        ...loadOptions.fetch,
+        ...(loadOptions && loadOptions.fetch),
         signal
       },
       terrain: {

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -28,13 +28,13 @@ const defaultProps = {
   fetch: {
     type: 'function',
     value: (url, {layer, loaders, options, signal}) => {
-      const loadOptions = {...options, ...layer.getLoadOptions()};
+      const loadOptions = options || layer.getLoadOptions();
       loadOptions.fetch = {
         ...loadOptions.fetch,
         signal
       };
 
-      return load(url, loaders, loadOptions);
+      return loaders ? load(url, loaders, loadOptions) : load(url, loadOptions);
     },
     compare: false
   },

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -27,14 +27,14 @@ const defaultProps = {
   // Use load directly so we don't use ResourceManager
   fetch: {
     type: 'function',
-    value: (url, {layer, signal}) => {
-      const loadOptions = {...layer.getLoadOptions()};
+    value: (url, {layer, loaders, options, signal}) => {
+      const loadOptions = {...options, ...layer.getLoadOptions()};
       loadOptions.fetch = {
         ...loadOptions.fetch,
         signal
       };
 
-      return load(url, loadOptions);
+      return load(url, loaders, loadOptions);
     },
     compare: false
   },


### PR DESCRIPTION
Implements https://github.com/visgl/deck.gl/issues/5808

I've tested that the extra header is present in the requests (note that this causes CORS errors in your specific example from terrarium @Pessimistress, but this is a server side problem, the OSM tiles work fine). Additionally, I've verified that when moving the map quickly tile requests do get aborted.

Where possible I rewrote the code to use the Layers `fetch` prop, but decided that it wasn't worth it for the case of loading terrain data as:

- it would be challenging to implement
- the loading of terrain tiles is closely coupled to the layer anyway
- having the `fetch` prop be invoked for two different types of request (imagery & terrain) would be error prone
