### PR TITLE
Fix z stacking of MapboxLayers

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -183,9 +183,10 @@ function updateLayers(deck) {
   }
 
   const layers = [];
+  let layerIndex = 0;
   deck.props.userData.mapboxLayers.forEach(deckLayer => {
     const LayerType = deckLayer.props.type;
-    const layer = new LayerType(deckLayer.props);
+    const layer = new LayerType(deckLayer.props, {_offset: layerIndex++});
     layers.push(layer);
   });
   deck.setProps({layers});


### PR DESCRIPTION
For #6284, #6541

Each MapboxLayer gets its own `LayersPass.render` call, so `layerIndex` always starts from 0, and `getPolygonOffset` is therefore ineffective.

#### Change List
- Override layer index
