### PR TITLE
Bump loaders to 3.0.0-beta.5

### DIFF
--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -9,8 +9,8 @@
     "start-local-production": "webpack-dev-server --env.local --env.production --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/ply": "^3.0.0-alpha.21",
-    "@loaders.gl/gltf": "^3.0.0-alpha.21",
+    "@loaders.gl/ply": "^3.0.0-beta.5",
+    "@loaders.gl/gltf": "^3.0.0-beta.5",
     "@luma.gl/experimental": "^8.3.1",
     "@luma.gl/debug": "^8.3.1",
     "colorbrewer": "^1.0.0",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -8,11 +8,11 @@
     "build": "rm -rf dist && mkdir dist && cp index.html dist/ && webpack --env.local --env.production=true"
   },
   "dependencies": {
-    "@loaders.gl/3d-tiles": "^3.0.0-alpha.21",
-    "@loaders.gl/core": "^3.0.0-alpha.21",
-    "@loaders.gl/csv": "^3.0.0-alpha.21",
-    "@loaders.gl/draco": "^3.0.0-alpha.21",
-    "@loaders.gl/gltf": "^3.0.0-alpha.21",
+    "@loaders.gl/3d-tiles": "^3.0.0-beta.5",
+    "@loaders.gl/core": "^3.0.0-beta.5",
+    "@loaders.gl/csv": "^3.0.0-beta.5",
+    "@loaders.gl/draco": "^3.0.0-beta.5",
+    "@loaders.gl/gltf": "^3.0.0-beta.5",
     "@luma.gl/constants": "^8.3.1",
     "brace": "^0.11.1",
     "deck.gl": "^8.3.0",

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "@loaders.gl/3d-tiles": "^3.0.0-alpha.21",
+    "@loaders.gl/3d-tiles": "^3.0.0-beta.5",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/globe/package.json
+++ b/examples/website/globe/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/csv": "^3.0.0-alpha.21",
+    "@loaders.gl/csv": "^3.0.0-beta.5",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "deck.gl": "^8.4.0",

--- a/examples/website/i3s/package.json
+++ b/examples/website/i3s/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/i3s": "^3.0.0-alpha.21",
+    "@loaders.gl/i3s": "^3.0.0-beta.5",
     "deck.gl": "^8.4.0"
   },
   "devDependencies": {

--- a/examples/website/mesh/package.json
+++ b/examples/website/mesh/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/obj": "^3.0.0-alpha.21",
+    "@loaders.gl/obj": "^3.0.0-beta.5",
     "deck.gl": "^8.4.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/examples/website/point-cloud/package.json
+++ b/examples/website/point-cloud/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/las": "^3.0.0-alpha.21",
+    "@loaders.gl/las": "^3.0.0-beta.5",
     "deck.gl": "^8.4.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"

--- a/examples/website/radio/package.json
+++ b/examples/website/radio/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/csv": "^3.0.0-alpha.21",
+    "@loaders.gl/csv": "^3.0.0-beta.5",
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "d3-scale": "^2.0.0",

--- a/examples/website/safegraph/package.json
+++ b/examples/website/safegraph/package.json
@@ -7,7 +7,7 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/csv": "^3.0.0-alpha.21",
+    "@loaders.gl/csv": "^3.0.0-beta.5",
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.4.0",
     "mapbox-gl": "^1.0.0"

--- a/examples/website/scenegraph/package.json
+++ b/examples/website/scenegraph/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "@loaders.gl/gltf": "^3.0.0-alpha.21",
+    "@loaders.gl/gltf": "^3.0.0-beta.5",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -31,9 +31,9 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/loader-utils": "^3.0.0-alpha.21",
-    "@loaders.gl/mvt": "^3.0.0-alpha.21",
-    "@loaders.gl/tiles": "^3.0.0-alpha.21",
+    "@loaders.gl/loader-utils": "^3.0.0-beta.5",
+    "@loaders.gl/mvt": "^3.0.0-beta.5",
+    "@loaders.gl/tiles": "^3.0.0-beta.5",
     "@math.gl/web-mercator": "^3.4.2",
     "cartocolor": "^4.0.2",
     "d3-scale": "^3.2.3"
@@ -42,6 +42,6 @@
     "@deck.gl/core": "^8.0.0",
     "@deck.gl/geo-layers": "^8.0.0",
     "@deck.gl/layers": "^8.0.0",
-    "@loaders.gl/core": "^3.0.0-alpha"
+    "@loaders.gl/core": "^3.0.0-beta"
   }
 }

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -31,8 +31,8 @@
     "prepublishOnly": "npm run build-debugger && npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/core": "^3.0.0-alpha.21",
