### PR TITLE
Google overlay state synchronization

### DIFF
--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -157,7 +157,13 @@ export default class GoogleMapsOverlay {
 
     deck.setProps({
       ...getViewPropsFromCoordinateTransformer(this._map, coordinateTransformer),
-      _customRender: () => {}
+      _customRender: reason => {
+        if (reason !== 'viewState changed') {
+          // The viewState is controlled by Google Maps, but other
+          // renders need to explicitly trigger a redraw
+          this._overlay.requestRedraw();
+        }
+      }
     });
 
     if (deck.layerManager) {
@@ -177,8 +183,6 @@ export default class GoogleMapsOverlay {
           stencilFunc: [gl.ALWAYS, 0, 255, gl.ALWAYS, 0, 255]
         });
       }
-
-      //this._overlay.requestRedraw();
 
       withParameters(gl, GL_STATE, () => {
         deck._drawLayers('google-vector', {

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -158,11 +158,7 @@ export default class GoogleMapsOverlay {
     deck.setProps({
       ...getViewPropsFromCoordinateTransformer(this._map, coordinateTransformer),
       _customRender: reason => {
-        if (reason !== 'viewState changed') {
-          // The viewState is controlled by Google Maps, but other
-          // renders need to explicitly trigger a redraw
-          this._overlay.requestRedraw();
-        }
+        this._overlay.requestRedraw();
       }
     });
 
@@ -171,6 +167,11 @@ export default class GoogleMapsOverlay {
       // which we need to pass onto deck
       const _framebuffer = getParameters(gl, GL.FRAMEBUFFER_BINDING);
       deck.setProps({_framebuffer});
+
+      // Camera changed, will trigger a map repaint right after this
+      // Clear any change flag triggered by setting viewState so that deck does not request
+      // a second repaint
+      deck.needsRedraw({clearRedrawFlags: true});
 
       // Workaround for bug in Google maps where viewport state is wrong
       // TODO remove once fixed

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -169,7 +169,7 @@ export default class GoogleMapsOverlay {
     if (deck.layerManager) {
       // As an optimization, some renders are to an separate framebuffer
       // which we need to pass onto deck
-      const _framebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+      const _framebuffer = getParameters(gl, GL.FRAMEBUFFER_BINDING);
       deck.setProps({_framebuffer});
 
       // Workaround for bug in Google maps where viewport state is wrong

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -111,7 +111,14 @@ export default class GoogleMapsOverlay {
   }
 
   _onContextRestored(gl) {
-    this._deck = createDeckInstance(this._map, this._overlay, this._deck, {gl, ...this.props});
+    const _customRender = () => {
+      this._overlay.requestRedraw();
+    };
+    this._deck = createDeckInstance(this._map, this._overlay, this._deck, {
+      gl,
+      _customRender,
+      ...this.props
+    });
   }
 
   _onContextLost() {

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -156,7 +156,8 @@ export default class GoogleMapsOverlay {
     const deck = this._deck;
 
     deck.setProps({
-      ...getViewPropsFromCoordinateTransformer(this._map, coordinateTransformer)
+      ...getViewPropsFromCoordinateTransformer(this._map, coordinateTransformer),
+      _customRender: () => {}
     });
 
     if (deck.layerManager) {

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -161,7 +161,13 @@ export default class GoogleMapsOverlay {
     });
 
     if (deck.layerManager) {
-      this._overlay.requestRedraw();
+      // As an optimization, some renders are to an separate framebuffer
+      // which we need to pass onto deck
+      const _framebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+      deck.setProps({_framebuffer});
+
+      //this._overlay.requestRedraw();
+
       withParameters(gl, GL_STATE, () => {
         deck._drawLayers('google-vector', {
           clearCanvas: false

--- a/modules/google-maps/src/google-maps-overlay.js
+++ b/modules/google-maps/src/google-maps-overlay.js
@@ -156,10 +156,7 @@ export default class GoogleMapsOverlay {
     const deck = this._deck;
 
     deck.setProps({
-      ...getViewPropsFromCoordinateTransformer(this._map, coordinateTransformer),
-      _customRender: reason => {
-        this._overlay.requestRedraw();
-      }
+      ...getViewPropsFromCoordinateTransformer(this._map, coordinateTransformer)
     });
 
     if (deck.layerManager) {
@@ -175,15 +172,11 @@ export default class GoogleMapsOverlay {
 
       // Workaround for bug in Google maps where viewport state is wrong
       // TODO remove once fixed
-      const viewport = getParameters(gl, GL.VIEWPORT);
-      const canvasViewport = [0, 0, gl.canvas.width, gl.canvas.height];
-      if (!canvasViewport.every((v, i) => v === viewport[i])) {
-        setParameters(gl, {
-          viewport: [0, 0, gl.canvas.width, gl.canvas.height],
-          scissor: [0, 0, gl.canvas.width, gl.canvas.height],
-          stencilFunc: [gl.ALWAYS, 0, 255, gl.ALWAYS, 0, 255]
-        });
-      }
+      setParameters(gl, {
+        viewport: [0, 0, gl.canvas.width, gl.canvas.height],
+        scissor: [0, 0, gl.canvas.width, gl.canvas.height],
+        stencilFunc: [gl.ALWAYS, 0, 255, gl.ALWAYS, 0, 255]
+      });
 
       withParameters(gl, GL_STATE, () => {
         deck._drawLayers('google-vector', {

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -37,9 +37,6 @@ export function createDeckInstance(map, overlay, deck, props) {
       zoom: 1
     },
     controller: false,
-    _customRender: () => {
-      overlay.requestRedraw();
-    },
     userData: {
       _googleMap: map,
       _eventListeners: eventListeners

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -188,8 +188,9 @@ export function getViewPropsFromCoordinateTransformer(map, coordinateTransformer
   const focalDistance = 0.5 * projectionMatrix[5];
 
   return {
-    width,
-    height,
+    // Using external gl context - do not set css size
+    width: false,
+    height: false,
     viewState: {
       altitude: focalDistance,
       bearing,

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -37,6 +37,9 @@ export function createDeckInstance(map, overlay, deck, props) {
       zoom: 1
     },
     controller: false,
+    _customRender: () => {
+      overlay.requestRedraw();
+    },
     userData: {
       _googleMap: map,
       _eventListeners: eventListeners

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -228,7 +228,6 @@ function getEventPixel(event, deck) {
 
 // Triggers picking on a mouse event
 function handleMouseEvent(deck, type, event) {
-  return; // Disable event handling to avoid touching state outside of lifecycle methods
   const mockEvent = {
     type,
     offsetCenter: getEventPixel(event, deck),

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -228,6 +228,7 @@ function getEventPixel(event, deck) {
 
 // Triggers picking on a mouse event
 function handleMouseEvent(deck, type, event) {
+  return; // Disable event handling to avoid touching state outside of lifecycle methods
   const mockEvent = {
     type,
     offsetCenter: getEventPixel(event, deck),

--- a/test/modules/google-maps/google-maps-overlay.spec.js
+++ b/test/modules/google-maps/google-maps-overlay.spec.js
@@ -156,8 +156,13 @@ function drawPickTest(renderingType) {
     t.ok(equals(viewState.longitude, map.opts.longitude), 'longitude is set');
     t.ok(equals(viewState.latitude, map.opts.latitude), 'latitude is set');
     t.ok(equals(viewState.zoom, map.opts.zoom - 1), 'zoom is set');
-    t.ok(equals(width, map.opts.width), 'width is set');
-    t.ok(equals(height, map.opts.height), 'height is set');
+    if (renderingType === mapsApi.RenderingType.RASTER) {
+      t.ok(equals(width, map.opts.width), 'width is set');
+      t.ok(equals(height, map.opts.height), 'height is set');
+    } else {
+      t.ok(equals(width, false), 'width is not set');
+      t.ok(equals(height, false), 'height is not set');
+    }
 
     if (renderingType === mapsApi.RenderingType.RASTER) {
       t.notOk(deck.props.layerFilter, 'layerFilter is empty');


### PR DESCRIPTION
https://github.com/visgl/deck.gl/issues/5980

#### Background

We were seeing issues with the integration where the Google basemap didn't display due to deck.gl changing WebGL state when the Google library didn't expect it

#### Change List

- Disable rendering using the deck.gl animation loop to ensure we only modify GL state in the Google `onDraw` lifecycle method
- Workaround for incorrect view state (hopefully we can remove this in the future if Google resolve on their end)
- Support rendering to framebuffer when present (supports optimized render path for Google maps)
- No longer need to continuously render (due to framebuffer fix)
- Animated layers and other state changed correctly request rerender via Google maps
