### PR TITLE
Fix MVTLayer autoHighlight with binary data

### DIFF
--- a/modules/geo-layers/src/mvt-layer/find-index-binary.js
+++ b/modules/geo-layers/src/mvt-layer/find-index-binary.js
@@ -1,0 +1,112 @@
+const GEOM_TYPES = ['points', 'lines', 'polygons'];
+/**
+ * Return the index of feature (numericProps or featureIds) for given feature id
+ * Example: findIndexBinary(data, 'id', 33) will return the index in the array of numericProps
+ * of the feature 33.
+ * @param {Object} data - The data in binary format
+ * @param {String} uniqueIdProperty - Name of the unique id property
+ * @param {Number|String} featureId - feature id to find
+ * @param {String} layerName - the layer to search in
+ */
+export default function findIndexBinary(data, uniqueIdProperty, featureId, layerName) {
+  for (const gt of GEOM_TYPES) {
+    const index = data[gt] && findIndexByType(data[gt], uniqueIdProperty, featureId, layerName);
+    if (index >= 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function findIndexByType(geomData, uniqueIdProperty, featureId, layerName) {
+  const featureIds = geomData.featureIds.value;
+
+  if (!featureIds.length) {
+    return -1;
+  }
+
+  let startFeatureIndex = 0;
+  let endFeatureIndex = featureIds[featureIds.length - 1] + 1;
+  if (layerName) {
+    const layerRange = getLayerRange(geomData, layerName);
+    if (layerRange) {
+      startFeatureIndex = layerRange[0];
+      endFeatureIndex = layerRange[1] + 1;
+    } else {
+      return -1;
+    }
+  }
+
+  // Look for the uniqueIdProperty
+  let featureIndex = -1;
+  if (uniqueIdProperty in geomData.numericProps) {
+    const vertexIndex = geomData.numericProps[uniqueIdProperty].value.findIndex(
+      (x, i) =>
+        x === featureId && featureIds[i] >= startFeatureIndex && featureIds[i] < endFeatureIndex
+    );
+    return vertexIndex >= 0 ? geomData.globalFeatureIds.value[vertexIndex] : -1;
+  } else if (uniqueIdProperty) {
+    featureIndex = findIndex(
+      geomData.properties,
+      elem => elem[uniqueIdProperty] === featureId,
+      startFeatureIndex,
+      endFeatureIndex
+    );
+  } else {
+    featureIndex = findIndex(
+      geomData.fields,
+      elem => elem.id === featureId,
+      startFeatureIndex,
+      endFeatureIndex
+    );
+  }
+  return featureIndex >= 0 ? getGlobalFeatureId(geomData, featureIndex) : -1;
+}
+
+// Returns [firstFeatureIndex, lastFeatureIndex]
+// MVTLoader parses tiles layer-by-layer, so each layer is a continuous range
+function getLayerRange(geomData, layerName) {
+  if (!geomData.__layers) {
+    // Cache a map from properties.layerName to index ranges
+    const layerNames = {};
+    const {properties} = geomData;
+    for (let i = 0; i < properties.length; i++) {
+      const {layerName: key} = properties[i];
+      if (!key) {
+        // ignore
+      } else if (layerNames[key]) {
+        layerNames[key][1] = i;
+      } else {
+        layerNames[key] = [i, i];
+      }
+    }
+    geomData.__layers = layerNames;
+  }
+  return geomData.__layers[layerName];
+}
+
+// Returns global feature id
+function getGlobalFeatureId(geomData, featureIndex) {
+  if (!geomData.__ids) {
+    // Cache a map from featureId to globalFeatureId
+    const result = [];
+    const featureIds = geomData.featureIds.value;
+    const globalFeatureIds = geomData.globalFeatureIds.value;
+    for (let i = 0; i < featureIds.length; i++) {
+      result[featureIds[i]] = globalFeatureIds[i];
+    }
+    geomData.__ids = result;
+  }
+  return geomData.__ids[featureIndex];
+}
+
+// Like array.findIndex, but only search within a range
+function findIndex(array, predicate, startIndex, endIndex) {
+  for (let i = startIndex; i < endIndex; i++) {
+    if (predicate(array[i], i)) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -3,12 +3,12 @@ import {Matrix4} from 'math.gl';
 import {MVTWorkerLoader} from '@loaders.gl/mvt';
 import {binaryToGeojson} from '@loaders.gl/gis';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
-import {_findIndexBinary} from '@deck.gl/layers';
 import {ClipExtension} from '@deck.gl/extensions';
 
 import TileLayer from '../tile-layer/tile-layer';
 import {getURLFromTemplate, isURLTemplate} from '../tile-layer/utils';
 import {transform} from './coordinate-transform';
+import findIndexBinary from './find-index-binary';
 
 import {GeoJsonLayer} from '@deck.gl/layers';
 
@@ -221,13 +221,12 @@ export default class MVTLayer extends TileLayer {
       // Non-iterable data
     } else if (data && binary) {
       // Get the feature index of the selected item to highlight
-      const featureIdIndex = _findIndexBinary(data, uniqueIdProperty, featureIdToHighlight);
-
-      const geometries = ['points', 'lines', 'polygons'];
-      for (const geometry of geometries) {
-        const index = data[geometry] && data[geometry].featureIds.value[featureIdIndex];
-        if (index !== undefined) return index;
-      }
+      return findIndexBinary(
+        data,
+        uniqueIdProperty,
+        featureIdToHighlight,
+        isHighlighted ? '' : hoveredFeatureLayerName
+      );
     }
 
     return -1;

--- a/modules/layers/src/geojson-layer/geojson-binary.js
+++ b/modules/layers/src/geojson-layer/geojson-binary.js
@@ -2,8 +2,6 @@
 // the geojson-binary format defined at loaders.gl:
 // https://github.com/visgl/loaders.gl/blob/master/modules/gis/docs/api-reference/geojson-to-binary.md
 
-const GEOM_TYPES = ['points', 'lines', 'polygons'];
-
 /**
  * Return the feature for an accesor
  *
@@ -35,50 +33,6 @@ function getPropertiesForIndex(data, propertiesIndex, numericPropsIndex) {
   }
 
   return feature;
-}
-
-/**
- * Return the index of feature (numericProps or featureIds) for given feature id
- * Example: findIndexBinary(data, 'id', 33) will return the index in the array of numericProps
- * of the feature 33.
- * @param {Object} data - The data in binary format
- * @param {String} uniqueIdProperty - Name of the unique id property
- * @param {Number} featureId - feature id to find
- */
-export function findIndexBinary(data, uniqueIdProperty, featureId) {
-  if (!data) {
-    return -1;
-  }
-
-  for (const gt of GEOM_TYPES) {
-    const index = findIndexByType(data, uniqueIdProperty, featureId, gt);
-    if (index !== -1) {
-      return index;
-    }
-  }
-
-  return -1;
-}
-
-function findIndexByType(data, uniqueIdProperty, featureId, geomType) {
-  if (!data) {
-    return -1;
-  }
-
-  if (!(geomType in data) || !data[geomType].positions.value.length) return -1;
-
-  // Look for the uniqueIdProperty
-  let index = -1;
-  if (data[geomType].numericProps[uniqueIdProperty]) {
-    index = data[geomType].numericProps[uniqueIdProperty].value.indexOf(featureId);
-  } else {
-    const propertyIndex = data[geomType].properties.findIndex(
-      elem => elem[uniqueIdProperty] === featureId
-    );
-    index = data[geomType].featureIds.value.indexOf(propertyIndex);
-  }
-
-  return index;
 }
 
 // Custom picking color to keep binary indexes

--- a/modules/layers/src/index.js
+++ b/modules/layers/src/index.js
@@ -39,5 +39,3 @@ export {default as _MultiIconLayer} from './text-layer/multi-icon-layer/multi-ic
 export {
   default as _TextBackgroundLayer
 } from './text-layer/text-background-layer/text-background-layer';
-
-export {findIndexBinary as _findIndexBinary} from './geojson-layer/geojson-binary';

--- a/test/apps/mapbox-tile/app.js
+++ b/test/apps/mapbox-tile/app.js
@@ -17,41 +17,27 @@ const INITIAL_VIEW_STATE = {
 };
 
 const MAP_LAYER_STYLES = {
-  stroked: true,
-  extruded: true,
-
-  getElevation: f => (f.properties.extrude && f.properties.height) || 0,
-
-  getLineColor: [192, 192, 192],
+  maxZoom: 14,
 
   getFillColor: f => {
-    switch (f.properties.layer) {
+    switch (f.properties.layerName) {
+      case 'poi':
+        return [255, 0, 0];
       case 'water':
-        return [140, 170, 180];
-      case 'landcover':
-        return [120, 190, 100];
-      default:
+        return [120, 150, 180];
+      case 'building':
         return [218, 218, 218];
+      default:
+        return [240, 240, 240];
     }
   },
 
-  getLineWidth: f => {
-    if (f.properties.layer === 'transportation') {
-      switch (f.properties.class) {
-        case 'primary':
-          return 12;
-        case 'motorway':
-          return 16;
-        default:
-          return 6;
-      }
-    }
-    return 1;
-  },
-  lineWidthMinPixels: 1,
+  getLineWidth: 1,
+  lineWidthUnits: 'pixels',
+  getLineColor: [192, 192, 192],
 
-  getPointRadius: 100,
-  pointRadiusMinPixels: 2
+  getPointRadius: 4,
+  pointRadiusUnits: 'pixels'
 };
 
 class Root extends PureComponent {
@@ -73,7 +59,11 @@ class Root extends PureComponent {
       return null;
     }
 
-    return <div className="clicked-info">{JSON.stringify(clickedItem.properties)}</div>;
+    return (
+      <div className="clicked-info">
+        id: {clickedItem.id} {JSON.stringify(clickedItem.properties)}
+      </div>
+    );
   }
 
   render() {
@@ -85,8 +75,13 @@ class Root extends PureComponent {
         layers={[
           new MVTLayer({
             ...MAP_LAYER_STYLES,
-            data: `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=${MAPBOX_TOKEN}`,
-            pickable: true
+            data:
+              'https://tiles-a.basemaps.cartocdn.com/vectortiles/carto.streets/v1/{z}/{x}/{y}.mvt',
+
+            onClick: this._onClick.bind(this),
+            pickable: true,
+            autoHighlight: true,
+            binary: true
           })
         ]}
       >

--- a/test/apps/mapbox-tile/webpack.config.js
+++ b/test/apps/mapbox-tile/webpack.config.js
@@ -1,8 +1,6 @@
 // NOTE: To use this example standalone (e.g. outside of deck.gl repo)
 // delete the local development overrides at the bottom of this file
 
-const webpack = require('webpack');
-
 const CONFIG = {
   mode: 'development',
 
@@ -23,10 +21,7 @@ const CONFIG = {
         }
       }
     ]
-  },
-
-  // Optional: Enables reading mapbox token from environment variable
-  plugins: [new webpack.EnvironmentPlugin(['MapboxAccessToken'])]
+  }
 };
 
 // This line enables bundling against src in this repo rather than installed module

--- a/test/modules/layers/geojson-binary.spec.js
+++ b/test/modules/layers/geojson-binary.spec.js
@@ -1,7 +1,6 @@
 import test from 'tape-catch';
 import {geojsonToBinary} from '@loaders.gl/gis';
 import {calculatePickingColors} from '@deck.gl/layers/geojson-layer/geojson-binary';
-import {_findIndexBinary} from '@deck.gl/layers';
 import {Layer} from '@deck.gl/core';
 import {geoJSONData, pickingColorsSample} from './data/fixtures';
 
@@ -23,20 +22,6 @@ test('calculatePickingColors', t => {
     pickingColorsSample,
     'creates a right picking colors array for binary geojson'
   );
-
-  t.end();
-});
-
-test('findIndexBinaryByNumericProp', t => {
-  const index = _findIndexBinary(geoJSONBinaryData, 'cartodb_id', 149);
-  t.equal(index, 4, 'finds the index of a feature by one of its numeric properties');
-
-  t.end();
-});
-
-test('findIndexBinaryByTextProperty', t => {
-  const index = _findIndexBinary(geoJSONBinaryData, 'name', 'Second');
-  t.equal(index, 4, 'finds the index of a feature by one of its properties');
 
   t.end();
 });


### PR DESCRIPTION
For #6006

#### Change List
- Fix incorrect usage of feature id (should return global feature id)
- Move `findIndexBinary` from GeoJsonLayer to MVTLayer (logic does not apply to generic GeoJSON)
- Handle default `uniqueIdProperty`
- Handle filter by layer name
- Update MVT test app
- Unit tests