-    "@loaders.gl/images": "^3.0.0-alpha.21",
+    "@loaders.gl/core": "^3.0.0-beta.5",
+    "@loaders.gl/images": "^3.0.0-beta.5",
     "@luma.gl/core": "^8.5.0-alpha.1",
     "@math.gl/web-mercator": "^3.4.2",
     "gl-matrix": "^3.0.0",

--- a/modules/core/src/utils/json-loader.js
+++ b/modules/core/src/utils/json-loader.js
@@ -10,6 +10,7 @@ export default {
   // TODO - can we stream process geojson?
   extensions: ['json', 'geojson'],
   mimeTypes: ['application/json', 'application/geo+json'],
+  text: true,
   testText: isJSON,
   parseTextSync: JSON.parse
 };

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -47,6 +47,6 @@
     "@deck.gl/extensions": "^8.0.0",
     "@deck.gl/layers": "^8.0.0",
     "@deck.gl/mesh-layers": "^8.0.0",
-    "@loaders.gl/core": "^3.0.0-alpha"
+    "@loaders.gl/core": "^3.0.0-beta"
   }
 }

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -37,9 +37,9 @@
     "@deck.gl/layers": "8.5.0-alpha.11",
     "@deck.gl/mesh-layers": "8.5.0-alpha.11",
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3",
-    "@loaders.gl/3d-tiles": "^3.0.0-alpha.21",
-    "@loaders.gl/core": "^3.0.0-alpha.21",
-    "@loaders.gl/csv": "^3.0.0-alpha.21",
+    "@loaders.gl/3d-tiles": "^3.0.0-beta.5",
+    "@loaders.gl/core": "^3.0.0-beta.5",
+    "@loaders.gl/csv": "^3.0.0-beta.5",
     "@luma.gl/constants": "^8.5.0-alpha.1",
     "mapbox-gl": "^1.2.1"
   },

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -28,13 +28,13 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@loaders.gl/images": "^3.0.0-alpha.21",
+    "@loaders.gl/images": "^3.0.0-beta.5",
     "@mapbox/tiny-sdf": "^1.1.0",
     "@math.gl/polygon": "^3.4.2",
     "earcut": "^2.0.6"
   },
   "peerDependencies": {
     "@deck.gl/core": "^8.0.0",
-    "@loaders.gl/core": "^3.0.0-alpha"
+    "@loaders.gl/core": "^3.0.0-beta"
   }
 }

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -32,7 +32,7 @@
     "@deck.gl/core": "^8.0.0"
   },
   "dependencies": {
-    "@loaders.gl/gltf": "^3.0.0-alpha.21",
+    "@loaders.gl/gltf": "^3.0.0-beta.5",
     "@luma.gl/experimental": "^8.5.0-alpha.1",
     "@luma.gl/shadertools": "^8.5.0-alpha.1"
   }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "devDependencies": {
     "@babel/register": "^7.13.0",
-    "@loaders.gl/csv": "^3.0.0-alpha.21",
-    "@loaders.gl/polyfills": "^3.0.0-alpha.21",
+    "@loaders.gl/csv": "^3.0.0-beta.5",
+    "@loaders.gl/polyfills": "^3.0.0-beta.5",
     "@luma.gl/test-utils": "^8.5.0-alpha.1",
     "@probe.gl/bench": "^3.3.1",
     "@probe.gl/test-utils": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,20 +1968,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@loaders.gl/3d-tiles@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/3d-tiles/-/3d-tiles-3.0.0-alpha.21.tgz#c29fb0fb2331728a71981ecbeede5b220e703448"
-  integrity sha512-+7mkxjjiYMffRc2OURGDgtbb46H+UXXclkbYHowO8YneG/1t+kCbat8npZO/02KhKz3Zk1MnAKit5kfDrANMew==
-  dependencies:
-    "@loaders.gl/core" "3.0.0-alpha.21"
-    "@loaders.gl/draco" "3.0.0-alpha.21"
-    "@loaders.gl/gltf" "3.0.0-alpha.21"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@loaders.gl/math" "3.0.0-alpha.21"
-    "@loaders.gl/tiles" "3.0.0-alpha.21"
-    "@math.gl/core" "3.5.0-alpha.1"
-    "@math.gl/geospatial" "3.5.0-alpha.1"
-
 "@loaders.gl/3d-tiles@^3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/3d-tiles/-/3d-tiles-3.0.0-beta.5.tgz#8e3def3078107b18d7ae9d1c2bdb85cbf03ced73"
@@ -1996,16 +1982,7 @@
     "@math.gl/core" "3.5.0-alpha.1"
     "@math.gl/geospatial" "3.5.0-alpha.1"
 
-"@loaders.gl/core@3.0.0-alpha.21", "@loaders.gl/core@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-3.0.0-alpha.21.tgz#780f0aaab1cbf17c0cd4d982a9a561af8b27ce81"
-  integrity sha512-RZqzm7xbFka5Syo5Mm+l0V6hCER+MlZKj5mstC5znHLfgTLKKEV40OKPP5a2K+EuMKvTYrD2qtUutc/4cmMg/w==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@loaders.gl/worker-utils" "3.0.0-alpha.21"
-
-"@loaders.gl/core@3.0.0-beta.5":
+"@loaders.gl/core@3.0.0-beta.5", "@loaders.gl/core@^3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-3.0.0-beta.5.tgz#7cac5e9c85a0f6a353bb63bd29303a520e777a37"
   integrity sha512-WPjHQCCxvhjW7cZvqF55/PazEaeicPZb4y9+yziEKeLMLLLm1y23Oc5lyYvlifz+PLPulx6o1g8kPO9RIZUXKg==
@@ -2014,23 +1991,13 @@
     "@loaders.gl/loader-utils" "3.0.0-beta.5"
     "@loaders.gl/worker-utils" "3.0.0-beta.5"
 
-"@loaders.gl/csv@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/csv/-/csv-3.0.0-alpha.21.tgz#e8f19dc00bd59ab7d653ac37b514d4437902314b"
-  integrity sha512-RyocEYhKytUdmost4qgYkzBiHQvqlYNEUt1vIm3+JeBkmJ06Li/1vhHsjKsFyHSO0aBvQhn46UEMDQqHAUsfuw==
+"@loaders.gl/csv@^3.0.0-beta.5":
+  version "3.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/csv/-/csv-3.0.0-beta.5.tgz#8ba3cc7700f2f72d0f150c05dab74ad8eaad2a1f"
+  integrity sha512-Xwv+2hUbRyOE+1Zw+EkyLZCDs3vVIcKAqAuS65iX9uxk2ZkVaz6Y+HPfX4OBvas1c9IX4gWImBwgXXMlGhpVVw==
   dependencies:
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@loaders.gl/tables" "3.0.0-alpha.21"
-
-"@loaders.gl/draco@3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-3.0.0-alpha.21.tgz#a39636cf886f2880b00d537533a1ab9f46f1390e"
-  integrity sha512-9+TZU5TulKBov/ovFQ1OBWXeOfMaRbG9S0nLtGdP2Obw89wWZO/ZYHYnPqXzMZw38PQ+Xmla38Zt7fXr00rxog==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@loaders.gl/worker-utils" "3.0.0-alpha.21"
-    draco3d "1.4.1"
+    "@loaders.gl/loader-utils" "3.0.0-beta.5"
+    "@loaders.gl/schema" "3.0.0-beta.5"
 
 "@loaders.gl/draco@3.0.0-beta.5":
   version "3.0.0-beta.5"
@@ -2043,15 +2010,6 @@
     "@loaders.gl/worker-utils" "3.0.0-beta.5"
     draco3d "1.4.1"
 
-"@loaders.gl/gis@3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-3.0.0-alpha.21.tgz#7efb264bf0683a58f28f91f84558b76dbb063eef"
-  integrity sha512-rlQs8/03DCw4D9bxJffEB7rnIz9uKi1OW9ngjkHmCQyLMw+ypA5xQ5sZjnIZOtALctlrnDe2iUG7eoh7BRcyaw==
-  dependencies:
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@mapbox/vector-tile" "^1.3.1"
-    pbf "^3.2.1"
-
 "@loaders.gl/gis@3.0.0-beta.5", "@loaders.gl/gis@^3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-3.0.0-beta.5.tgz#2821f681de7c0b906429d2e721b5a984f3145e66"
@@ -2061,17 +2019,7 @@
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
-"@loaders.gl/gltf@3.0.0-alpha.21", "@loaders.gl/gltf@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-3.0.0-alpha.21.tgz#e90e5c0602877d17bacb60b1cdb80bc7519d4f49"
-  integrity sha512-2RBJH9q3GW7BM2p+ZGLtIa8bxvwM/xD+JY+vZRH7wisZCr6k2jACHH1SLETo/zVXv2uKrHExfAqO47LBrsXrKQ==
-  dependencies:
-    "@loaders.gl/core" "3.0.0-alpha.21"
-    "@loaders.gl/draco" "3.0.0-alpha.21"
-    "@loaders.gl/images" "3.0.0-alpha.21"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-
-"@loaders.gl/gltf@3.0.0-beta.5":
+"@loaders.gl/gltf@3.0.0-beta.5", "@loaders.gl/gltf@^3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-3.0.0-beta.5.tgz#5dd3019a3b2c9f117e1da6d1bab5b11ea1012f50"
   integrity sha512-dWEeVfVFX3YHugAK+Gjf9J+hMVtHH5GUJ2GUyqqWgzgevyPrkW+A91KsX4tS7gJQFkT5ACJ1dzwp48YRKCmgAw==
@@ -2081,28 +2029,12 @@
     "@loaders.gl/images" "3.0.0-beta.5"
     "@loaders.gl/loader-utils" "3.0.0-beta.5"
 
-"@loaders.gl/images@3.0.0-alpha.21", "@loaders.gl/images@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-3.0.0-alpha.21.tgz#29b77b72c50ab378a7797f861b46fa2f4c60e0f1"
-  integrity sha512-iDzG7M+SAGiFB8yjSQD9eEZJ3rGY+bFQAVMiW0hUJ+5TWp3CUMOSjJkrHoCiR2jzgm9cXLmpAaqQ5+o5zxITSA==
-  dependencies:
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-
-"@loaders.gl/images@3.0.0-beta.5":
+"@loaders.gl/images@3.0.0-beta.5", "@loaders.gl/images@^3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-3.0.0-beta.5.tgz#5bb136f80f4bfde20edb3f3321665a1ddfb9517b"
   integrity sha512-o+ggkOspFjum41Xo7CLRH8NyS3q41bML9uGwLVbz/+Dokne7PBFi1x7npRWoX2/x2x3a8Byi/1foPiMchfnVOQ==
   dependencies:
     "@loaders.gl/loader-utils" "3.0.0-beta.5"
-
-"@loaders.gl/loader-utils@3.0.0-alpha.21", "@loaders.gl/loader-utils@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-3.0.0-alpha.21.tgz#eafdf56eb1846a196efb3b0abe00e93675f5d2c4"
-  integrity sha512-1+0j2g/Er0ydRbsYbUzrbUURFxuDnyrBymsbcqO+AO5o86NQeB8MHl10PKB0DBg6QpLDJs1GllhOLiAyCyhYfg==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/worker-utils" "3.0.0-alpha.21"
-    "@probe.gl/stats" "^3.3.0"
 
 "@loaders.gl/loader-utils@3.0.0-beta.5", "@loaders.gl/loader-utils@^3.0.0-beta.5":
   version "3.0.0-beta.5"
@@ -2113,15 +2045,6 @@
     "@loaders.gl/worker-utils" "3.0.0-beta.5"
     "@probe.gl/stats" "^3.3.0"
 
-"@loaders.gl/math@3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/math/-/math-3.0.0-alpha.21.tgz#ff2de4a48b48ac7cf926ea5c5b79afc528e66e5f"
-  integrity sha512-rJU/D0PkhEVOhuGoq1BMFmwGx5Yitm2P0X7IPQWTzaACcEwJ3cTpTvuxnJyyvc7x1t+3j+EKJCWxOI6yanQ9GQ==
-  dependencies:
-    "@loaders.gl/images" "3.0.0-alpha.21"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@math.gl/core" "3.5.0-alpha.1"
-
 "@loaders.gl/math@3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/math/-/math-3.0.0-beta.5.tgz#66790ff1bea7cbb9bbc59c9af5a4141e4e279096"
@@ -2130,16 +2053,6 @@
     "@loaders.gl/images" "3.0.0-beta.5"
     "@loaders.gl/loader-utils" "3.0.0-beta.5"
     "@math.gl/core" "3.5.0-alpha.1"
-
-"@loaders.gl/mvt@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/mvt/-/mvt-3.0.0-alpha.21.tgz#42b96bd8a414112d1e9a3c04c5cb84daf923451c"
-  integrity sha512-WD0Fh3GgZ+UccU/5q8GgiSRyr+X07bK8MMWSF2Pulmp+/SLNXYjcEhMk9XKWWPjdsjY++1BHeodUngoYzASQWg==
-  dependencies:
-    "@loaders.gl/gis" "3.0.0-alpha.21"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@math.gl/polygon" "3.5.0-alpha.1"
-    pbf "^3.2.1"
 
 "@loaders.gl/mvt@^3.0.0-beta.5":
   version "3.0.0-beta.5"
@@ -2151,10 +2064,10 @@
     "@math.gl/polygon" "3.5.0-alpha.1"
     pbf "^3.2.1"
 
-"@loaders.gl/polyfills@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-3.0.0-alpha.21.tgz#9638892aeacad695a8eeed27a034ad4da166e30a"
-  integrity sha512-QsVUWJr8z/747WXZ1BeNQB8eyaGSoS64tfFWb/KQs9BRuOCRgBUe4s5zpZzk/shwRFqL5LygjEdDi9SxBqGtdQ==
+"@loaders.gl/polyfills@^3.0.0-beta.5":
+  version "3.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-3.0.0-beta.5.tgz#5a1dd8b08f03747edd9f0f0a4f9d41f6a0ab72fd"
+  integrity sha512-K5yj77/K+QUOuEP+mxYg74p8BFSVYPYTKtuFUo/5IjldFFVAQKEs0CLrZh1vBGsn1u245QE62dd209/apY/qJg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     get-pixels "^3.3.2"
@@ -2172,14 +2085,6 @@
   dependencies:
     d3-dsv "^1.2.0"
 
-"@loaders.gl/tables@3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tables/-/tables-3.0.0-alpha.21.tgz#6b4e0e5654c5f63182df9be8d9f1332cc3f51926"
-  integrity sha512-jUOBXZOcsmt8grilKVBPbL696NiqhrC3sFokk0KOJjGvTzycwlkwJImqdan8XYpr/UkMrFjgoXSpPDriEfIfbQ==
-  dependencies:
-    "@loaders.gl/core" "3.0.0-alpha.21"
-    d3-dsv "^1.2.0"
-
 "@loaders.gl/terrain@^3.0.0-beta.5":
   version "3.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/@loaders.gl/terrain/-/terrain-3.0.0-beta.5.tgz#7060afce1e74fdda72d9360d6481fba6076fbee7"
@@ -2188,20 +2093,6 @@
     "@babel/runtime" "^7.3.1"
     "@loaders.gl/loader-utils" "3.0.0-beta.5"
     "@mapbox/martini" "^0.2.0"
-
-"@loaders.gl/tiles@3.0.0-alpha.21", "@loaders.gl/tiles@^3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tiles/-/tiles-3.0.0-alpha.21.tgz#bd43526171e9e80c3a0e025b429b70bcb37b6df9"
-  integrity sha512-o8ZWHJjv3n/HDeTxIj3c53p3PZjH5j3TtLjrrlOgjOOa9DaF/94EY5qtoGGKaKrHO5LXeF+n2RcLQleoeH4c+Q==
-  dependencies:
-    "@loaders.gl/core" "3.0.0-alpha.21"
-    "@loaders.gl/loader-utils" "3.0.0-alpha.21"
-    "@loaders.gl/math" "3.0.0-alpha.21"
-    "@math.gl/core" "3.5.0-alpha.1"
-    "@math.gl/culling" "3.5.0-alpha.1"
-    "@math.gl/geospatial" "3.5.0-alpha.1"
-    "@math.gl/web-mercator" "3.5.0-alpha.1"
-    "@probe.gl/stats" "^3.3.0"
 
 "@loaders.gl/tiles@3.0.0-beta.5", "@loaders.gl/tiles@^3.0.0-beta.5":
   version "3.0.0-beta.5"
@@ -2216,13 +2107,6 @@
     "@math.gl/geospatial" "3.5.0-alpha.1"
     "@math.gl/web-mercator" "3.5.0-alpha.1"
     "@probe.gl/stats" "^3.3.0"
-
-"@loaders.gl/worker-utils@3.0.0-alpha.21":
-  version "3.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/worker-utils/-/worker-utils-3.0.0-alpha.21.tgz#94fab6bd40f78f750831e9d3c785c2d2c5f23f05"
-  integrity sha512-Pv3KsnKZ+gV++fFJs8ZPJ/ozQJRvRN5mUhPypvcPW3kbGd1nuLFqxkzbYdkBw70tvKHVpXkc8GFlBmvhyjvsSw==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
 
 "@loaders.gl/worker-utils@3.0.0-beta.5":
   version "3.0.0-beta.5"


### PR DESCRIPTION
We have another failing test:
```
not ok 4639 testing MVTLayer
  ---
    operator: notOk
    expected: |-
      false
    actual: |-
      [Error: loading TileJSON: Cannot convert supplied data type]
    stack: |-
      Error: loading TileJSON: Cannot convert supplied data type
          at getArrayBufferOrStringFromDataSync (http://localhost:5000/test-browser.js:58691:9)
          at getArrayBufferOrStringFromData (http://localhost:5000/test-browser.js:58697:12)
          at parseWithLoader (http://localhost:5000/test-browser.js:57955:109)
          at parse (http://localhost:5000/test-browser.js:57950:16)
          at async load (http://localhost:5000/test-browser.js:57698:10)
          at async TestMVTLayer._updateTileData (http://localhost:5000/test-browser.js:28565:20)
```