### PR TITLE
Correctly calculate GLViewport with Framebuffer

### DIFF
--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -282,19 +282,15 @@ function getGLViewport(gl, {moduleParameters, target, viewport}) {
   const useTarget = target && target.id !== 'default-framebuffer';
   const pixelRatio =
     (moduleParameters && moduleParameters.devicePixelRatio) || cssToDeviceRatio(gl);
-  const targetHeight = target ? target.height / pixelRatio : 100;
-
-  // Fallback to width/height when clientWidth/clientHeight are 0 or undefined.
-  const canvasHeight = gl.canvas ? gl.canvas.clientHeight || gl.canvas.height : 100;
 
   // Default framebuffer is used when writing to canvas
-  const height = useTarget ? targetHeight : canvasHeight;
+  const height = useTarget ? target.height : gl.drawingBufferHeight;
 
   // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
   const dimensions = viewport;
   return [
     dimensions.x * pixelRatio,
-    (height - dimensions.y - dimensions.height) * pixelRatio,
+    height - (dimensions.y + dimensions.height) * pixelRatio,
     dimensions.width * pixelRatio,
     dimensions.height * pixelRatio
   ];

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -97,8 +97,12 @@ export default class LayersPass extends Pass {
   // TODO - when picking we could completely skip rendering viewports that dont
   // intersect with the picking rect
   /* eslint-disable max-depth, max-statements */
-  _drawLayersInViewport(gl, {layers, pass, viewport, view}, drawLayerParams) {
-    const glViewport = getGLViewport(gl, {viewport});
+  _drawLayersInViewport(
+    gl,
+    {layers, moduleParameters, pass, target, viewport, view},
+    drawLayerParams
+  ) {
+    const glViewport = getGLViewport(gl, {moduleParameters, target, viewport});
 
     if (view && view.props.clear) {
       const clearOpts = view.props.clear === true ? {color: true, depth: true} : view.props.clear;
@@ -270,13 +274,20 @@ export function layerIndexResolver(startIndex = 0, layerIndices = {}) {
 }
 
 // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
-function getGLViewport(gl, {viewport}) {
-  // TODO - dummy default for node
+function getGLViewport(gl, {moduleParameters, target, viewport}) {
+  const useTarget = target && target.id !== 'default-framebuffer';
+  const pixelRatio =
+    (moduleParameters && moduleParameters.devicePixelRatio) || cssToDeviceRatio(gl);
+  const targetHeight = target ? target.height / pixelRatio : 100;
+
   // Fallback to width/height when clientWidth/clientHeight are 0 or undefined.
-  const height = gl.canvas ? gl.canvas.clientHeight || gl.canvas.height : 100;
+  const canvasHeight = gl.canvas ? gl.canvas.clientHeight || gl.canvas.height : 100;
+
+  // Default framebuffer is used when writing to canvas
+  const height = useTarget ? targetHeight : canvasHeight;
+
   // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates
   const dimensions = viewport;
-  const pixelRatio = cssToDeviceRatio(gl);
   return [
     dimensions.x * pixelRatio,
     (height - dimensions.y - dimensions.height) * pixelRatio,

--- a/modules/core/src/passes/layers-pass.js
+++ b/modules/core/src/passes/layers-pass.js
@@ -99,10 +99,14 @@ export default class LayersPass extends Pass {
   /* eslint-disable max-depth, max-statements */
   _drawLayersInViewport(
     gl,
-    {layers, moduleParameters, pass, target, viewport, view},
+    {layers, moduleParameters: globalModuleParameters, pass, target, viewport, view},
     drawLayerParams
   ) {
-    const glViewport = getGLViewport(gl, {moduleParameters, target, viewport});
+    const glViewport = getGLViewport(gl, {
+      moduleParameters: globalModuleParameters,
+      target,
+      viewport
+    });
 
     if (view && view.props.clear) {
       const clearOpts = view.props.clear === true ? {color: true, depth: true} : view.props.clear;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->

For https://github.com/visgl/deck.gl/issues/6552

#### Background

When passing a `Framebuffer` as a `target` the GLViewport calculated assumed the width and height to be equal to the GL canvas

#### Change List
- When a custom target is passed to the layers pass, use its width&height rather than that of the canvas
- When the `moduleParameters` specify a pixel ratio, respect this when calculating the GL viewport
