### PR TITLE
TextLayer supports characterSet:auto

### DIFF
--- a/docs/api-reference/layers/geojson-layer.md
+++ b/docs/api-reference/layers/geojson-layer.md
@@ -313,7 +313,7 @@ The following props are forwarded to a `TextLayer` if `pointType` is `'text'`.
 | `textSizeScale` | `1` | [sizeScale](/docs/api-reference/layers/text-layer.md#sizescale) |
 | `textSizeMinPixels` | `0` | [sizeMinPixels](/docs/api-reference/layers/text-layer.md#sizeminpixels) |
 | `textSizeMaxPixels` | `Number.MAX_SAFE_INTEGER` | [sizeMaxPixels](/docs/api-reference/layers/text-layer.md#sizemaxpixels) |
-| `textCharacterSet` | `'auto'` | [characterSet](/docs/api-reference/layers/text-layer.md#characterset) |
+| `textCharacterSet` | ASCII chars 32-128 | [characterSet](/docs/api-reference/layers/text-layer.md#characterset) |
 | `textFontFamily` | `'Monaco, monospace'` | [fontFamily](/docs/api-reference/layers/text-layer.md#fontfamily) |
 | `textFontWeight` | `'normal'` | [fontWeight](/docs/api-reference/layers/text-layer.md#fontweight) |
 | `textLineHeight` | `1` | [lineHeight](/docs/api-reference/layers/text-layer.md#lineheight) |

--- a/docs/api-reference/layers/geojson-layer.md
+++ b/docs/api-reference/layers/geojson-layer.md
@@ -313,6 +313,7 @@ The following props are forwarded to a `TextLayer` if `pointType` is `'text'`.
 | `textSizeScale` | `1` | [sizeScale](/docs/api-reference/layers/text-layer.md#sizescale) |
 | `textSizeMinPixels` | `0` | [sizeMinPixels](/docs/api-reference/layers/text-layer.md#sizeminpixels) |
 | `textSizeMaxPixels` | `Number.MAX_SAFE_INTEGER` | [sizeMaxPixels](/docs/api-reference/layers/text-layer.md#sizemaxpixels) |
+| `textCharacterSet` | `'auto'` | [characterSet](/docs/api-reference/layers/text-layer.md#characterset) |
 | `textFontFamily` | `'Monaco, monospace'` | [fontFamily](/docs/api-reference/layers/text-layer.md#fontfamily) |
 | `textFontWeight` | `'normal'` | [fontWeight](/docs/api-reference/layers/text-layer.md#fontweight) |
 | `textLineHeight` | `1` | [lineHeight](/docs/api-reference/layers/text-layer.md#lineheight) |

--- a/docs/api-reference/layers/text-layer.md
+++ b/docs/api-reference/layers/text-layer.md
@@ -126,9 +126,16 @@ Specifies a prioritized list of one or more font family names and/or generic fam
 
 See the [remarks](#remarks) section below for tips on using web fonts.
 
-##### `characterSet` (Array | String, optional)
+##### `characterSet` (Array | Set | String, optional)
 
-Specifies a list of characters to include in the font. By default, only characters in the Ascii code range 32-128 are included. Use this prop if you need to display special characters.
+* Default: ASCII characters 32-128
+
+Specifies a list of characters to include in the font.
+
+- If set to `'auto'`, automatically detects the characters used in the data. This option has a performance overhead and may cause the layer to take longer to load if the data is very large.
+- If set to an array or set of characters, the generated font will be limited to these characters. If you already know all the characters that are needed (e.g. numbers, latin alphabet), using this option provides better performance. If a character outside of the specified range is referenced by `getText`, a warning will be logged to the JavaScript console.
+
+Note that there is a limit to the number of unique characters supported by a single layer. The maximum number subjects to `fontSettings.fontSize` and the [MAX_TEXTURE_SIZE](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#understand_system_limits) of the device/browser.
 
 ##### `fontWeight` (Number | String, optional)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -74,6 +74,8 @@ New props are added for more flexible styling of the texts:
 * `getBorderWidth`
 * `getBorderColor`
 
+The layer now supports automatically detecting the characters used in the data. Set `characterSet: 'auto'` to enable this feature.
+
 See [documentation](/docs/api-reference/layers/text-layer.md) for details.
 
 ### React

--- a/examples/website/tagmap/app.js
+++ b/examples/website/tagmap/app.js
@@ -32,6 +32,7 @@ export default function App({
     ? new TagmapLayer({
         id: 'twitter-topics-tagmap',
         data,
+        characterSet: 'auto',
         getLabel: x => x.label,
         getPosition: x => x.coordinates,
         minFontSize: 14,
@@ -40,6 +41,7 @@ export default function App({
     : new TextLayer({
         id: 'twitter-topics-raw',
         data,
+        characterSet: 'auto',
         getText: d => d.label,
         getPosition: x => x.coordinates,
         getColor: d => DEFAULT_COLOR,

--- a/examples/website/tagmap/tagmap-layer/tagmap-layer.js
+++ b/examples/website/tagmap/tagmap-layer/tagmap-layer.js
@@ -127,7 +127,7 @@ export default class TagmapLayer extends CompositeLayer {
     const {tags, colorScale} = this.state;
 
     return [
-      new TextLayer({
+      new TextLayer(this.props, {
         id: 'tagmap-layer',
         data: tags,
         getText: d => d.label,

--- a/modules/layers/src/geojson-layer/sub-layer-map.js
+++ b/modules/layers/src/geojson-layer/sub-layer-map.js
@@ -61,6 +61,7 @@ export const POINT_LAYER = {
       textOutlineColor: 'outlineColor',
       textOutlineWidth: 'outlineWidth',
       textWordBreak: 'wordBreak',
+      textCharacterSet: 'characterSet',
 
       getText: 'getText',
       getTextAngle: 'getAngle',

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -73,7 +73,7 @@ const defaultProps = {
   getBorderWidth: {type: 'accessor', value: 0},
   backgroundPadding: {type: 'array', value: [0, 0]},
 
-  characterSet: DEFAULT_CHAR_SET,
+  characterSet: {type: 'object', value: DEFAULT_CHAR_SET},
   fontFamily: DEFAULT_FONT_FAMILY,
   fontWeight: DEFAULT_FONT_WEIGHT,
   lineHeight: DEFAULT_LINE_HEIGHT,
@@ -108,7 +108,16 @@ export default class TextLayer extends CompositeLayer {
 
   // eslint-disable-next-line complexity
   updateState({props, oldProps, changeFlags}) {
-    const fontChanged = this._fontChanged(oldProps, props);
+    const textChanged =
+      changeFlags.dataChanged ||
+      (changeFlags.updateTriggersChanged &&
+        (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getText));
+
+    if (textChanged) {
+      this._updateText();
+    }
+
+    const fontChanged = textChanged || this._fontChanged(oldProps, props);
 
     if (fontChanged) {
       this._updateFontAtlas(oldProps, props);
@@ -120,14 +129,6 @@ export default class TextLayer extends CompositeLayer {
       props.wordBreak !== oldProps.wordBreak ||
       props.maxWidth !== oldProps.maxWidth;
 
-    const textChanged =
-      changeFlags.dataChanged ||
-      (changeFlags.updateTriggersChanged &&
-        (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getText));
-
-    if (textChanged) {
-      this._updateText();
-    }
     if (styleChanged) {
       this.setState({
         styleVersion: this.state.styleVersion + 1
@@ -143,10 +144,10 @@ export default class TextLayer extends CompositeLayer {
   }
 
   _updateFontAtlas(oldProps, props) {
-    const {characterSet, fontSettings, fontFamily, fontWeight} = props;
+    const {fontSettings, fontFamily, fontWeight} = props;
 
     // generate test characterSet
-    const {fontAtlasManager} = this.state;
+    const {fontAtlasManager, characterSet} = this.state;
     fontAtlasManager.setProps({
       ...DEFAULT_FONT_SETTINGS,
       ...fontSettings,
@@ -154,8 +155,6 @@ export default class TextLayer extends CompositeLayer {
       fontFamily,
       fontWeight
     });
-
-    this.setNeedsRedraw(true);
   }
 
   _fontChanged(oldProps, props) {
@@ -180,17 +179,20 @@ export default class TextLayer extends CompositeLayer {
   // Text strings are variable width objects
   // Returns the index at the start of each string (every character is rendered by one instance)
   _updateText() {
-    const {data} = this.props;
+    const {data, characterSet} = this.props;
     const textBuffer = data.attributes && data.attributes.getText;
     let {getText} = this.props;
     let {startIndices} = data;
     let numInstances;
 
+    const autoCharacterSet = characterSet === 'auto' && new Set(DEFAULT_CHAR_SET);
+
     if (textBuffer && startIndices) {
       const {texts, characterCount} = getTextFromBuffer({
         ...(ArrayBuffer.isView(textBuffer) ? {value: textBuffer} : textBuffer),
         length: data.length,
-        startIndices
+        startIndices,
+        characterSet: autoCharacterSet
       });
       numInstances = characterCount;
       getText = (_, {index}) => texts[index];
@@ -201,14 +203,22 @@ export default class TextLayer extends CompositeLayer {
 
       for (const object of iterable) {
         objectInfo.index++;
-        const text = getText(object, objectInfo) || '';
+        const text = Array.from(getText(object, objectInfo) || '');
+        if (autoCharacterSet) {
+          text.forEach(autoCharacterSet.add, autoCharacterSet);
+        }
         // When dealing with double-length unicode characters, `str.length` is incorrect
-        numInstances += Array.from(text).length;
+        numInstances += text.length;
         startIndices.push(numInstances);
       }
     }
 
-    this.setState({getText, startIndices, numInstances});
+    this.setState({
+      getText,
+      startIndices,
+      numInstances,
+      characterSet: autoCharacterSet || characterSet
+    });
   }
 
   // Returns the x, y offsets of each character in a text string

--- a/test/modules/layers/text-layer/text-layer.spec.js
+++ b/test/modules/layers/text-layer/text-layer.spec.js
@@ -59,12 +59,14 @@ test('TextLayer - special texts', t => {
     {
       props: {
         data: ['\u{F0004}', null, '\u{F0004}+\u{F0005}'],
+        characterSet: 'auto',
         getText: d => d,
         getPosition: d => [0, 0]
       },
       onAfterUpdate: ({layer, subLayer}) => {
         t.is(subLayer.props.numInstances, 4, 'sublayer has correct prop');
         t.deepEqual(subLayer.props.startIndices, [0, 1, 1, 4], 'sublayer has correct prop');
+        t.ok(layer.state.characterSet.has('\u{F0005}'), 'characterSet is auto populated');
       }
     }
   ];
@@ -109,6 +111,36 @@ test('TextLayer - binary', t => {
       onAfterUpdate: ({layer, subLayer}) => {
         t.is(subLayer.props.numInstances, 6, 'sublayer has correct prop');
         t.is(subLayer.props.startIndices, startIndices2, 'sublayer has correct prop');
+      }
+    }
+  ];
+
+  testLayer({Layer: TextLayer, testCases, onError: t.notOk});
+
+  t.end();
+});
+
+test('TextLayer - binary unicode characters', t => {
+  const value = new Uint32Array([7200, 983044, 983045, 43, 983044]);
+  const startIndices = [0, 3];
+
+  const testCases = [
+    {
+      props: {
+        data: {
+          length: 2,
+          startIndices,
+          attributes: {
+            getText: value
+          }
+        },
+        characterSet: 'auto',
+        getPosition: d => [0, 0]
+      },
+      onAfterUpdate: ({layer, subLayer}) => {
+        t.is(subLayer.props.numInstances, 5, 'sublayer has correct prop');
+        t.is(subLayer.props.startIndices, startIndices, 'sublayer has correct prop');
+        t.ok(layer.state.characterSet.has('\u{F0005}'), 'characterSet is auto populated');
       }
     }
   ];


### PR DESCRIPTION
For #5815 

#### Background

Make it possible to render text labels in MVTLayer without knowing the characters used.

#### Change List
- TextLayer supports `characterSet: 'auto'`
- GeoJsonLayer exposes `textCharacterSet`
- Tests
- Update TextLayer example to use new feature
- Documentation
- What's new