### PR TITLE
Export getURLFromTemplate at geo-layers

### DIFF
--- a/modules/carto/src/layers/carto-dynamic-tile-layer.js
+++ b/modules/carto/src/layers/carto-dynamic-tile-layer.js
@@ -1,11 +1,10 @@
 /* global TextDecoder */
 import {log} from '@deck.gl/core';
 import {ClipExtension} from '@deck.gl/extensions';
-import {MVTLayer} from '@deck.gl/geo-layers';
+import {MVTLayer, _getURLFromTemplate} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {geojsonToBinary} from '@loaders.gl/gis';
 import {encodeParameter} from '../api/maps-api-common';
-import {getURLFromTemplate} from '@deck.gl/geo-layers/tile-layer/utils';
 
 function parseJSON(arrayBuffer) {
   return JSON.parse(new TextDecoder().decode(arrayBuffer));
@@ -37,7 +36,7 @@ const CartoDynamicTileLoader = {
 
 export default class CartoDynamicTileLayer extends MVTLayer {
   getTileData(tile) {
-    let url = getURLFromTemplate(this.state.data, tile);
+    let url = _getURLFromTemplate(this.state.data, tile);
     if (!url) {
       return Promise.reject('Invalid URL');
     }

--- a/modules/geo-layers/src/index.ts
+++ b/modules/geo-layers/src/index.ts
@@ -28,3 +28,5 @@ export {default as H3HexagonLayer} from './h3-layers/h3-hexagon-layer';
 export {default as Tile3DLayer} from './tile-3d-layer/tile-3d-layer';
 export {default as TerrainLayer} from './terrain-layer/terrain-layer';
 export {default as MVTLayer} from './mvt-layer/mvt-layer';
+
+export { getURLFromTemplate as _getURLFromTemplate } from './tile-layer/utils';

--- a/modules/geo-layers/src/index.ts
+++ b/modules/geo-layers/src/index.ts
@@ -29,4 +29,4 @@ export {default as Tile3DLayer} from './tile-3d-layer/tile-3d-layer';
 export {default as TerrainLayer} from './terrain-layer/terrain-layer';
 export {default as MVTLayer} from './mvt-layer/mvt-layer';
 
-export { getURLFromTemplate as _getURLFromTemplate } from './tile-layer/utils';
+export {getURLFromTemplate as _getURLFromTemplate} from './tile-layer/utils';


### PR DESCRIPTION
CARTO module uses getURLFromTemplate and this function can be useful for other modules too. CARTO module has a bug at dynamic tile layer when we try to import  it works in local but not in the bundle because getURLFromTemplate is not exported