### PR TITLE
pydeck: Add on_drag_start, on_drag, and on_drag_end handlers

### DIFF
--- a/bindings/pydeck/pydeck/widget/widget.py
+++ b/bindings/pydeck/pydeck/widget/widget.py
@@ -59,7 +59,9 @@ class DeckGLWidget(DOMWidget):
     google_maps_key = Unicode("", allow_none=True).tag(sync=True)
 
     json_input = Unicode("").tag(sync=True)
-    data_buffer = Any(default_value=None, allow_none=True).tag(sync=True, **data_buffer_serialization)
+    data_buffer = Any(default_value=None, allow_none=True).tag(
+        sync=True, **data_buffer_serialization
+    )
     custom_libraries = Any(allow_none=True).tag(sync=True)
     tooltip = Any(True).tag(sync=True)
     height = Int(500).tag(sync=True)
@@ -71,6 +73,9 @@ class DeckGLWidget(DOMWidget):
         self._click_handlers = CallbackDispatcher()
         self._resize_handlers = CallbackDispatcher()
         self._view_state_handlers = CallbackDispatcher()
+        self._drag_handlers = CallbackDispatcher()
+        self._drag_start_handlers = CallbackDispatcher()
+        self._drag_end_handlers = CallbackDispatcher()
         self.on_msg(self._handle_custom_msgs)
 
         self.handler_exception = None
@@ -84,11 +89,22 @@ class DeckGLWidget(DOMWidget):
         self._resize_handlers.register_callback(callback, remove=remove)
 
     def on_view_state_change(self, callback, debounce_seconds=0.2, remove=False):
-        callback = debounce(debounce_seconds)(callback) if debounce_seconds > 0 else callback
+        callback = (
+            debounce(debounce_seconds)(callback) if debounce_seconds > 0 else callback
+        )
         self._view_state_handlers.register_callback(callback, remove=remove)
 
     def on_click(self, callback, remove=False):
         self._click_handlers.register_callback(callback, remove=remove)
+
+    def on_drag_start(self, callback, remove=False):
+        self._drag_start_handlers.register_callback(callback, remove=remove)
+
+    def on_drag(self, callback, remove=False):
+        self._drag_handlers.register_callback(callback, remove=remove)
+
+    def on_drag_end(self, callback, remove=False):
+        self._drag_end_handlers.register_callback(callback, remove=remove)
 
     def _handle_custom_msgs(self, _, content, buffers=None):
         content = json.loads(content)
@@ -101,3 +117,9 @@ class DeckGLWidget(DOMWidget):
             self._view_state_handlers(self, content)
         elif event_type == "deck-click-event":
             self._click_handlers(self, content)
+        elif event_type == "deck-drag-start-event":
+            self._drag_start_handlers(self, content)
+        elif event_type == "deck-drag-event":
+            self._drag_handlers(self, content)
+        elif event_type == "deck-drag-end-event":
+            self._drag_end_handlers(self, content)

--- a/modules/jupyter-widget/src/playground/create-deck.js
+++ b/modules/jupyter-widget/src/playground/create-deck.js
@@ -122,7 +122,10 @@ function createStandaloneFromProvider({
           viewState.nw = viewport.unproject([0, 0]);
           viewState.se = viewport.unproject([viewport.width, viewport.height]);
           handleEvent('deck-view-state-change-event', viewState);
-        }
+        },
+        onDragStart: info => handleEvent('deck-drag-start-event', info),
+        onDrag: info => handleEvent('deck-drag-event', info),
+        onDragEnd: info => handleEvent('deck-drag-end-event', info)
       }
     : null;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/discussions/5132
<!-- For other PRs without open issue -->
#### Background

Add `on_drag_*` event handlers to pydeck

<!-- For all the PRs -->
#### Change List
- Update Jupyter widget to support `on_drag_*` handlers
