### PR TITLE
H3HexagonLayer: force low precision; early exit for data analysis loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Data sources are listed in each example.
 
 #### The deck.gl project is supported by
 
-<a href="https://www.browserstack.com/">
- <img src="https://d98b8t1nnulk5.cloudfront.net/production/images/static/logo.svg" alt="BrowserStack" width="200" />
-</a>
+<a href="https://www.unfolded.ai"><img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/branding/unfolded.png" height="32" /></a>
+<a href="https://www.foursquare.com"><img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/branding/fsq.svg" height="40" /></a>
+
+<a href="https://www.carto.com"><img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/branding/carto.svg" height="48" /></a>
+
+<a href="https://www.mapbox.com"><img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/branding/mapbox.svg" height="44" /></a>
+<a href="https://www.uber.com"><img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/branding/uber.png" height="40" /></a>
+
+<a href="https://www.browserstack.com/"><img src="https://d98b8t1nnulk5.cloudfront.net/production/images/static/logo.svg" alt="BrowserStack" width="200" /></a>

--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -102,7 +102,7 @@ Possible values:
 
 * `'auto'`: The layer chooses the mode automatically. High-precision rendering is only used if an edge case is encountered in the data.
 * `true`: Always use high-precision rendering.
-* `false`: Always use low-precision rendering regardless of the resolution of the data.
+* `false`: Always use instanced rendering, regardless of the characteristics of the data.
 
 ##### `resolution` (number, optional)
 

--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -104,28 +104,6 @@ Possible values:
 * `true`: Always use high-precision rendering.
 * `false`: Always use instanced rendering, regardless of the characteristics of the data.
 
-##### `resolution` (number, optional)
-
-* Default: `-1`
-
-Resolution of the data. It's possible to save some initialization time by passing the resolution, especially for large datasets. Values other than `-1` indicate that the data has only one resolution.
-
-Possible values:
-* `-1`: Indicates that the resolution is unknown and should be calculated.
-* `[0, 15]`: Valid h3 resolution.
-
-##### `hasPentagon` (boolean | null, optional)
-
-* Default: `null`
-
-By passing non-null `hasPentagon` property it's possible to save some initialization time, especially for large datasets.
-
-Possible values:
-
-* `true`: Indicates that the data contains at least one h3 index which represents a pentagon.
-* `false`: Indicates that all h3 indices in the data represent hexagons.
-* `null`: Indicates that it's unknown whether all h3 indices represent hexagons. In such case `hasPentagon` property will be calculated.
-
 ##### `coverage` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`

--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -103,6 +103,38 @@ Possible values:
 * `false`: The layer chooses the mode automatically. High-precision rendering is only used if an edge case is encountered in the data.
 * `true`: always use high-precision rendering.
 
+##### `lowPrecision` (Boolean, optional)
+
+* Default: `false`
+
+Used to draw a large number of hexagons efficiently. Forces `H3HexagonLayer` to use low-precision instanced drawing by assuming that all hexagons within the current viewport have the same shape as the one at the center of the current viewport. The discrepancy is usually too small to be visible for resolutions higher than 5.
+
+Possible values:
+
+* `false`: The layer chooses the rendering mode automatically.
+* `true`: Forces low-precision drawing regardless of resolution of the data and other factors. Has a priority over `highPrecision` property.
+
+##### `resolution` (number, optional)
+
+* Default: `-1`
+
+Resolution of the data. It's possible to save some initialization time by passing the resolution, especially for larger datasets. Values other than `-1` indicates that the data has only one resolution.
+
+Possible values:
+* `-1`: Indicates that the resolution is unknown and should be calculated.
+* `[0, 15]`: Valid h3 resolution.
+
+##### `hasPentagon` (boolean | null, optional)
+
+* Default: `null`
+
+By passing non-null `hasPentagon` property it's possible to save some initialization time, especially for larger datasets.
+
+Possible values:
+
+* `true`: Indicates that the data contains at least one h3 index which represent a pentagon.
+* `false`: Indicates that all h3 indices in the data represent hexagons.
+* `null`: Indicates that it's unknown whether all h3 indices represent hexagons. In such case `hasPentagon` property will be calculated for resolution 0.
 
 ##### `coverage` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 

--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -118,7 +118,7 @@ Possible values:
 
 * Default: `-1`
 
-Resolution of the data. It's possible to save some initialization time by passing the resolution, especially for larger datasets. Values other than `-1` indicates that the data has only one resolution.
+Resolution of the data. It's possible to save some initialization time by passing the resolution, especially for large datasets. Values other than `-1` indicate that the data has only one resolution.
 
 Possible values:
 * `-1`: Indicates that the resolution is unknown and should be calculated.
@@ -128,11 +128,11 @@ Possible values:
 
 * Default: `null`
 
