### PR TITLE
TileLayer retains cache on data change

### DIFF
--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -290,7 +290,8 @@ Properties:
 - `y` (Number) - y index of the tile
 - `z` (Number) - z index of the tile
 - `bbox` (Object) - bounding box of the tile. When used with a geospatial view, `bbox` is in the shape of `{west: <longitude>, north: <latitude>, east: <longitude>, south: <latitude>}`. When used with a non-geospatial view, `bbox` is in the shape of `{left, top, right, bottom}`.
-- `data` (Array) - tiles content as returned by `getTileData`. 
+- `content` (Object) - the tile's cached content. `null` if the tile's initial load is pending, cancelled, or encountered an error.
+- `data` (Object|Promise) - the tile's requested content. If the tile is loading, returns a Promise that resolves to the loaded content when loading is completed.
 
 ## Source
 

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -198,7 +198,7 @@ export default class MVTLayer extends TileLayer {
   getHighlightedObjectIndex(tile) {
     const {hoveredFeatureId, hoveredFeatureLayerName} = this.state;
     const {uniqueIdProperty, highlightedFeatureId, binary} = this.props;
-    const {data} = tile;
+    const data = tile.content;
 
     const isHighlighted = isFeatureIdDefined(highlightedFeatureId);
     const isFeatureIdPresent = isFeatureIdDefined(hoveredFeatureId) || isHighlighted;

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -45,58 +45,52 @@ export default class Tile2DHeader {
 
   /* eslint-disable max-statements */
   async _loadData(getTileData, requestScheduler) {
+    const {x, y, z, bbox} = this;
+
+    this._abortController = new AbortController(); // eslint-disable-line no-undef
+    const {signal} = this._abortController;
+    this._isLoaded = false;
+    const requestToken = await requestScheduler.scheduleRequest(this, tile => {
+      return tile.isSelected ? 1 : -1;
+    });
+
+    if (!requestToken) {
+      this._isCancelled = true;
+      return;
+    }
+    // A tile can be cancelled while being scheduled
+    if (this._isCancelled) {
+      requestToken.done();
+      return;
+    }
+
+    let tileData;
+    let error;
     try {
-      const {x, y, z, bbox} = this;
-
-      this._abortController = new AbortController(); // eslint-disable-line no-undef
-      const {signal} = this._abortController;
-      this._isLoaded = false;
-      console.log('here!', x, y, z); // eslint-disable-line
-      const requestToken = await requestScheduler.scheduleRequest(this, tile => {
-        return tile.isSelected ? 1 : -1;
-      });
-      console.log('here!', x, y, z); // eslint-disable-line
-
-      if (!requestToken) {
-        this._isCancelled = true;
-        return;
-      }
-      // A tile can be cancelled while being scheduled
-      if (this._isCancelled) {
-        requestToken.done();
-        return;
-      }
-
-      let tileData;
-      let error;
-      try {
-        tileData = await getTileData({x, y, z, bbox, signal});
-      } catch (err) {
-        error = err || true;
-      } finally {
-        requestToken.done();
-
-        if (this._isCancelled && !tileData) {
-          this._isLoaded = false;
-        } else {
-          // Consider it loaded if we tried to cancel but `getTileData` still returned data
-          this._isLoaded = true;
-          this._isCancelled = false;
-        }
-      }
-
-      if (!this._isLoaded) {
-        return;
-      }
-
-      if (error) {
-        this.onTileError(error, this);
-      } else {
-        this.content = tileData;
-        this.onTileLoad(this);
-      }
+      tileData = await getTileData({x, y, z, bbox, signal});
     } catch (err) {
-      console.log(err); // eslint-disable-line
+      error = err || true;
+    } finally {
+      requestToken.done();
+
+      if (this._isCancelled && !tileData) {
+        this._isLoaded = false;
+      } else {
+        // Consider it loaded if we tried to cancel but `getTileData` still returned data
+        this._isLoaded = true;
+        this._isCancelled = false;
+      }
+    }
+
+    if (!this._isLoaded) {
+      return;
+    }
+
+    if (error) {
+      this.onTileError(error, this);
+    } else {
+      this.content = tileData;
+      this.onTileLoad(this);
     }
   }
   /* eslint-enable max-statements */

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -45,52 +45,58 @@ export default class Tile2DHeader {
 
   /* eslint-disable max-statements */
   async _loadData(getTileData, requestScheduler) {
-    const {x, y, z, bbox} = this;
-
-    this._abortController = new AbortController(); // eslint-disable-line no-undef
-    const {signal} = this._abortController;
-    this._isLoaded = false;
-    const requestToken = await requestScheduler.scheduleRequest(this, tile => {
-      return tile.isSelected ? 1 : -1;
-    });
-
-    if (!requestToken) {
-      this._isCancelled = true;
-      return;
-    }
-    // A tile can be cancelled while being scheduled
-    if (this._isCancelled) {
-      requestToken.done();
-      return;
-    }
-
-    let tileData;
-    let error;
     try {
-      tileData = await getTileData({x, y, z, bbox, signal});
-    } catch (err) {
-      error = err || true;
-    } finally {
-      requestToken.done();
+      const {x, y, z, bbox} = this;
 
-      if (this._isCancelled && !tileData) {
-        this._isLoaded = false;
-      } else {
-        // Consider it loaded if we tried to cancel but `getTileData` still returned data
-        this._isLoaded = true;
-        this._isCancelled = false;
+      this._abortController = new AbortController(); // eslint-disable-line no-undef
+      const {signal} = this._abortController;
+      this._isLoaded = false;
+      console.log('here!', x, y, z); // eslint-disable-line
+      const requestToken = await requestScheduler.scheduleRequest(this, tile => {
+        return tile.isSelected ? 1 : -1;
+      });
+      console.log('here!', x, y, z); // eslint-disable-line
+
+      if (!requestToken) {
+        this._isCancelled = true;
+        return;
       }
-    }
+      // A tile can be cancelled while being scheduled
+      if (this._isCancelled) {
+        requestToken.done();
+        return;
+      }
 
-    if (!this._isLoaded) {
-      return;
-    }
+      let tileData;
+      let error;
+      try {
+        tileData = await getTileData({x, y, z, bbox, signal});
+      } catch (err) {
+        error = err || true;
+      } finally {
+        requestToken.done();
 
-    if (error) {
-      this.onTileError(error, this);
-    } else {
-      this.content = tileData;
-      this.onTileLoad(this);
+        if (this._isCancelled && !tileData) {
+          this._isLoaded = false;
+        } else {
+          // Consider it loaded if we tried to cancel but `getTileData` still returned data
+          this._isLoaded = true;
+          this._isCancelled = false;
+        }
+      }
+
+      if (!this._isLoaded) {
+        return;
+      }
+
+      if (error) {
+        this.onTileError(error, this);
+      } else {
+        this.content = tileData;
+        this.onTileLoad(this);
+      }
+    } catch (err) {
+      console.log(err); // eslint-disable-line
     }
   }
   /* eslint-enable max-statements */

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -45,52 +45,58 @@ export default class Tile2DHeader {
 
   /* eslint-disable max-statements */
   async _loadData(getTileData, requestScheduler) {
-    const {x, y, z, bbox} = this;
-
-    this._abortController = new AbortController(); // eslint-disable-line no-undef
-    const {signal} = this._abortController;
-    this._isLoaded = false;
-    const requestToken = await requestScheduler.scheduleRequest(this, tile => {
-      return tile.isSelected ? 1 : -1;
-    });
-
-    if (!requestToken) {
-      this._isCancelled = true;
-      return;
-    }
-    // A tile can be cancelled while being scheduled
-    if (this._isCancelled) {
-      requestToken.done();
-      return;
-    }
-
-    let tileData;
-    let error;
     try {
-      tileData = await getTileData({x, y, z, bbox, signal});
-    } catch (err) {
-      error = err || true;
-    } finally {
-      requestToken.done();
+      const {x, y, z, bbox} = this;
 
-      if (this._isCancelled && !tileData) {
-        this._isLoaded = false;
-      } else {
-        // Consider it loaded if we tried to cancel but `getTileData` still returned data
-        this._isLoaded = true;
-        this._isCancelled = false;
+      this._abortController = new AbortController(); // eslint-disable-line no-undef
+      const {signal} = this._abortController;
+      this._isLoaded = false;
+      console.log('waiting for request token!'); // eslint-disable-line
+      const requestToken = await requestScheduler.scheduleRequest(this, tile => {
+        return tile.isSelected ? 1 : -1;
+      });
+      console.log('got request token!'); // eslint-disable-line
+
+      if (!requestToken) {
+        this._isCancelled = true;
+        return;
       }
-    }
+      // A tile can be cancelled while being scheduled
+      if (this._isCancelled) {
+        requestToken.done();
+        return;
+      }
 
-    if (!this._isLoaded) {
-      return;
-    }
+      let tileData;
+      let error;
+      try {
+        tileData = await getTileData({x, y, z, bbox, signal});
+      } catch (err) {
+        error = err || true;
+      } finally {
+        requestToken.done();
 
-    if (error) {
-      this.onTileError(error, this);
-    } else {
-      this.content = tileData;
-      this.onTileLoad(this);
+        if (this._isCancelled && !tileData) {
+          this._isLoaded = false;
+        } else {
+          // Consider it loaded if we tried to cancel but `getTileData` still returned data
+          this._isLoaded = true;
+          this._isCancelled = false;
+        }
+      }
+
+      if (!this._isLoaded) {
+        return;
+      }
+
+      if (error) {
+        this.onTileError(error, this);
+      } else {
+        this.content = tileData;
+        this.onTileLoad(this);
+      }
+    } catch (err) {
+      console.log(err); // eslint-disable-line
     }
   }
   /* eslint-enable max-statements */

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -45,52 +45,58 @@ export default class Tile2DHeader {
 
   /* eslint-disable max-statements */
   async _loadData(getTileData, requestScheduler) {
-    const {x, y, z, bbox} = this;
-
-    this._abortController = new AbortController(); // eslint-disable-line no-undef
-    const {signal} = this._abortController;
-
-    const requestToken = await requestScheduler.scheduleRequest(this, tile => {
-      return tile.isSelected ? 1 : -1;
-    });
-
-    if (!requestToken) {
-      this._isCancelled = true;
-      return;
-    }
-    // A tile can be cancelled while being scheduled
-    if (this._isCancelled) {
-      requestToken.done();
-      return;
-    }
-
-    let tileData;
-    let error;
     try {
-      tileData = await getTileData({x, y, z, bbox, signal});
-    } catch (err) {
-      error = err || true;
-    } finally {
-      requestToken.done();
+      const {x, y, z, bbox} = this;
 
-      if (this._isCancelled && !tileData) {
-        this._isLoaded = false;
-      } else {
-        // Consider it loaded if we tried to cancel but `getTileData` still returned data
-        this._isLoaded = true;
-        this._isCancelled = false;
+      this._abortController = new AbortController(); // eslint-disable-line no-undef
+      const {signal} = this._abortController;
+      this._isLoaded = false;
+      console.log('here!', x, y, z); // eslint-disable-line
+      const requestToken = await requestScheduler.scheduleRequest(this, tile => {
+        return tile.isSelected ? 1 : -1;
+      });
+      console.log('here!', x, y, z); // eslint-disable-line
+
+      if (!requestToken) {
+        this._isCancelled = true;
+        return;
       }
-    }
+      // A tile can be cancelled while being scheduled
+      if (this._isCancelled) {
+        requestToken.done();
+        return;
+      }
 
-    if (!this._isLoaded) {
-      return;
-    }
+      let tileData;
+      let error;
+      try {
+        tileData = await getTileData({x, y, z, bbox, signal});
+      } catch (err) {
+        error = err || true;
+      } finally {
+        requestToken.done();
 
-    if (error) {
-      this.onTileError(error, this);
-    } else {
-      this.content = tileData;
-      this.onTileLoad(this);
+        if (this._isCancelled && !tileData) {
+          this._isLoaded = false;
+        } else {
+          // Consider it loaded if we tried to cancel but `getTileData` still returned data
+          this._isLoaded = true;
+          this._isCancelled = false;
+        }
+      }
+
+      if (!this._isLoaded) {
+        return;
+      }
+
+      if (error) {
+        this.onTileError(error, this);
+      } else {
+        this.content = tileData;
+        this.onTileLoad(this);
+      }
+    } catch (err) {
+      console.log(err); // eslint-disable-line
     }
   }
   /* eslint-enable max-statements */

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -45,58 +45,52 @@ export default class Tile2DHeader {
 
   /* eslint-disable max-statements */
   async _loadData(getTileData, requestScheduler) {
+    const {x, y, z, bbox} = this;
+
+    this._abortController = new AbortController(); // eslint-disable-line no-undef
+    const {signal} = this._abortController;
+    this._isLoaded = false;
+    const requestToken = await requestScheduler.scheduleRequest(this, tile => {
+      return tile.isSelected ? 1 : -1;
+    });
+
+    if (!requestToken) {
+      this._isCancelled = true;
+      return;
+    }
+    // A tile can be cancelled while being scheduled
+    if (this._isCancelled) {
+      requestToken.done();
+      return;
+    }
+
+    let tileData;
+    let error;
     try {
-      const {x, y, z, bbox} = this;
-
-      this._abortController = new AbortController(); // eslint-disable-line no-undef
-      const {signal} = this._abortController;
-      this._isLoaded = false;
-      console.log('waiting for request token!'); // eslint-disable-line
-      const requestToken = await requestScheduler.scheduleRequest(this, tile => {
-        return tile.isSelected ? 1 : -1;
-      });
-      console.log('got request token!'); // eslint-disable-line
-
-      if (!requestToken) {
-        this._isCancelled = true;
-        return;
-      }
-      // A tile can be cancelled while being scheduled
-      if (this._isCancelled) {
-        requestToken.done();
-        return;
-      }
-
-      let tileData;
-      let error;
-      try {
-        tileData = await getTileData({x, y, z, bbox, signal});
-      } catch (err) {
-        error = err || true;
-      } finally {
-        requestToken.done();
-
-        if (this._isCancelled && !tileData) {
-          this._isLoaded = false;
-        } else {
-          // Consider it loaded if we tried to cancel but `getTileData` still returned data
-          this._isLoaded = true;
-          this._isCancelled = false;
-        }
-      }
-
-      if (!this._isLoaded) {
-        return;
-      }
-
-      if (error) {
-        this.onTileError(error, this);
-      } else {
-        this.content = tileData;
-        this.onTileLoad(this);
-      }
+      tileData = await getTileData({x, y, z, bbox, signal});
     } catch (err) {
-      console.log(err); // eslint-disable-line
+      error = err || true;
+    } finally {
+      requestToken.done();
+
+      if (this._isCancelled && !tileData) {
+        this._isLoaded = false;
+      } else {
+        // Consider it loaded if we tried to cancel but `getTileData` still returned data
+        this._isLoaded = true;
+        this._isCancelled = false;
+      }
+    }
+
+    if (!this._isLoaded) {
+      return;
+    }
+
+    if (error) {
+      this.onTileError(error, this);
+    } else {
+      this.content = tileData;
+      this.onTileLoad(this);
     }
   }
   /* eslint-enable max-statements */

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -20,7 +20,7 @@ export default class Tile2DHeader {
   }
 
   get data() {
-    return this._isLoaded || this._isCancelled ? this.content : this._loader.then(() => this.data);
+    return this.isLoading ? this._loader.then(() => this.data) : this.content;
   }
 
   get isLoaded() {

--- a/modules/geo-layers/src/tile-layer/tile-2d-header.js
+++ b/modules/geo-layers/src/tile-layer/tile-2d-header.js
@@ -20,19 +20,15 @@ export default class Tile2DHeader {
   }
 
   get data() {
-    return this._isLoaded ? this.content : this._loader;
+    return this._isLoaded || this._isCancelled ? this.content : this._loader.then(() => this.data);
   }
 
   get isLoaded() {
-    return this._isLoaded;
+    return this._isLoaded && !this._needsReload;
   }
 
   get isLoading() {
-    return Boolean(this._loader);
-  }
-
-  get isCancelled() {
-    return this._isCancelled;
+    return Boolean(this._loader) && !this._isCancelled;
   }
 
   get needsReload() {
@@ -106,6 +102,7 @@ export default class Tile2DHeader {
   /* eslint-enable max-statements */
 
   loadData(opts) {
+    this._isLoaded = false;
     this._isCancelled = false;
     this._needsReload = false;
     this._loaderId++;

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -57,42 +57,28 @@ export default class TileLayer extends CompositeLayer {
       changeFlags.dataChanged ||
       (changeFlags.updateTriggersChanged &&
         (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getTileData));
+
     if (createTileCache) {
-      const opts = {
+      if (tileset) {
+        tileset.finalize();
+      }
+      tileset = new Tileset2D({
         ...this._getTilesetOptions(props),
         getTileData: this.getTileData.bind(this),
         onTileLoad: this._onTileLoad.bind(this),
         onTileError: this._onTileError.bind(this),
         onTileUnload: this._onTileUnload.bind(this)
-      };
-      let reload = false;
-      // If there is a tileset already, update it and force a reload.
-      if (tileset) {
-        reload = true;
-        tileset.finalize();
-        tileset.loadOptions(opts);
-        this._updateTileset(tileset, reload);
-        // Otherwise, we need to create a new tileset.
-      } else {
-        tileset = new Tileset2D(opts);
-        this._updateTileset(tileset, reload);
-        this.setState({tileset});
-      }
-      // Force an update of the tile layers without deleting them to prevent skipped frames.
-      tileset.tiles.forEach(tile => {
-        tile.updateLayers = true;
       });
+      this.setState({tileset});
     } else if (changeFlags.propsChanged || changeFlags.updateTriggersChanged) {
       tileset.setOptions(this._getTilesetOptions(props));
       // if any props changed, delete the cached layers
-      // Should we do the same as the above?  Not delete but use a boolean to cause an update?
-      tileset.tiles.forEach(tile => {
+      this.state.tileset.tiles.forEach(tile => {
         tile.layers = null;
       });
-      this._updateTileset(tileset);
-    } else {
-      this._updateTileset(tileset);
     }
+
+    this._updateTileset();
   }
 
   _getTilesetOptions(props) {
@@ -121,19 +107,17 @@ export default class TileLayer extends CompositeLayer {
     };
   }
 
-  _updateTileset(tileset, reload = false) {
+  _updateTileset() {
+    const {tileset} = this.state;
     const {zRange, modelMatrix} = this.props;
     const frameNumber = tileset.update(this.context.viewport, {zRange, modelMatrix});
-    if (reload) {
-      tileset.reload();
-    }
     const {isLoaded} = tileset;
 
     const loadingStateChanged = this.state.isLoaded !== isLoaded;
     const tilesetChanged = this.state.frameNumber !== frameNumber;
 
     if (isLoaded && (loadingStateChanged || tilesetChanged)) {
-      this._onViewportLoad(tileset);
+      this._onViewportLoad();
     }
 
     if (tilesetChanged) {
@@ -144,7 +128,8 @@ export default class TileLayer extends CompositeLayer {
     this.state.isLoaded = isLoaded;
   }
 
-  _onViewportLoad(tileset) {
+  _onViewportLoad() {
+    const {tileset} = this.state;
     const {onViewportLoad} = this.props;
 
     if (onViewportLoad) {
@@ -165,7 +150,7 @@ export default class TileLayer extends CompositeLayer {
     const layer = this.getCurrentLayer();
     layer.props.onTileError(error);
     // errorred tiles should not block rendering, are considered "loaded" with empty data
-    layer._updateTileset(this.state.tileset);
+    layer._updateTileset();
 
     if (tile.isVisible) {
       this.setNeedsUpdate();
@@ -220,7 +205,7 @@ export default class TileLayer extends CompositeLayer {
       // cache the rendered layer in the tile
       if (!tile.isLoaded) {
         // no op
-      } else if (!tile.layers || tile.updateLayers) {
+      } else if (!tile.layers) {
         const layers = this.renderSubLayers({
           ...this.props,
           id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -84,9 +84,10 @@ export default class TileLayer extends CompositeLayer {
       });
     } else if (changeFlags.propsChanged || changeFlags.updateTriggersChanged) {
       tileset.setOptions(this._getTilesetOptions(props));
-      // Force an update of the tile layers without deleting them to prevent skipped frames.
+      // if any props changed, delete the cached layers
+      // Should we do the same as the above?  Not delete but use a boolean to cause an update?
       tileset.tiles.forEach(tile => {
-        tile.updateLayers = true;
+        tile.layers = null;
       });
       this._updateTileset(tileset);
     } else {

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -84,10 +84,9 @@ export default class TileLayer extends CompositeLayer {
       });
     } else if (changeFlags.propsChanged || changeFlags.updateTriggersChanged) {
       tileset.setOptions(this._getTilesetOptions(props));
-      // if any props changed, delete the cached layers
-      // Should we do the same as the above?  Not delete but use a boolean to cause an update?
+      // Force an update of the tile layers without deleting them to prevent skipped frames.
       tileset.tiles.forEach(tile => {
-        tile.layers = null;
+        tile.updateLayers = true;
       });
       this._updateTileset(tileset);
     } else {

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -42,7 +42,7 @@ export default class TileLayer extends CompositeLayer {
   get isLoaded() {
     const {tileset} = this.state;
     return tileset.selectedTiles.every(
-      tile => !tile.isLoading && tile.layers && tile.layers.every(layer => layer.isLoaded)
+      tile => tile.isLoaded && tile.layers && tile.layers.every(layer => layer.isLoaded)
     );
   }
 
@@ -174,7 +174,7 @@ export default class TileLayer extends CompositeLayer {
       return getTileData(tile);
     }
     if (tile.url) {
-      return fetch(tile.url, {propName: 'data', layer, signal});
+      return fetch(tile.url, {propName: 'data', layer: this, signal});
     }
     return null;
   }
@@ -202,13 +202,13 @@ export default class TileLayer extends CompositeLayer {
     return this.state.tileset.tiles.map(tile => {
       const highlightedObjectIndex = this.getHighlightedObjectIndex(tile);
       // cache the rendered layer in the tile
-      if (!tile.isLoaded) {
-        // no op
+      if (!tile.isLoaded && !tile.content) {
+        // nothing to show
       } else if (!tile.layers) {
         const layers = this.renderSubLayers({
           ...this.props,
           id: `${this.id}-${tile.x}-${tile.y}-${tile.z}`,
-          data: tile.data,
+          data: tile.content,
           _offset: 0,
           tile
         });

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -42,7 +42,7 @@ export default class TileLayer extends CompositeLayer {
   get isLoaded() {
     const {tileset} = this.state;
     return tileset.selectedTiles.every(
-      tile => tile.layers && tile.layers.every(layer => layer.isLoaded)
+      tile => !tile.isLoading && tile.layers && tile.layers.every(layer => layer.isLoaded)
     );
   }
 
@@ -52,30 +52,28 @@ export default class TileLayer extends CompositeLayer {
 
   updateState({props, changeFlags}) {
     let {tileset} = this.state;
-    const createTileCache =
-      !tileset ||
+    const propsChanged = changeFlags.propsOrDataChanged || changeFlags.updateTriggersChanged;
+    const dataChanged =
       changeFlags.dataChanged ||
       (changeFlags.updateTriggersChanged &&
         (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getTileData));
 
-    if (createTileCache) {
-      if (tileset) {
-        tileset.finalize();
-      }
-      tileset = new Tileset2D({
-        ...this._getTilesetOptions(props),
-        getTileData: this.getTileData.bind(this),
-        onTileLoad: this._onTileLoad.bind(this),
-        onTileError: this._onTileError.bind(this),
-        onTileUnload: this._onTileUnload.bind(this)
-      });
+    if (!tileset) {
+      tileset = new Tileset2D(this._getTilesetOptions(props));
       this.setState({tileset});
-    } else if (changeFlags.propsChanged || changeFlags.updateTriggersChanged) {
+    } else if (propsChanged) {
       tileset.setOptions(this._getTilesetOptions(props));
-      // if any props changed, delete the cached layers
-      this.state.tileset.tiles.forEach(tile => {
-        tile.layers = null;
-      });
+
+      if (dataChanged) {
+        // reload all tiles
+        // use cached layers until new content is loaded
+        tileset.reloadAll();
+      } else {
+        // some render options changed, regenerate sub layers now
+        this.state.tileset.tiles.forEach(tile => {
+          tile.layers = null;
+        });
+      }
     }
 
     this._updateTileset();
@@ -103,7 +101,12 @@ export default class TileLayer extends CompositeLayer {
       refinementStrategy,
       extent,
       maxRequests,
-      zoomOffset
+      zoomOffset,
+
+      getTileData: this.getTileData.bind(this),
+      onTileLoad: this._onTileLoad.bind(this),
+      onTileError: this._onTileError.bind(this),
+      onTileUnload: this._onTileUnload.bind(this)
     };
   }
 
@@ -138,8 +141,8 @@ export default class TileLayer extends CompositeLayer {
   }
 
   _onTileLoad(tile) {
-    const layer = this.getCurrentLayer();
-    layer.props.onTileLoad(tile);
+    this.props.onTileLoad(tile);
+    tile.layers = null;
 
     if (tile.isVisible) {
       this.setNeedsUpdate();
@@ -147,10 +150,8 @@ export default class TileLayer extends CompositeLayer {
   }
 
   _onTileError(error, tile) {
-    const layer = this.getCurrentLayer();
-    layer.props.onTileError(error);
-    // errorred tiles should not block rendering, are considered "loaded" with empty data
-    layer._updateTileset();
+    this.props.onTileError(error);
+    tile.layers = null;
 
     if (tile.isVisible) {
       this.setNeedsUpdate();
@@ -158,15 +159,13 @@ export default class TileLayer extends CompositeLayer {
   }
 
   _onTileUnload(tile) {
-    const layer = this.getCurrentLayer();
-    layer.props.onTileUnload(tile);
+    this.props.onTileUnload(tile);
   }
 
   // Methods for subclass to override
 
   getTileData(tile) {
-    const layer = this.getCurrentLayer();
-    const {data, getTileData, fetch} = layer.props;
+    const {data, getTileData, fetch} = this.props;
     const {signal} = tile;
 
     tile.url = getURLFromTemplate(data, tile);

--- a/modules/geo-layers/src/tile-layer/tileset-2d.js
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.js
@@ -46,17 +46,14 @@ export default class Tileset2D {
    */
   constructor(opts) {
     this.opts = opts;
-    this._getTileData = opts.getTileData;
 
-    this.onTileError = opts.onTileError;
     this.onTileLoad = tile => {
-      opts.onTileLoad(tile);
+      this.opts.onTileLoad(tile);
       if (this.opts.maxCacheByteSize) {
         this._cacheByteSize += tile.byteLength;
         this._resizeCache();
       }
     };
-    this.onTileUnload = opts.onTileUnload;
 
     this._requestScheduler = new RequestScheduler({
       maxRequests: opts.maxRequests,
@@ -106,6 +103,15 @@ export default class Tileset2D {
       if (tile.isLoading) {
         tile.abort();
       }
+    }
+    this._cache.clear();
+    this._tiles = [];
+    this._selectedTiles = null;
+  }
+
+  reloadAll() {
+    for (const tile of this._cache.values()) {
+      tile.setNeedsReload();
     }
   }
 
@@ -304,7 +310,7 @@ export default class Tileset2D {
           // delete tile
           this._cacheByteSize -= opts.maxCacheByteSize ? tile.byteLength : 0;
           _cache.delete(tileId);
-          this.onTileUnload(tile);
+          this.opts.onTileUnload(tile);
         }
         if (_cache.size <= maxCacheSize && this._cacheByteSize <= maxCacheByteSize) {
           break;
@@ -326,21 +332,24 @@ export default class Tileset2D {
   _getTile({x, y, z}, create) {
     const tileId = `${x},${y},${z}`;
     let tile = this._cache.get(tileId);
+    let needsReload = false;
 
     if (!tile && create) {
-      tile = new Tile2DHeader({
-        x,
-        y,
-        z,
-        onTileLoad: this.onTileLoad,
-        onTileError: this.onTileError
-      });
+      tile = new Tile2DHeader({x, y, z});
       Object.assign(tile, this.getTileMetadata(tile));
-      tile.loadData(this._getTileData, this._requestScheduler);
+      needsReload = true;
       this._cache.set(tileId, tile);
       this._dirty = true;
-    } else if (tile && tile.isCancelled && !tile.isLoading) {
-      tile.loadData(this._getTileData, this._requestScheduler);
+    } else if (tile && tile.needsReload && !tile.isLoading) {
+      needsReload = true;
+    }
+    if (needsReload) {
+      tile.loadData({
+        getData: this.opts.getTileData,
+        requestScheduler: this._requestScheduler,
+        onLoad: this.onTileLoad,
+        onError: this.opts.onTileError
+      });
     }
 
     return tile;

--- a/modules/geo-layers/src/tile-layer/tileset-2d.js
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.js
@@ -45,38 +45,6 @@ export default class Tileset2D {
    * Cache size defaults to 5 * number of tiles in the current viewport
    */
   constructor(opts) {
-    this._loadOptions(opts);
-
-    // Maps tile id in string {z}-{x}-{y} to a Tile object
-    this._cache = new Map();
-    this._tiles = [];
-    this._dirty = false;
-    this._cacheByteSize = 0;
-
-    // Cache the last processed viewport
-    this._viewport = null;
-    this._selectedTiles = null;
-    this._frameNumber = 0;
-  }
-
-  loadOptions(opts) {
-    this._loadOptions(opts);
-  }
-
-  /**
-   * Reload function is called to force a reload of the tile data and clear out the cache of tiles not on the screen.
-   * This gives a sort of "lazy reload" of the cache - visible tiles are reloaded while others are discarded instead of loaded.
-   */
-  reload() {
-    this._selectedTiles = this._selectedTiles.map(index => this._getTile(index, true, true));
-    for (const [tileId, tile] of this._cache) {
-      if (!this._selectedTiles.includes(tile)) {
-        this._cache.delete(tileId);
-      }
-    }
-  }
-
-  _loadOptions(opts) {
     this.opts = opts;
     this._getTileData = opts.getTileData;
 
@@ -94,6 +62,17 @@ export default class Tileset2D {
       maxRequests: opts.maxRequests,
       throttleRequests: opts.maxRequests > 0
     });
+
+    // Maps tile id in string {z}-{x}-{y} to a Tile object
+    this._cache = new Map();
+    this._tiles = [];
+    this._dirty = false;
+    this._cacheByteSize = 0;
+
+    // Cache the last processed viewport
+    this._viewport = null;
+    this._selectedTiles = null;
+    this._frameNumber = 0;
 
     this.setOptions(opts);
   }
@@ -344,7 +323,7 @@ export default class Tileset2D {
   }
   /* eslint-enable complexity */
 
-  _getTile({x, y, z}, create, reload) {
+  _getTile({x, y, z}, create) {
     const tileId = `${x},${y},${z}`;
     let tile = this._cache.get(tileId);
 
@@ -361,11 +340,6 @@ export default class Tileset2D {
       this._cache.set(tileId, tile);
       this._dirty = true;
     } else if (tile && tile.isCancelled && !tile.isLoading) {
-      tile.loadData(this._getTileData, this._requestScheduler);
-    } else if (reload) {
-      tile.onTileLoad = this.onTileLoad;
-      tile.onTileError = this.onTileError;
-      Object.assign(tile, this.getTileMetadata(tile));
       tile.loadData(this._getTileData, this._requestScheduler);
     }
 

--- a/modules/geo-layers/src/tile-layer/tileset-2d.js
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.js
@@ -340,7 +340,7 @@ export default class Tileset2D {
       needsReload = true;
       this._cache.set(tileId, tile);
       this._dirty = true;
-    } else if (tile && tile.needsReload && !tile.isLoading) {
+    } else if (tile && tile.needsReload) {
       needsReload = true;
     }
     if (needsReload) {

--- a/modules/geo-layers/src/tile-layer/tileset-2d.js
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.js
@@ -110,8 +110,13 @@ export default class Tileset2D {
   }
 
   reloadAll() {
-    for (const tile of this._cache.values()) {
-      tile.setNeedsReload();
+    for (const tileId of this._cache.keys()) {
+      const tile = this._cache.get(tileId);
+      if (!this._selectedTiles.includes(tile)) {
+        this._cache.delete(tileId);
+      } else {
+        tile.setNeedsReload();
+      }
     }
   }
 

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -324,14 +324,11 @@ test('MVTLayer#TileJSON', async t => {
   };
 
   const onAfterUpdate = ({layer, subLayers}) => {
-    if (!layer.isLoaded) {
-      t.is(subLayers.length, 0);
-    } else {
+    if (layer.isLoaded) {
       t.is(subLayers.length, 2, 'Rendered sublayers');
       t.is(layer.state.data.length, 3, 'Data is loaded');
       t.is(layer.state.tileset.minZoom, tileJSON.minZoom, 'Min zoom layer is correct');
       t.is(layer.state.tileset.minZoom, tileJSON.maxZoom, 'Max zoom layer is correct');
-      t.ok(layer.isLoaded, 'Layer is loaded');
     }
   };
 

--- a/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
@@ -3,65 +3,135 @@ import Tile2DHeader from '@deck.gl/geo-layers/tile-layer/tile-2d-header';
 import {RequestScheduler} from '@loaders.gl/loader-utils';
 
 test('Tile2DHeader', async t => {
+  let onTileLoadCalled = false;
   let onTileErrorCalled = false;
-
   const requestScheduler = new RequestScheduler({throttleRequests: false});
-  const getTileData = () => {
-    throw new Error('getTileData with error');
-  };
 
-  const tile2d = new Tile2DHeader({
-    onTileError: () => {
-      onTileErrorCalled = true;
-    }
+  let tile2d = new Tile2DHeader({});
+  await tile2d.loadData({
+    requestScheduler,
+    getData: () => 'loaded data',
+    onLoad: () => (onTileLoadCalled = true),
+    onError: () => (onTileErrorCalled = true)
   });
-  await tile2d._loadData(getTileData, requestScheduler);
 
   t.ok(tile2d.isLoaded, 'Tile is loaded');
-  t.ok(onTileErrorCalled, 'onTileError called');
+  t.ok(onTileLoadCalled, 'invoked onLoad callback');
+  t.is(tile2d.data, 'loaded data', 'data field is populated');
+
+  tile2d = new Tile2DHeader({});
+  await tile2d.loadData({
+    requestScheduler,
+    getData: () => {
+      throw new Error('getTileData error');
+    },
+    onLoad: () => (onTileLoadCalled = true),
+    onError: () => (onTileErrorCalled = true)
+  });
+  t.ok(tile2d.isLoaded, 'Tile is loaded');
+  t.ok(onTileErrorCalled, 'invoked onError callback');
+
   t.end();
 });
 
 test('Tile2DHeader#Cancel request if not selected', async t => {
   let tileRequestCount = 0;
+  let onTileLoadCalled = 0;
+  let onTileErrorCalled = 0;
 
   const requestScheduler = new RequestScheduler({throttleRequests: true, maxRequests: 1});
-  const getTileData = () => tileRequestCount++;
-  const onTileLoad = () => null;
-  const onTileError = () => null;
+  const opts = {
+    requestScheduler,
+    getData: () => tileRequestCount++,
+    onLoad: () => onTileLoadCalled++,
+    onError: () => onTileErrorCalled++
+  };
 
-  const tile1 = new Tile2DHeader({onTileLoad, onTileError});
-  const tile2 = new Tile2DHeader({onTileLoad, onTileError});
+  const tile1 = new Tile2DHeader({});
+  const tile2 = new Tile2DHeader({});
   tile1.isSelected = true;
   tile2.isSelected = false;
 
   // Await later so that request scheduler has both queued at the same time
-  const loader1 = tile1._loadData(getTileData, requestScheduler);
-  const loader2 = tile2._loadData(getTileData, requestScheduler);
+  const loader1 = tile1.loadData(opts);
+  const loader2 = tile2.loadData(opts);
   await loader1;
   await loader2;
 
   t.equals(tileRequestCount, 1, 'One successful request');
   t.notOk(tile1.isCancelled, 'First request was not cancelled');
   t.ok(tile2.isCancelled, 'Second request was cancelled');
+  t.ok(onTileLoadCalled === 1 && onTileErrorCalled === 0, 'Callbacks invoked');
   t.end();
 });
 
-test('Tile2DHeader#Abort quickly', async t => {
+test('Tile2DHeader#abort', async t => {
   const requestScheduler = new RequestScheduler({throttleRequests: true, maxRequests: 1});
+  let onTileLoadCalled = false;
+  let onTileErrorCalled = false;
 
-  const getTileData = () => null;
-  const onTileLoad = () => null;
-  const onTileError = () => null;
-
-  const tile = new Tile2DHeader({onTileLoad, onTileError});
+  const opts = {
+    requestScheduler,
+    getData: () => null,
+    onLoad: () => (onTileLoadCalled = true),
+    onError: () => (onTileErrorCalled = true)
+  };
+  const tile = new Tile2DHeader({});
   tile.isSelected = true;
 
   // Await later so that the abort could go off before the getTileData call.
-  const loader = tile._loadData(getTileData, requestScheduler);
+  const loader = tile.loadData(opts);
   tile.abort();
   await loader;
 
+  t.notOk(onTileErrorCalled || onTileLoadCalled, 'Callbacks should not be invoked');
   t.notOk(requestScheduler.requestMap.has(tile), 'Scheduler deletes tile on abort');
+  t.end();
+});
+
+test('Tile2DHeader#reload', async t => {
+  const requestScheduler = new RequestScheduler({throttleRequests: true, maxRequests: 2});
+  const getTileData = (result, delay) =>
+    new Promise(resolve => {
+      /* global setTimeout */
+      setTimeout(() => {
+        t.comment(`Loaded ${result}`);
+        resolve(result);
+      }, delay);
+    });
+
+  let onTileLoadCalled = 0;
+  let onTileErrorCalled = 0;
+  const opts = {
+    requestScheduler,
+    onLoad: () => onTileLoadCalled++,
+    onError: () => onTileErrorCalled++
+  };
+
+  const tile = new Tile2DHeader({});
+  tile.isSelected = true;
+
+  await tile.loadData({...opts, getData: () => getTileData('a', 0)});
+  t.is(tile.data, 'a', 'initial load');
+
+  tile.setNeedsReload();
+  await tile.loadData({...opts, getData: () => getTileData('b', 0)});
+  t.is(tile.data, 'b', 'reloaded');
+
+  // Reload before a load is finished
+  const loaderc1 = tile.loadData({...opts, getData: () => getTileData('c1', 0)});
+  const loaderc2 = tile.loadData({...opts, getData: () => getTileData('c2', 10)});
+  await loaderc1;
+  t.is(tile.data, 'b', 'outdated result is discarded');
+  await loaderc2;
+  t.is(tile.data, 'c2', 'loaded the result of the last request');
+
+  // Multiple load requests resolved out of order
+  const loaderd1 = tile.loadData({...opts, getData: () => getTileData('d1', 50)});
+  const loaderd2 = tile.loadData({...opts, getData: () => getTileData('d2', 0)});
+  await loaderd2;
+  await loaderd1;
+  t.is(tile.data, 'd2', 'loaded the result of the last request');
+
   t.end();
 });

--- a/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-2d-header.spec.js
@@ -59,8 +59,8 @@ test('Tile2DHeader#Cancel request if not selected', async t => {
   await loader2;
 
   t.equals(tileRequestCount, 1, 'One successful request');
-  t.notOk(tile1.isCancelled, 'First request was not cancelled');
-  t.ok(tile2.isCancelled, 'Second request was cancelled');
+  t.notOk(tile1._isCancelled, 'First request was not cancelled');
+  t.ok(tile2._isCancelled, 'Second request was cancelled');
   t.ok(onTileLoadCalled === 1 && onTileErrorCalled === 0, 'Callbacks invoked');
   t.end();
 });
@@ -120,18 +120,15 @@ test('Tile2DHeader#reload', async t => {
 
   // Reload before a load is finished
   const loaderc1 = tile.loadData({...opts, getData: () => getTileData('c1', 0)});
-  const loaderc2 = tile.loadData({...opts, getData: () => getTileData('c2', 10)});
+  tile.loadData({...opts, getData: () => getTileData('c2', 10)});
   await loaderc1;
-  t.is(tile.data, 'b', 'outdated result is discarded');
-  await loaderc2;
-  t.is(tile.data, 'c2', 'loaded the result of the last request');
+  t.is(tile.content, 'b', 'outdated result is discarded');
+  t.is(await tile.data, 'c2', 'loaded the result of the last request');
 
   // Multiple load requests resolved out of order
-  const loaderd1 = tile.loadData({...opts, getData: () => getTileData('d1', 50)});
-  const loaderd2 = tile.loadData({...opts, getData: () => getTileData('d2', 0)});
-  await loaderd2;
-  await loaderd1;
-  t.is(tile.data, 'd2', 'loaded the result of the last request');
+  tile.loadData({...opts, getData: () => getTileData('d1', 50)});
+  tile.loadData({...opts, getData: () => getTileData('d2', 0)});
+  t.is(await tile.data, 'd2', 'loaded the result of the last request');
 
   t.end();
 });

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -163,7 +163,7 @@ test('TileLayer', async t => {
       onAfterUpdate: ({layer, subLayers}) => {
         if (layer.isLoaded) {
           t.is(getTileDataCalled, 6, 'Refetched tile data');
-          t.is(subLayers.length, 8, 'Update trigger does not reset number of layers.');
+          t.is(subLayers.length, 8, 'Update trigger does not change reset number of layers.');
         }
       }
     }

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -163,7 +163,7 @@ test('TileLayer', async t => {
       onAfterUpdate: ({layer, subLayers}) => {
         if (layer.isLoaded) {
           t.is(getTileDataCalled, 6, 'Refetched tile data');
-          t.is(subLayers.length, 4, 'Invalidated cached sublayers with prop change');
+          t.is(subLayers.length, 8, 'Update trigger does not change reset number of layers.');
         }
       }
     }

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -96,7 +96,7 @@ test('TileLayer', async t => {
       },
       onAfterUpdate: ({layer, subLayers}) => {
         if (!layer.isLoaded) {
-          t.ok(subLayers.length < 2);
+          t.is(subLayers.length, 2, 'Cached layers are used while loading');
         } else {
           t.is(subLayers.length, 2, 'Rendered sublayers');
           t.is(getTileDataCalled, 2, 'Fetched tile data');
@@ -163,7 +163,7 @@ test('TileLayer', async t => {
       onAfterUpdate: ({layer, subLayers}) => {
         if (layer.isLoaded) {
           t.is(getTileDataCalled, 6, 'Refetched tile data');
-          t.is(subLayers.length, 4, 'Invalidated cached sublayers with prop change');
+          t.is(subLayers.length, 8, 'Cached content is used to render sub layers');
         }
       }
     }
@@ -261,7 +261,7 @@ test('TileLayer#AbortRequestsOnNewLayer', async t => {
     zoom: 1,
     repeat: true
   });
-  let tileset;
+  let tiles;
 
   const testCases = [
     {
@@ -269,7 +269,7 @@ test('TileLayer#AbortRequestsOnNewLayer', async t => {
         getTileData: () => sleep(10)
       },
       onAfterUpdate: ({layer}) => {
-        tileset = layer.state.tileset;
+        tiles = layer.state.tileset._tiles;
       }
     },
     {
@@ -278,7 +278,7 @@ test('TileLayer#AbortRequestsOnNewLayer', async t => {
       },
       onAfterUpdate: () => {
         t.is(
-          tileset._tiles.map(tile => tile._isCancelled).length,
+          tiles.map(tile => tile.isCancelled).length,
           4,
           'all tiles from discarded layer should be cancelled'
         );

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -163,7 +163,7 @@ test('TileLayer', async t => {
       onAfterUpdate: ({layer, subLayers}) => {
         if (layer.isLoaded) {
           t.is(getTileDataCalled, 6, 'Refetched tile data');
-          t.is(subLayers.length, 8, 'Update trigger does not change reset number of layers.');
+          t.is(subLayers.length, 4, 'Invalidated cached sublayers with prop change');
         }
       }
     }

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -278,7 +278,7 @@ test('TileLayer#AbortRequestsOnNewLayer', async t => {
       },
       onAfterUpdate: () => {
         t.is(
-          tiles.map(tile => tile.isCancelled).length,
+          tiles.filter(tile => tile._isCancelled).length,
           4,
           'all tiles from discarded layer should be cancelled'
         );

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.js
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.js
@@ -163,7 +163,7 @@ test('TileLayer', async t => {
       onAfterUpdate: ({layer, subLayers}) => {
         if (layer.isLoaded) {
           t.is(getTileDataCalled, 6, 'Refetched tile data');
-          t.is(subLayers.length, 8, 'Update trigger does not change reset number of layers.');
+          t.is(subLayers.length, 8, 'Update trigger does not reset number of layers.');
         }
       }
     }

--- a/test/modules/geo-layers/tile-layer/tileset-2d.spec.js
+++ b/test/modules/geo-layers/tile-layer/tileset-2d.spec.js
@@ -63,6 +63,7 @@ test('Tileset2D#finalize', async t => {
     onTileLoad: () => {}
   });
   tileset.update(testViewport);
+  const tile1 = tileset.selectedTiles[0];
 
   await sleep(60);
 
@@ -74,64 +75,17 @@ test('Tileset2D#finalize', async t => {
       })
     )
   );
+  const tile2 = tileset.selectedTiles[0];
 
   tileset.finalize();
+  t.notOk(tileset._cache.size, 'cache is purged');
 
   t.is(
-    tileset._cache.get('1171,1566,12')._isCancelled,
+    tile1.isCancelled,
     false,
     'first tile should not have been loading and thus not been aborteed'
   );
-  t.is(tileset._cache.get('910,459,12')._isCancelled, true, 'second tile should have been aborted');
-
-  t.end();
-});
-
-test('Tileset2D#finalize-partial', async t => {
-  const tileset = new Tileset2D({
-    getTileData: () => sleep(10),
-    onTileLoad: () => {},
-    onTileError: () => {}
-  });
-  tileset.update(new WebMercatorViewport({longitude: 0, latitude: 0, zoom: 0}));
-
-  // Tiles that should be loaded
-  tileset._getTile({x: 1, y: 1, z: 1}, true);
-  await sleep(20);
-
-  // Tiles that should be cancelled
-  tileset._getTile({x: 0, y: 0, z: 1}, true);
-  tileset.finalize();
-
-  // Tiles that should be loaded
-  tileset._getTile({x: 1, y: 0, z: 1}, true);
-  await sleep(20);
-
-  t.is(
-    tileset._cache.get('0,0,0').isCancelled,
-    false,
-    'visible tile should have loaded and thus not been aborted'
-  );
-  t.is(
-    tileset._cache.get('1,1,1').isCancelled,
-    false,
-    'first tile should not have been loading and thus not been aborted'
-  );
-  t.is(tileset._cache.get('0,0,1').isCancelled, true, 'second tile should have been aborted');
-  t.is(
-    tileset._cache.get('1,0,1').isCancelled,
-    false,
-    'third tile should not have been loading and thus not been aborted'
-  );
-
-  // Now, these tiles should be loaded
-  tileset._getTile({x: 0, y: 0, z: 1}, true);
-  await sleep(20);
-  t.is(
-    tileset._cache.get('0,0,1').isCancelled,
-    false,
-    'second tile should should have loaded and not been aborted'
-  );
+  t.is(tile2.isCancelled, true, 'second tile should have been aborted');
 
   t.end();
 });

--- a/test/modules/geo-layers/tile-layer/tileset-2d.spec.js
+++ b/test/modules/geo-layers/tile-layer/tileset-2d.spec.js
@@ -81,11 +81,11 @@ test('Tileset2D#finalize', async t => {
   t.notOk(tileset._cache.size, 'cache is purged');
 
   t.is(
-    tile1.isCancelled,
+    tile1._isCancelled,
     false,
     'first tile should not have been loading and thus not been aborteed'
   );
-  t.is(tile2.isCancelled, true, 'second tile should have been aborted');
+  t.is(tile2._isCancelled, true, 'second tile should have been aborted');
 
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #6179
<!-- For all the PRs -->
#### Change List
- Add a `reload` method for `Tileset2D` to be called on updates by `updateTriggers` instead of creating a new tileset
