### PR TITLE
fixed typo in debounce_seconds name

### DIFF
--- a/bindings/pydeck/pydeck/widget/widget.py
+++ b/bindings/pydeck/pydeck/widget/widget.py
@@ -83,8 +83,8 @@ class DeckGLWidget(DOMWidget):
     def on_resize(self, callback, remove=False):
         self._resize_handlers.register_callback(callback, remove=remove)
 
-    def on_view_state_change(self, callback, debouce_seconds=0.2, remove=False):
-        callback = debounce(debouce_seconds)(callback) if debouce_seconds > 0 else callback
+    def on_view_state_change(self, callback, debounce_seconds=0.2, remove=False):
+        callback = debounce(debouce_seconds)(callback) if debounce_seconds > 0 else callback
         self._view_state_handlers.register_callback(callback, remove=remove)
 
     def on_click(self, callback, remove=False):

--- a/bindings/pydeck/pydeck/widget/widget.py
+++ b/bindings/pydeck/pydeck/widget/widget.py
@@ -84,7 +84,7 @@ class DeckGLWidget(DOMWidget):
         self._resize_handlers.register_callback(callback, remove=remove)
 
     def on_view_state_change(self, callback, debounce_seconds=0.2, remove=False):
-        callback = debounce(debouce_seconds)(callback) if debounce_seconds > 0 else callback
+        callback = debounce(debounce_seconds)(callback) if debounce_seconds > 0 else callback
         self._view_state_handlers.register_callback(callback, remove=remove)
 
     def on_click(self, callback, remove=False):


### PR DESCRIPTION
#### Background
This is just a proposed typo fix
#### Change List
I just renamed a variable from `debouce_seconds` to `debounce_seconds`