### PR TITLE
Bump luma.gl to 8.5.5

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -13,7 +13,7 @@
     "@loaders.gl/csv": "^3.0.8",
     "@loaders.gl/draco": "^3.0.8",
     "@loaders.gl/gltf": "^3.0.8",
-    "@luma.gl/constants": "^8.5.2",
+    "@luma.gl/constants": "^8.5.5",
     "brace": "^0.11.1",
     "deck.gl": "^8.3.0",
     "react": "~16.9.0",

--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@luma.gl/shadertools": "^8.5.4",
+    "@luma.gl/shadertools": "^8.5.5",
     "@math.gl/web-mercator": "^3.5.4",
     "d3-hexbin": "^0.2.1"
   },

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@loaders.gl/core": "^3.0.8",
     "@loaders.gl/images": "^3.0.8",
-    "@luma.gl/core": "^8.5.4",
+    "@luma.gl/core": "^8.5.5",
     "@math.gl/web-mercator": "^3.5.4",
     "gl-matrix": "^3.0.0",
     "math.gl": "^3.5.4",

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env.dev"
   },
   "dependencies": {
-    "@luma.gl/shadertools": "^8.5.4"
+    "@luma.gl/shadertools": "^8.5.5"
   },
   "peerDependencies": {
     "@deck.gl/core": "^8.0.0",

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -35,7 +35,7 @@
     "@loaders.gl/mvt": "^3.0.8",
     "@loaders.gl/terrain": "^3.0.8",
     "@loaders.gl/tiles": "^3.0.8",
-    "@luma.gl/experimental": "^8.5.4",
+    "@luma.gl/experimental": "^8.5.5",
     "@math.gl/culling": "^3.5.4",
     "@math.gl/web-mercator": "^3.5.4",
     "h3-js": "^3.6.0",

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -40,7 +40,7 @@
     "@loaders.gl/3d-tiles": "^3.0.8",
     "@loaders.gl/core": "^3.0.8",
     "@loaders.gl/csv": "^3.0.8",
-    "@luma.gl/constants": "^8.5.4",
+    "@luma.gl/constants": "^8.5.5",
     "mapbox-gl": "^1.2.1"
   },
   "jupyterlab": {

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@loaders.gl/gltf": "^3.0.8",
-    "@luma.gl/experimental": "^8.5.4",
-    "@luma.gl/shadertools": "^8.5.4"
+    "@luma.gl/experimental": "^8.5.5",
+    "@luma.gl/shadertools": "^8.5.5"
   }
 }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -24,8 +24,8 @@
   ],
   "peerDependencies": {
     "@deck.gl/core": "^8.0.0",
-    "@luma.gl/test-utils": "^8.5.2",
-    "@luma.gl/webgl": "^8.5.2",
+    "@luma.gl/test-utils": "^8.5.0",
+    "@luma.gl/webgl": "^8.5.0",
     "@probe.gl/test-utils": "^3.4.0"
   },
   "scripts": {}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/register": "^7.13.0",
     "@loaders.gl/csv": "^3.0.8",
     "@loaders.gl/polyfills": "^3.0.8",
-    "@luma.gl/test-utils": "^8.5.4",
+    "@luma.gl/test-utils": "^8.5.5",
     "@probe.gl/bench": "^3.4.0",
     "@probe.gl/test-utils": "^3.4.0",
     "abortcontroller-polyfill": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,82 +2120,82 @@
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-"@luma.gl/constants@8.5.4", "@luma.gl/constants@^8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-8.5.4.tgz#f7be8146bd60f9426c5a72ef6773ff134cb85bf5"
-  integrity sha512-lrA4ja92om/gDHYOvM9itL5S7FVzjKulyknDz6S+Y7gmgHgXk2ln1Xar5zUCsLnhAYx4glHITXGH5Y5rdWgT1Q==
+"@luma.gl/constants@8.5.5", "@luma.gl/constants@^8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-8.5.5.tgz#3de04c81d1c67fef619951cb4ba123aac7a192ed"
+  integrity sha512-3pDC7jFaXliDP7Gvr6pPkorLFBXDnuakNeN87aEYcIM+p3XrkF0rPnDQJEzwScWS9RIopXT858xmL3vG7IYsDw==
 
 "@luma.gl/constants@^8.4.0":
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-8.4.0.tgz#07584e76fbb184f8b26d323b8d52e3a6c8815ce8"
   integrity sha512-R4lW8nZ2Mon+62uOH6l1M7KlCMzxhr+J2cHuArK8KzvdUz/+oJU/GdII6AP9zvix3A0rpGRf5p0hpL2tnjzXGw==
 
