### PR TITLE
OrthographicView supports independent x/y zoom levels

### DIFF
--- a/docs/api-reference/core/orthographic-controller.md
+++ b/docs/api-reference/core/orthographic-controller.md
@@ -43,6 +43,10 @@ Supports all [Controller options](/docs/api-reference/core/controller.md#options
 - `touchRotate`: not effective, this view cannot be rotated
 - `keyboard`: arrow keys to pan, +/- to zoom
 
+Also accepts additional options:
+
+- `zoomAxis` (String) - which axes to apply zoom to. Affects scroll, keyboard +/- and double tap. One of `X` (zoom along the X axis only), `Y` (zoom along the Y axis only), `all`. Default `all`. If this option is set to `X` or `Y`, `viewState.zoom` must be an array to enable independent zoom for each axis.
+
 ## Custom OrthographicController
 
 You can further customize the `OrthographicController`'s behavior by extending the class:

--- a/docs/api-reference/core/orthographic-view.md
+++ b/docs/api-reference/core/orthographic-view.md
@@ -40,7 +40,7 @@ Distance of far clipping plane. Default `1000`.
 To render, `OrthographicView` needs to be used together with a `viewState` with the following parameters:
 
 * `target` (Number[3], optional) - The world position at the center of the viewport. Default `[0, 0, 0]`.
-* `zoom` (Number, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. Default `0`.
+* `zoom` (Number|Number[2], optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. To apply independent zoom levels to the X and Y axes, supply an array `[zoomX, zoomY]`. Default `0`.
 * `minZoom` (Number, optional) - The min zoom level of the viewport. Default `-Infinity`.
 * `maxZoom` (Number, optional) - The max zoom level of the viewport. Default `Infinity`.
 

--- a/modules/core/src/controllers/orbit-controller.js
+++ b/modules/core/src/controllers/orbit-controller.js
@@ -202,7 +202,7 @@ export class OrbitState extends ViewState {
    * @param {Number} scale - a number between [0, 1] specifying the accumulated
    *   relative scale.
    */
-  zoom({pos, startPos, scale}) {
+  zoom({pos, startPos, scale, axis}) {
     const {zoom} = this._viewportProps;
     let {startZoom, startZoomPosition} = this._state;
     if (!Number.isFinite(startZoom)) {
@@ -216,7 +216,7 @@ export class OrbitState extends ViewState {
       startZoomPosition = this._unproject(startPos) || this._unproject(pos);
     }
 
-    const newZoom = this._calculateNewZoom({scale, startZoom});
+    const newZoom = this._calculateNewZoom({scale, startZoom, axis});
     const zoomedViewport = this.makeViewport({...this._viewportProps, zoom: newZoom});
 
     return this._getUpdatedState({
@@ -315,7 +315,7 @@ export class OrbitState extends ViewState {
 
   _getUpdatedState(newProps) {
     // Update _viewportProps
-    return new OrbitState({...this._viewportProps, ...this._state, ...newProps});
+    return new this.constructor({...this._viewportProps, ...this._state, ...newProps});
   }
 
   // Apply any constraints (mathematical or defined by _viewportProps) to map state

--- a/modules/core/src/controllers/orbit-controller.js
+++ b/modules/core/src/controllers/orbit-controller.js
@@ -202,7 +202,7 @@ export class OrbitState extends ViewState {
    * @param {Number} scale - a number between [0, 1] specifying the accumulated
    *   relative scale.
    */
-  zoom({pos, startPos, scale, axis}) {
+  zoom({pos, startPos, scale}) {
     const {zoom} = this._viewportProps;
     let {startZoom, startZoomPosition} = this._state;
     if (!Number.isFinite(startZoom)) {
@@ -216,7 +216,7 @@ export class OrbitState extends ViewState {
       startZoomPosition = this._unproject(startPos) || this._unproject(pos);
     }
 
-    const newZoom = this._calculateNewZoom({scale, startZoom, axis});
+    const newZoom = this._calculateNewZoom({scale, startZoom});
     const zoomedViewport = this.makeViewport({...this._viewportProps, zoom: newZoom});
 
     return this._getUpdatedState({

--- a/modules/core/src/controllers/orthographic-controller.js
+++ b/modules/core/src/controllers/orthographic-controller.js
@@ -49,6 +49,9 @@ class OrthographicState extends OrbitState {
       }
       return [newZoomX, newZoomY];
     }
+    // Ignore `zoomAxis`
+    // `LinearTransitionInterpolator` does not support interpolation between a number and an array
+    // So if zoom is a number (legacy use case), new zoom still has to be a number
     return clamp(startZoom + deltaZoom, minZoom, maxZoom);
   }
 }

--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -34,7 +34,11 @@ class OrthographicViewport extends Viewport {
       target = [0, 0, 0],
       flipY = true
     } = props;
-    const scale = Math.pow(2, zoom);
+    const zoomX = Array.isArray(zoom) ? zoom[0] : zoom;
+    const zoomY = Array.isArray(zoom) ? zoom[1] : zoom;
+    const zoom_ = Math.min(zoomX, zoomY);
+    const scale = Math.pow(2, zoom_);
+
     super({
       ...props,
       // in case viewState contains longitude/latitude values,
@@ -43,15 +47,36 @@ class OrthographicViewport extends Viewport {
       position: target,
       viewMatrix: viewMatrix.clone().scale([scale, scale * (flipY ? -1 : 1), scale]),
       projectionMatrix: getProjectionMatrix({width, height, near, far}),
-      zoom
+      zoom: zoom_
     });
+
+    if (zoomX !== zoomY) {
+      const scaleX = Math.pow(2, zoomX);
+      const scaleY = Math.pow(2, zoomY);
+
+      this.distanceScales = {
+        unitsPerMeter: [scaleX / scale, scaleY / scale, 1],
+        metersPerUnit: [scale / scaleX, scale / scaleY, 1]
+      };
+    }
+  }
+
+  projectFlat([X, Y]) {
+    const {unitsPerMeter} = this.distanceScales;
+    return [X * unitsPerMeter[0], Y * unitsPerMeter[1]];
+  }
+
+  unprojectFlat([x, y]) {
+    const {metersPerUnit} = this.distanceScales;
+    return [x * metersPerUnit[0], y * metersPerUnit[1]];
   }
 
   /* Needed by LinearInterpolator */
   panByPosition(coords, pixel) {
     const fromLocation = pixelsToWorld(pixel, this.pixelUnprojectionMatrix);
+    const toLocation = this.projectFlat(coords);
 
-    const translate = vec2.add([], coords, vec2.negate([], fromLocation));
+    const translate = vec2.add([], toLocation, vec2.negate([], fromLocation));
     const newCenter = vec2.add([], this.center, translate);
 
     return {target: newCenter};

--- a/test/modules/core/controllers/controllers.spec.js
+++ b/test/modules/core/controllers/controllers.spec.js
@@ -77,6 +77,21 @@ test('OrthographicController', async t => {
   t.end();
 });
 
+test('OrthographicController#2d zoom', async t => {
+  await testController(
+    t,
+    OrthographicView,
+    {
+      target: [1, 1, 0],
+      zoom: [1, 2]
+    },
+    // OrthographicView cannot be rotated
+    ['pan#function key', 'tripan']
+  );
+
+  t.end();
+});
+
 test('FirstPersonController', async t => {
   await testController(
     t,


### PR DESCRIPTION
#### Background

For the charting use case

![deck gl-orthographic-controller](https://user-images.githubusercontent.com/2059298/129968421-985b060e-84b3-427e-b477-76d2dd30bd2a.gif)

#### Change List
- `OrthographicViewport` accepts `zoom` as either a number (uniform zoom) or an array (independent zoom)
- `OrthographicController` new option `zoomAxis`
- Documentation
- Test