-By passing non-null `hasPentagon` property it's possible to save some initialization time, especially for larger datasets.
+By passing non-null `hasPentagon` property it's possible to save some initialization time, especially for large datasets.
 
 Possible values:
 
-* `true`: Indicates that the data contains at least one h3 index which represent a pentagon.
+* `true`: Indicates that the data contains at least one h3 index which represents a pentagon.
 * `false`: Indicates that all h3 indices in the data represent hexagons.
 * `null`: Indicates that it's unknown whether all h3 indices represent hexagons. In such case `hasPentagon` property will be calculated for resolution 0.
 

--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -88,7 +88,7 @@ Inherits from all [Base Layer](/docs/api-reference/core/layer.md), [CompositeLay
 
 ##### `highPrecision` (Boolean, optional)
 
-* Default: `false`
+* Default: `'auto'`
 
 Each hexagon in the H3 indexing system is [slightly different in shape](https://h3geo.org/docs/core-library/coordsystems). To draw a large number of hexagons efficiently, the `H3HexagonLayer` may choose to use instanced drawing by assuming that all hexagons within the current viewport have the same shape as the one at the center of the current viewport. The discrepancy is usually too small to be visible.
 
@@ -100,19 +100,9 @@ There are several cases in which high-precision mode is required. In these cases
 
 Possible values:
 
-* `false`: The layer chooses the mode automatically. High-precision rendering is only used if an edge case is encountered in the data.
-* `true`: always use high-precision rendering.
-
-##### `lowPrecision` (Boolean, optional)
-
-* Default: `false`
-
-Used to draw a large number of hexagons efficiently. Forces `H3HexagonLayer` to use low-precision instanced drawing by assuming that all hexagons within the current viewport have the same shape as the one at the center of the current viewport. The discrepancy is usually too small to be visible for resolutions higher than 5.
-
-Possible values:
-
-* `false`: The layer chooses the rendering mode automatically.
-* `true`: Forces low-precision drawing regardless of resolution of the data and other factors. Has a priority over `highPrecision` property.
+* `'auto'`: The layer chooses the mode automatically. High-precision rendering is only used if an edge case is encountered in the data.
+* `true`: Always use high-precision rendering.
+* `false`: Always use low-precision rendering regardless of the resolution of the data.
 
 ##### `resolution` (number, optional)
 
@@ -134,7 +124,7 @@ Possible values:
 
 * `true`: Indicates that the data contains at least one h3 index which represents a pentagon.
 * `false`: Indicates that all h3 indices in the data represent hexagons.
-* `null`: Indicates that it's unknown whether all h3 indices represent hexagons. In such case `hasPentagon` property will be calculated for resolution 0.
+* `null`: Indicates that it's unknown whether all h3 indices represent hexagons. In such case `hasPentagon` property will be calculated.
 
 ##### `coverage` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -56,7 +56,7 @@ The module entry point is now only lightly transpiled for the most commonly used
 - `TileLayer` no longer uses `tileSize` to offset zoom in non-geospatial views. It is recommended to use the new `zoomOffset` prop to affect the `zoom` resolution at which tiles are fetched.
 - `MVTLayer` and `TerrainLayer`'s default loaders no longer support parsing on the main thread. This does not change the layers' default behavior, just reduces the bundle size by dropping unused code. Should you need to use the layers in an environment where web worker is not available, or debug the loaders, follow the examples in [loaders and workers](/docs/developer-guide/loading-data.md#loaders-and-web-workers).
 - `TerrainLayer`'s `workerUrl` prop is removed, use `loadOptions.terrain.workerUrl` instead.
-- `H3HexagonLayer`'s `highPrecision` prop default value is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md) for details.
+- `H3HexagonLayer`'s `highPrecision` prop default value is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md#highprecision-boolean-optional) for details.
 
 #### Deprecations
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -56,7 +56,7 @@ The module entry point is now only lightly transpiled for the most commonly used
 - `TileLayer` no longer uses `tileSize` to offset zoom in non-geospatial views. It is recommended to use the new `zoomOffset` prop to affect the `zoom` resolution at which tiles are fetched.
 - `MVTLayer` and `TerrainLayer`'s default loaders no longer support parsing on the main thread. This does not change the layers' default behavior, just reduces the bundle size by dropping unused code. Should you need to use the layers in an environment where web worker is not available, or debug the loaders, follow the examples in [loaders and workers](/docs/developer-guide/loading-data.md#loaders-and-web-workers).
 - `TerrainLayer`'s `workerUrl` prop is removed, use `loadOptions.terrain.workerUrl` instead.
-- `H3HexagonLayer`'s default `highPrecision` prop is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md) for details.
+- `H3HexagonLayer`'s `highPrecision` prop default value is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md) for details.
 
 #### Deprecations
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -56,6 +56,7 @@ The module entry point is now only lightly transpiled for the most commonly used
 - `TileLayer` no longer uses `tileSize` to offset zoom in non-geospatial views. It is recommended to use the new `zoomOffset` prop to affect the `zoom` resolution at which tiles are fetched.
 - `MVTLayer` and `TerrainLayer`'s default loaders no longer support parsing on the main thread. This does not change the layers' default behavior, just reduces the bundle size by dropping unused code. Should you need to use the layers in an environment where web worker is not available, or debug the loaders, follow the examples in [loaders and workers](/docs/developer-guide/loading-data.md#loaders-and-web-workers).
 - `TerrainLayer`'s `workerUrl` prop is removed, use `loadOptions.terrain.workerUrl` instead.
+- `H3HexagonLayer`'s default `highPrecision` prop is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md) for details.
 
 #### Deprecations
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,6 +4,7 @@
 
 #### Breaking changes
 
+- `H3HexagonLayer`'s `highPrecision` prop default value is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md#highprecision-boolean-optional) for details.
 - `layerFilter` is now only called with top-level layers. For example, if you have a `GeoJsonLayer` with `id: 'regions'`, in previous versions the callback would look like:
 
   ```js
@@ -56,7 +57,6 @@ The module entry point is now only lightly transpiled for the most commonly used
 - `TileLayer` no longer uses `tileSize` to offset zoom in non-geospatial views. It is recommended to use the new `zoomOffset` prop to affect the `zoom` resolution at which tiles are fetched.
 - `MVTLayer` and `TerrainLayer`'s default loaders no longer support parsing on the main thread. This does not change the layers' default behavior, just reduces the bundle size by dropping unused code. Should you need to use the layers in an environment where web worker is not available, or debug the loaders, follow the examples in [loaders and workers](/docs/developer-guide/loading-data.md#loaders-and-web-workers).
 - `TerrainLayer`'s `workerUrl` prop is removed, use `loadOptions.terrain.workerUrl` instead.
-- `H3HexagonLayer`'s `highPrecision` prop default value is changed to `'auto'`. Setting `highPrecision` to `false` now forces instanced rendering. See updated [layer documentation](/docs/api-reference/geo-layers/h3-hexagon-layer.md#highprecision-boolean-optional) for details.
 
 #### Deprecations
 

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -135,7 +135,7 @@ export default class H3HexagonLayer extends CompositeLayer {
   }
 
   _calculateH3DataProps(props) {
-    let resolution = props.resolution ?? -1;
+    let resolution = props.resolution;
     let hasPentagon = props.hasPentagon ?? false;
     let hasMultipleRes = false;
 

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -124,18 +124,18 @@ export default class H3HexagonLayer extends CompositeLayer {
 
   updateState({props, oldProps, changeFlags}) {
     if (
-      !props.highPrecision &&
+      !(props.highPrecision && !props.lowPrecision) &&
       (changeFlags.dataChanged ||
         (changeFlags.updateTriggers && changeFlags.updateTriggers.getHexagon))
     ) {
-      const dataProps = this._calculateHexDataProps(props);
+      const dataProps = this._calculateH3DataProps(props);
       this.setState(dataProps);
     }
 
     this._updateVertices(this.context.viewport);
   }
 
-  _calculateHexDataProps(props) {
+  _calculateH3DataProps(props) {
     let resolution = props.resolution ?? -1;
     let hasPentagon = props.hasPentagon ?? false;
     let hasMultipleRes = false;

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -91,8 +91,7 @@ function mergeTriggers(getHexagon, coverage) {
 
 const defaultProps = {
   ...PolygonLayer.defaultProps,
-  highPrecision: false,
-  lowPrecision: false,
+  highPrecision: 'auto',
   resolution: -1,
   hasPentagon: null,
   coverage: {type: 'number', min: 0, max: 1, value: 1},
@@ -124,7 +123,7 @@ export default class H3HexagonLayer extends CompositeLayer {
 
   updateState({props, oldProps, changeFlags}) {
     if (
-      !(props.highPrecision && !props.lowPrecision) &&
+      props.highPrecision !== true &&
       (changeFlags.dataChanged ||
         (changeFlags.updateTriggers && changeFlags.updateTriggers.getHexagon))
     ) {
@@ -140,7 +139,7 @@ export default class H3HexagonLayer extends CompositeLayer {
     let hasPentagon = props.hasPentagon ?? false;
     let hasMultipleRes = false;
 
-    if (resolution < 0 || (resolution < 1 && props.hasPentagon === null)) {
+    if (resolution < 0 || props.hasPentagon === null) {
       const {iterable, objectInfo} = createIterable(props.data);
       for (const object of iterable) {
         objectInfo.index++;
@@ -168,19 +167,15 @@ export default class H3HexagonLayer extends CompositeLayer {
   }
 
   _shouldUseHighPrecision() {
-    if (this.props.lowPrecision) {
-      return false;
+    if (this.props.highPrecision === 'auto') {
+      const {resolution, hasPentagon, hasMultipleRes} = this.state;
+      const {viewport} = this.context;
+      return (
+        viewport.resolution || hasMultipleRes || hasPentagon || (resolution >= 0 && resolution <= 5)
+      );
     }
 
-    const {resolution, hasPentagon, hasMultipleRes} = this.state;
-    const {viewport} = this.context;
-    return (
-      this.props.highPrecision ||
-      viewport.resolution ||
-      hasMultipleRes ||
-      hasPentagon ||
-      (resolution >= 0 && resolution <= 5)
-    );
+    return this.props.highPrecision;
   }
 
   _updateVertices(viewport) {

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -92,9 +92,9 @@ function mergeTriggers(getHexagon, coverage) {
 const defaultProps = {
   ...PolygonLayer.defaultProps,
   highPrecision: false,
-  _lowPrecision: false,
-  _resolution: -1,
-  _hasPentagon: null,
+  lowPrecision: false,
+  resolution: -1,
+  hasPentagon: null,
   coverage: {type: 'number', min: 0, max: 1, value: 1},
   centerHexagon: null,
   getHexagon: {type: 'accessor', value: x => x.hexagon},
@@ -136,11 +136,11 @@ export default class H3HexagonLayer extends CompositeLayer {
   }
 
   _calculateHexDataProps(props) {
-    let resolution = props._resolution ?? -1;
-    let hasPentagon = props._hasPentagon ?? false;
+    let resolution = props.resolution ?? -1;
+    let hasPentagon = props.hasPentagon ?? false;
     let hasMultipleRes = false;
 
-    if (props._resolution < 0 || (props._resolution < 1 && props._hasPentagon === null)) {
+    if (resolution < 0 || (resolution < 1 && props.hasPentagon === null)) {
       const {iterable, objectInfo} = createIterable(props.data);
       for (const object of iterable) {
         objectInfo.index++;
@@ -168,7 +168,7 @@ export default class H3HexagonLayer extends CompositeLayer {
   }
 
   _shouldUseHighPrecision() {
-    if (this.props._lowPrecision) {
+    if (this.props.lowPrecision) {
       return false;
     }
 

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -145,7 +145,7 @@ export default class H3HexagonLayer extends CompositeLayer {
       const hexResolution = h3GetResolution(hexId);
       if (resolution < 0) {
         resolution = hexResolution;
-        if (props.highPrecision === false) break;
+        if (!props.highPrecision) break;
       } else if (resolution !== hexResolution) {
         hasMultipleRes = true;
         break;

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.js
@@ -92,8 +92,6 @@ function mergeTriggers(getHexagon, coverage) {
 const defaultProps = {
   ...PolygonLayer.defaultProps,
   highPrecision: 'auto',
-  resolution: -1,
-  hasPentagon: null,
   coverage: {type: 'number', min: 0, max: 1, value: 1},
   centerHexagon: null,
   getHexagon: {type: 'accessor', value: x => x.hexagon},
@@ -135,26 +133,26 @@ export default class H3HexagonLayer extends CompositeLayer {
   }
 
   _calculateH3DataProps(props) {
-    let resolution = props.resolution;
-    let hasPentagon = props.hasPentagon ?? false;
+    let resolution = -1;
+    let hasPentagon = false;
     let hasMultipleRes = false;
 
-    if (resolution < 0 || props.hasPentagon === null) {
-      const {iterable, objectInfo} = createIterable(props.data);
-      for (const object of iterable) {
-        objectInfo.index++;
-        const hexId = props.getHexagon(object, objectInfo);
-        // Take the resolution of the first hex
-        const hexResolution = h3GetResolution(hexId);
-        if (resolution < 0) resolution = hexResolution;
-        else if (resolution !== hexResolution) {
-          hasMultipleRes = true;
-          break;
-        }
-        if (h3IsPentagon(hexId)) {
-          hasPentagon = true;
-          break;
-        }
+    const {iterable, objectInfo} = createIterable(props.data);
+    for (const object of iterable) {
+      objectInfo.index++;
+      const hexId = props.getHexagon(object, objectInfo);
+      // Take the resolution of the first hex
+      const hexResolution = h3GetResolution(hexId);
+      if (resolution < 0) {
+        resolution = hexResolution;
+        if (props.highPrecision === false) break;
+      } else if (resolution !== hexResolution) {
+        hasMultipleRes = true;
+        break;
+      }
+      if (h3IsPentagon(hexId)) {
+        hasPentagon = true;
+        break;
       }
     }
 


### PR DESCRIPTION
For #6238

#### Change List
- Update highPrecision prop to expect 'auto' | true | false values. Default is now 'auto'. (Breaking change)
- The h3 data is fully analyzed only for highPrecision: auto mode. 