### PR TITLE
pydeck/setup.cfg: replace dashes with underscores

### DIFF
--- a/bindings/pydeck/setup.cfg
+++ b/bindings/pydeck/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [metadata]
 license_file = LICENSE.txt
-description-file = README.md 
+description_file = README.md 
 
 [aliases]
 test=pytest


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Dash-separated options in 'setup.cfg' will become unsupported at some
point in the future: https://github.com/pypa/setuptools/pull/2588

<!-- For all the PRs -->
#### Change List
- Update setup.cfg format to avoid future deprecation issues
