### PR TITLE
Provide default skirt height for tiled TerrainLayer

### DIFF
--- a/modules/geo-layers/src/terrain-layer/terrain-layer.js
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.js
@@ -110,6 +110,7 @@ export default class TerrainLayer extends CompositeLayer {
     loadOptions = {
       ...loadOptions,
       terrain: {
+        skirtHeight: this.state.isTiled ? meshMaxError * 2 : 0,
         ...loadOptions?.terrain,
         bounds,
         meshMaxError,


### PR DESCRIPTION
#### Background

#5979 bumped our use of loaders.gl to 3.0.2. That release includes support for terrain skirting https://github.com/visgl/loaders.gl/pull/1662, which we can now enable in the TerrainLayer. Users can enable `skirtHeight` through the user of `loadOptions.terrain.skirtHeight`, but setting a default will make it easier to use for users who don't know the loaders.gl API as well. Setting a skirt height of 2 * the max error of the mesh should cover any seams (assuming the source elevation model is continuous).

#### Change List

- Set a default `skirtHeight` when using the TerrainLayer in tiled mode.
