### PR TITLE
Heatmap - expose additional properties

### DIFF
--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -120,6 +120,24 @@ Operation used to aggregate all data point weights to calculate a pixel's color 
 
 The weight of each data object is distributed to all the pixels in a circle centered at the object position. The weight that a pixel receives is inversely proportional to its distance from the center. In `'SUM'` mode, pixels that fall into multiple circles will have the sum of all weights. In `'MEAN'` mode, pixels that fall into multiple circles will have their weight calculated as the weighted average from all the neighboring data points. And the weight of the pixel determines its color. 
 
+##### `weightsTextureSize` (String, optional)
+
+* Default: `2048`
+
+`weightsTextureSize` specifies the size of weight texture. Smaller texture sizes can improve rendering performance.
+
+##### `debounceTimeout` (String, optional)
+
+* Default: `500`
+
+`debounceTimeout` is an interval in milliseconds during which changes to the viewport don't trigger aggregation.
+
+##### `_modifyWeightsTransformShaders` (String, optional)
+
+* Default: `{vs: string, _fs: string} => {vs: string, _fs: string}`
+
+A callback to modify default weight transform shaders.
+
 ### Data Accessors
 
 ##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)

--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -132,12 +132,6 @@ The weight of each data object is distributed to all the pixels in a circle cent
 
 `debounceTimeout` is an interval in milliseconds during which changes to the viewport don't trigger aggregation.
 
-##### `_modifyWeightsTransformShaders` (Function, optional)
-
-* Default: `({vs: string, _fs: string}) => {vs: string, _fs: string}`
-
-A callback to modify default weights transform shaders.
-
 ### Data Accessors
 
 ##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional)

--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -120,23 +120,23 @@ Operation used to aggregate all data point weights to calculate a pixel's color 
 
 The weight of each data object is distributed to all the pixels in a circle centered at the object position. The weight that a pixel receives is inversely proportional to its distance from the center. In `'SUM'` mode, pixels that fall into multiple circles will have the sum of all weights. In `'MEAN'` mode, pixels that fall into multiple circles will have their weight calculated as the weighted average from all the neighboring data points. And the weight of the pixel determines its color. 
 
-##### `weightsTextureSize` (String, optional)
+##### `weightsTextureSize` (Number, optional)
 
 * Default: `2048`
 
 `weightsTextureSize` specifies the size of weight texture. Smaller texture sizes can improve rendering performance.
 
-##### `debounceTimeout` (String, optional)
+##### `debounceTimeout` (Number, optional)
 
 * Default: `500`
 
 `debounceTimeout` is an interval in milliseconds during which changes to the viewport don't trigger aggregation.
 
-##### `_modifyWeightsTransformShaders` (String, optional)
+##### `_modifyWeightsTransformShaders` (Function, optional)
 
-* Default: `{vs: string, _fs: string} => {vs: string, _fs: string}`
+* Default: `({vs: string, _fs: string}) => {vs: string, _fs: string}`
 
-A callback to modify default weight transform shaders.
+A callback to modify default weights transform shaders.
 
 ### Data Accessors
 

--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -124,13 +124,13 @@ The weight of each data object is distributed to all the pixels in a circle cent
 
 * Default: `2048`
 
-`weightsTextureSize` specifies the size of weight texture. Smaller texture sizes can improve rendering performance.
+`weightsTextureSize` specifies the size of weight texture. Smaller texture sizes can improve rendering performance. Heatmap aggregation calculates the maximum weight value in the texture and the process can take 50-100 ms for 2048x2048 texture, but only 5-7ms for 512x512 texture. Smaller texture sizes lead to visible pixelation.
 
 ##### `debounceTimeout` (Number, optional)
 
 * Default: `500`
 
-`debounceTimeout` is an interval in milliseconds during which changes to the viewport don't trigger aggregation.
+`debounceTimeout` is an interval in milliseconds during which changes to the viewport don't trigger aggregation. Large datasets combined with a large `radiusPixels` can cause freezes during user interactions due to aggregation updates. Setting positive debounceTimeout delays aggregation updates and prevents freezes during the interaction. As a side effect, the user has to wait to see updated results after the end of the interaction. 
 
 ### Data Accessors
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -71,9 +71,7 @@ const defaultProps = {
   // 'SUM' or 'MEAN'
   aggregation: 'SUM',
   weightsTextureSize: {type: 'number', min: 128, max: 2048, value: 2048},
-  debounceTimeout: {type: 'number', min: 0, max: 1000, value: 500},
-
-  _modifyWeightsTransformShaders: shaderInfo => shaderInfo
+  debounceTimeout: {type: 'number', min: 0, max: 1000, value: 500}
 };
 
 const REQUIRED_FEATURES = [
@@ -284,14 +282,17 @@ export default class HeatmapLayer extends AggregationLayer {
     }
   }
 