-"@luma.gl/core@^8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-8.5.4.tgz#66fd4e1624eda99b25f4109a6e0168f00bfa4f38"
-  integrity sha512-+saDz1D3mcPd53vgbG60ryg1w5CF9Z2wdakKHzR810VoJLw97t4aNdg/eNgyWOvbOHxaKJBPm8K0sGjej67+jw==
+"@luma.gl/core@^8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-8.5.5.tgz#c10ba2c8423a7677efe2922363b269a7619feafa"
+  integrity sha512-/J9T2gleSoWcn38WWpfRqsuwk46fQKigFJdcXF5mBHdVaGDuVUWY2K4ZY8sp0pBaVpLI44FccF05Rm7SHGsrFw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "8.5.4"
-    "@luma.gl/engine" "8.5.4"
-    "@luma.gl/gltools" "8.5.4"
-    "@luma.gl/shadertools" "8.5.4"
-    "@luma.gl/webgl" "8.5.4"
+    "@luma.gl/constants" "8.5.5"
+    "@luma.gl/engine" "8.5.5"
+    "@luma.gl/gltools" "8.5.5"
+    "@luma.gl/shadertools" "8.5.5"
+    "@luma.gl/webgl" "8.5.5"
 
-"@luma.gl/engine@8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/engine/-/engine-8.5.4.tgz#b8a2695fa57bd5174d54964e070d9aadd2eeff49"
-  integrity sha512-Sfv972IzvR9s9kKWugs67XQUh9jC0e/PpBrzvyGVnPU4XvFq42RZVF73pzEklVU6AlpR8Zg5CPtxGdhyOHtT7w==
+"@luma.gl/engine@8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/engine/-/engine-8.5.5.tgz#1740b0e6097207d1c1dea40cc6c11d48c15b7bc4"
+  integrity sha512-DZRxWmq1ZtP4RGdUITFk6p5bl9ugGTesgMP9nQSiF0JuP4w0pjdajb//Wy0SgmrlVAb43Qn5Z/kI3JQIT/GGbA==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "8.5.4"
-    "@luma.gl/gltools" "8.5.4"
-    "@luma.gl/shadertools" "8.5.4"
-    "@luma.gl/webgl" "8.5.4"
+    "@luma.gl/constants" "8.5.5"
+    "@luma.gl/gltools" "8.5.5"
+    "@luma.gl/shadertools" "8.5.5"
+    "@luma.gl/webgl" "8.5.5"
     "@math.gl/core" "^3.5.0"
     probe.gl "^3.4.0"
 
-"@luma.gl/experimental@^8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/experimental/-/experimental-8.5.4.tgz#fbf77dea7502c75f65da7bab658cf91b9ade6e04"
-  integrity sha512-09waqRhgIrw+Sq0/in4tw4jPag5YsFfV1nEHJaLAg5RFv92S53IEubSJgkuG02HoOBkPxQ7KYvs9VNmriisnYg==
+"@luma.gl/experimental@^8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/experimental/-/experimental-8.5.5.tgz#98a179160137dd81f8a3c98742eadd677337f6d8"
+  integrity sha512-joXdGkNLbNyKHQ7lZBldOqHvzGsYgVKggeVH5KlWyTv5FTvwEUiRG90+KfU0W/ivicBQ5irJpSQSoE56TeoVvw==
   dependencies:
