### PR TITLE
Remove Matrix4 dependency from project module getUniforms

### DIFF
--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -221,7 +221,7 @@ function calculateViewportUniforms({
   // When using Viewport class's default projection matrix, this yields 1 for orthographic
   // and `viewport.focalDistance` for perspective views
   const focalDistance =
-    viewport.projectionMatrix.transform([0, 0, -viewport.focalDistance, 1])[3] || 1;
+    vec4.transformMat4([], [0, 0, -viewport.focalDistance, 1], viewport.projectionMatrix)[3] || 1;
 
   const uniforms = {
     // Projection mode values


### PR DESCRIPTION
For #6350

While it's unclear to me how the math.gl dependency does not get resolved correctly for the reporting users, it may potentially crash in case the user provides a custom `projectionMatrix` that is not a Matrix4 instance:

https://github.com/visgl/deck.gl/blob/efc46e015dbf74520db3011b2c575f5e9aff4521/modules/core/src/viewports/viewport.js#L402-L404

#### Change List
- remove Matrix4 dependency from project module `getUniforms`
