### PR TITLE
Correct data.length for geojson-layer-props polygons

### DIFF
--- a/modules/layers/src/geojson-layer/geojson-layer-props.js
+++ b/modules/layers/src/geojson-layer/geojson-layer-props.js
@@ -79,7 +79,7 @@ export function createLayerPropsFromBinary(geojsonBinary, uniqueIdProperty, enco
   layerProps.lines._pathType = 'open';
 
   layerProps.polygons.data = {
-    length: polygons.primitivePolygonIndices.value.length,
+    length: polygons.primitivePolygonIndices.value.length - 1,
     startIndices: polygons.primitivePolygonIndices.value,
     attributes: {
       getPolygon: polygons.positions,
@@ -98,7 +98,7 @@ export function createLayerPropsFromBinary(geojsonBinary, uniqueIdProperty, enco
   }
 
   layerProps.polygonsOutline.data = {
-    length: polygons.primitivePolygonIndices.value.length,
+    length: polygons.primitivePolygonIndices.value.length - 1,
     startIndices: polygons.primitivePolygonIndices.value,
     attributes: {
       getPath: polygons.positions,

--- a/modules/layers/src/geojson-layer/geojson-layer-props.js
+++ b/modules/layers/src/geojson-layer/geojson-layer-props.js
@@ -79,7 +79,8 @@ export function createLayerPropsFromBinary(geojsonBinary, uniqueIdProperty, enco
   layerProps.lines._pathType = 'open';
 
   layerProps.polygons.data = {
-    startIndices: polygons.primitivePolygonIndices.value,
+    length: polygons.polygonIndices.value.length - 1,
+    startIndices: polygons.polygonIndices.value,
     attributes: {
       getPolygon: polygons.positions,
       pickingColors: {
@@ -94,9 +95,6 @@ export function createLayerPropsFromBinary(geojsonBinary, uniqueIdProperty, enco
   layerProps.polygons._normalize = false;
   if (polygons.triangles) {
     layerProps.polygons.data.attributes.indices = polygons.triangles.value;
-    layerProps.polygons.data.length = polygons.polygonIndices.value.length - 1;
-  } else {
-    layerProps.polygons.data.length = polygons.primitivePolygonIndices.value.length - 1;
   }
 
   layerProps.polygonsOutline.data = {

--- a/modules/layers/src/geojson-layer/geojson-layer-props.js
+++ b/modules/layers/src/geojson-layer/geojson-layer-props.js
@@ -79,7 +79,6 @@ export function createLayerPropsFromBinary(geojsonBinary, uniqueIdProperty, enco
   layerProps.lines._pathType = 'open';
 
   layerProps.polygons.data = {
-    length: polygons.primitivePolygonIndices.value.length - 1,
     startIndices: polygons.primitivePolygonIndices.value,
     attributes: {
       getPolygon: polygons.positions,
@@ -95,6 +94,9 @@ export function createLayerPropsFromBinary(geojsonBinary, uniqueIdProperty, enco
   layerProps.polygons._normalize = false;
   if (polygons.triangles) {
     layerProps.polygons.data.attributes.indices = polygons.triangles.value;
+    layerProps.polygons.data.length = polygons.polygonIndices.value.length - 1;
+  } else {
+    layerProps.polygons.data.length = polygons.primitivePolygonIndices.value.length - 1;
   }
 
   layerProps.polygonsOutline.data = {

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -475,8 +475,6 @@ test('MVTLayer#data.length', async t => {
     const geoJsonLayer = layer.internalState.subLayers[0];
     const polygons = geoJsonLayer.state.layerProps.polygons;
     if (layer.props.binary) {
-      /* eslint-disable no-console, no-undef */
-      // console.log(geoJsonLayer.props.data.polygons);
       binaryDataLength = polygons.data.length;
     } else {
       t.equals(polygons.data.length, binaryDataLength, 'should have equal length');

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -458,55 +458,59 @@ test('MVTLayer#triangulation', async t => {
   t.end();
 });
 
-test('MVTLayer#data.length', async t => {
-  const viewport = new WebMercatorViewport({
-    longitude: -100,
-    latitude: 40,
-    zoom: 3,
-    pitch: 0,
-    bearing: 0
+for (const tileset of ['mvt-tiles', 'mvt-with-hole']) {
+  test(`MVTLayer#data.length ${tileset}`, async t => {
+    const viewport = new WebMercatorViewport({
+      longitude: -100,
+      latitude: 40,
+      zoom: 3,
+      pitch: 0,
+      bearing: 0
+    });
+
+    let binaryDataLength;
+    let geoJsonDataLength;
+    let requests = 0;
+    const onAfterUpdate = ({layer}) => {
+      if (!layer.isLoaded) {
+        return;
+      }
+      const geoJsonLayer = layer.internalState.subLayers[0];
+      const polygons = geoJsonLayer.state.layerProps.polygons;
+      if (layer.props.binary) {
+        binaryDataLength = polygons.data.length;
+        requests++;
+      } else {
+        geoJsonDataLength = polygons.data.length;
+        requests++;
+      }
+
+      if (requests === 2) {
+        t.equals(geoJsonDataLength, binaryDataLength, 'should have equal length');
+      }
+    };
+
+    // To avoid caching use different URLs
+    const url1 = [`./test/data/${tileset}/{z}/{x}/{y}.mvt?test1`];
+    const url2 = [`./test/data/${tileset}/{z}/{x}/{y}.mvt?test2`];
+    const props = {
+      onTileError: error => {
+        if (!(error.message && error.message.includes('404'))) {
+          throw error;
+        }
+      },
+      loadOptions: {
+        mvt: {
+          workerUrl: null
+        }
+      }
+    };
+    const testCases = [
+      {props: {binary: false, data: url1, ...props}, onAfterUpdate},
+      {props: {binary: true, data: url2, ...props}, onAfterUpdate}
+    ];
+
+    await testLayerAsync({Layer: MVTLayer, viewport, testCases, onError: t.notOk});
+    t.end();
   });
-
-  let binaryDataLength;
-  let geoJsonDataLength;
-  let requests = 0;
-  const onAfterUpdate = ({layer}) => {
-    if (!layer.isLoaded) {
-      return;
-    }
-    const geoJsonLayer = layer.internalState.subLayers[0];
-    const polygons = geoJsonLayer.state.layerProps.polygons;
-    if (layer.props.binary) {
-      binaryDataLength = polygons.data.length;
-      requests++;
-    } else {
-      geoJsonDataLength = polygons.data.length;
-      requests++;
-    }
-
-    if (requests === 2) {
-      t.equals(geoJsonDataLength, binaryDataLength, 'should have equal length');
-    }
-  };
-
-  const props = {
-    data: ['./test/data/mvt-tiles/{z}/{x}/{y}.mvt'],
-    onTileError: error => {
-      if (!(error.message && error.message.includes('404'))) {
-        throw error;
-      }
-    },
-    loadOptions: {
-      mvt: {
-        workerUrl: null
-      }
-    }
-  };
-  const testCases = [
-    {props: {binary: false, ...props}, onAfterUpdate},
-    {props: {binary: true, ...props}, onAfterUpdate}
-  ];
-
-  await testLayerAsync({Layer: MVTLayer, viewport, testCases, onError: t.notOk});
-  t.end();
-});
+}


### PR DESCRIPTION
Fix for https://github.com/visgl/deck.gl/issues/5851

This change does fix the issue with the radio example, but I hope I haven't missed something about how the data is then uploaded to the GPU or used elsewhere. In other words, I hope that I haven't fixed an apparent off-by-one error and inadvertently created another elsewhere
