### PR TITLE
in carto module, method to get domain for scales takes into account t…

### DIFF
--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -104,6 +104,11 @@ function domainFromAttribute(attribute, scaleType) {
 function domainFromValues(values, scaleType) {
   if (scaleType === 'ordinal') {
     return [...new Set(values)].sort();
+  } else if (scaleType === 'quantile') {
+    return values.sort((a, b) => a - b);
+  } else if (scaleType === 'log') {
+    const [d0, d1] = extent(values);
+    return [d0 === 0 ? 1e-5 : d0, d1];
   }
   return extent(values);
 }

--- a/modules/carto/src/api/parseMap.js
+++ b/modules/carto/src/api/parseMap.js
@@ -146,12 +146,11 @@ function createChannelProps(visualChannels, type, config, data) {
     );
   }
   if (strokeColorField) {
-    const opacity =
-      visConfig.strokeOpacity !== undefined ? visConfig.strokeOpacity / visConfig.opacity : 1;
+    const opacity = visConfig.strokeOpacity !== undefined ? visConfig.strokeOpacity : 1;
     result.getLineColor = getColorAccessor(
       strokeColorField,
       strokeColorScale,
-      visConfig.colorRange,
+      visConfig.strokeColorRange,
       opacity,
       data
     );


### PR DESCRIPTION
#### Background
-Layers returned by the fetchMap Carto module method use wrong domains in their scales when their types are quantile or logarithmic. The result of this is that some maps don't have the same style as the Builder maps.
- Layers returned by the fetchMap Carto module use `colorRange` instead of `strokeColorRange` to style lines layers
- Fixed wrong calculation of `strokeOpacity` for Layers returned by the fetchMap Carto module.
#### Change List
- Modified `domainFromValues` Carto module method to take into account the scale type.
- Use `strokeColorRange` instead of `colorRange` to style lines layers returned by fetchMap Carto module method.
- Fixed the calculation of `strokeOpacity` for Layers returned by the fetchMap Carto module.