### PR TITLE
Fix MVTLayer functional highlightColor

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -43,6 +43,10 @@ export default class MVTLayer extends TileLayer {
       super.updateState({props, oldProps, context, changeFlags});
       this._setWGS84PropertyForTiles();
     }
+    const {highlightColor} = props;
+    if (highlightColor !== oldProps.highlightColor && Array.isArray(highlightColor)) {
+      this.setState({highlightColor});
+    }
   }
 
   /* eslint-disable complexity */
@@ -167,12 +171,17 @@ export default class MVTLayer extends TileLayer {
       newHoveredFeatureId = getFeatureUniqueId(hoveredFeature, uniqueIdProperty);
       newHoveredFeatureLayerName = getFeatureLayerName(hoveredFeature);
     }
+    let {highlightColor} = this.props;
+    if (typeof highlightColor === 'function') {
+      highlightColor = highlightColor(info);
+    }
 
     if (
       hoveredFeatureId !== newHoveredFeatureId ||
       hoveredFeatureLayerName !== newHoveredFeatureLayerName
     ) {
       this.setState({
+        highlightColor,
         hoveredFeatureId: newHoveredFeatureId,
         hoveredFeatureLayerName: newHoveredFeatureLayerName
       });
@@ -193,6 +202,13 @@ export default class MVTLayer extends TileLayer {
     }
 
     return info;
+  }
+
+  getSubLayerPropsByTile(tile) {
+    return {
+      highlightedObjectIndex: this.getHighlightedObjectIndex(tile),
+      highlightColor: this.state.highlightColor
+    };
   }
 
   getHighlightedObjectIndex(tile) {

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -179,8 +179,8 @@ export default class TileLayer extends CompositeLayer {
     return this.props.renderSubLayers(props);
   }
 
-  getHighlightedObjectIndex() {
-    return -1;
+  getSubLayerPropsByTile(tile) {
+    return null;
   }
 
   getPickingInfo({info, sourceLayer}) {
@@ -196,7 +196,7 @@ export default class TileLayer extends CompositeLayer {
 
   renderLayers() {
     return this.state.tileset.tiles.map(tile => {
-      const highlightedObjectIndex = this.getHighlightedObjectIndex(tile);
+      const subLayerProps = this.getSubLayerPropsByTile(tile);
       // cache the rendered layer in the tile
       if (!tile.isLoaded && !tile.content) {
         // nothing to show
@@ -211,14 +211,17 @@ export default class TileLayer extends CompositeLayer {
         tile.layers = flatten(layers, Boolean).map(layer =>
           layer.clone({
             tile,
-            highlightedObjectIndex
+            ...subLayerProps
           })
         );
       } else if (
+        subLayerProps &&
         tile.layers[0] &&
-        tile.layers[0].props.highlightedObjectIndex !== highlightedObjectIndex
+        Object.keys(subLayerProps).some(
+          propName => tile.layers[0].props[propName] !== subLayerProps[propName]
+        )
       ) {
-        tile.layers = tile.layers.map(layer => layer.clone({highlightedObjectIndex}));
+        tile.layers = tile.layers.map(layer => layer.clone(subLayerProps));
       }
       return tile.layers;
     });


### PR DESCRIPTION
For #6120 

#### Change List
- Evaluate `highlightColor` if it's a function
- Rename TileLayer `getHighlightedObjectIndex` to `getSubLayerPropsByTile` for generic overrides