### PR TITLE
TileLayer uses props.extent to cull tiles in geospatial mode

### DIFF
--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -154,24 +154,21 @@ This offset changes the zoom level at which the tiles are fetched.  Needs to be 
 
 ##### `maxZoom` (Number|Null, optional)
 
-Use tiles from this level when over-zoomed.
+The max zoom level of the layer's data. When overzoomed (i.e. `zoom > maxZoom`), tiles from this level will be displayed.
 
 - Default: `null`
 
-
 ##### `minZoom` (Number, optional)
 
-Hide tiles when under-zoomed.
+The min zoom level of the layer's data. When underzoomed (i.e. `zoom < minZoom`), the layer will not display any tiles unless `extent` is defined, to avoid issuing too many tile requests.
 
 - Default: 0
 
 ##### `extent` (Array, optional)
 
-If provided, the layer will load and render the tiles in this box at `minZoom` when underzoomed (i.e. `zoom < minZoom`).  The box is of the form `[minX, minY, maxX, maxY]`.
+The bounding box of the layer's data, in the form of `[minX, minY, maxX, maxY]`. If provided, the layer will only load and render the tiles that are needed to fill this box. 
 
-If `null`, the layer will not display any tiles when underzoomed to avoid issuing too many tile requests.
-
-- Default: null
+- Default: `null`
 
 
 ##### `maxCacheSize` (Number, optional)

--- a/modules/geo-layers/src/tile-layer/utils.js
+++ b/modules/geo-layers/src/tile-layer/utils.js
@@ -197,7 +197,7 @@ export function getTileIndices({
     transformedExtent = transformBox(extent, modelMatrix);
   }
   return viewport.isGeospatial
-    ? getOSMTileIndices(viewport, z, zRange, extent || DEFAULT_EXTENT)
+    ? getOSMTileIndices(viewport, z, zRange, extent)
     : getIdentityTileIndices(
         viewport,
         z,

--- a/test/modules/geo-layers/tile-layer/utils.spec.js
+++ b/test/modules/geo-layers/tile-layer/utils.spec.js
@@ -38,6 +38,22 @@ const TEST_CASES = [
     output: ['0,2,3', '0,3,3', '1,2,3', '1,3,3', '2,1,3', '2,2,3', '2,3,3', '3,2,3', '3,3,3']
   },
   {
+    title: 'tilted viewport with extent',
+    viewport: new WebMercatorViewport({
+      width: 800,
+      height: 400,
+      pitch: 30,
+      bearing: -25,
+      longitude: -90,
+      latitude: 45,
+      zoom: 2.5
+    }),
+    minZoom: undefined,
+    maxZoom: undefined,
+    extent: [-90, 30, 0, 60],
+    output: ['2,2,3', '2,3,3', '3,2,3', '3,3,3']
+  },
+  {
     title: 'extreme pitch',
     viewport: new WebMercatorViewport({
       width: 800,


### PR DESCRIPTION
For #6188


#### Change List
- Check tiles against `extent` in geospatial mode
- Clarify behavior in documentation