-    "@luma.gl/constants" "8.5.4"
+    "@luma.gl/constants" "8.5.5"
     "@math.gl/core" "^3.5.0"
     earcut "^2.0.6"
 
-"@luma.gl/gltools@8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/gltools/-/gltools-8.5.4.tgz#00ddb766d089a84ce099479c1a084d64abb20794"
-  integrity sha512-JotiPuymQz2Xc41AYlS2moJC/EHxU+OX/OMKi0+/MeOlEFLsdochgTA0I64j8yofLTXdeiGCneGtD1Ao8fk+bw==
+"@luma.gl/gltools@8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/gltools/-/gltools-8.5.5.tgz#920de44d11f348dea1b147b67a43afffcadba13e"
+  integrity sha512-4PnBR/cEm0EmRkAOSuHJhdAnI8oU6eqTxM6F3iSO11qsPy8SliuyULwdoIJXlCj22ppjvir+kHTt9E3qHiiokg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "8.5.4"
+    "@luma.gl/constants" "8.5.5"
     probe.gl "^3.4.0"
 
-"@luma.gl/shadertools@8.5.4", "@luma.gl/shadertools@^8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-8.5.4.tgz#a1caf78bffa60133b37db9d5830dc5731fe89d5e"
-  integrity sha512-rwLBLrACi75aWnuJm8rVKCQnJR2sMTCxHuexfjHJ7Uecl0vVcVJZT7c9EnCFaz5LUTNbdupvuhq0SKNckKiKmw==
+"@luma.gl/shadertools@8.5.5", "@luma.gl/shadertools@^8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-8.5.5.tgz#1ca324b905d335cdb029568173c9ab41d365cd6d"
+  integrity sha512-DxthL1r159fJ5dCmcRWNPqQBGUMNEuTXLWsY70W4IAu15e7tKlUJ0FT22zZbiOuCF/2EwxIGwmwxSqesYo7REg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@math.gl/core" "^3.5.0"
 
-"@luma.gl/test-utils@^8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/test-utils/-/test-utils-8.5.4.tgz#c2a85689f4dad1e539fc434f19bae9333fcd16cd"
-  integrity sha512-KL6q5Vt8v0a6KX6ezWF2zV5B3GRpyCXxC+Ww+p5n+nHmkoccS6lcl0HY1xlCsuKbWZM+Uti/hiJ/luAi40+rQw==
+"@luma.gl/test-utils@^8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/test-utils/-/test-utils-8.5.5.tgz#b9617487386ff9e0b10504b6b2abc0ce8c639745"
+  integrity sha512-6SG66xU8ToOn1LhithYj3TD7/iY6JTjSsLfDBX3ap6oLbLxvUh9ZQXB/9Mnu+IcVgHATMr+4i3vWkx2wuR186g==
   dependencies:
     probe.gl "^3.4.0"
 
-"@luma.gl/webgl@8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-8.5.4.tgz#7558fbc4b97e607d6ad1ea199c54340a7ec720e6"
-  integrity sha512-dWy4dhTbtvDO9zQBdx1Yb+DxNx/1JWV9rhhJxJUtTKbGZSX0RjkASTT6GBWMl5jrH1JYJefS1wswHmmPVXjK0Q==
+"@luma.gl/webgl@8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-8.5.5.tgz#959174437bf26c28ca97a8740c4a9ff4d6d89574"
+  integrity sha512-aGJ9k3NwDHy8t3Ry1yVNSEXRXW8p3/dvxDd3T5rOE7CNUa2UITx40cAgWfvz7duRwfvOFH2L3wtzJkgaSpPmfw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    "@luma.gl/constants" "8.5.4"
-    "@luma.gl/gltools" "8.5.4"
+    "@luma.gl/constants" "8.5.5"
+    "@luma.gl/gltools" "8.5.5"
     probe.gl "^3.4.0"
 
 "@lumino/algorithm@^1.2.3", "@lumino/algorithm@^1.3.0":
