### PR TITLE
Fix TileLayer and Tile3DLayer visiblility

### DIFF
--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
@@ -99,7 +99,7 @@ export default class Tile3DLayer extends CompositeLayer {
   filterSubLayer({layer, viewport}) {
     const {tile} = layer.props;
     const {id: viewportId} = viewport;
-    return tile.viewportIds.includes(viewportId);
+    return this.props.visible && tile.selected && tile.viewportIds.includes(viewportId);
   }
 
   _updateAutoHighlight(info) {
@@ -319,15 +319,7 @@ export default class Tile3DLayer extends CompositeLayer {
             // props have changed, rerender layer
             layer = this._getSubLayer(tile, layer);
             layerCache.needsUpdate = false;
-          } else if (!layer.props.visible) {
-            // update layer visibility
-            // Still has GPU resource but visibility is turned off so turn it back on so we can render it.
-            layer = layer.clone({visible: true});
           }
-        } else if (layer && layer.props.visible) {
-          // hide non-selected tiles
-          // Still in tileset cache but doesn't need to render this frame. Keep the GPU resource bound but don't render it.
-          layer = layer.clone({visible: false});
         }
         layerCache.layer = layer;
         return layer;

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -200,7 +200,6 @@ export default class TileLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    const {visible} = this.props;
     return this.state.tileset.tiles.map(tile => {
       const highlightedObjectIndex = this.getHighlightedObjectIndex(tile);
       // cache the rendered layer in the tile
@@ -211,7 +210,6 @@ export default class TileLayer extends CompositeLayer {
           ...this.props,
           id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
           data: tile.data,
-          visible,
           _offset: 0,
           tile
         });
@@ -232,7 +230,7 @@ export default class TileLayer extends CompositeLayer {
   }
 
   filterSubLayer({layer}) {
-    return layer.props.tile.isVisible;
+    return this.props.visible && layer.props.tile.isVisible;
   }
 }
 


### PR DESCRIPTION

For #6122

There are various issues in TileLayer/Tile3DLayer's override of sublayer `visible` prop:
- `Tile3DLayer` is not forwarding its `visible` prop to cached sub layers correctly
- `TileLayer` does not hide sub layers when toggled off if the `visible` prop is set by `renderSubLayers` explicitly

#### Change List
- Use `filterSubLayer` to hide all tiles if `visible` is false
