### PR TITLE
Fix Default Values in `AttributeManager` `add` method

### DIFF
--- a/modules/core/src/lib/attribute/attribute-manager.js
+++ b/modules/core/src/lib/attribute/attribute-manager.js
@@ -296,15 +296,18 @@ export default class AttributeManager {
   /* eslint-enable max-statements */
 
   _createAttribute(name, attribute, extraProps) {
+    // For expected default values see:
+    // https://github.com/visgl/luma.gl/blob/1affe21352e289eeaccee2a876865138858a765c/modules/webgl/src/classes/accessor.js#L5-L13
+    // and https://deck.gl/docs/api-reference/core/attribute-manager#add
     const props = {
       ...attribute,
       id: name,
+      isIndexed: attribute.isIndexed || attribute.elements || false,
       // Luma fields
       constant: attribute.constant || false,
-      isIndexed: attribute.isIndexed || attribute.elements,
-      size: (attribute.elements && 1) || attribute.size,
+      size: (attribute.elements && 1) || attribute.size || 1,
       value: attribute.value || null,
-      divisor: attribute.instanced || extraProps.instanced ? 1 : attribute.divisor
+      divisor: attribute.instanced || extraProps.instanced ? 1 : attribute.divisor || 0
     };
 
     return new Attribute(this.gl, props);

--- a/test/modules/core/lib/attribute/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute/attribute-manager.spec.js
@@ -79,6 +79,16 @@ test('AttributeManager.add', t => {
     {positions: ['positions'], getPosition: ['positions']},
     'AttributeManager.add - build update triggers mapping'
   );
+  t.equals(
+    attributeManager.getAttributes()['positions'].settings.divisor,
+    0,
+    'AttributeManager.add creates attribute with default divisor of 0'
+  );
+  t.equals(
+    attributeManager.getAttributes()['positions'].settings.isIndexed,
+    false,
+    'AttributeManager.add creates attribute with default isIndexed of false'
+  );
   t.end();
 });
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #6129 (see [discussion](https://github.com/visgl/deck.gl/discussions/6128) as well).
<!-- For other PRs without open issue -->
#### Change List
- Make sure default values of added attributes match docs/luma.gl constants
