### PR TITLE
Fix depth picking accuracy

### DIFF
--- a/modules/core/src/lib/deck-picker.js
+++ b/modules/core/src/lib/deck-picker.js
@@ -217,9 +217,7 @@ export default class DeckPicker {
         });
         // picked value is in common space (pixels) from the camera target (viewport.position)
         // convert it to meters from the ground
-        z =
-          pickedResultPass2.pickedColors[0] * viewports[0].distanceScales.metersPerUnit[2] +
-          viewports[0].position[2];
+        z = pickedResultPass2.pickedColors[0];
       }
 
       // Only exclude if we need to run picking again.

--- a/modules/core/src/lib/picking/pick-info.js
+++ b/modules/core/src/lib/picking/pick-info.js
@@ -29,8 +29,7 @@ export function getEmptyPickingInfo({pickInfo, viewports, pixelRatio, x, y, z}) 
     pickedViewport = getViewportFromCoordinates(pickInfo?.pickedViewports || viewports, {x, y});
   }
   const coordinate =
-    pickedViewport &&
-    pickedViewport.unproject([x - pickedViewport.x, y - pickedViewport.y], {targetZ: z});
+    pickedViewport && pickedViewport.unproject([x - pickedViewport.x, y - pickedViewport.y, z]);
 
   return {
     color: null,

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -361,7 +361,7 @@ function getGLViewport(
     target?: Framebuffer;
     viewport: Viewport;
   }
-): [x: number, y: number, width: number, height: number] {
+): [number, number, number, number] {
   const useTarget = target && target.id !== 'default-framebuffer';
   const pixelRatio =
     (moduleParameters && moduleParameters.devicePixelRatio) || cssToDeviceRatio(gl);

--- a/modules/core/src/shaderlib/picking/picking.js
+++ b/modules/core/src/shaderlib/picking/picking.js
@@ -2,10 +2,12 @@ import {picking} from '@luma.gl/core';
 
 export default {
   inject: {
+    'vs:DECKGL_FILTER_GL_POSITION': `
+    // for picking depth values
+    picking_setPickingAttribute(position.z / position.w);
+  `,
     'vs:DECKGL_FILTER_COLOR': `
   picking_setPickingColor(geometry.pickingColor);
-  // for picking depth values
-  picking_setPickingAttribute(geometry.position.z);
   `,
     'fs:DECKGL_FILTER_COLOR': {
       order: 99,


### PR DESCRIPTION
For #6587

#### Background
The interpolation-based `targetZ` approach does not have acceptable precision in OrbitView.

#### Change List
- Encode clipspace z in depth picking instead of commonspace z
