### PR TITLE
MapboxLayer only repeats if the base map renders multiple copies

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -126,7 +126,7 @@ function getViewport(deck, map, useMapboxProjection = true) {
         y: 0,
         width: deck.width,
         height: deck.height,
-        repeat: true
+        repeat: map.getRenderWorldCopies()
       },
       getViewState(map),
       useMapboxProjection

--- a/test/modules/mapbox/mapbox-layer.spec.js
+++ b/test/modules/mapbox/mapbox-layer.spec.js
@@ -55,6 +55,9 @@ class MockMapboxMap {
   getBearing() {
     return this.opts.bearing || 0;
   }
+  getRenderWorldCopies() {
+    return true;
+  }
 }
 
 test('MapboxLayer#onAdd, onRemove, setProps', t => {


### PR DESCRIPTION
For #6584

#### Change List
- MapboxLayer's viewport gets `repeat` dynamically
