### PR TITLE
CARTO default to v3 API

### DIFF
--- a/modules/carto/src/api/maps-v3-client.js
+++ b/modules/carto/src/api/maps-v3-client.js
@@ -268,10 +268,14 @@ async function fillInMapDatasets({datasets, publicToken}) {
   return await Promise.all(promises);
 }
 
-export async function fetchMap({mapId, credentials, autoRefresh, onNewData}) {
-  const localCreds = {...getDefaultCredentials(), ...credentials};
+export async function fetchMap({cartoMapId, credentials, autoRefresh, onNewData}) {
+  const defaultCredentials = getDefaultCredentials();
+  const localCreds = {
+    ...(defaultCredentials.apiVersion === API_VERSIONS.V3 && defaultCredentials),
+    ...credentials
+  };
 
-  log.assert(mapId, 'Must define map id');
+  log.assert(cartoMapId, `Must define CARTO map id: fetchMap({cartoMapId: 'XXXX-XXXX-XXXX'})`);
 
   log.assert(localCreds.apiVersion === API_VERSIONS.V3, 'Method only available for v3');
   log.assert(localCreds.apiBaseUrl, 'Must define apiBaseUrl');
@@ -285,7 +289,7 @@ export async function fetchMap({mapId, credentials, autoRefresh, onNewData}) {
     log.assert(autoRefresh > 0, '`autoRefresh` must be a positive number');
   }
 
-  const url = `${localCreds.mapsUrl}/public/${mapId}`;
+  const url = `${localCreds.mapsUrl}/public/${cartoMapId}`;
   const map = await request({url});
 
   // Periodically check if the data has changed. Note that this

--- a/modules/carto/src/api/parseMap.js
+++ b/modules/carto/src/api/parseMap.js
@@ -20,7 +20,7 @@ export function parseMap(json) {
     description: json.description,
     createdAt: json.createdAt,
     updatedAt: json.updatedAt,
-    mapState,
+    initialViewState: mapState,
     mapStyle,
     layers: extractTextLayers(layers.reverse()).map(({id, type, config, visualChannels}) => {
       log.assert(type in LAYER_MAP, `Unsupported layer type: ${type}`);

--- a/modules/carto/src/config.js
+++ b/modules/carto/src/config.js
@@ -14,16 +14,16 @@ let credentials = {};
 
 setDefaultCredentials({});
 
-export function setDefaultCredentials(opts) {
-  const apiVersion = opts.apiVersion || API_VERSIONS.V3;
+export function setDefaultCredentials({apiVersion, ...rest}) {
+  apiVersion = apiVersion || API_VERSIONS.V3;
 
   switch (apiVersion) {
     case API_VERSIONS.V1:
     case API_VERSIONS.V2:
-      credentials = {apiVersion, ...defaultClassicCredentials, ...opts};
+      credentials = {apiVersion, ...defaultClassicCredentials, ...rest};
       break;
     case API_VERSIONS.V3:
-      credentials = {apiVersion, ...defaultCloudNativeCredentials, ...opts};
+      credentials = {apiVersion, ...defaultCloudNativeCredentials, ...rest};
       break;
     default:
       throw new Error(`Invalid API version ${apiVersion}. Use API_VERSIONS enum.`);

--- a/modules/carto/src/config.js
+++ b/modules/carto/src/config.js
@@ -1,16 +1,13 @@
-import {API_VERSIONS, DEFAULT_MAPS_URL_FORMAT} from './api/maps-api-common';
+import {API_VERSIONS} from './api/maps-api-common';
 
 export const defaultClassicCredentials = {
-  username: 'public',
   apiKey: 'default_public',
   region: 'us',
-  mapsUrl: null
+  username: 'public'
 };
 
-const defaultCloudNativeCredentials = {
-  accessToken: null,
-  apiBaseUrl: null,
-  mapsUrl: null
+export const defaultCloudNativeCredentials = {
+  apiBaseUrl: 'https://gcp-us-east1.api.carto.com'
 };
 
 let credentials = {};
@@ -18,43 +15,15 @@ let credentials = {};
 setDefaultCredentials({});
 
 export function setDefaultCredentials(opts) {
-  const apiVersion = opts.apiVersion || API_VERSIONS.V2;
+  const apiVersion = opts.apiVersion || API_VERSIONS.V3;
 
   switch (apiVersion) {
     case API_VERSIONS.V1:
-      opts.mapsUrl = opts.mapsUrl || DEFAULT_MAPS_URL_FORMAT[apiVersion];
-      credentials = {
-        apiVersion,
-        ...defaultClassicCredentials,
-        ...opts
-      };
-      break;
-
     case API_VERSIONS.V2:
-      opts.mapsUrl = opts.mapsUrl || DEFAULT_MAPS_URL_FORMAT[apiVersion];
-      credentials = {
-        apiVersion,
-        ...defaultClassicCredentials,
-        ...opts
-      };
-
+      credentials = {apiVersion, ...defaultClassicCredentials, ...opts};
       break;
     case API_VERSIONS.V3:
-      if (!opts.apiBaseUrl) {
-        throw new Error(
-          `API version ${
-            API_VERSIONS.V3
-          } requires to define apiBaseUrl at credentials. Go to https://app.carto.com to get your apiBaseUrl.`
-        );
-      }
-
-      const apiBaseUrl = opts.apiBaseUrl || defaultCloudNativeCredentials.apiBaseUrl;
-      opts.mapsUrl = opts.mapsUrl || buildMapsUrlFromBase(apiBaseUrl);
-      credentials = {
-        apiVersion,
-        ...defaultCloudNativeCredentials,
-        ...opts
-      };
+      credentials = {apiVersion, ...defaultCloudNativeCredentials, ...opts};
       break;
     default:
       throw new Error(`Invalid API version ${apiVersion}. Use API_VERSIONS enum.`);

--- a/test/apps/carto-map/app.js
+++ b/test/apps/carto-map/app.js
@@ -1,15 +1,14 @@
-import {fetchMap, setDefaultCredentials, API_VERSIONS} from '@deck.gl/carto';
+import {fetchMap} from '@deck.gl/carto';
 import {Deck} from '@deck.gl/core';
 import mapboxgl from 'mapbox-gl';
 
-setDefaultCredentials({
-  apiVersion: API_VERSIONS.V3,
-  apiBaseUrl: 'https://gcp-us-east1.api.carto.com'
-});
+// // Simplest instantiation
+// const cartoMapId = 'ff6ac53f-741a-49fb-b615-d040bc5a96b8';
+// fetchMap({cartoMapId}).then(map => new Deck(map));
 
-async function createMap(mapId) {
+async function createMap(cartoMapId) {
   const deck = new Deck({canvas: 'deck-canvas'});
-  const mapConfiguration = {mapId};
+  const mapConfiguration = {cartoMapId};
 
   // Auto-refresh (optional)
   const autoRefresh = true;
@@ -22,7 +21,7 @@ async function createMap(mapId) {
   }
 
   // Get map info from CARTO and update deck
-  const {mapState: initialViewState, mapStyle, layers} = await fetchMap(mapConfiguration);
+  const {initialViewState, mapStyle, layers} = await fetchMap(mapConfiguration);
   deck.setProps({initialViewState, layers});
 
   // Mapbox basemap (optional)
@@ -81,4 +80,5 @@ for (const e of examples) {
 const mapContainer = document.getElementById('container');
 mapContainer.style.height = 'calc(50% - 26px)';
 mapContainer.style.margin = '5px';
+
 createMap(id);

--- a/test/modules/carto/api/maps-api-client.spec.js
+++ b/test/modules/carto/api/maps-api-client.spec.js
@@ -136,18 +136,6 @@ test('getData#parameters', async t => {
 
   try {
     await getData({
-      ...params,
-      credentials: {
-        apiVersion: API_VERSIONS.V3
-      }
-    });
-    t.fail('it should throw an error');
-  } catch (e) {
-    t.is(e.message, 'Must define apiBaseUrl', 'should throw when no apiBaseUrl');
-  }
-
-  try {
-    await getData({
       type: MAP_TYPES.TABLE,
       connection: 'connection_name',
       source: 'table',

--- a/test/modules/carto/carto-bqtiler-layer.spec.js
+++ b/test/modules/carto/carto-bqtiler-layer.spec.js
@@ -1,13 +1,10 @@
-import test from 'tape-catch';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils';
 import {CartoBQTilerLayer} from '@deck.gl/carto';
-import {mockFetchMapsV2, restoreFetch} from './mock-fetch';
+import {mockedV2Test} from './mock-fetch';
 import {makeSpy} from '@probe.gl/test-utils';
 import {log} from '@deck.gl/core';
 
-test('CartoBQTilerLayer', t => {
-  const fetchMock = mockFetchMapsV2();
-
+mockedV2Test('CartoBQTilerLayer', t => {
   const testCases = generateLayerTests({
     Layer: CartoBQTilerLayer,
     assert: t.ok,
@@ -15,13 +12,9 @@ test('CartoBQTilerLayer', t => {
   });
 
   testLayer({Layer: CartoBQTilerLayer, testCases, onError: t.notOk});
-
-  restoreFetch(fetchMock);
-  t.end();
 });
 
-test('CartoBQTilerLayer#should throw warning message', t => {
-  const fetchMock = mockFetchMapsV2();
+mockedV2Test('CartoBQTilerLayer#should throw warning message', t => {
   makeSpy(log, 'warn');
 
   const testCases = [
@@ -38,6 +31,4 @@ test('CartoBQTilerLayer#should throw warning message', t => {
   testLayer({Layer: CartoBQTilerLayer, testCases, onError: t.notOk});
 
   log.warn.restore();
-  restoreFetch(fetchMock);
-  t.end();
 });

--- a/test/modules/carto/carto-layer.spec.js
+++ b/test/modules/carto/carto-layer.spec.js
@@ -4,7 +4,7 @@ import {makeSpy} from '@probe.gl/test-utils';
 import {CartoLayer, API_VERSIONS, MAP_TYPES} from '@deck.gl/carto';
 import {MVTLayer} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
-import {mockFetchMapsV2, mockFetchMapsV1, mockFetchMapsV3, restoreFetch} from './mock-fetch';
+import {mockedV1Test, mockedV2Test, mockFetchMapsV3, restoreFetch} from './mock-fetch';
 
 const CREDENTIALS_V3 = {
   apiVersion: API_VERSIONS.V3,
@@ -12,9 +12,7 @@ const CREDENTIALS_V3 = {
   accessToken: 'XXX'
 };
 
-test('CartoLayer#v2', async t => {
-  const fetchMock = mockFetchMapsV2();
-
+mockedV2Test('CartoLayer#v2', async t => {
   const onAfterUpdate = ({layer, subLayers, subLayer}) => {
     const {data} = layer.state;
     if (!data) {
@@ -49,9 +47,7 @@ test('CartoLayer#v2', async t => {
     ]
   });
 
-  restoreFetch(fetchMock);
   spy.restore();
-  t.end();
 });
 
 test('CartoLayer#v3', async t => {
@@ -118,9 +114,7 @@ test('CartoLayer#v3', async t => {
   t.end();
 });
 
-test('CartoLayer#should throw with invalid params for v1 and v2', t => {
-  const fetchMock = mockFetchMapsV1();
-
+mockedV1Test('CartoLayer#should throw with invalid params for v1 and v2', t => {
   const layer = new CartoLayer();
 
   const TEST_CASES = [
@@ -207,14 +201,9 @@ test('CartoLayer#should throw with invalid params for v1 and v2', t => {
   TEST_CASES.forEach(c => {
     t.throws(() => layer._checkProps(c.props), c.regex, c.title);
   });
-
-  restoreFetch(fetchMock);
-
-  t.end();
 });
 
-test('CartoLayer#should throw with invalid params for v3', t => {
-  const fetchMock = mockFetchMapsV1();
+mockedV1Test('CartoLayer#should throw with invalid params for v3', t => {
   const layer = new CartoLayer();
 
   const TEST_CASES = [
@@ -263,10 +252,6 @@ test('CartoLayer#should throw with invalid params for v3', t => {
   TEST_CASES.forEach(c => {
     t.throws(() => layer._checkProps(c.props), c.regex, c.title);
   });
-
-  restoreFetch(fetchMock);
-
-  t.end();
 });
 
 test('CartoLayer#_updateData executed when props changes', async t => {

--- a/test/modules/carto/carto-layer.spec.js
+++ b/test/modules/carto/carto-layer.spec.js
@@ -1,10 +1,9 @@
-import test from 'tape-catch';
 import {testLayerAsync} from '@deck.gl/test-utils';
 import {makeSpy} from '@probe.gl/test-utils';
 import {CartoLayer, API_VERSIONS, MAP_TYPES} from '@deck.gl/carto';
 import {MVTLayer} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
-import {mockedV1Test, mockedV2Test, mockFetchMapsV3, restoreFetch} from './mock-fetch';
+import {mockedV1Test, mockedV2Test, mockedV3Test} from './mock-fetch';
 
 const CREDENTIALS_V3 = {
   apiVersion: API_VERSIONS.V3,
@@ -50,8 +49,7 @@ mockedV2Test('CartoLayer#v2', async t => {
   spy.restore();
 });
 
-test('CartoLayer#v3', async t => {
-  const fetchMock = mockFetchMapsV3();
+mockedV3Test('CartoLayer#v3', async t => {
   const spy = makeSpy(MVTLayer.prototype, 'getTileData');
   spy.returns([]);
 
@@ -108,10 +106,7 @@ test('CartoLayer#v3', async t => {
     ]
   });
 
-  restoreFetch(fetchMock);
   spy.restore();
-
-  t.end();
 });
 
 mockedV1Test('CartoLayer#should throw with invalid params for v1 and v2', t => {
@@ -254,9 +249,7 @@ mockedV1Test('CartoLayer#should throw with invalid params for v3', t => {
   });
 });
 
-test('CartoLayer#_updateData executed when props changes', async t => {
-  const fetchMock = mockFetchMapsV3();
-
+mockedV3Test('CartoLayer#_updateData executed when props changes', async t => {
   const testCases = [
     {
       spies: ['_updateData'],
@@ -357,15 +350,9 @@ test('CartoLayer#_updateData executed when props changes', async t => {
   ];
 
   await testLayerAsync({Layer: CartoLayer, testCases, onError: t.notOk});
-
-  restoreFetch(fetchMock);
-
-  t.end();
 });
 
-test('CartoSQLLayer#onDataLoad', async t => {
-  const fetchMock = mockFetchMapsV3();
-
+mockedV3Test('CartoSQLLayer#onDataLoad', async t => {
   const spy = makeSpy(MVTLayer.prototype, 'getTileData');
   spy.returns([]);
 
@@ -403,7 +390,4 @@ test('CartoSQLLayer#onDataLoad', async t => {
   await testLayerAsync({Layer: CartoLayer, testCases, onError: t.notOk});
 
   spy.restore();
-  t.end();
-
-  restoreFetch(fetchMock);
 });

--- a/test/modules/carto/carto-sql-layer.spec.js
+++ b/test/modules/carto/carto-sql-layer.spec.js
@@ -1,13 +1,10 @@
-import test from 'tape-catch';
 import {log} from '@deck.gl/core';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils';
 import {CartoSQLLayer} from '@deck.gl/carto';
-import {mockFetchMapsV2, restoreFetch} from './mock-fetch';
+import {mockedV2Test} from './mock-fetch';
 import {makeSpy} from '@probe.gl/test-utils';
 
-test('CartoSQLLayer', t => {
-  const fetchMock = mockFetchMapsV2();
-
+mockedV2Test('CartoSQLLayer', t => {
   const testCases = generateLayerTests({
     Layer: CartoSQLLayer,
     assert: t.ok,
@@ -15,13 +12,10 @@ test('CartoSQLLayer', t => {
   });
 
   testLayer({Layer: CartoSQLLayer, testCases, onError: t.notOk});
-
-  restoreFetch(fetchMock);
   t.end();
 });
 
-test('CartoSQLLayer#should throw warning message', t => {
-  const fetchMock = mockFetchMapsV2();
+mockedV2Test('CartoSQLLayer#should throw warning message', t => {
   makeSpy(log, 'warn');
 
   const testCases = [
@@ -38,6 +32,5 @@ test('CartoSQLLayer#should throw warning message', t => {
   testLayer({Layer: CartoSQLLayer, testCases, onError: t.notOk});
 
   log.warn.restore();
-  restoreFetch(fetchMock);
   t.end();
 });

--- a/test/modules/carto/carto-sql-layer.spec.js
+++ b/test/modules/carto/carto-sql-layer.spec.js
@@ -12,7 +12,6 @@ mockedV2Test('CartoSQLLayer', t => {
   });
 
   testLayer({Layer: CartoSQLLayer, testCases, onError: t.notOk});
-  t.end();
 });
 
 mockedV2Test('CartoSQLLayer#should throw warning message', t => {
@@ -32,5 +31,4 @@ mockedV2Test('CartoSQLLayer#should throw warning message', t => {
   testLayer({Layer: CartoSQLLayer, testCases, onError: t.notOk});
 
   log.warn.restore();
-  t.end();
 });

--- a/test/modules/carto/config.spec.js
+++ b/test/modules/carto/config.spec.js
@@ -17,24 +17,26 @@ for (const apiVersion of [API_VERSIONS.V1, API_VERSIONS.V2]) {
   });
 }
 
-test('config#default values v3', t => {
-  setDefaultCredentials({});
+for (const apiVersion of [API_VERSIONS.V3, undefined]) {
+  test(`config#default values ${apiVersion || ''}`, t => {
+    setDefaultCredentials({apiVersion});
 
-  const credentials = getDefaultCredentials();
-  t.notOk(credentials === null, 'default credentials available');
-  t.is(credentials.apiVersion, API_VERSIONS.V3, 'v3 is the default');
-  t.is(
-    credentials.apiBaseUrl,
-    'https://gcp-us-east1.api.carto.com',
-    'us-east1 region is the default'
-  );
-  t.is(credentials.mapsUrl, undefined, 'mapsUrl has no default value');
+    const credentials = getDefaultCredentials();
+    t.notOk(credentials === null, 'default credentials available');
+    t.is(credentials.apiVersion, API_VERSIONS.V3, 'v3 is the default');
+    t.is(
+      credentials.apiBaseUrl,
+      'https://gcp-us-east1.api.carto.com',
+      'us-east1 region is the default'
+    );
+    t.is(credentials.mapsUrl, undefined, 'mapsUrl has no default value');
 
-  setDefaultCredentials({});
-  t.end();
-});
+    setDefaultCredentials({});
+    t.end();
+  });
+}
 
-test('config#setDefaultCredentials', t => {
+test('config#setDefaultCredentials invalid version', t => {
   t.throws(
     () => setDefaultCredentials({apiVersion: -123}),
     /Invalid API version -123/,

--- a/test/modules/carto/config.spec.js
+++ b/test/modules/carto/config.spec.js
@@ -1,19 +1,21 @@
 import test from 'tape-catch';
 import {getDefaultCredentials, setDefaultCredentials, API_VERSIONS} from '@deck.gl/carto';
 
-test('config#default values v2', t => {
-  setDefaultCredentials({apiVersion: API_VERSIONS.V2});
+for (const apiVersion of [API_VERSIONS.V1, API_VERSIONS.V2]) {
+  test(`config#default values ${apiVersion}`, t => {
+    setDefaultCredentials({apiVersion});
 
-  const credentials = getDefaultCredentials();
-  t.notOk(credentials === null, 'default credentials available');
-  t.is(credentials.apiVersion, API_VERSIONS.V2, 'version is retained');
-  t.is(credentials.apiKey, 'default_public', 'default_public is the default apiKey');
-  t.is(credentials.username, 'public', 'public is the default username');
-  t.is(credentials.region, 'us', 'us region is the default');
-  t.is(credentials.mapsUrl, undefined, 'mapsUrl has no default value');
-  setDefaultCredentials({});
-  t.end();
-});
+    const credentials = getDefaultCredentials();
+    t.notOk(credentials === null, 'default credentials available');
+    t.is(credentials.apiVersion, apiVersion, 'version is retained');
+    t.is(credentials.apiKey, 'default_public', 'default_public is the default apiKey');
+    t.is(credentials.username, 'public', 'public is the default username');
+    t.is(credentials.region, 'us', 'us region is the default');
+    t.is(credentials.mapsUrl, undefined, 'mapsUrl has no default value');
+    setDefaultCredentials({});
+    t.end();
+  });
+}
 
 test('config#default values v3', t => {
   setDefaultCredentials({});

--- a/test/modules/carto/config.spec.js
+++ b/test/modules/carto/config.spec.js
@@ -1,58 +1,44 @@
 import test from 'tape-catch';
 import {getDefaultCredentials, setDefaultCredentials, API_VERSIONS} from '@deck.gl/carto';
 
-test('config#default values', t => {
+test('config#default values v2', t => {
+  setDefaultCredentials({apiVersion: API_VERSIONS.V2});
+
   const credentials = getDefaultCredentials();
   t.notOk(credentials === null, 'default credentials available');
-  t.is(credentials.apiVersion, API_VERSIONS.V2, 'v2 is the default');
-  t.is(credentials.region, 'us', 'us region is the default');
+  t.is(credentials.apiVersion, API_VERSIONS.V2, 'version is retained');
+  t.is(credentials.apiKey, 'default_public', 'default_public is the default apiKey');
   t.is(credentials.username, 'public', 'public is the default username');
+  t.is(credentials.region, 'us', 'us region is the default');
+  t.is(credentials.mapsUrl, undefined, 'mapsUrl has no default value');
+  setDefaultCredentials({});
+  t.end();
+});
+
+test('config#default values v3', t => {
+  setDefaultCredentials({});
+
+  const credentials = getDefaultCredentials();
+  t.notOk(credentials === null, 'default credentials available');
+  t.is(credentials.apiVersion, API_VERSIONS.V3, 'v3 is the default');
+  t.is(
+    credentials.apiBaseUrl,
+    'https://gcp-us-east1.api.carto.com',
+    'us-east1 region is the default'
+  );
+  t.is(credentials.mapsUrl, undefined, 'mapsUrl has no default value');
+
+  setDefaultCredentials({});
   t.end();
 });
 
 test('config#setDefaultCredentials', t => {
-  setDefaultCredentials({apiVersion: API_VERSIONS.V1});
-  let credentials = getDefaultCredentials();
-  t.is(credentials.mapsUrl, 'https://{user}.carto.com/api/v1/map', 'right endpoint for v1');
-
-  setDefaultCredentials({apiVersion: API_VERSIONS.V1, mapsUrl: 'http://onprem'});
-  credentials = getDefaultCredentials();
-  t.is(credentials.mapsUrl, 'http://onprem', 'should allow to override mapsUrl for v1');
-
-  setDefaultCredentials({apiVersion: API_VERSIONS.V2});
-  credentials = getDefaultCredentials();
-  t.is(
-    credentials.mapsUrl,
-    'https://maps-api-v2.{region}.carto.com/user/{user}',
-    'right endpoint for v2'
-  );
-
-  setDefaultCredentials({apiVersion: API_VERSIONS.V2, mapsUrl: 'http://onprem'});
-  credentials = getDefaultCredentials();
-  t.is(credentials.mapsUrl, 'http://onprem', 'should allow to override mapsUrl for v2');
-
-  setDefaultCredentials({apiVersion: API_VERSIONS.V3, apiBaseUrl: 'http://server'});
-  credentials = getDefaultCredentials();
-  t.is(credentials.mapsUrl, 'http://server/v3/maps', 'right endpoint for v3');
-
-  setDefaultCredentials({
-    apiVersion: API_VERSIONS.V3,
-    apiBaseUrl: 'http://server',
-    mapsUrl: 'http://server2'
-  });
-  credentials = getDefaultCredentials();
-  t.is(credentials.mapsUrl, 'http://server2', 'should allow to override mapsUrl for v3');
-
   t.throws(
-    () => {
-      setDefaultCredentials({apiVersion: API_VERSIONS.V3});
-    },
-    /requires to define apiBaseUrl/i,
-    'should throw when apiBaseUrl is not defined at v3'
+    () => setDefaultCredentials({apiVersion: -123}),
+    /Invalid API version -123/,
+    'should throw on invalid API_VERSION'
   );
-
-  credentials = getDefaultCredentials();
-
   setDefaultCredentials({});
+
   t.end();
 });

--- a/test/modules/carto/mock-fetch.js
+++ b/test/modules/carto/mock-fetch.js
@@ -1,4 +1,5 @@
 /* global global, window */
+import test from 'tape-catch';
 const _global = typeof global !== 'undefined' ? global : window;
 
 export const TILEJSON_RESPONSE = {
@@ -85,4 +86,10 @@ export function mockFetchMapsV3() {
 
 export function restoreFetch(fetch) {
   _global.fetch = fetch;
+}
+
+export function mockedV2Test(name, testFunc) {
+  const fetchMock = mockFetchMapsV2();
+  test(name, testFunc);
+  restoreFetch(fetchMock);
 }

--- a/test/modules/carto/mock-fetch.js
+++ b/test/modules/carto/mock-fetch.js
@@ -29,7 +29,7 @@ export const MAPS_API_V1_RESPONSE = {
   }
 };
 
-export function mockFetchMapsV1() {
+function mockFetchMapsV1() {
   const fetch = _global.fetch;
   _global.fetch = url =>
     Promise.resolve({
@@ -39,7 +39,7 @@ export function mockFetchMapsV1() {
   return fetch;
 }
 
-export function mockFetchMapsV2() {
+function mockFetchMapsV2() {
   const fetch = _global.fetch;
   _global.fetch = url => {
     return Promise.resolve({
@@ -88,8 +88,19 @@ export function restoreFetch(fetch) {
   _global.fetch = fetch;
 }
 
+export function mockedV1Test(name, testFunc) {
+  test(name, async t => {
+    const fetchMock = mockFetchMapsV1();
+    await testFunc(t);
+    restoreFetch(fetchMock);
+    t.end();
+  });
+}
 export function mockedV2Test(name, testFunc) {
-  const fetchMock = mockFetchMapsV2();
-  test(name, testFunc);
-  restoreFetch(fetchMock);
+  test(name, async t => {
+    const fetchMock = mockFetchMapsV2();
+    await testFunc(t);
+    restoreFetch(fetchMock);
+    t.end();
+  });
 }

--- a/test/modules/carto/mock-fetch.js
+++ b/test/modules/carto/mock-fetch.js
@@ -50,7 +50,7 @@ function mockFetchMapsV2() {
   return fetch;
 }
 
-export function mockFetchMapsV3() {
+function mockFetchMapsV3() {
   const fetch = _global.fetch;
   _global.fetch = url => {
     return Promise.resolve({
@@ -96,9 +96,19 @@ export function mockedV1Test(name, testFunc) {
     t.end();
   });
 }
+
 export function mockedV2Test(name, testFunc) {
   test(name, async t => {
     const fetchMock = mockFetchMapsV2();
+    await testFunc(t);
+    restoreFetch(fetchMock);
+    t.end();
+  });
+}
+
+export function mockedV3Test(name, testFunc) {
+  test(name, async t => {
+    const fetchMock = mockFetchMapsV3();
     await testFunc(t);
     restoreFetch(fetchMock);
     t.end();

--- a/test/modules/carto/mock-fetch.js
+++ b/test/modules/carto/mock-fetch.js
@@ -1,5 +1,6 @@
 /* global global, window */
 import test from 'tape-catch';
+import {API_VERSIONS, setDefaultCredentials} from '@deck.gl/carto';
 const _global = typeof global !== 'undefined' ? global : window;
 
 export const TILEJSON_RESPONSE = {
@@ -41,6 +42,7 @@ function mockFetchMapsV1() {
 
 function mockFetchMapsV2() {
   const fetch = _global.fetch;
+
   _global.fetch = url => {
     return Promise.resolve({
       json: () => TILEJSON_RESPONSE,
@@ -100,6 +102,7 @@ export function mockedV1Test(name, testFunc) {
 export function mockedV2Test(name, testFunc) {
   test(name, async t => {
     const fetchMock = mockFetchMapsV2();
+    setDefaultCredentials({apiVersion: API_VERSIONS.V2});
     await testFunc(t);
     restoreFetch(fetchMock);
     t.end();


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/6375

<!-- For all the PRs -->
#### Change List
- Switch to V3 API by default
- Simplify `setDefaultCredentials`
- Update tests
- Update `fetchMap` function to use `cartoMapId` and `credentials` options