### PR TITLE
Support multiple masks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ const config = deepMerge(defaultConfig, {
     {
       files: ['**/*.ts', '**/*.tsx', '**/*.d.ts'],
       rules: {
+        indent: 0,
         // For parquet module
         '@typescript-eslint/no-non-null-assertion': 0,
         '@typescript-eslint/no-non-null-asserted-optional-chain': 0,

--- a/modules/core/src/effects/mask/mask-effect.js
+++ b/modules/core/src/effects/mask/mask-effect.js
@@ -34,7 +34,6 @@ export default class MaskEffect extends Effect {
     this.masks = {};
 
     if (!this.maskPass) {
-      // TODO - support multiple masks
       this.maskPass = new MaskPass(gl, {id: 'default-mask'});
       this.maskMap = this.maskPass.maskMap;
     }
@@ -136,7 +135,7 @@ export default class MaskEffect extends Effect {
       const {id} = layer.root;
       let channelInfo = channelMap[id];
       if (!channelInfo) {
-        if (++channelCount > 3) {
+        if (++channelCount > 4) {
           log.warn('Too many mask layers. The max supported is 4')();
           continue;
         }

--- a/modules/core/src/effects/mask/mask-effect.js
+++ b/modules/core/src/effects/mask/mask-effect.js
@@ -95,7 +95,7 @@ export default class MaskEffect extends Effect {
           });
         }
       }
-      this.masks[channelInfo.id] = {channel: channelInfo.index, maskBounds: channelInfo.maskBounds};
+      this.masks[channelInfo.id] = {index: channelInfo.index, bounds: channelInfo.maskBounds};
     }
 
     // // Debug show FBO contents on screen
@@ -157,7 +157,7 @@ export default class MaskEffect extends Effect {
     for (let i = 0; i < 4; i++) {
       const channelInfo = this.channels[i];
       if (!channelInfo || !(channelInfo.id in channelMap)) {
-        // The mask id at the channel no longer exists
+        // The mask id at this channel no longer exists
         this.channels[i] = null;
       }
     }

--- a/modules/core/src/effects/mask/mask-effect.js
+++ b/modules/core/src/effects/mask/mask-effect.js
@@ -1,7 +1,5 @@
-import {
-  Texture2D
-  // , readPixelsToArray
-} from '@luma.gl/core';
+import {Texture2D} from '@luma.gl/core';
+// import {readPixelsToArray} from '@luma.gl/core';
 import {equals} from '@math.gl/core';
 import MaskPass from '../../passes/mask-pass';
 import Effect from '../../lib/effect';
@@ -84,7 +82,7 @@ export default class MaskEffect extends Effect {
 
           maskPass.render({
             channel: channelInfo.index,
-            layers,
+            layers: channelInfo.layers,
             layerFilter,
             viewports: maskViewport ? [maskViewport] : [],
             onViewportActive,

--- a/modules/core/src/effects/mask/utils.js
+++ b/modules/core/src/effects/mask/utils.js
@@ -65,6 +65,9 @@ export function getMaskViewport({bounds, viewport, width, height}) {
   if (bounds[2] <= bounds[0] || bounds[3] <= bounds[1]) {
     return null;
   }
+  const padding = 1;
+  width -= padding * 2;
+  height -= padding * 2;
 
   if (viewport instanceof WebMercatorViewport) {
     const {longitude, latitude, zoom} = fitBounds({
@@ -76,13 +79,24 @@ export function getMaskViewport({bounds, viewport, width, height}) {
       ],
       maxZoom: 20
     });
-    return new WebMercatorViewport({longitude, latitude, zoom, width, height});
+    return new WebMercatorViewport({
+      longitude,
+      latitude,
+      zoom,
+      x: padding,
+      y: padding,
+      width,
+      height
+    });
   }
 
   const center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2, 0];
   const scale = Math.min(20, width / (bounds[2] - bounds[0]), height / (bounds[3] - bounds[1]));
 
-  return new OrthographicView().makeViewport({
+  return new OrthographicView({
+    x: padding,
+    y: padding
+  }).makeViewport({
     width,
     height,
     viewState: {

--- a/modules/core/src/effects/mask/utils.js
+++ b/modules/core/src/effects/mask/utils.js
@@ -62,6 +62,10 @@ export function getMaskBounds({layers, viewport}) {
  * Compute viewport to render the mask into, covering the given bounds
  */
 export function getMaskViewport({bounds, viewport, width, height}) {
+  if (bounds[2] <= bounds[0] || bounds[3] <= bounds[1]) {
+    return null;
+  }
+
   if (viewport instanceof WebMercatorViewport) {
     const {longitude, latitude, zoom} = fitBounds({
       width,

--- a/modules/core/src/effects/mask/utils.js
+++ b/modules/core/src/effects/mask/utils.js
@@ -65,6 +65,8 @@ export function getMaskViewport({bounds, viewport, width, height}) {
   if (bounds[2] <= bounds[0] || bounds[3] <= bounds[1]) {
     return null;
   }
+
+  // Single pixel border to prevent mask bleeding at edge of texture
   const padding = 1;
   width -= padding * 2;
   height -= padding * 2;

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -10,7 +10,7 @@ import type Effect from '../lib/effect';
 
 export type LayersPassRenderOptions = {
   target?: Framebuffer;
-  pass: string;
+  pass?: string;
   layers: Layer[];
   viewports: Viewport[];
   onViewportActive: (viewport: Viewport) => void;

--- a/modules/core/src/passes/mask-pass.ts
+++ b/modules/core/src/passes/mask-pass.ts
@@ -1,4 +1,4 @@
-import {Framebuffer, Texture2D, withParameters, clearGLCanvas} from '@luma.gl/core';
+import {Framebuffer, Texture2D, withParameters} from '@luma.gl/core';
 import {OPERATION} from '../lib/constants';
 import LayersPass from './layers-pass';
 
@@ -37,25 +37,10 @@ export default class MaskPass extends LayersPass {
         [gl.COLOR_ATTACHMENT0]: this.maskMap
       }
     });
-
-    // Fill the texture with 1
-    withParameters(
-      gl,
-      {
-        framebuffer: this.fbo,
-        viewport: [0, 0, mapSize, mapSize],
-        clearColor: [255, 255, 255, 255]
-      },
-      () => {
-        gl.clear(gl.COLOR_BUFFER_BIT);
-      }
-    );
   }
 
   render(options: MaskPassRenderOptions) {
     const gl = this.gl;
-    const {width, height} = this.fbo;
-    const padding = 1;
 
     const colorMask = [false, false, false, false];
     colorMask[options.channel] = true;
@@ -68,12 +53,7 @@ export default class MaskPass extends LayersPass {
         blendFunc: [gl.ZERO, gl.ONE],
         blendEquation: gl.FUNC_SUBTRACT,
         colorMask,
-
-        depthTest: false,
-
-        // Prevent mask bleeding over edge by adding transparent padding
-        scissorTest: true,
-        scissor: [padding, padding, width - 2 * padding, height - 2 * padding]
+        depthTest: false
       },
       () => super.render({...options, target: this.fbo, pass: 'mask'})
     );

--- a/modules/extensions/src/mask/mask.js
+++ b/modules/extensions/src/mask/mask.js
@@ -1,4 +1,4 @@
-import {LayerExtension} from '@deck.gl/core';
+import {LayerExtension, log} from '@deck.gl/core';
 import mask from './shader-module';
 
 const defaultProps = {
@@ -22,11 +22,19 @@ export default class MaskExtension extends LayerExtension {
 
   draw({uniforms, moduleParameters}) {
     uniforms.mask_maskByInstance = this.state.maskByInstance;
-    const {maskBounds} = moduleParameters;
-    if (maskBounds) {
+    const {maskEnabled = true, maskId} = this.props;
+    const {maskChannels} = moduleParameters;
+    if (maskChannels && maskChannels[maskId]) {
+      const {channel, maskBounds} = maskChannels[maskId];
+
       const bl = this.projectPosition([maskBounds[0], maskBounds[1], 0]);
       const tr = this.projectPosition([maskBounds[2], maskBounds[3], 0]);
+      uniforms.mask_enabled = maskEnabled;
+      uniforms.mask_channel = channel;
       uniforms.mask_bounds = [bl[0], bl[1], tr[0], tr[1]];
+    } else {
+      log.warn(`Could not find a mask layer with id: ${maskId}`)();
+      uniforms.mask_enabled = false;
     }
   }
 }

--- a/modules/extensions/src/mask/mask.js
+++ b/modules/extensions/src/mask/mask.js
@@ -2,7 +2,7 @@ import {LayerExtension, log} from '@deck.gl/core';
 import mask from './shader-module';
 
 const defaultProps = {
-  maskEnabled: true
+  maskId: ''
 };
 
 export default class MaskExtension extends LayerExtension {
@@ -22,18 +22,20 @@ export default class MaskExtension extends LayerExtension {
 
   draw({uniforms, moduleParameters}) {
     uniforms.mask_maskByInstance = this.state.maskByInstance;
-    const {maskEnabled = true, maskId} = this.props;
+    const {maskId} = this.props;
     const {maskChannels} = moduleParameters;
     if (maskChannels && maskChannels[maskId]) {
       const {index, bounds} = maskChannels[maskId];
 
       const bl = this.projectPosition([bounds[0], bounds[1], 0]);
       const tr = this.projectPosition([bounds[2], bounds[3], 0]);
-      uniforms.mask_enabled = maskEnabled;
+      uniforms.mask_enabled = true;
       uniforms.mask_channel = index;
       uniforms.mask_bounds = [bl[0], bl[1], tr[0], tr[1]];
     } else {
-      log.warn(`Could not find a mask layer with id: ${maskId}`)();
+      if (maskId) {
+        log.warn(`Could not find a mask layer with id: ${maskId}`)();
+      }
       uniforms.mask_enabled = false;
     }
   }

--- a/modules/extensions/src/mask/mask.js
+++ b/modules/extensions/src/mask/mask.js
@@ -25,12 +25,12 @@ export default class MaskExtension extends LayerExtension {
     const {maskEnabled = true, maskId} = this.props;
     const {maskChannels} = moduleParameters;
     if (maskChannels && maskChannels[maskId]) {
-      const {channel, maskBounds} = maskChannels[maskId];
+      const {index, bounds} = maskChannels[maskId];
 
-      const bl = this.projectPosition([maskBounds[0], maskBounds[1], 0]);
-      const tr = this.projectPosition([maskBounds[2], maskBounds[3], 0]);
+      const bl = this.projectPosition([bounds[0], bounds[1], 0]);
+      const tr = this.projectPosition([bounds[2], bounds[3], 0]);
       uniforms.mask_enabled = maskEnabled;
-      uniforms.mask_channel = channel;
+      uniforms.mask_channel = index;
       uniforms.mask_bounds = [bl[0], bl[1], tr[0], tr[1]];
     } else {
       log.warn(`Could not find a mask layer with id: ${maskId}`)();

--- a/modules/extensions/src/mask/shader-module.js
+++ b/modules/extensions/src/mask/shader-module.js
@@ -60,7 +60,7 @@ varying vec2 mask_texCoords;
 `
 };
 
-const getMaskUniforms = (opts = {}, context = {}) => {
+const getMaskUniforms = (opts = {}) => {
   const uniforms = {};
   if (opts.maskMap) {
     uniforms.mask_texture = opts.maskMap;

--- a/modules/extensions/src/mask/shader-module.js
+++ b/modules/extensions/src/mask/shader-module.js
@@ -10,13 +10,24 @@ vec2 mask_getCoords(vec4 position) {
 
 const fs = `
 uniform sampler2D mask_texture;
+uniform int mask_channel;
 uniform bool mask_enabled;
 bool mask_isInBounds(vec2 texCoords) {
   if (!mask_enabled) {
     return true;
   }
   vec4 maskColor = texture2D(mask_texture, texCoords);
-  return maskColor.a > 0.5;
+  float maskValue = 1.0;
+  if (mask_channel == 0) {
+    maskValue = maskColor.r;
+  } else if (mask_channel == 1) {
+    maskValue = maskColor.g;
+  } else if (mask_channel == 2) {
+    maskValue = maskColor.b;
+  } else if (mask_channel == 3) {
+    maskValue = maskColor.a;
+  }
+  return maskValue < 0.5;
 }
 `;
 
@@ -52,7 +63,6 @@ varying vec2 mask_texCoords;
 const getMaskUniforms = (opts = {}, context = {}) => {
   const uniforms = {};
   if (opts.maskMap) {
-    uniforms.mask_enabled = opts.maskEnabled !== false;
     uniforms.mask_texture = opts.maskMap;
   }
   return uniforms;

--- a/test/apps/mask-orthographic/app.js
+++ b/test/apps/mask-orthographic/app.js
@@ -30,6 +30,7 @@ export default function App() {
     new SolidPolygonLayer({
       id: 'square',
       extensions: [new MaskExtension()],
+      maskId: 'mask',
       maskEnabled,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
       data: [

--- a/test/modules/core/passes/mask-pass.spec.js
+++ b/test/modules/core/passes/mask-pass.spec.js
@@ -29,7 +29,7 @@ test('MaskPass#shouldDrawLayer', t => {
   ];
 
   const layerManager = new LayerManager(gl, {});
-  const maskPass = new MaskPass(gl);
+  const maskPass = new MaskPass(gl, {});
   layerManager.setLayers(layers);
 
   const renderStats = maskPass.render({

--- a/test/modules/extensions/mask.spec.js
+++ b/test/modules/extensions/mask.spec.js
@@ -12,16 +12,31 @@ test('MaskExtension', t => {
         stroked: true,
         filled: true,
         extensions: [new MaskExtension()],
+        maskId: 'mask',
 
         // simulate MaskEffect parameters
         maskMap: {},
-        maskBounds: [0, 10, 5, 20]
+        maskChannels: {
+          mask: {
+            index: 0,
+            bounds: [0, 10, 5, 20]
+          }
+        }
       },
       onAfterUpdate: ({layer}) => {
         const uniforms = layer.getModels()[0].getUniforms();
         t.ok(uniforms.mask_enabled, 'mask_enabled in uniforms');
         t.ok(uniforms.mask_maskByInstance, 'mask_maskByInstance in uniforms');
         t.ok(uniforms.mask_bounds.every(Number.isFinite), 'mask_bounds in uniforms');
+      }
+    },
+    {
+      updateProps: {
+        maskId: 'mask2'
+      },
+      onAfterUpdate: ({layer}) => {
+        const uniforms = layer.getModels()[0].getUniforms();
+        t.notOk(uniforms.mask_enabled, 'mask disabled for invalid maskId');
       }
     }
   ];

--- a/test/render/test-cases/effects.js
+++ b/test/render/test-cases/effects.js
@@ -97,6 +97,7 @@ export default [
       }),
       new SolidPolygonLayer({
         id: 'polygon-masked',
+        maskId: 'mask-layer',
         extensions: [new MaskExtension()],
         data: polygons,
         getPolygon: f => f,
@@ -104,6 +105,7 @@ export default [
       }),
       new ScatterplotLayer({
         id: 'points',
+        maskId: 'mask-layer',
         extensions: [new MaskExtension()],
         data: points,
         getPosition: d => d.COORDINATES,


### PR DESCRIPTION
For #4161 

Support up to 4 mask layers. `maskId` is now required to enable masking. If `maskId` is not found, it is treated as if `maskEnabled: false`.

@felixpalmer Do we still need `maskEnabled` in this case?

![Screen Shot 2022-01-26 at 3 16 39 PM](https://user-images.githubusercontent.com/2059298/151267199-6217295b-a05b-4f2c-8ac5-b76f2e1fc7bd.png)

#### Change List
- MaskEffect
- MaskExtension
- Test app
- Unit tests
