### PR TITLE
CARTO module: Fix extensions don't work with CartoDynamicTileLayer

### DIFF
--- a/modules/carto/src/layers/carto-dynamic-tile-layer.js
+++ b/modules/carto/src/layers/carto-dynamic-tile-layer.js
@@ -103,7 +103,7 @@ export default class CartoDynamicTileLayer extends MVTLayer {
     const {
       bbox: {west, south, east, north}
     } = props.tile;
-    props.extensions = [new ClipExtension()];
+    props.extensions = [new ClipExtension(), ...props.extensions];
     props.clipBounds = [west, south, east, north];
 
     const subLayer = new GeoJsonLayer({


### PR DESCRIPTION
#### Background
If you try to use an extension with the CartoDynamicTileLayer it doesn't work because the CartoDynamicTileLayer is overwriting the `props.extensions`
#### Change List
- Include  extensions sent in properties in the CartoDynamicTileLayer
