### PR TITLE
Check for correct matching layerName when highlighting in MVTLayer

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -158,16 +158,25 @@ export default class MVTLayer extends TileLayer {
   _updateAutoHighlight(info) {
     const {uniqueIdProperty} = this.props;
 
-    const {hoveredFeatureId} = this.state;
+    const {hoveredFeatureId, hoveredFeatureLayerName} = this.state;
     const hoveredFeature = info.object;
     let newHoveredFeatureId;
+    let newHoveredFeatureLayerName;
 
     if (hoveredFeature) {
       newHoveredFeatureId = getFeatureUniqueId(hoveredFeature, uniqueIdProperty);
+      newHoveredFeatureLayerName = getFeatureLayerName(hoveredFeature);
     }
 
-    if (hoveredFeatureId !== newHoveredFeatureId && newHoveredFeatureId !== -1) {
-      this.setState({hoveredFeatureId: newHoveredFeatureId});
+    if (
+      (hoveredFeatureId !== newHoveredFeatureId && newHoveredFeatureId !== -1) ||
+      (hoveredFeatureLayerName !== newHoveredFeatureLayerName &&
+        newHoveredFeatureLayerName !== null)
+    ) {
+      this.setState({
+        hoveredFeatureId: newHoveredFeatureId,
+        hoveredFeatureLayerName: newHoveredFeatureLayerName
+      });
     }
   }
 
@@ -188,26 +197,27 @@ export default class MVTLayer extends TileLayer {
   }
 
   getHighlightedObjectIndex(tile) {
-    const {hoveredFeatureId} = this.state;
+    const {hoveredFeatureId, hoveredFeatureLayerName} = this.state;
     const {uniqueIdProperty, highlightedFeatureId, binary} = this.props;
     const {data} = tile;
 
-    const isFeatureIdPresent =
-      isFeatureIdDefined(hoveredFeatureId) || isFeatureIdDefined(highlightedFeatureId);
+    const isHighlighted = isFeatureIdDefined(highlightedFeatureId);
+    const isFeatureIdPresent = isFeatureIdDefined(hoveredFeatureId) || isHighlighted;
 
     if (!isFeatureIdPresent) {
       return -1;
     }
 
-    const featureIdToHighlight = isFeatureIdDefined(highlightedFeatureId)
-      ? highlightedFeatureId
-      : hoveredFeatureId;
+    const featureIdToHighlight = isHighlighted ? highlightedFeatureId : hoveredFeatureId;
 
     // Iterable data
     if (Array.isArray(data)) {
-      return data.findIndex(
-        feature => getFeatureUniqueId(feature, uniqueIdProperty) === featureIdToHighlight
-      );
+      return data.findIndex(feature => {
+        const isMatchingId = getFeatureUniqueId(feature, uniqueIdProperty) === featureIdToHighlight;
+        const isMatchingLayer =
+          isHighlighted || getFeatureLayerName(feature) === hoveredFeatureLayerName;
+        return isMatchingId && isMatchingLayer;
+      });
 
       // Non-iterable data
     } else if (data && binary) {
@@ -300,6 +310,14 @@ function getFeatureUniqueId(feature, uniqueIdProperty) {
   }
 
   return -1;
+}
+
+function getFeatureLayerName(feature) {
+  if (feature.properties && feature.properties.layerName) {
+    return feature.properties.layerName;
+  }
+
+  return null;
 }
 
 function isFeatureIdDefined(value) {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -169,9 +169,8 @@ export default class MVTLayer extends TileLayer {
     }
 
     if (
-      (hoveredFeatureId !== newHoveredFeatureId && newHoveredFeatureId !== -1) ||
-      (hoveredFeatureLayerName !== newHoveredFeatureLayerName &&
-        newHoveredFeatureLayerName !== null)
+      hoveredFeatureId !== newHoveredFeatureId ||
+      hoveredFeatureLayerName !== newHoveredFeatureLayerName
     ) {
       this.setState({
         hoveredFeatureId: newHoveredFeatureId,
@@ -313,11 +312,7 @@ function getFeatureUniqueId(feature, uniqueIdProperty) {
 }
 
 function getFeatureLayerName(feature) {
-  if (feature.properties && feature.properties.layerName) {
-    return feature.properties.layerName;
-  }
-
-  return null;
+  return feature.properties?.layerName || null;
 }
 
 function isFeatureIdDefined(value) {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -251,7 +251,7 @@ export default class MVTLayer extends TileLayer {
     for (const f of features) {
       const featureId = getFeatureUniqueId(f.object, this.props.uniqueIdProperty);
 
-      if (featureId === -1) {
+      if (featureId === undefined) {
         // we have no id for the feature, we just add to the list
         renderedFeatures.push(f.object);
       } else if (!featureCache.has(featureId)) {
@@ -308,7 +308,7 @@ function getFeatureUniqueId(feature, uniqueIdProperty) {
     return feature.id;
   }
 
-  return -1;
+  return undefined;
 }
 
 function getFeatureLayerName(feature) {

--- a/modules/test-utils/src/index.js
+++ b/modules/test-utils/src/index.js
@@ -2,7 +2,12 @@ export {toLowPrecision} from './utils/precision';
 export {default as gl} from './utils/setup-gl';
 
 // Utilities for update tests (lifecycle tests)
-export {testLayer, testLayerAsync, testInitializeLayer} from './lifecycle-test';
+export {
+  testLayer,
+  testLayerAsync,
+  testInitializeLayer,
+  testInitializeLayerAsync
+} from './lifecycle-test';
 export {generateLayerTests} from './generate-layer-tests';
 
 // Basic utility for rendering multiple scenes (could go into "deck.gl/core")

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -35,15 +35,29 @@ function defaultOnError(error, title) {
   }
 }
 
-export function testInitializeLayer({layer, viewport = testViewport, onError = defaultOnError}) {
+function initializeLayerManager({layer, viewport = testViewport, onError = defaultOnError}) {
   const layerManager = new LayerManager(gl, {viewport});
   layerManager.setProps({
     onError: error => onError(error, `initializing ${layer.id}`)
   });
 
   layerManager.setLayers([layer]);
-  layerManager.finalize();
+  return layerManager;
+}
 
+export function testInitializeLayer(opts) {
+  const layerManager = initializeLayerManager(opts);
+  layerManager.finalize();
+  return null;
+}
+
+export async function testInitializeLayerAsync(opts) {
+  const layerManager = initializeLayerManager(opts);
+  const deckRenderer = new DeckRenderer(gl);
+  while (!opts.layer.isLoaded) {
+    await update({layerManager, deckRenderer});
+  }
+  layerManager.finalize();
   return null;
 }
 

--- a/test/modules/core/lib/picking.spec.js
+++ b/test/modules/core/lib/picking.spec.js
@@ -57,6 +57,7 @@ TestMVTLayer.componentName = 'TestMVTLayer';
 
 const testMVTLayer = new TestMVTLayer({
   id: 'test-mvt-layer',
+  autoHighlight: true,
   data: [
     {
       id: 12,
@@ -248,6 +249,7 @@ test('processPickInfo', async t => {
           properties: {layerName: 'layerA'}
         }
       },
+      highlightedObjectIndex: 0,
       lastPickedInfo: {layerId: 'test-mvt-layer-0-0-1-points-circle', index: 0},
       testLayerUniforms: {picking_uSelectedColorValid: 0}
     },
@@ -269,6 +271,7 @@ test('processPickInfo', async t => {
           properties: {layerName: 'layerB'}
         }
       },
+      highlightedObjectIndex: 1,
       lastPickedInfo: {layerId: 'test-mvt-layer-0-0-1-points-circle', index: 1},
       testLayerUniforms: {picking_uSelectedColorValid: 0}
     },
@@ -346,6 +349,12 @@ test('processPickInfo', async t => {
         validateUniforms(currentLayerUniforms, testCase.currentLayerUniforms),
         'currentLayerUniforms'
       );
+    }
+
+    if (testCase.highlightedObjectIndex !== undefined) {
+      const renderedLayer = info.layer.renderLayers()[0][0];
+      const {highlightedObjectIndex} = renderedLayer.props;
+      t.deepEqual(highlightedObjectIndex, testCase.highlightedObjectIndex, 'highlightObjectIndex');
     }
   }
 

--- a/test/modules/core/lib/picking.spec.js
+++ b/test/modules/core/lib/picking.spec.js
@@ -22,7 +22,8 @@ import test from 'tape-catch';
 import {processPickInfo} from '@deck.gl/core/lib/picking/pick-info';
 import {WebMercatorViewport} from '@deck.gl/core';
 import {ScatterplotLayer, GeoJsonLayer} from '@deck.gl/layers';
-import {testInitializeLayer} from '@deck.gl/test-utils';
+import {MVTLayer} from '@deck.gl/geo-layers';
+import {testInitializeLayer, testInitializeLayerAsync} from '@deck.gl/test-utils';
 
 import {equals} from 'math.gl';
 
@@ -44,6 +45,32 @@ const testLayerWithCallback = new ScatterplotLayer({
 const testCompositeLayer = new GeoJsonLayer({
   id: 'test-composite-layer',
   data: [{type: 'Feature', geometry: {type: 'Point', coordinates: [0, 0]}}]
+});
+
+class TestMVTLayer extends MVTLayer {
+  getTileData() {
+    return this.props.data;
+  }
+}
+
+TestMVTLayer.componentName = 'TestMVTLayer';
+
+const testMVTLayer = new TestMVTLayer({
+  id: 'test-mvt-layer',
+  data: [
+    {
+      id: 12,
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [0, 0]},
+      properties: {layerName: 'layerA'}
+    },
+    {
+      id: 12,
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [0, 0]},
+      properties: {layerName: 'layerB'}
+    }
+  ]
 });
 
 const parameters = {
@@ -78,7 +105,7 @@ const parameters = {
       height: 100
     })
   ],
-  layers: [testLayer, testLayerWithCallback, testCompositeLayer],
+  layers: [testLayer, testLayerWithCallback, testCompositeLayer, testMVTLayer],
   layerFilter: ({layer, viewport}) => {
     if (viewport.id === 'minimap') {
       return layer.id !== 'test-layer-with-callback';
@@ -98,10 +125,11 @@ function validateUniforms(actual, expected) {
 }
 
 /* eslint-disable max-statements */
-test('processPickInfo', t => {
+test('processPickInfo', async t => {
   testInitializeLayer({layer: testLayer});
   testInitializeLayer({layer: testLayerWithCallback});
   testInitializeLayer({layer: testCompositeLayer});
+  await testInitializeLayerAsync({layer: testMVTLayer});
 
   const TEST_CASES = [
     {
@@ -205,6 +233,48 @@ test('processPickInfo', t => {
     {
       pickInfo: {
         pickedColor: [1, 0, 0, 0],
+        pickedLayer: testMVTLayer.getSubLayers()[0].getSubLayers()[0],
+        pickedObjectIndex: 0
+      },
+      x: 100,
+      y: 100,
+      size: 2,
+      info: {
+        layer: testMVTLayer,
+        object: {
+          id: 12,
+          type: 'Feature',
+          geometry: {type: 'Point'},
+          properties: {layerName: 'layerA'}
+        }
+      },
+      lastPickedInfo: {layerId: 'test-mvt-layer-0-0-1-points-circle', index: 0},
+      testLayerUniforms: {picking_uSelectedColorValid: 0}
+    },
+    {
+      pickInfo: {
+        pickedColor: [2, 0, 0, 0],
+        pickedLayer: testMVTLayer.getSubLayers()[0].getSubLayers()[0],
+        pickedObjectIndex: 1
+      },
+      x: 100,
+      y: 100,
+      size: 2,
+      info: {
+        layer: testMVTLayer,
+        object: {
+          id: 12,
+          type: 'Feature',
+          geometry: {type: 'Point'},
+          properties: {layerName: 'layerB'}
+        }
+      },
+      lastPickedInfo: {layerId: 'test-mvt-layer-0-0-1-points-circle', index: 1},
+      testLayerUniforms: {picking_uSelectedColorValid: 0}
+    },
+    {
+      pickInfo: {
+        pickedColor: [1, 0, 0, 0],
         pickedLayer: testLayer,
         pickedObjectIndex: 0
       },
@@ -282,6 +352,7 @@ test('processPickInfo', t => {
   testLayer._finalize();
   testLayerWithCallback._finalize();
   testCompositeLayer._finalize();
+  testMVTLayer._finalize();
 
   t.end();
 });


### PR DESCRIPTION
#### Background

The MVTLayer has incorrect picking behavior if two features in the source data share the same `id`, but have a different `layerName`


#### Change List
- `MVTLayer.getHighlightedObjectIndex()` checks that the hovered feature has the correct `layerName` as well as the correct `id`. This PR is only for the non-binary codepath.
- Add `MVTLayer` test cases to the `picking.spec.js` tests
- Test picking in `MVTLayer` for two features with matching `id`, but different `layerName`