+  _getWeightsTransformShaders() {
+    return {vs: weights_vs, _fs: weights_fs};
+  }
+
   _createWeightsTransform(shaderOptions = {}) {
     const {gl} = this.context;
-    const {_modifyWeightsTransformShaders} = this.props;
     let {weightsTransform} = this.state;
     const {weightsTexture} = this.state;
     weightsTransform?.delete();
 
-    const shaderInfo = _modifyWeightsTransformShaders({vs: weights_vs, _fs: weights_fs});
+    const shaderInfo = this._getWeightsTransformShaders();
     const shaders = mergeShaders(shaderInfo, shaderOptions);
 
     weightsTransform = new Transform(gl, {
@@ -508,7 +509,7 @@ export default class HeatmapLayer extends AggregationLayer {
       // update
       this._updateBounds(true);
       this._updateTextureRenderingBounds();
-      this._updateWeightmap();
+      this.setState({isWeightMapDirty: true});
     } else {
       this.setState({isWeightMapDirty: false});
       clearTimeout(updateTimer);

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -107,7 +107,6 @@ export default class HeatmapLayer extends AggregationLayer {
       return;
     }
     super.updateState(opts);
-
     this._updateHeatmapState(opts);
   }
 
@@ -315,9 +314,11 @@ export default class HeatmapLayer extends AggregationLayer {
     const {gl} = this.context;
     this._createTextures();
     const {textureSize, weightsTexture, maxWeightsTexture} = this.state;
-    this._createWeightsTransform(this.getShaders('weights-transform'));
 
-    const maxWeightsShaders = this.getShaders('max-weights-transform');
+    const weightsTransformShaders = this.getShaders('weights-transform');
+    this._createWeightsTransform(weightsTransformShaders);
+
+    const maxWeightsTransformShaders = this.getShaders('max-weights-transform');
     const maxWeightTransform = new Transform(gl, {
       id: `${this.id}-max-weights-transform`,
       _sourceTextures: {
@@ -325,8 +326,7 @@ export default class HeatmapLayer extends AggregationLayer {
       },
       _targetTexture: maxWeightsTexture,
       _targetTextureVarying: 'outTexture',
-      vs: maxWeightsShaders.vs,
-      _fs: maxWeightsShaders._fs,
+      ...maxWeightsTransformShaders,
       elementCount: textureSize * textureSize
     });
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -29,12 +29,7 @@ import {
   getTextureParams
 } from './heatmap-layer-utils';
 import {Buffer, Texture2D, Transform, getParameters, FEATURES, hasFeatures} from '@luma.gl/core';
-import {
-  AttributeManager,
-  COORDINATE_SYSTEM,
-  log,
-  _mergeShaders as mergeShaders
-} from '@deck.gl/core';
+import {AttributeManager, COORDINATE_SYSTEM, log} from '@deck.gl/core';
 import TriangleLayer from './triangle-layer';
 import AggregationLayer from '../aggregation-layer';
 import {defaultColorRange, colorRangeToFlatArray} from '../utils/color-utils';

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -114,10 +114,11 @@ export default class HeatmapLayer extends AggregationLayer {
       return;
     }
     super.updateState(opts);
-    this.updateStateLogic(opts);
+
+    this._updateHeatmapState(opts);
   }
 
-  updateStateLogic(opts) {
+  _updateHeatmapState(opts) {
     const {props, oldProps} = opts;
     const changeFlags = this._getChangeFlags(opts);
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -73,7 +73,7 @@ const defaultProps = {
   weightsTextureSize: {type: 'number', min: 128, max: 2048, value: 2048},
   debounceTimeout: {type: 'number', min: 0, max: 1000, value: 500},
 
-  _modifyWeightsTransformShaders: f => f
+  _modifyWeightsTransformShaders: shaderInfo => shaderInfo
 };
 
 const REQUIRED_FEATURES = [

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -276,10 +276,6 @@ export default class HeatmapLayer extends AggregationLayer {
     }
   }
 
-  _getWeightsTransformShaders() {
-    return {vs: weights_vs, _fs: weights_fs};
-  }
-
   getShaders(type) {
     return super.getShaders(
       type === 'max-weights-transform'


### PR DESCRIPTION
For #6157

#### Change List
- debounceTimeout prop for Heatmap layer to control debounce timeout by adjusting it based on dataset size and radius.
- weightsTextureSize prop for Heatmap to control performance of max-weight calculation, rendering quality, memory usage.
- HeatmapLayer::getShaders methods can be used to override weights transform shaders in extended layers.
- heatmap-related logic from updateState is moved to _updateHeatmapState method to be able to override it in an extended class.