### PR TITLE
Fix Heatmap data update

### DIFF
--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.js
@@ -114,8 +114,9 @@ export default class HeatmapLayer extends AggregationLayer {
     const {props, oldProps} = opts;
     const changeFlags = this._getChangeFlags(opts);
 
-    if (changeFlags.viewportChanged) {
-      changeFlags.boundsChanged = this._updateBounds();
+    if (changeFlags.dataChanged || changeFlags.viewportChanged) {
+      // if data is changed, do not debounce and immediately update the weight map
+      changeFlags.boundsChanged = this._updateBounds(changeFlags.dataChanged);
       this._updateTextureRenderingBounds();
     }
 


### PR DESCRIPTION
For #6221

When data changes, we cancel the denounced weight map update and rerender immediately with outdated bounds.

#### Change List
- force update bounds if data is changed
