### PR TITLE
Create unique MaskEffect per EffectManager

### DIFF
--- a/modules/core/src/lib/effect-manager.ts
+++ b/modules/core/src/lib/effect-manager.ts
@@ -4,7 +4,6 @@ import MaskEffect from '../effects/mask/mask-effect';
 import type Effect from './effect';
 
 const DEFAULT_LIGHTING_EFFECT = new LightingEffect();
-const DEFAULT_MASK_EFFECT = new MaskEffect();
 
 export default class EffectManager {
   effects: Effect[];
@@ -49,7 +48,8 @@ export default class EffectManager {
     this.effects = effects;
 
     this._internalEffects = effects.slice();
-    this._internalEffects.push(DEFAULT_MASK_EFFECT);
+    // Unique MaskEffect per EffectManager as GL context may be different
+    this._internalEffects.push(new MaskEffect());
     if (!effects.some(effect => effect instanceof LightingEffect)) {
       this._internalEffects.push(DEFAULT_LIGHTING_EFFECT);
     }


### PR DESCRIPTION
For #6552

#### Background

When rendering into multiple WebGL contexts, the `MaskEffect.maskMap` texture created by the `DEFAULT_MASK_EFFECT` isn't valid in all contexts. This is an issue in Kepler when rendering in split screen mode. To repro in `test/apps/mask.js` add:

```jsx
<div style={{position: 'relative', height: '450px'}}>
  <DeckGL
    layers={showLayers ? getLayers() : []}
    initialViewState={INITIAL_VIEW_STATE}
    controller={true}
  >
    <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
  </DeckGL>
</div>
<div style={{position: 'relative', height: '450px'}}>
  <DeckGL
    layers={showLayers ? getLayers() : []}
    initialViewState={INITIAL_VIEW_STATE}
    controller={true}
  >
    <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
  </DeckGL>
</div>

```

#### Change List
- Create a new `MaskEffect` for every `EffectManager` instance
