### PR TITLE
Fix OrthographicView projection when using independent scales

### DIFF
--- a/modules/core/src/views/orthographic-view.js
+++ b/modules/core/src/views/orthographic-view.js
@@ -39,6 +39,17 @@ class OrthographicViewport extends Viewport {
     const zoom_ = Math.min(zoomX, zoomY);
     const scale = Math.pow(2, zoom_);
 
+    let distanceScales;
+    if (zoomX !== zoomY) {
+      const scaleX = Math.pow(2, zoomX);
+      const scaleY = Math.pow(2, zoomY);
+
+      distanceScales = {
+        unitsPerMeter: [scaleX / scale, scaleY / scale, 1],
+        metersPerUnit: [scale / scaleX, scale / scaleY, 1]
+      };
+    }
+
     super({
       ...props,
       // in case viewState contains longitude/latitude values,
@@ -47,18 +58,9 @@ class OrthographicViewport extends Viewport {
       position: target,
       viewMatrix: viewMatrix.clone().scale([scale, scale * (flipY ? -1 : 1), scale]),
       projectionMatrix: getProjectionMatrix({width, height, near, far}),
-      zoom: zoom_
+      zoom: zoom_,
+      distanceScales
     });
-
-    if (zoomX !== zoomY) {
-      const scaleX = Math.pow(2, zoomX);
-      const scaleY = Math.pow(2, zoomY);
-
-      this.distanceScales = {
-        unitsPerMeter: [scaleX / scale, scaleY / scale, 1],
-        metersPerUnit: [scale / scaleX, scale / scaleY, 1]
-      };
-    }
   }
 
   projectFlat([X, Y]) {

--- a/test/modules/core/views/view.spec.js
+++ b/test/modules/core/views/view.spec.js
@@ -200,7 +200,7 @@ test('OrbitView#project', t => {
 
 test('OrthographicView', t => {
   const view = new OrthographicView({id: '2d-view'});
-  const viewport = view.makeViewport({
+  let viewport = view.makeViewport({
     width: 100,
     height: 100,
     viewState: {
@@ -214,6 +214,19 @@ test('OrthographicView', t => {
   t.is(viewport.id, view.id, 'Viewport has correct id');
   t.ok(viewport.width === 100 && viewport.height === 100, 'Viewport has correct size');
   t.is(viewport.zoom, 9, 'Viewport has correct parameters');
+
+  viewport = view.makeViewport({
+    width: 400,
+    height: 300,
+    viewState: {
+      target: [50, 100, 0],
+      zoom: [1, 3]
+    }
+  });
+  const center = viewport.project([50, 100, 0]);
+  t.ok(equals(center[0], 200) && equals(center[1], 150), 'target is at viewport center');
+  const p = viewport.project([40, 90, 0]);
+  t.ok(equals(center[0] - p[0], 20) && equals(center[1] - p[1], 80), 'independent scales');
 
   t.end();
 });


### PR DESCRIPTION
#### Background

The `target` position is not projected correctly when using independent zooms.

#### Change List
- OrthographicViewport passes custom `distanceScale` to base constructor
- Unit tests
