### PR TITLE
Fix: MVT throwing with 204 and wrong content-type

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -102,6 +102,7 @@ export default class MVTLayer extends TileLayer {
     loadOptions = {
       ...loadOptions,
       mimeType: 'application/x-protobuf',
+      nothrow: true, 
       mvt: {
         ...loadOptions?.mvt,
         coordinates: this.context.viewport.resolution ? 'wgs84' : 'local',

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -102,7 +102,7 @@ export default class MVTLayer extends TileLayer {
     loadOptions = {
       ...loadOptions,
       mimeType: 'application/x-protobuf',
-      nothrow: true, 
+      nothrow: true,
       mvt: {
         ...loadOptions?.mvt,
         coordinates: this.context.viewport.resolution ? 'wgs84' : 'local',


### PR DESCRIPTION
If an MVT server returns a tile with a 204 and a `Contet-Type`: `text/html` it throws:

```
No valid loader found data: "", contentType: "text/html" 
```

https://github.com/visgl/loaders.gl/pull/1584 added a fallback in the case of a missing `Content-Type`, but it doesn't work when the `Content-Type` of the server is not accurate

I've added a fix by setting `nothrow` to true
