### PR TITLE
CARTO: fix layer credentials overwrite

### DIFF
--- a/modules/carto/src/api/index.js
+++ b/modules/carto/src/api/index.js
@@ -1,3 +1,3 @@
 export {FORMATS, MAP_TYPES, API_VERSIONS} from './maps-api-common';
 export {getDataV2, CONNECTIONS} from './maps-client';
-export {getData, mapInstantiation} from './maps-v3-client';
+export {fetchLayerData, getData, mapInstantiation} from './maps-v3-client';

--- a/modules/carto/src/api/maps-api-common.js
+++ b/modules/carto/src/api/maps-api-common.js
@@ -7,6 +7,11 @@ export const API_VERSIONS = {
   V3: 'v3'
 };
 
+export const DEFAULT_MAPS_URL_FORMAT = {
+  [API_VERSIONS.V1]: `https://${DEFAULT_USER_COMPONENT_IN_URL}.carto.com/api/v1/map`,
+  [API_VERSIONS.V2]: `https://maps-api-v2.${DEFAULT_REGION_COMPONENT_IN_URL}.carto.com/user/${DEFAULT_USER_COMPONENT_IN_URL}`
+};
+
 export const MAP_TYPES = {
   QUERY: 'query',
   TABLE: 'table',

--- a/modules/carto/src/api/maps-client.js
+++ b/modules/carto/src/api/maps-client.js
@@ -1,7 +1,7 @@
 /**
  * Maps API Client for Maps API v1 and Maps API v2
  */
-import {getDefaultCredentials} from '../config';
+import {defaultClassicCredentials, getDefaultCredentials} from '../config';
 import {
   API_VERSIONS,
   DEFAULT_MAPS_URL_FORMAT,
@@ -28,6 +28,7 @@ export async function getDataV2({type, source, credentials}) {
   // Only pick up default credentials if they have been defined for
   // correct API version
   const localCreds = {
+    ...defaultClassicCredentials,
     ...(defaultCredentials.apiVersion === apiVersion && defaultCredentials),
     ...credentials
   };

--- a/modules/carto/src/api/maps-client.js
+++ b/modules/carto/src/api/maps-client.js
@@ -4,6 +4,7 @@
 import {getDefaultCredentials} from '../config';
 import {
   API_VERSIONS,
+  DEFAULT_MAPS_URL_FORMAT,
   DEFAULT_REGION_COMPONENT_IN_URL,
   DEFAULT_USER_COMPONENT_IN_URL,
   encodeParameter,
@@ -22,8 +23,19 @@ const TILE_EXTENT = 4096;
  * Obtain a TileJson from Maps API v1 and v2
  */
 export async function getDataV2({type, source, credentials}) {
-  const localCreds = {...getDefaultCredentials(), ...credentials};
-  const {apiVersion} = localCreds;
+  const defaultCredentials = getDefaultCredentials();
+  const apiVersion = (credentials && credentials.apiVersion) || defaultCredentials.apiVersion;
+  // Only pick up default credentials if they have been defined for
+  // correct API version
+  const localCreds = {
+    ...(defaultCredentials.apiVersion === apiVersion && defaultCredentials),
+    ...credentials
+  };
+
+  if (!localCreds.mapsUrl) {
+    localCreds.mapsUrl = DEFAULT_MAPS_URL_FORMAT[apiVersion];
+  }
+
   let url;
 
   const connection = type === 'tileset' ? CONNECTIONS.BIGQUERY : CONNECTIONS.CARTO;

--- a/modules/carto/src/api/maps-v3-client.js
+++ b/modules/carto/src/api/maps-v3-client.js
@@ -68,9 +68,11 @@ function dealWithError({response, error}) {
 /**
  * Build a URL with all required parameters
  */
-function getParameters({type, source, geoColumn, columns}) {
-  const encodedClient = encodeParameter('client', 'deck-gl-carto');
-  const parameters = [encodedClient];
+function getParameters({type, source, geoColumn, columns, schema}) {
+  const parameters = [encodeParameter('client', 'deck-gl-carto')];
+  if (schema) {
+    parameters.push(encodeParameter('schema', true));
+  }
 
   const sourceName = type === MAP_TYPES.QUERY ? 'q' : 'name';
   parameters.push(encodeParameter(sourceName, source));
@@ -93,10 +95,11 @@ export async function mapInstantiation({
   connection,
   credentials,
   geoColumn,
-  columns
+  columns,
+  schema
 }) {
   const baseUrl = `${credentials.mapsUrl}/${connection}/${type}`;
-  const url = `${baseUrl}?${getParameters({type, source, geoColumn, columns})}`;
+  const url = `${baseUrl}?${getParameters({type, source, geoColumn, columns, schema})}`;
   const {accessToken} = credentials;
 
   const format = 'json';
@@ -123,15 +126,7 @@ function getUrlFromMetadata(metadata, format) {
   return null;
 }
 
-export async function getData({type, source, connection, credentials, geoColumn, columns, format}) {
-  const defaultCredentials = getDefaultCredentials();
-  // Only pick up default credentials if they have been defined for
-  // correct API version
-  const localCreds = {
-    ...(defaultCredentials.apiVersion === API_VERSIONS.V3 && defaultCredentials),
-    ...credentials
-  };
-
+function checkGetLayerDataParameters({type, source, connection, localCreds}) {
   log.assert(connection, 'Must define connection');
   log.assert(type, 'Must define a type');
   log.assert(source, 'Must define a source');
@@ -139,6 +134,26 @@ export async function getData({type, source, connection, credentials, geoColumn,
   log.assert(localCreds.apiVersion === API_VERSIONS.V3, 'Method only available for v3');
   log.assert(localCreds.apiBaseUrl, 'Must define apiBaseUrl');
   log.assert(localCreds.accessToken, 'Must define an accessToken');
+}
+
+export async function fetchLayerData({
+  type,
+  source,
+  connection,
+  credentials,
+  geoColumn,
+  columns,
+  format,
+  schema
+}) {
+  const defaultCredentials = getDefaultCredentials();
+  // Only pick up default credentials if they have been defined for
+  // correct API version
+  const localCreds = {
+    ...(defaultCredentials.apiVersion === API_VERSIONS.V3 && defaultCredentials),
+    ...credentials
+  };
+  checkGetLayerDataParameters({type, source, connection, localCreds});
 
   if (!localCreds.mapsUrl) {
     localCreds.mapsUrl = buildMapsUrlFromBase(localCreds.apiBaseUrl);
@@ -150,7 +165,8 @@ export async function getData({type, source, connection, credentials, geoColumn,
     connection,
     credentials: localCreds,
     geoColumn,
-    columns
+    columns,
+    schema
   });
   let url;
   let mapFormat;
@@ -173,5 +189,25 @@ export async function getData({type, source, connection, credentials, geoColumn,
 
   const {accessToken} = localCreds;
 
-  return await request({url, format: mapFormat, accessToken});
+  const data = await request({url, format: mapFormat, accessToken});
+  const result = {data, format: mapFormat};
+  if (schema) {
+    result.schema = metadata.schema;
+  }
+
+  return result;
+}
+
+export async function getData({type, source, connection, credentials, geoColumn, columns, format}) {
+  const layerData = await fetchLayerData({
+    type,
+    source,
+    connection,
+    credentials,
+    geoColumn,
+    columns,
+    format,
+    schema: false
+  });
+  return layerData.data;
 }

--- a/modules/carto/src/api/maps-v3-client.js
+++ b/modules/carto/src/api/maps-v3-client.js
@@ -124,7 +124,13 @@ function getUrlFromMetadata(metadata, format) {
 }
 
 export async function getData({type, source, connection, credentials, geoColumn, columns, format}) {
-  const localCreds = {...getDefaultCredentials(), ...credentials};
+  const defaultCredentials = getDefaultCredentials();
+  // Only pick up default credentials if they have been defined for
+  // correct API version
+  const localCreds = {
+    ...(defaultCredentials.apiVersion === API_VERSIONS.V3 && defaultCredentials),
+    ...credentials
+  };
 
   log.assert(connection, 'Must define connection');
   log.assert(type, 'Must define a type');
@@ -133,7 +139,6 @@ export async function getData({type, source, connection, credentials, geoColumn,
   log.assert(localCreds.apiVersion === API_VERSIONS.V3, 'Method only available for v3');
   log.assert(localCreds.apiBaseUrl, 'Must define apiBaseUrl');
   log.assert(localCreds.accessToken, 'Must define an accessToken');
-  log.assert(localCreds.mapsUrl, 'mapsUrl cannot be undefined');
 
   if (!localCreds.mapsUrl) {
     localCreds.mapsUrl = buildMapsUrlFromBase(localCreds.apiBaseUrl);

--- a/modules/carto/src/config.js
+++ b/modules/carto/src/config.js
@@ -1,4 +1,4 @@
-import {API_VERSIONS} from './api/maps-api-common';
+import {API_VERSIONS, DEFAULT_MAPS_URL_FORMAT} from './api/maps-api-common';
 
 const defaultClassicCredentials = {
   username: 'public',
@@ -22,7 +22,7 @@ export function setDefaultCredentials(opts) {
 
   switch (apiVersion) {
     case API_VERSIONS.V1:
-      opts.mapsUrl = opts.mapsUrl || 'https://{user}.carto.com/api/v1/map';
+      opts.mapsUrl = opts.mapsUrl || DEFAULT_MAPS_URL_FORMAT[apiVersion];
       credentials = {
         apiVersion,
         ...defaultClassicCredentials,
@@ -31,7 +31,7 @@ export function setDefaultCredentials(opts) {
       break;
 
     case API_VERSIONS.V2:
-      opts.mapsUrl = opts.mapsUrl || 'https://maps-api-v2.{region}.carto.com/user/{user}';
+      opts.mapsUrl = opts.mapsUrl || DEFAULT_MAPS_URL_FORMAT[apiVersion];
       credentials = {
         apiVersion,
         ...defaultClassicCredentials,

--- a/modules/carto/src/config.js
+++ b/modules/carto/src/config.js
@@ -1,6 +1,6 @@
 import {API_VERSIONS, DEFAULT_MAPS_URL_FORMAT} from './api/maps-api-common';
 
-const defaultClassicCredentials = {
+export const defaultClassicCredentials = {
   username: 'public',
   apiKey: 'default_public',
   region: 'us',

--- a/modules/carto/src/index.js
+++ b/modules/carto/src/index.js
@@ -10,6 +10,7 @@ export {
   FORMATS,
   MAP_TYPES,
   API_VERSIONS,
+  fetchLayerData,
   getDataV2 as _getDataV2,
   getData,
   mapInstantiation as _mapInstantiation

--- a/test/modules/carto/api/maps-api-client.spec.js
+++ b/test/modules/carto/api/maps-api-client.spec.js
@@ -12,103 +12,107 @@ import {
 } from '@deck.gl/carto';
 import {MAPS_API_V1_RESPONSE, TILEJSON_RESPONSE} from '../mock-fetch';
 
-test('getDataV2#v1', async t => {
-  setDefaultCredentials({
-    apiVersion: API_VERSIONS.V1,
-    mapsUrl: 'https://maps-v1'
-  });
+for (const useSetDefaultCredentials of [true, false]) {
+  test(`getDataV2#v1#setDefaultCredentials(${String(useSetDefaultCredentials)})`, async t => {
+    const credentials = {
+      apiVersion: API_VERSIONS.V1,
+      mapsUrl: 'https://maps-v1'
+    };
+    setDefaultCredentials(useSetDefaultCredentials ? credentials : {});
 
-  const _global = typeof global !== 'undefined' ? global : window;
-  const fetch = _global.fetch;
+    const _global = typeof global !== 'undefined' ? global : window;
+    const fetch = _global.fetch;
 
-  _global.fetch = url => {
-    t.is(
-      url,
-      'https://maps-v1?api_key=default_public&client=deck-gl-carto&config=%7B%22version%22%3A%221.3.1%22%2C%22buffersize%22%3A%7B%22mvt%22%3A16%7D%2C%22layers%22%3A%5B%7B%22type%22%3A%22mapnik%22%2C%22options%22%3A%7B%22sql%22%3A%22select%20*%20from%20a%22%2C%22vector_extent%22%3A4096%7D%7D%5D%7D',
-      'should be a right map instantiation v1'
-    );
-    return Promise.resolve({
-      json: () => MAPS_API_V1_RESPONSE,
-      ok: true
+    _global.fetch = url => {
+      t.is(
+        url,
+        'https://maps-v1?api_key=default_public&client=deck-gl-carto&config=%7B%22version%22%3A%221.3.1%22%2C%22buffersize%22%3A%7B%22mvt%22%3A16%7D%2C%22layers%22%3A%5B%7B%22type%22%3A%22mapnik%22%2C%22options%22%3A%7B%22sql%22%3A%22select%20*%20from%20a%22%2C%22vector_extent%22%3A4096%7D%7D%5D%7D',
+        'should be a right map instantiation v1'
+      );
+      return Promise.resolve({
+        json: () => MAPS_API_V1_RESPONSE,
+        ok: true
+      });
+    };
+
+    const data = await _getDataV2({
+      type: MAP_TYPES.QUERY,
+      source: 'select * from a',
+      credentials: useSetDefaultCredentials ? getDefaultCredentials() : credentials
     });
-  };
 
-  const data = await _getDataV2({
-    type: MAP_TYPES.QUERY,
-    source: 'select * from a',
-    credentials: getDefaultCredentials()
-  });
-
-  t.ok(
-    Array.isArray(data.tiles) && data.tiles.length === 1,
-    'tiles should be an array with content'
-  );
-
-  setDefaultCredentials({});
-  _global.fetch = fetch;
-
-  t.end();
-});
-
-test('getDataV2#v2', async t => {
-  setDefaultCredentials({
-    apiVersion: API_VERSIONS.V2,
-    mapsUrl: 'https://maps-v2'
-  });
-
-  const _global = typeof global !== 'undefined' ? global : window;
-  const fetch = _global.fetch;
-
-  _global.fetch = url => {
-    t.is(
-      url,
-      'https://maps-v2/carto/sql?source=select%20*%20from%20a&format=tilejson&api_key=default_public&client=deck-gl-carto',
-      'should be a right url for a query at v2'
+    t.ok(
+      Array.isArray(data.tiles) && data.tiles.length === 1,
+      'tiles should be an array with content'
     );
-    return Promise.resolve({
-      json: () => TILEJSON_RESPONSE,
-      ok: true
-    });
-  };
 
-  let data = await _getDataV2({
-    type: MAP_TYPES.QUERY,
-    source: 'select * from a',
-    credentials: getDefaultCredentials()
+    setDefaultCredentials({});
+    _global.fetch = fetch;
+
+    t.end();
   });
 
-  t.ok(
-    Array.isArray(data.tiles) && data.tiles.length === 1,
-    'tiles should be an array with content'
-  );
+  test(`getDataV2#v2#setDefaultCredentials(${String(useSetDefaultCredentials)})`, async t => {
+    const credentials = {
+      apiVersion: API_VERSIONS.V2,
+      mapsUrl: 'https://maps-v2'
+    };
+    setDefaultCredentials(useSetDefaultCredentials ? credentials : {});
 
-  _global.fetch = url => {
-    t.is(
-      url,
-      'https://maps-v2/bigquery/tileset?source=tileset&format=tilejson&api_key=default_public&client=deck-gl-carto',
-      'should be a right url for a tileset at v2'
+    const _global = typeof global !== 'undefined' ? global : window;
+    const fetch = _global.fetch;
+
+    _global.fetch = url => {
+      t.is(
+        url,
+        'https://maps-v2/carto/sql?source=select%20*%20from%20a&format=tilejson&api_key=default_public&client=deck-gl-carto',
+        'should be a right url for a query at v2'
+      );
+      return Promise.resolve({
+        json: () => TILEJSON_RESPONSE,
+        ok: true
+      });
+    };
+
+    let data = await _getDataV2({
+      type: MAP_TYPES.QUERY,
+      source: 'select * from a',
+      credentials: useSetDefaultCredentials ? getDefaultCredentials() : credentials
+    });
+
+    t.ok(
+      Array.isArray(data.tiles) && data.tiles.length === 1,
+      'tiles should be an array with content'
     );
-    return Promise.resolve({
-      json: () => TILEJSON_RESPONSE,
-      ok: true
+
+    _global.fetch = url => {
+      t.is(
+        url,
+        'https://maps-v2/bigquery/tileset?source=tileset&format=tilejson&api_key=default_public&client=deck-gl-carto',
+        'should be a right url for a tileset at v2'
+      );
+      return Promise.resolve({
+        json: () => TILEJSON_RESPONSE,
+        ok: true
+      });
+    };
+
+    data = await _getDataV2({
+      type: MAP_TYPES.TILESET,
+      source: 'tileset',
+      credentials: useSetDefaultCredentials ? getDefaultCredentials() : credentials
     });
-  };
 
-  data = await _getDataV2({
-    type: MAP_TYPES.TILESET,
-    source: 'tileset',
-    credentials: getDefaultCredentials()
+    t.ok(
+      Array.isArray(data.tiles) && data.tiles.length === 1,
+      'tiles should be an array with content'
+    );
+
+    _global.fetch = fetch;
+    setDefaultCredentials({});
+    t.end();
   });
-
-  t.ok(
-    Array.isArray(data.tiles) && data.tiles.length === 1,
-    'tiles should be an array with content'
-  );
-
-  _global.fetch = fetch;
-  setDefaultCredentials({});
-  t.end();
-});
+}
 
 test('getData#parameters', async t => {
   const params = {

--- a/test/modules/carto/api/maps-api-client.spec.js
+++ b/test/modules/carto/api/maps-api-client.spec.js
@@ -7,6 +7,7 @@ import {
   MAP_TYPES,
   API_VERSIONS,
   getData,
+  fetchLayerData,
   setDefaultCredentials,
   getDefaultCredentials
 } from '@deck.gl/carto';
@@ -183,10 +184,15 @@ test('getData#parameters', async t => {
     props: {columns: ['a', 'b', 'c'], geoColumn: 'geog'},
     mapInstantiationUrl:
       'http://carto-api/v3/maps/connection_name/table?client=deck-gl-carto&name=table&geo_column=geog&columns=a%2Cb%2Cc'
+  },
+  {
+    props: {schema: true},
+    mapInstantiationUrl:
+      'http://carto-api/v3/maps/connection_name/table?client=deck-gl-carto&schema=true&name=table'
   }
 ].forEach(({props, mapInstantiationUrl}) => {
   for (const useSetDefaultCredentials of [true, false]) {
-    test(`getData#setDefaultCredentials(${String(useSetDefaultCredentials)})`, async t => {
+    test(`fetchLayerData#setDefaultCredentials(${String(useSetDefaultCredentials)})`, async t => {
       const geojsonURL = 'http://geojson';
       const accessToken = 'XXX';
       const credentials = {
@@ -233,7 +239,7 @@ test('getData#parameters', async t => {
       };
 
       try {
-        await getData({
+        await fetchLayerData({
           type: MAP_TYPES.TABLE,
           connection: 'connection_name',
           source: 'table',


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/6230

#### Change List
- Add tests to capture case where CARTO is initialized without `setDefaultCredentials` (repro for bug)
- Modify `getData` to only use default credentials if they have been defined for correct API version

Source of bug was fact that V1 & V2 API uses a format string for the `mapsUrl` so it is by default not null. Sanity checking we have the right API version in the default credentials is good anyway and removes the source of this bug