@@ -2379,7 +2379,7 @@
     "@babel/runtime" "^7.12.0"
     gl-matrix "^3.0.0"
 
-"@math.gl/culling@3.5.4", "@math.gl/culling@^3.5.1", "@math.gl/culling@^3.5.4":
+"@math.gl/culling@^3.5.1", "@math.gl/culling@^3.5.4":
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.5.4.tgz#f7b60e7e4259f28bc04d505c1602b5160a64588b"
   integrity sha512-P2XOAxZEm08FjAlwqW5ONcLuMDit88cdiQJ5z6mvmAmJ5kwfKw1L4d6jIEA1YJ3auSuI19iaVdUvCqJUmXLH3Q==
@@ -2388,7 +2388,7 @@
     "@math.gl/core" "3.5.4"
     gl-matrix "^3.0.0"
 
-"@math.gl/geospatial@3.5.4", "@math.gl/geospatial@^3.5.1":
+"@math.gl/geospatial@^3.5.1":
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.5.4.tgz#7f5aa00b512604b659aeea0d599cf9901275351a"
   integrity sha512-iuEz19OXlPs9RxZ1t47B+7t+9hpJ/9LzmceNg8FMXuotZEakF0XVV3Ddi3hG4sy5tTBhbDBt+K22pbEVgwCgtQ==
@@ -2397,14 +2397,14 @@
     "@math.gl/core" "3.5.4"
     gl-matrix "^3.0.0"
 
-"@math.gl/polygon@3.5.4", "@math.gl/polygon@^3.5.1", "@math.gl/polygon@^3.5.4":
+"@math.gl/polygon@^3.5.1", "@math.gl/polygon@^3.5.4":
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/@math.gl/polygon/-/polygon-3.5.4.tgz#61e2545015725d69f5eb382b1a935315e8d8eb94"
   integrity sha512-Qco432yukFC+mJum/CgCVX2AT0JOmSlOhwC2mHQWUJlDLe9mSYZ9SmIKHfxSsY8uRxkzqQAxBJoHPKgyoTJbag==
   dependencies:
     "@math.gl/core" "3.5.4"
 
-"@math.gl/web-mercator@3.5.4", "@math.gl/web-mercator@^3.1.3", "@math.gl/web-mercator@^3.5.1", "@math.gl/web-mercator@^3.5.4":
+"@math.gl/web-mercator@^3.1.3", "@math.gl/web-mercator@^3.5.1", "@math.gl/web-mercator@^3.5.4":
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.5.4.tgz#2eca3136d33a66be665c08de01671c2ebd46867b"
   integrity sha512-oSicpji8Rdyil2xWC5G3UrVVONl3vEvH8F0f6HgZHyQDw1LDiauthnTNIUbdWIvm6TF+WGd+GZ/mMLCmlKs+6w==
@@ -7928,7 +7928,7 @@ mapbox-gl@^1.0.0, mapbox-gl@^1.2.1:
     tinyqueue "^2.0.0"
     vt-pbf "^3.1.1"
 
-math.gl@3.5.4, math.gl@^3.5.4:
+math.gl@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-3.5.4.tgz#80ecebb5268394ab141e4c83c02170d9b8956d3c"
   integrity sha512-WD4PwQ7WoYBcCMDKJUHdYeC+aye0OMrtsp1zHlTXVKpc+r7r0QCfgvoWDSRPeH6hQQt3CipT9HE/zWoM5xu1LA==


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/discussions/6126

[Looks like](https://bugs.webkit.org/show_bug.cgi?id=229508) the issue is going to be fixed in Webkit in a future release.

#### Change List
- Bump luma.gl dependency to bring in this fix: https://github.com/visgl/luma.gl/pull/1491
