### PR TITLE
Update HexagonLayer to use the new unit system

### DIFF
--- a/modules/layers/src/column-layer/column-layer-vertex.glsl.js
+++ b/modules/layers/src/column-layer/column-layer-vertex.glsl.js
@@ -47,6 +47,7 @@ uniform float edgeDistance;
 uniform float widthScale;
 uniform float widthMinPixels;
 uniform float widthMaxPixels;
+uniform int radiusUnits;
 uniform int widthUnits;
 
 // Result
@@ -84,7 +85,11 @@ void main(void) {
   // project center of column
   vec3 centroidPosition = vec3(instancePositions.xy, instancePositions.z + elevation);
   vec3 centroidPosition64Low = instancePositions64Low;
-  vec3 pos = vec3(project_size(rotationMatrix * positions.xy * strokeOffsetRatio + offset) * dotRadius, 0.);
+  vec2 offset = (rotationMatrix * positions.xy * strokeOffsetRatio + offset) * dotRadius;
+  if (radiusUnits == UNIT_METERS) {
+    offset = project_size(offset);
+  }
+  vec3 pos = vec3(offset, 0.);
   DECKGL_FILTER_SIZE(pos, geometry);
 
   gl_Position = project_position_to_clipspace(centroidPosition, centroidPosition64Low, pos, geometry.position);

--- a/modules/layers/src/column-layer/column-layer.js
+++ b/modules/layers/src/column-layer/column-layer.js
@@ -36,7 +36,7 @@ const defaultProps = {
   offset: {type: 'array', value: [0, 0]},
   coverage: {type: 'number', min: 0, max: 1, value: 1},
   elevationScale: {type: 'number', min: 0, value: 1},
-
+  radiusUnits: 'meters',
   lineWidthUnits: 'meters',
   lineWidthScale: 1,
   lineWidthMinPixels: 0,
@@ -178,7 +178,7 @@ export default class ColumnLayer extends Layer {
       lineWidthScale,
       lineWidthMinPixels,
       lineWidthMaxPixels,
-
+      radiusUnits,
       elevationScale,
       extruded,
       filled,
@@ -199,6 +199,7 @@ export default class ColumnLayer extends Layer {
       coverage,
       elevationScale,
       edgeDistance,
+      radiusUnits: UNIT[radiusUnits],
       widthUnits: UNIT[lineWidthUnits],
       widthScale: lineWidthScale,
       widthMinPixels: lineWidthMinPixels,

--- a/modules/layers/src/column-layer/grid-cell-layer.js
+++ b/modules/layers/src/column-layer/grid-cell-layer.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import {CubeGeometry} from '@luma.gl/core';
+import {UNIT} from '@deck.gl/core';
 import ColumnLayer from './column-layer';
 
 const defaultProps = {
@@ -32,11 +33,12 @@ export default class GridCellLayer extends ColumnLayer {
   }
 
   draw({uniforms}) {
-    const {elevationScale, extruded, offset, coverage, cellSize, angle} = this.props;
+    const {elevationScale, extruded, offset, coverage, cellSize, angle, radiusUnits} = this.props;
     this.state.model
       .setUniforms(uniforms)
       .setUniforms({
         radius: cellSize / 2,
+        radiusUnits: UNIT[radiusUnits],
         angle,
         offset,
         extruded,


### PR DESCRIPTION
For #6181 

#### Change List
- Add `radiusUnits` to `ColumnLayer`
- `HexagonLayer` uses common radius with d3-hexbin, removes rerenders on viewport change
