### PR TITLE
Increase Google maps version from 3.39 to 3.45

### DIFF
--- a/examples/get-started/pure-js/google-maps/app.js
+++ b/examples/get-started/pure-js/google-maps/app.js
@@ -8,7 +8,7 @@ const AIR_PORTS =
 
 // Set your Google Maps API key here or via environment variable
 const GOOGLE_MAPS_API_KEY = process.env.GoogleMapsAPIKey; // eslint-disable-line
-const GOOGLE_MAPS_API_URL = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&libraries=visualization&v=3.39`;
+const GOOGLE_MAPS_API_URL = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&libraries=visualization&v=3.45`;
 
 function loadScript(url) {
   const script = document.createElement('script');

--- a/examples/get-started/scripting/google-maps/index.html
+++ b/examples/get-started/scripting/google-maps/index.html
@@ -5,7 +5,7 @@
 
     <!-- Google Maps dependencies -->
     <!-- Replace google_maps_api_key with your API key! -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=<google_maps_api_key>&libraries=visualization&v=3.34"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<google_maps_api_key>&libraries=visualization&v=3.45"></script>
 
     <style type="text/css">
       body {margin: 0; padding: 0;}


### PR DESCRIPTION
Avoid deprecation warning in Google Maps example by using latest library (3.45) https://developers.google.com/maps/documentation/javascript/versions
