### PR TITLE
Drop sublayers with no data even if the _subLayerProps prop contains

### DIFF
--- a/docs/api-reference/core/composite-layer.md
+++ b/docs/api-reference/core/composite-layer.md
@@ -270,7 +270,7 @@ Parameters:
 * `id` (String) - the sublayer id
 * `data` (Array) - the sublayer data
 
-Returns `true` if the sublayer should be rendered. The base class implementation returns `true` if either `data` is not empty or the `_subLayerProps` prop contains override for this sublayer.
+Returns `true` if the sublayer should be rendered. The base class implementation returns `true` if `data` is not empty.
 
 
 ##### `getSubLayerClass`

--- a/modules/core/src/lib/composite-layer.js
+++ b/modules/core/src/lib/composite-layer.js
@@ -90,9 +90,7 @@ export default class CompositeLayer extends Layer {
 
   // Returns true if sub layer needs to be rendered
   shouldRenderSubLayer(id, data) {
-    const {_subLayerProps: overridingProps} = this.props;
-
-    return (data && data.length) || (overridingProps && overridingProps[id]);
+    return data && data.length;
   }
 
   // Returns sub layer class for a specific sublayer


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #6149

<!-- For all the PRs -->
#### Change List
- Drop checking `_subLayerProps` exists or not in `shouldRenderSubLayer`