### PR TITLE
Fix excessive allocation for constant attributes

### DIFF
--- a/modules/core/src/lib/attribute/attribute-manager.js
+++ b/modules/core/src/lib/attribute/attribute-manager.js
@@ -349,6 +349,13 @@ export default class AttributeManager {
     const {attribute, numInstances} = opts;
     debug(TRACE_ATTRIBUTE_UPDATE_START, attribute);
 
+    if (attribute.constant) {
+      // The attribute is flagged as constant outside of an update cycle
+      // Skip allocation and updater call
+      attribute.setConstantValue(attribute.value);
+      return;
+    }
+
     if (attribute.allocate(numInstances)) {
       debug(TRACE_ATTRIBUTE_ALLOCATE, attribute, numInstances);
     }

--- a/modules/core/src/lib/attribute/attribute.js
+++ b/modules/core/src/lib/attribute/attribute.js
@@ -161,6 +161,9 @@ export default class Attribute extends DataColumn {
           value: this.value,
           constant: this.constant
         });
+        // Setting attribute.constant in updater is a legacy approach that interferes with allocation in the next cycle
+        // Respect it here but reset after use
+        this.constant = false;
       } else {
         for (const [startRow, endRow] of updateRanges) {
           const startOffset = Number.isFinite(startRow) ? this.getVertexOffset(startRow) : 0;

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -119,7 +119,7 @@ test('Attribute#allocate', t => {
   t.is(attribute.value, allocatedValue, 'reused the same typed array');
 
   attribute.setConstantValue([1, 1]);
-  t.notOk(attributeNoAlloc.allocate(4), 'Should not allocate if constant value is used');
+  t.deepEquals(attribute.value, [1, 1], 'value overwritten by external constant');
 
   attribute.setConstantValue(undefined);
   t.ok(attribute.allocate(4), 'allocate successful');


### PR DESCRIPTION
For #6211

#### Change List
- Skip allocation if `attribute.constant` is `true`
- Unit tests
