### PR TITLE
Allow user to control React wrapper id

### DIFF
--- a/modules/core/src/lib/deck.js
+++ b/modules/core/src/lib/deck.js
@@ -106,7 +106,7 @@ function getPropTypes(PropTypes) {
 }
 
 const defaultProps = {
-  id: 'deckgl-overlay',
+  id: '',
   width: '100%',
   height: '100%',
 
@@ -424,13 +424,12 @@ export default class Deck {
 
     if (!canvas) {
       canvas = document.createElement('canvas');
+      canvas.id = props.id || 'deckgl-overlay';
       const parent = props.parent || document.body;
       parent.appendChild(canvas);
     }
 
-    const {id, style} = props;
-    canvas.id = id;
-    Object.assign(canvas.style, style);
+    Object.assign(canvas.style, props.style);
 
     return canvas;
   }

--- a/modules/react/src/deckgl.js
+++ b/modules/react/src/deckgl.js
@@ -190,7 +190,7 @@ const DeckGL = forwardRef((props, ref) => {
   const {viewManager} = thisRef.deck || {};
   const currentViewports = viewManager && viewManager.getViewports();
 
-  const {ContextProvider, width, height, style} = props;
+  const {ContextProvider, width, height, id, style} = props;
 
   const {containerStyle, canvasStyle} = useMemo(() => extractStyles({width, height, style}), [
     width,
@@ -221,6 +221,7 @@ const DeckGL = forwardRef((props, ref) => {
 
     const canvas = createElement('canvas', {
       key: 'canvas',
+      id: id || 'deckgl-overlay',
       ref: canvasRef,
       style: canvasStyle
     });
@@ -228,7 +229,7 @@ const DeckGL = forwardRef((props, ref) => {
     // Render deck.gl as the last child
     thisRef.control = createElement(
       'div',
-      {id: 'deckgl-wrapper', ref: containerRef, style: containerStyle},
+      {id: `${id || 'deckgl'}-wrapper`, ref: containerRef, style: containerStyle},
       [canvas, childrenUnderViews]
     );
   }


### PR DESCRIPTION
For #5999

#### Change List
- Deck should not overwrite the id of an externally-provided canvas
- The React wrapper div is now assigned id `${props.id}-wrapper`. If `props.id` is not specified, the id is default to `deckgl-wrapper`, consistent with the previous behavior.
