### PR TITLE
Bump math.gl to 3.5.7

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@luma.gl/shadertools": "^8.5.10",
-    "@math.gl/web-mercator": "^3.5.6",
+    "@math.gl/web-mercator": "^3.5.7",
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -35,7 +35,7 @@
     "@loaders.gl/loader-utils": "^3.1.5",
     "@loaders.gl/mvt": "^3.1.5",
     "@loaders.gl/tiles": "^3.1.5",
-    "@math.gl/web-mercator": "^3.5.6",
+    "@math.gl/web-mercator": "^3.5.7",
     "cartocolor": "^4.0.2",
     "d3-array": "^2.8.0",
     "d3-color": "^2.0.0",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -37,13 +37,13 @@
     "@loaders.gl/core": "^3.1.5",
     "@loaders.gl/images": "^3.1.5",
     "@luma.gl/core": "^8.5.10",
-    "@math.gl/core": "^3.5.6",
-    "@math.gl/web-mercator": "^3.5.6",
+    "@math.gl/core": "^3.5.7",
+    "@math.gl/web-mercator": "^3.5.7",
     "@probe.gl/env": "^3.5.0",
     "@probe.gl/log": "^3.5.0",
     "@probe.gl/stats": "^3.5.0",
     "gl-matrix": "^3.0.0",
-    "math.gl": "^3.5.6",
+    "math.gl": "^3.5.7",
     "mjolnir.js": "^2.5.0"
   }
 }

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -36,9 +36,9 @@
     "@loaders.gl/terrain": "^3.1.5",
     "@loaders.gl/tiles": "^3.1.5",
     "@luma.gl/experimental": "^8.5.10",
-    "@math.gl/core": "^3.5.6",
-    "@math.gl/culling": "^3.5.6",
-    "@math.gl/web-mercator": "^3.5.6",
+    "@math.gl/core": "^3.5.7",
+    "@math.gl/culling": "^3.5.7",
+    "@math.gl/web-mercator": "^3.5.7",
     "h3-js": "^3.6.0",
     "long": "^3.2.0"
   },

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@loaders.gl/images": "^3.1.5",
     "@mapbox/tiny-sdf": "^1.1.0",
-    "@math.gl/polygon": "^3.5.6",
+    "@math.gl/polygon": "^3.5.7",
     "earcut": "^2.0.6"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,43 +2643,43 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@math.gl/core@3.5.6", "@math.gl/core@^3.5.0", "@math.gl/core@^3.5.1", "@math.gl/core@^3.5.6":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/core/-/core-3.5.6.tgz#d849db978d7d4a4984bb63868adc693975d97ce7"
-  integrity sha512-UGCKtJUBA9MBswclK6l8DuZqLcEnqlSfI57WzSDUB/Nki4tHfmdImJyhp8ky9W4cIahV1YLMhHRK1oRpLeC1sw==
+"@math.gl/core@3.5.7", "@math.gl/core@^3.5.0", "@math.gl/core@^3.5.1", "@math.gl/core@^3.5.7":
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/@math.gl/core/-/core-3.5.7.tgz#41145f214c36f20a6bf32e4c25551e97c6828e99"
+  integrity sha512-EtMS3Nzv//nc6gAVcmvVsZAkf8+sVNruPcWEaBh95h82T7GroMLLf1WBgOhtOBOvCh6vInxjcYDsJOn7RY5oqg==
   dependencies:
     "@babel/runtime" "^7.12.0"
     gl-matrix "~3.3.0"
 
-"@math.gl/culling@^3.5.1", "@math.gl/culling@^3.5.6":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.5.6.tgz#4c388d6c9b3182c1b5ee4ffbf9d1b1d2484c54fd"
-  integrity sha512-Sustyo3XRaGVeUAzKk9kzoWErfNUzi+YFsmLe00r4qLbzXPg0Z7uLGX6zloEELILgqOZMOuAhadfmWVMsbq8ZA==
+"@math.gl/culling@3.5.7", "@math.gl/culling@^3.5.1", "@math.gl/culling@^3.5.7":
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.5.7.tgz#bb5c75df96facbb5f3b64176220911a493cd5d0e"
+  integrity sha512-wQlcnT05/u2ByHX8xjjo2pQUE8O2zghpBL19S1Rzzn3Zloj1eL5okIXecTnQCGghpt5lSP1I4W91x7PhV7YU7Q==
   dependencies:
     "@babel/runtime" "^7.12.0"
