### PR TITLE
Remove <String> from CartoLayer doc

### DIFF
--- a/docs/api-reference/carto/carto-layer.md
+++ b/docs/api-reference/carto/carto-layer.md
@@ -117,7 +117,7 @@ Only supported when apiVersion is `API_VERSIONS.V3` and `type` is `MAP_TYPES.TAB
 
 Name of the `geo_column` in the CARTO platform. Use this override the default column ('geom'), from which the geometry information should be fetched.
 
-##### `columns` (Array<String>, optional)
+##### `columns` (Array, optional)
 
 Only supported when apiVersion is `API_VERSIONS.V3` and `type` is `MAP_TYPES.TABLE`.
 


### PR DESCRIPTION
Prevent gatsby build from failing (https://github.com/visgl/deck.gl/runs/3454234729). As no other doc mentions the the type of the object in an Array I just removed the annotation as it was causing gatsby to fail.
