### PR TITLE
Avoid mutating coordinateOrigin

### DIFF
--- a/modules/core/src/shaderlib/project/viewport-uniforms.js
+++ b/modules/core/src/shaderlib/project/viewport-uniforms.js
@@ -41,6 +41,10 @@ export function getOffsetOrigin(
   coordinateSystem,
   coordinateOrigin = DEFAULT_COORDINATE_ORIGIN
 ) {
+  if (coordinateOrigin.length < 3) {
+    coordinateOrigin = [coordinateOrigin[0], coordinateOrigin[1], 0];
+  }
+
   let shaderCoordinateOrigin = coordinateOrigin;
   let geospatialOrigin;
   let offsetMode = true;
@@ -88,6 +92,7 @@ export function getOffsetOrigin(
 
     case PROJECTION_MODE.IDENTITY:
       shaderCoordinateOrigin = viewport.position.map(Math.fround);
+      shaderCoordinateOrigin[2] = shaderCoordinateOrigin[2] || 0;
       break;
 
     case PROJECTION_MODE.GLOBE:
@@ -99,8 +104,6 @@ export function getOffsetOrigin(
       // Unknown projection mode
       offsetMode = false;
   }
-
-  shaderCoordinateOrigin[2] = shaderCoordinateOrigin[2] || 0;
 
   return {geospatialOrigin, shaderCoordinateOrigin, offsetMode};
 }

--- a/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
+++ b/test/modules/core/shaderlib/project/viewport-uniforms.spec.js
@@ -139,7 +139,7 @@ test('project#getUniforms', t => {
   uniforms = project.getUniforms({
     viewport: TEST_VIEWPORTS.mapHighZoom,
     coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
-    coordinateOrigin: [-122.4, 37.7]
+    coordinateOrigin: Object.freeze([-122.4, 37.7])
   });
   t.notOk(getUniformsError(uniforms, UNIFORMS), 'Uniforms validated');
   t.ok(


### PR DESCRIPTION

For #6480


#### Change List
- Avoid mutating `coordinateOrigin` when generating uniforms
- Unit test
