### PR TITLE
CARTO fetchMap: Fix h3 hexagon layers are not shown

### DIFF
--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -64,6 +64,13 @@ function mergePropMaps(a, b) {
 
 export function getLayer(type, config) {
   return {
+    hexagonId: {
+      Layer: H3HexagonLayer,
+      propMap: mergePropMaps(sharedPropMap, {
+        visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
+      }),
+      defaultProps: {...defaultProps, getHexagon: d => d[config.columns.hex_id]}
+    },
     point: {
       Layer: GeoJsonLayer,
       propMap: mergePropMaps(sharedPropMap, {
@@ -75,13 +82,6 @@ export function getLayer(type, config) {
       Layer: GeoJsonLayer,
       propMap: sharedPropMap,
       defaultProps: {...defaultProps, lineWidthScale: 2}
-    },
-    hexagonId: {
-      Layer: H3HexagonLayer,
-      propMap: mergePropMaps(sharedPropMap, {
-        visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
-      }),
-      defaultProps: {...defaultProps, getHexagon: d => d[config.columns.hex_id]}
     },
     mvt: {
       Layer: MVTLayer,

--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -62,37 +62,39 @@ function mergePropMaps(a, b) {
   return {...a, ...b, visConfig: {...a.visConfig, ...b.visConfig}};
 }
 
-export const LAYER_MAP = {
-  point: {
-    Layer: GeoJsonLayer,
-    propMap: mergePropMaps(sharedPropMap, {
-      visConfig: {outline: 'stroked'}
-    }),
-    defaultProps
-  },
-  geojson: {
-    Layer: GeoJsonLayer,
-    propMap: sharedPropMap,
-    defaultProps: {...defaultProps, lineWidthScale: 2}
-  },
-  hexagonId: {
-    Layer: H3HexagonLayer,
-    propMap: mergePropMaps(sharedPropMap, {
-      visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
-    }),
-    defaultProps: {...defaultProps, getHexagon: d => d.h3}
-  },
-  mvt: {
-    Layer: MVTLayer,
-    propMap: sharedPropMap,
-    defaultProps: {
-      ...defaultProps,
-      pointRadiusScale: 0.3,
-      lineWidthScale: 2,
-      uniqueIdProperty: 'geoid'
+export function getLayer(type, config) {
+  return {
+    point: {
+      Layer: GeoJsonLayer,
+      propMap: mergePropMaps(sharedPropMap, {
+        visConfig: {outline: 'stroked'}
+      }),
+      defaultProps
+    },
+    geojson: {
+      Layer: GeoJsonLayer,
+      propMap: sharedPropMap,
+      defaultProps: {...defaultProps, lineWidthScale: 2}
+    },
+    hexagonId: {
+      Layer: H3HexagonLayer,
+      propMap: mergePropMaps(sharedPropMap, {
+        visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
+      }),
+      defaultProps: {...defaultProps, getHexagon: d => d[config.columns.hex_id]}
+    },
+    mvt: {
+      Layer: MVTLayer,
+      propMap: sharedPropMap,
+      defaultProps: {
+        ...defaultProps,
+        pointRadiusScale: 0.3,
+        lineWidthScale: 2,
+        uniqueIdProperty: 'geoid'
+      }
     }
-  }
-};
+  }[type];
+}
 
 function domainFromAttribute(attribute, scaleType) {
   if (scaleType === 'ordinal' || scaleType === 'point') {

--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -11,6 +11,7 @@ import {
 } from 'd3-scale';
 import {format as d3Format} from 'd3-format';
 import moment from 'moment-timezone';
+import {log} from '@deck.gl/core';
 import {H3HexagonLayer, MVTLayer} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
 
@@ -63,14 +64,9 @@ function mergePropMaps(a, b) {
 }
 
 export function getLayer(type, config) {
-  return {
-    hexagonId: {
-      Layer: H3HexagonLayer,
-      propMap: mergePropMaps(sharedPropMap, {
-        visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
-      }),
-      defaultProps: {...defaultProps, getHexagon: d => d[config.columns.hex_id]}
-    },
+  const hexagonId = config.columns?.hex_id;
+
+  const layer = {
     point: {
       Layer: GeoJsonLayer,
       propMap: mergePropMaps(sharedPropMap, {
@@ -83,6 +79,13 @@ export function getLayer(type, config) {
       propMap: sharedPropMap,
       defaultProps: {...defaultProps, lineWidthScale: 2}
     },
+    hexagonId: {
+      Layer: H3HexagonLayer,
+      propMap: mergePropMaps(sharedPropMap, {
+        visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
+      }),
+      defaultProps: {...defaultProps, getHexagon: d => d[hexagonId]}
+    },
     mvt: {
       Layer: MVTLayer,
       propMap: sharedPropMap,
@@ -94,6 +97,10 @@ export function getLayer(type, config) {
       }
     }
   }[type];
+
+  log.assert(layer, `Unsupported layer type: ${type}`);
+
+  return layer;
 }
 
 function domainFromAttribute(attribute, scaleType) {

--- a/modules/carto/src/api/parseMap.js
+++ b/modules/carto/src/api/parseMap.js
@@ -1,6 +1,6 @@
 import GL from '@luma.gl/constants';
 import {
-  LAYER_MAP,
+  getLayer,
   getColorAccessor,
   getSizeAccessor,
   getTextAccessor,
@@ -24,8 +24,10 @@ export function parseMap(json) {
     mapStyle,
     layers: extractTextLayers(layers.reverse()).map(({id, type, config, visualChannels}) => {
       try {
-        log.assert(type in LAYER_MAP, `Unsupported layer type: ${type}`);
-        const {Layer, propMap, defaultProps} = LAYER_MAP[type];
+        const layer = getLayer(type, config);
+
+        log.assert(getLayer(type, config), `Unsupported layer type: ${type}`);
+        const {Layer, propMap, defaultProps} = layer;
 
         const {dataId} = config;
         const dataset = datasets.find(d => d.id === dataId);

--- a/modules/carto/src/api/parseMap.js
+++ b/modules/carto/src/api/parseMap.js
@@ -26,7 +26,7 @@ export function parseMap(json) {
       try {
         const layer = getLayer(type, config);
 
-        log.assert(getLayer(type, config), `Unsupported layer type: ${type}`);
+        log.assert(layer, `Unsupported layer type: ${type}`);
         const {Layer, propMap, defaultProps} = layer;
 
         const {dataId} = config;

--- a/modules/carto/src/api/parseMap.js
+++ b/modules/carto/src/api/parseMap.js
@@ -24,11 +24,7 @@ export function parseMap(json) {
     mapStyle,
     layers: extractTextLayers(layers.reverse()).map(({id, type, config, visualChannels}) => {
       try {
-        const layer = getLayer(type, config);
-
-        log.assert(layer, `Unsupported layer type: ${type}`);
-        const {Layer, propMap, defaultProps} = layer;
-
+        const {Layer, propMap, defaultProps} = getLayer(type, config);
         const {dataId} = config;
         const dataset = datasets.find(d => d.id === dataId);
         log.assert(dataset, `No dataset matching dataId: ${dataId}`);

--- a/test/modules/carto/api/layer-map.spec.js
+++ b/test/modules/carto/api/layer-map.spec.js
@@ -4,7 +4,7 @@ import {
   getSizeAccessor,
   getTextAccessor,
   getTextPixelOffsetAccessor,
-  LAYER_MAP,
+  getLayer,
   _domainFromValues
 } from '@deck.gl/carto/api/layer-map';
 
@@ -163,7 +163,7 @@ for (const {anchor, alignment, radius, size, data, expected} of TEXT_PIXEL_OFFSE
 }
 
 test('getHexagon', t => {
-  const accessor = LAYER_MAP.hexagonId.defaultProps.getHexagon;
+  const accessor = getLayer('hexagonId', {columns: {hex_id: 'h3'}}).defaultProps.getHexagon;
   const data = {h3: 1234};
   t.deepEquals(accessor(data), 1234, 'getHexagon correctly returns 1234');
   t.end();


### PR DESCRIPTION
#### Background
H3 hexagon layers are not shown when you load a map using the fechMap Carto module method. It's because we are assuming that the hexagon column is always 'h3'. Instead, we should read this column from the map config. To get this, I've replaced the `LAYER_MAP` constant with a function that receives the layer type and the config as params. This also allows us to read more configuration parameters if would be necessary.

#### Change List
- Replaced the `LAYER_MAP` constant with a function that receives the layer type and the config as params
