### PR TITLE
Fix type documentation for canvas in Deck

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -44,9 +44,9 @@ See the [Properties](#properties) section.
 
 The following properties are used to initialize a `Deck` instance. Any custom value should always be provided to the `Deck` constructor. Changing them with `setProps` afterwards will have no effect.
 
-##### `canvas` (HTMLCanvasElement)
+##### `canvas` (HTMLCanvasElement | String, optional)
 
-The canvas to render into. Will be auto-created if not supplied.
+The canvas to render into. Can be either a HTMLCanvasElement or the element id. Will be auto-created if not supplied.
 
 ##### `gl` (WebGLContext)
 


### PR DESCRIPTION
Documentation style has been taken from https://github.com/visgl/deck.gl/blob/master/docs/api-reference/core/deckgl.md#container-domelement--string-optional

Code supports it here: https://github.com/visgl/deck.gl/blob/c5ff0470f6ae18a5d3b838406c7e8647628a58d8/modules/core/src/lib/deck.js#L415-L436