### PR TITLE
Fix Highlighting in Carto module

### DIFF
--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -85,7 +85,12 @@ export const LAYER_MAP = {
   mvt: {
     Layer: MVTLayer,
     propMap: sharedPropMap,
-    defaultProps: {...defaultProps, pointRadiusScale: 0.3, lineWidthScale: 2}
+    defaultProps: {
+      ...defaultProps,
+      pointRadiusScale: 0.3,
+      lineWidthScale: 2,
+      uniqueIdProperty: 'geoid'
+    }
   }
 };
 

--- a/test/modules/carto/data/visState.json
+++ b/test/modules/carto/data/visState.json
@@ -565,7 +565,8 @@
           "getLineWidth": 0.6,
           "getPointRadius": 10,
           "wireframe": false,
-          "highlightColor": [252, 242, 26, 255]
+          "highlightColor": [252, 242, 26, 255],
+          "uniqueIdProperty": "geoid"
         }
       }
     ]
@@ -787,7 +788,8 @@
           "getLineWidth": 0.5,
           "getPointRadius": 10,
           "wireframe": false,
-          "highlightColor": [252, 242, 26, 255]
+          "highlightColor": [252, 242, 26, 255],
+          "uniqueIdProperty": "geoid"
         }
       }
     ]


### PR DESCRIPTION
#### Background
Highlighting doesn't work in layers returned by fetchMap Carto module method when these layers are MVT layers. This happens because these layers don't have uniqueIdProperty. To replicate the same behavior as in Builder we are assuming that tilesets returned by the maps API normally have a geoid
#### Change List
- uniqueIdProperty added to MVT layers returned by fetchMap Carto module
