### PR TITLE
Add external Timeline to Deck props

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -297,8 +297,7 @@ The array of effects to be rendered. A lighting effect will be added if an empty
 
 * Default: `null`
 
-(Experimental) Supply an external timeline for animations. If not supplied deck will use an internal timeline.
-
+(Experimental) Supply an external timeline for animations. If not supplied deck will use an internal timeline. See the [luma.gl Timeline](https://luma.gl/docs/api-reference/engine/animation/timeline) documentation.
 
 ### Interaction Settings
 

--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -293,7 +293,7 @@ The array of effects to be rendered. A lighting effect will be added if an empty
 
 (Experimental) Forces deck.gl to redraw layers every animation frame. Normally deck.gl layers are only redrawn if any change is detected.
 
-##### `_timeline` (Timeline)
+##### `_timeline` ([Timeline](https://luma.gl/docs/api-reference/engine/animation/timeline))
 
 * Default: `null`
 

--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -293,6 +293,12 @@ The array of effects to be rendered. A lighting effect will be added if an empty
 
 (Experimental) Forces deck.gl to redraw layers every animation frame. Normally deck.gl layers are only redrawn if any change is detected.
 
+##### `_timeline` (Timeline)
+
+* Default: `null`
+
+(Experimental) Supply an external timeline for animations. If not supplied deck will use an internal timeline.
+
 
 ### Interaction Settings
 

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -94,6 +94,8 @@ function getPropTypes(PropTypes) {
     _framebuffer: PropTypes.object,
     // Forces a redraw every animation frame
     _animate: PropTypes.bool,
+    // supply an external Timeline
+    _timeline: PropTypes.object,
 
     // UNSAFE options - not exhaustively tested, not guaranteed to work in all cases, use at your own risk
 
@@ -640,8 +642,11 @@ export default class Deck {
     this.props.onWebGLInitialized(gl);
 
     // timeline for transitions
-    const timeline = new Timeline();
-    timeline.play();
+    let timeline = this.props._timeline;
+    if (!timeline) {
+      timeline = new Timeline();
+      timeline.play();
+    }
     this.animationLoop.attachTimeline(timeline);
 
     this.eventManager = new EventManager(this.props.parent || gl.canvas, {

--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -289,6 +289,9 @@ export default class Deck {
 
     // Update the animation loop
     this.animationLoop.setProps(resolvedProps);
+    if ('_timeline' in props) {
+      this.animationLoop.attachTimeline(props._timeline);
+    }
 
     // If initialized, update sub manager props
     if (this.layerManager) {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Supply a `Timeline` on deck props to sync internal animations (such as GLTF) with external animations. If not supplied deck will use an internal timeline. This makes it easier to integrate with other animation libraries, such as hubble.gl ([see usage](https://github.com/uber/hubble.gl/pull/112/files#diff-8e8bad12de9a4cf8db92d4ab9e6cc1d372cb351ce776227f536b44a2fa113eedR95))

See https://github.com/uber/hubble.gl/pull/115
<!-- For all the PRs -->
#### Change List
- Add optional `_timeline: Timeline` to Deck props.