### PR TITLE
Fix: CARTO module WebGL invalid value for table

### DIFF
--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -126,7 +126,7 @@ export default class CartoLayer extends CompositeLayer {
       layer = GeoJsonLayer;
     }
 
-    const props = {...layer.defaultProps, ...this.props};
+    const props = {...this.props};
     delete props.data;
 
     // eslint-disable-next-line new-cap


### PR DESCRIPTION
Since we added support pointType prop to allow changing point rendering in GeoJsonLayer  at #5835, CARTO module was throwing (for table and query maptypes):
```
WebGL: INVALID_VALUE: uniform1fv: invalid srcOffset
```

https://codepen.io/alasarr/pen/MWpxGxY

It happens because CartoLayer tries to merge with sublayer `defaultProps`, however it's not required to do it to inherit sublayer default props.