### PR TITLE
fix: MVTLayer set binary to false by default

### DIFF
--- a/docs/api-reference/geo-layers/mvt-layer.md
+++ b/docs/api-reference/geo-layers/mvt-layer.md
@@ -121,7 +121,7 @@ Note that by default, the `MVTLoader` parses data using web workers, with code l
 
 ##### `binary` (Boolean, optional)
 
-* Default: true
+* Default: false
 
 Use tile data in [binary format](https://github.com/visgl/loaders.gl/blob/master/modules/gis/docs/api-reference/geojson-to-binary.md) to improve performance (2-3x faster on large datasets). It removes the need for serialization and deserialization of data transferred by the worker back to the main process. 
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -20,7 +20,6 @@ The module entry point is now only lightly transpiled for the most commonly used
 - Dashed lines via `PathStyleExtension` now draw rounded dash caps if `capRounded` is `true`.
 - `@deck.gl/geo-layers` now depends on `@deck.gl/extensions`.
 - `HeatmapLayer`'s `colorDomain` prop has redefined the unit of its values. See updated [layer documentation](/docs/api-reference/aggregation-layers/heatmap-layer.md) for details.
-- `MVTLayer`'s `binary` prop is now set to `true` by default to take advantage of the performance boost.
 - `TileLayer` no longer uses `tileSize` to offset zoom in non-geospatial views. It is recommended to use the new `zoomOffset` prop to affect the `zoom` resolution at which tiles are fetched.
 - `MVTLayer` and `TerrainLayer`'s default loaders no longer support parsing on the main thread. This does not change the layers' default behavior, just reduces the bundle size by dropping unused code. Should you need to use the layers in an environment where web worker is not available, or debug the loaders, follow the examples in [loaders and workers](/docs/developer-guide/loading-data.md#loaders-and-web-workers).
 - `TerrainLayer`'s `workerUrl` prop is removed, use `loadOptions.terrain.workerUrl` instead.

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -18,7 +18,7 @@ const defaultProps = {
   uniqueIdProperty: {type: 'string', value: ''},
   highlightedFeatureId: null,
   loaders: [MVTWorkerLoader],
-  binary: true
+  binary: false
 };
 
 export default class MVTLayer extends TileLayer {


### PR DESCRIPTION
Set MVTLayer binary to `false`. Related to https://github.com/visgl/deck.gl/issues/6006
