### PR TITLE
Change highlightedObjectIndex default to null

### DIFF
--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -212,11 +212,13 @@ RGBA color to blend with the highlighted object (either the hovered over object 
 - If an array is supplied, it is used for the object that is currently highlighted.
 - If a function is supplied, it is called with a [pickingInfo](/docs/developer-guide/interactivity.md#the-picking-info-object) object when the hovered object changes. The return value is used as the highlight color for the picked object. Only works with `autoHighlight: true`.
 
-##### `highlightedObjectIndex` (Integer, optional)
+##### `highlightedObjectIndex` (Number|null, optional)
 
-* Default: `-1`
+* Default: `null`
 
-When provided a valid value corresponding object (one instance in instanced rendering or group of primitives with same picking color) will be highlighted with `highlightColor`.
+The index of the object in `data` to highlight. If specified, overrides the effect of `autoHighlight`.
+
+When set to an integer that corresponds to an object, the object will be highlighted with `highlightColor`. When set to an integer that does not correspond to an object (e.g. `-1`), nothing is highlighted.
 
 ##### `autoHighlight` (Boolean, optional)
 

--- a/modules/core/src/lib/layer-props.ts
+++ b/modules/core/src/lib/layer-props.ts
@@ -118,7 +118,7 @@ export type LayerProps = {
   /**
    * The index of the data object to highlight. If unspecified, the currently hoverred object is highlighted.
    */
-  highlightedObjectIndex?: number;
+  highlightedObjectIndex?: number | null;
   /**
    * The color of the highlight.
    */

--- a/modules/core/src/lib/layer.js
+++ b/modules/core/src/lib/layer.js
@@ -137,7 +137,7 @@ const defaultProps = {
   },
 
   // Selection/Highlighting
-  highlightedObjectIndex: -1,
+  highlightedObjectIndex: null,
   autoHighlight: false,
   highlightColor: {type: 'accessor', value: [0, 0, 128, 128]}
 };
@@ -363,8 +363,9 @@ export default class Layer extends Component {
       }
     }
 
-    const neededPickingBuffer = oldProps.highlightedObjectIndex >= 0 || oldProps.pickable;
-    const needPickingBuffer = props.highlightedObjectIndex >= 0 || props.pickable;
+    const neededPickingBuffer =
+      Number.isInteger(oldProps.highlightedObjectIndex) || oldProps.pickable;
+    const needPickingBuffer = Number.isInteger(props.highlightedObjectIndex) || props.pickable;
     if (neededPickingBuffer !== needPickingBuffer && attributeManager) {
       const {pickingColors, instancePickingColors} = attributeManager.attributes;
       const pickingColorsAttribute = pickingColors || instancePickingColors;
@@ -905,7 +906,7 @@ export default class Layer extends Component {
   }
 
   updateAutoHighlight(info) {
-    if (this.props.autoHighlight) {
+    if (this.props.autoHighlight && !Number.isInteger(this.props.highlightedObjectIndex)) {
       this._updateAutoHighlight(info);
     }
   }


### PR DESCRIPTION
For #6630 

The stated behavior is that `highlightedObjectIndex` overrides `autoHighlight`. However, we use `Number.isFinite` to check if `highlightedObjectIndex` is specified, while the default value is `-1`.

https://github.com/visgl/deck.gl/blob/ef64ce181a76c13ba16d3c021f776063a50a47e9/modules/core/src/lib/layer.js#L934-L938

This PR does not change this overriding order, but makes sure that no overrides happen if `highlightedObjectIndex` is unspecified.

#### Change List
- `highlightedObjectIndex` default to `null`
- Documentation
