### PR TITLE
fix(geo-layers): _MeshLayer & repeating textures

### DIFF
--- a/modules/geo-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
@@ -37,9 +37,7 @@ vec2 applyUVRegion(vec2 uv) {
 
 void main(void) {
   vec2 uv = applyUVRegion(texCoords);
-
   geometry.uv = uv;
-  geometry.uv = texCoords;
 
   if (u_pickFeatureIds) {
     geometry.pickingColor = featureIdsPickingColors;

--- a/modules/geo-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer-vertex.glsl.js
@@ -26,9 +26,17 @@ out vec3 normals_commonspace;
 out vec4 position_commonspace;
 out vec4 vColor;
 
+vec2 applyUVRegion(vec2 uv) {
+  #ifdef HAS_UV_REGIONS
+    // https://github.com/Esri/i3s-spec/blob/master/docs/1.7/geometryUVRegion.cmn.md
+    return fract(uv) * (uvRegions.zw - uvRegions.xy) + uvRegions.xy;
+  #else
+    return uv;
+  #endif
+}
+
 void main(void) {
-  // https://github.com/Esri/i3s-spec/blob/master/docs/1.7/geometryUVRegion.cmn.md
-  vec2 uv = fract(texCoords) * (uvRegions.zw - uvRegions.xy) + uvRegions.xy;
+  vec2 uv = applyUVRegion(texCoords);
 
   geometry.uv = uv;
   geometry.uv = texCoords;

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.js
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.js
@@ -11,9 +11,6 @@ function validateGeometryAttributes(attributes) {
   if (!hasColorAttribute) {
     attributes.colors = {constant: true, value: new Float32Array([1, 1, 1])};
   }
-  if (!attributes.uvRegions) {
-    attributes.uvRegions = {constant: true, value: new Float32Array([0, 0, 1, 1])};
-  }
 }
 
 const defaultProps = {
@@ -76,7 +73,11 @@ export default class _MeshLayer extends SimpleMeshLayer {
       ...this.getShaders(),
       id,
       geometry: mesh,
-      defines: {...shaders.defines, ...materialParser?.defines},
+      defines: {
+        ...shaders.defines,
+        ...materialParser?.defines,
+        HAS_UV_REGIONS: mesh.attributes.uvRegions
+      },
       parameters: materialParser?.parameters,
       isInstanced: true
     });


### PR DESCRIPTION
For #6467
#### Change List
- don't create constant attribute `uvRegions`;
- if `uvRegions` regions attribute is not presented, use UV0s as is.

The  changes were checked as fork in loader.gl repository: https://github.com/visgl/loaders.gl/pull/1935