-    "@math.gl/core" "3.5.6"
+    "@math.gl/core" "3.5.7"
     gl-matrix "~3.3.0"
 
-"@math.gl/geospatial@^3.5.1":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.5.6.tgz#c1d7c1650257c249df218410670ced003b92d9f9"
-  integrity sha512-pYdnVeqbR5ybvUl+vOn1Ybj3BEwXk44vuU+VxE/GFKlM9M2oQlOisdJ8v6lyUDu7mEx6t5xsu8VUwMz1PymKLQ==
+"@math.gl/geospatial@3.5.7", "@math.gl/geospatial@^3.5.1":
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.5.7.tgz#bf7feabd519eb7cb5bdfab22802bce70647d4be5"
+  integrity sha512-q0h2YAppH12M6mIYPyB1FPfxYCD+vGwt8IcFZB3KN0bisg+Yuzgv00cq9jhxPgaVRrtBCOa1J4gJfM+5B9gxmw==
   dependencies:
     "@babel/runtime" "^7.12.0"
-    "@math.gl/core" "3.5.6"
+    "@math.gl/core" "3.5.7"
     gl-matrix "~3.3.0"
 
-"@math.gl/polygon@^3.5.1", "@math.gl/polygon@^3.5.6":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/polygon/-/polygon-3.5.6.tgz#af33fa8a60c89176ff178f322d3005d1cea2311f"
-  integrity sha512-CUGPmD8Y9elPRsb4+wG0nuElbEYcTK+Azks96M9zleMaOACUDqUY6D4rDtqpyEIeqcun85Aq+7eV/rjVMahWgA==
+"@math.gl/polygon@3.5.7", "@math.gl/polygon@^3.5.1", "@math.gl/polygon@^3.5.7":
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/@math.gl/polygon/-/polygon-3.5.7.tgz#6ddab215552919a2f784e8ea746fe582475c1e33"
+  integrity sha512-fTi9Vfs7+LQ5Cn5ABSp0i+rfRec2fFuPhUE+Xpvg3dELQP+YMSw7FeR5SvUBgt3UY86qLmrkmxz3WwffcJA/eg==
   dependencies:
-    "@math.gl/core" "3.5.6"
+    "@math.gl/core" "3.5.7"
 
-"@math.gl/web-mercator@^3.1.3", "@math.gl/web-mercator@^3.5.1", "@math.gl/web-mercator@^3.5.6":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.5.6.tgz#3bdc62f578bc0f360bb3c2866d015065b869cc20"
-  integrity sha512-siWHLJGp9o8fDEM1t0Rby+JXftl6il0z3927liWGzkHqFftXPHY858ShPy45ThDU8q5lyCftg8aVgrv4nfD+Zw==
+"@math.gl/web-mercator@3.5.7", "@math.gl/web-mercator@^3.1.3", "@math.gl/web-mercator@^3.5.1", "@math.gl/web-mercator@^3.5.7":
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.5.7.tgz#180a1057ea622bd857c6931f67268c2e98f174c6"
+  integrity sha512-i0w6AcV2b5+yeUQOA/KdnnzTYMUZvEKzHbbxI+ZyCuFs3p9S/IUt/EWVw4KGGOjVbf3UrGFlWSM70Th+0KyrsA==
   dependencies:
     "@babel/runtime" "^7.12.0"
     gl-matrix "~3.3.0"
@@ -8868,12 +8868,12 @@ mapbox-gl@^1.0.0, mapbox-gl@^1.2.1:
     tinyqueue "^2.0.0"
     vt-pbf "^3.1.1"
 
-math.gl@^3.5.6:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-3.5.6.tgz#805ac7444f8e5b339e88989c0fbcb9870774e315"
-  integrity sha512-+IzdFaQk46iYU85XObRNqnb5NUQon+rWDPnCoEIOKOKdykr2gJ15BcVjEs0ZvH4EDv5K/JVmLkWzY/6DCEx2Fw==
+math.gl@^3.5.7:
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-3.5.7.tgz#533c7dd30baf419015493a5d70f23b2df838f86f"
+  integrity sha512-WS633GusobHd5L7+4aiMVRZL3MYQk59futWsKvEvSEtrd5UnBa+y6xMpgn0VGlYmr7VXYqmvcRh/PnfMPN2tpw==
   dependencies:
-    "@math.gl/core" "3.5.6"
+    "@math.gl/core" "3.5.7"
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
Fixes crash in MaskEffect if the mask bounds are beyond the Web Mercator boundaries

#### Change List
- Update dependencies
