### PR TITLE
geo: tile-3d wireframe mode

### DIFF
--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
@@ -18,6 +18,7 @@ const defaultProps = {
 
   data: null,
   loader: Tiles3DLoader,
+  wireframe: false,
 
   onTilesetLoad: {type: 'function', value: tileset3d => {}, compare: false},
   onTileLoad: {type: 'function', value: tileHeader => {}, compare: false},
@@ -252,7 +253,7 @@ export default class Tile3DLayer extends CompositeLayer {
   _makeSimpleMeshLayer(tileHeader, oldLayer) {
     const content = tileHeader.content;
     const {attributes, indices, modelMatrix, cartographicOrigin, material, featureIds} = content;
-    const {_getMeshColor} = this.props;
+    const {_getMeshColor, wireframe} = this.props;
 
     const geometry =
       (oldLayer && oldLayer.props.mesh) ||
@@ -277,6 +278,7 @@ export default class Tile3DLayer extends CompositeLayer {
         modelMatrix,
         coordinateOrigin: cartographicOrigin,
         coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
+        wireframe,
         featureIds
       }
     );


### PR DESCRIPTION
#### Background
In [I3S Debug Application](https://loaders.gl/examples/i3s-debug) we have "wireframe" mode. This PR allows to handle this option.
#### Change List
- Add "wireframe" prop to `Tile3DLayer`
