### PR TITLE
Enforce OrbitView orbitAxis prop

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -49,6 +49,12 @@ The module entry point is now only lightly transpiled for the most commonly used
 
 `Deck`'s default `onError` callback is changed to `console.error`. Explicitly setting `onError` to `null` now silently ignores all errors, instead of logging them to console.
 
+
+### OrbitView
+
+`OrbitView` no longer allows `orbitAxis` to be specified in the view state. Set `orbitAxis` in the `OrbitView` constructor instead.
+
+
 ## Upgrading from deck.gl v8.3 to v8.4
 
 ### wrapLongitude

--- a/examples/website/point-cloud/app.js
+++ b/examples/website/point-cloud/app.js
@@ -15,8 +15,6 @@ const INITIAL_VIEW_STATE = {
   target: [0, 0, 0],
   rotationX: 0,
   rotationOrbit: 0,
-  orbitAxis: 'Y',
-  fov: 50,
   minZoom: 0,
   maxZoom: 10,
   zoom: 1
@@ -82,7 +80,7 @@ export default function App({onLoad}) {
 
   return (
     <DeckGL
-      views={new OrbitView()}
+      views={new OrbitView({orbitAxis: 'Y', fov: 50})}
       viewState={viewState}
       controller={true}
       onViewStateChange={v => updateViewState(v.viewState)}

--- a/modules/core/src/controllers/orbit-controller.js
+++ b/modules/core/src/controllers/orbit-controller.js
@@ -4,7 +4,6 @@ import ViewState from './view-state';
 import {mod} from '../utils/math-utils';
 
 const DEFAULT_STATE = {
-  orbitAxis: 'Z',
   rotationX: 0,
   rotationOrbit: 0,
   zoom: 0,
@@ -24,7 +23,6 @@ export class OrbitState extends ViewState {
     /* Viewport arguments */
     width, // Width of viewport
     height, // Height of viewport
-    orbitAxis = DEFAULT_STATE.orbitAxis,
     rotationX = DEFAULT_STATE.rotationX, // Rotation around x axis
     rotationOrbit = DEFAULT_STATE.rotationOrbit, // Rotation around orbit axis
     target = DEFAULT_STATE.target,
@@ -50,7 +48,6 @@ export class OrbitState extends ViewState {
     super({
       width,
       height,
-      orbitAxis,
       rotationX,
       rotationOrbit,
       target,

--- a/modules/core/src/views/orbit-view.js
+++ b/modules/core/src/views/orbit-view.js
@@ -41,8 +41,8 @@ class OrbitViewport extends Viewport {
   constructor(props) {
     const {
       height,
-      fovy = 50, // From eye position to lookAt
-      orbitAxis = 'Z', // Orbit axis with 360 degrees rotating freedom, can only be 'Y' or 'Z'
+      fovy, // For setting camera position
+      orbitAxis, // Orbit axis with 360 degrees rotating freedom, can only be 'Y' or 'Z'
       target = [0, 0, 0], // Which point is camera looking at, default origin
 
       rotationX = 0, // Rotating angle around X axis
@@ -94,9 +94,12 @@ class OrbitViewport extends Viewport {
 }
 
 export default class OrbitView extends View {
-  constructor(props) {
+  constructor(props = {}) {
+    const {orbitAxis = 'Z'} = props;
+
     super({
       ...props,
+      orbitAxis,
       type: OrbitViewport
     });
   }

--- a/test/modules/core/views/view.spec.js
+++ b/test/modules/core/views/view.spec.js
@@ -139,7 +139,7 @@ test('OrbitView', t => {
 
 // eslint-disable-next-line complexity
 test('OrbitView#project', t => {
-  const view = new OrbitView({id: '3d-view'});
+  let view = new OrbitView({id: '3d-view', orbitAxis: 'Z'});
   let viewport;
   let p;
   let center;
@@ -161,7 +161,6 @@ test('OrbitView#project', t => {
     width: 100,
     height: 100,
     viewState: {
-      orbitAxis: 'Z',
       target: [0, 0, 0],
       zoom: 1,
       rotationOrbit: 0,
@@ -176,11 +175,11 @@ test('OrbitView#project', t => {
   p = viewport.project([1, 0, 0]);
   t.ok(p[0] > 50 && p[1] === 50 && p[2] === center[2], 'x axis points right');
 
+  view = new OrbitView({id: '3d-view', orbitAxis: 'Y'});
   viewport = view.makeViewport({
     width: 100,
     height: 100,
     viewState: {
-      orbitAxis: 'Y',
       target: [0, 0, 0],
       zoom: 1,
       rotationOrbit: 0,

--- a/test/render/test-cases/simple-mesh-layer.js
+++ b/test/render/test-cases/simple-mesh-layer.js
@@ -61,12 +61,12 @@ export default [
       target: [0, 0, 0],
       rotationX: 0,
       rotationOrbit: 0,
-      orbitAxis: 'Y',
       fov: 30,
       zoom: -1.5
     },
     views: [
       new OrbitView({
+        orbitAxis: 'Y',
         near: 0.1,
         far: 2
       })
@@ -117,11 +117,11 @@ export default [
       target: [0, 0, 0],
       rotationX: 0,
       rotationOrbit: 0,
-      orbitAxis: 'Y',
       zoom: 0
     },
     views: [
       new OrbitView({
+        orbitAxis: 'Y',
         near: 0.1,
         far: 10
       })
@@ -148,11 +148,11 @@ export default [
       target: [0, 0, 0],
       rotationX: 0,
       rotationOrbit: 0,
-      orbitAxis: 'Y',
       zoom: 0
     },
     views: [
       new OrbitView({
+        orbitAxis: 'Y',
         near: 0.1,
         far: 10
       })


### PR DESCRIPTION
For #5948 

`orbitAxis` has always been documented as a `OrbitView` prop, but in practice it could be set in the view state as well. This lead to various inconsistency bugs when we handle view state across viewport, controller and transition interpolators. 

This PR drops the default value from `OrbitController` and `OrbitViewport` for clarity. `orbitAxis` is now set once and for all in the `OrbitView` constructor.

#### Change List
- Set `orbitAxis` fall back in `OrbitView` constructor
- Upgrade guide
- Fix point cloud example