### PR TITLE
Fix: MVT update min/maXZoom props

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -47,8 +47,10 @@ export default class MVTLayer extends TileLayer {
 
   /* eslint-disable complexity */
   async _updateTileData() {
-    let {data, minZoom, maxZoom} = this.props;
+    let {data} = this.props;
     let tileJSON = null;
+    let minZoom = null;
+    let maxZoom = null;
 
     if (typeof data === 'string' && !isURLTemplate(data)) {
       const {onDataLoad, fetch} = this.props;
@@ -70,13 +72,13 @@ export default class MVTLayer extends TileLayer {
     if (tileJSON) {
       data = tileJSON.tiles;
 
-      if (Number.isFinite(tileJSON.minzoom) && tileJSON.minzoom > minZoom) {
+      if (Number.isFinite(tileJSON.minzoom) && tileJSON.minzoom > this.props.minZoom) {
         minZoom = tileJSON.minzoom;
       }
 
       if (
         Number.isFinite(tileJSON.maxzoom) &&
-        (!Number.isFinite(maxZoom) || tileJSON.maxzoom < maxZoom)
+        (!Number.isFinite(maxZoom) || tileJSON.maxzoom < this.props.maxZoom)
       ) {
         maxZoom = tileJSON.maxzoom;
       }

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -49,8 +49,6 @@ export default class MVTLayer extends TileLayer {
   async _updateTileData() {
     let {data} = this.props;
     let tileJSON = null;
-    let minZoom = null;
-    let maxZoom = null;
 
     if (typeof data === 'string' && !isURLTemplate(data)) {
       const {onDataLoad, fetch} = this.props;
@@ -71,21 +69,30 @@ export default class MVTLayer extends TileLayer {
 
     if (tileJSON) {
       data = tileJSON.tiles;
+    }
 
-      if (Number.isFinite(tileJSON.minzoom) && tileJSON.minzoom > this.props.minZoom) {
-        minZoom = tileJSON.minzoom;
+    this.setState({data, tileJSON});
+  }
+
+  _getTilesetOptions(props) {
+    const opts = super._getTilesetOptions(props);
+    const {tileJSON} = this.state;
+
+    if (tileJSON) {
+      if (Number.isFinite(tileJSON.minzoom) && tileJSON.minzoom > props.minZoom) {
+        opts.minZoom = tileJSON.minzoom;
       }
 
       if (
         Number.isFinite(tileJSON.maxzoom) &&
-        (!Number.isFinite(this.props.maxZoom) || tileJSON.maxzoom < this.props.maxZoom)
+        (!Number.isFinite(props.maxZoom) || tileJSON.maxzoom < props.maxZoom)
       ) {
-        maxZoom = tileJSON.maxzoom;
+        opts.maxZoom = tileJSON.maxzoom;
       }
     }
-
-    this.setState({data, tileJSON, minZoom, maxZoom});
+    return opts;
   }
+
   /* eslint-disable complexity */
 
   renderLayers() {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -78,7 +78,7 @@ export default class MVTLayer extends TileLayer {
 
       if (
         Number.isFinite(tileJSON.maxzoom) &&
-        (!Number.isFinite(maxZoom) || tileJSON.maxzoom < this.props.maxZoom)
+        (!Number.isFinite(this.props.maxZoom) || tileJSON.maxzoom < this.props.maxZoom)
       ) {
         maxZoom = tileJSON.maxzoom;
       }

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -82,14 +82,14 @@ export default class TileLayer extends CompositeLayer {
   }
 
   _getTilesetOptions(props) {
-    const maxZoom = Number.isFinite(this.state.maxZoom) ? this.state.maxZoom : props.maxZoom;
-    const minZoom = Number.isFinite(this.state.minZoom) ? this.state.minZoom : props.minZoom;
     const {
       tileSize,
       maxCacheSize,
       maxCacheByteSize,
       refinementStrategy,
       extent,
+      maxZoom,
+      minZoom,
       maxRequests,
       zoomOffset
     } = props;


### PR DESCRIPTION
Changes on `minZoom` or `maxZoom` props didn't work at MVTLayer. Reported at https://github.com/visgl/deck.gl/issues/6023