### PR TITLE
CARTO fetchMap: Support tiles in different formats 

### DIFF
--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -104,7 +104,7 @@ function getTileLayer(dataset) {
     }
   } = dataset;
   /* global URLSearchParams */
-  const formatTiles = new URLSearchParams(tileUrl).get('format');
+  const formatTiles = new URLSearchParams(tileUrl).get('formatTiles');
 
   return {
     Layer: formatTiles === TILE_FORMATS.MVT ? MVTLayer : _CartoDynamicTileLayer,

--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -14,6 +14,7 @@ import moment from 'moment-timezone';
 import {log} from '@deck.gl/core';
 import {H3HexagonLayer, MVTLayer} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
+import {_CartoDynamicTileLayer, TILE_FORMATS} from '@deck.gl/carto';
 
 const SCALE_FUNCS = {
   linear: scaleLinear,
@@ -63,9 +64,12 @@ function mergePropMaps(a, b) {
   return {...a, ...b, visConfig: {...a.visConfig, ...b.visConfig}};
 }
 
-export function getLayer(type, config) {
-  const hexagonId = config.columns?.hex_id;
+export function getLayer(type, config, dataset) {
+  if (type === 'mvt' || type === 'tileset') {
+    return getTileLayer(dataset);
+  }
 
+  const hexagonId = config.columns?.hex_id;
   const layer = {
     point: {
       Layer: GeoJsonLayer,
@@ -85,22 +89,34 @@ export function getLayer(type, config) {
         visConfig: {coverage: 'coverage', elevationScale: 'elevationScale'}
       }),
       defaultProps: {...defaultProps, getHexagon: d => d[hexagonId]}
-    },
-    mvt: {
-      Layer: MVTLayer,
-      propMap: sharedPropMap,
-      defaultProps: {
-        ...defaultProps,
-        pointRadiusScale: 0.3,
-        lineWidthScale: 2,
-        uniqueIdProperty: 'geoid'
-      }
     }
   }[type];
 
   log.assert(layer, `Unsupported layer type: ${type}`);
 
   return layer;
+}
+
+function getTileLayer(dataset) {
+  const {
+    data: {
+      tiles: [tileUrl]
+    }
+  } = dataset;
+  /* global URLSearchParams */
+  const formatTiles = new URLSearchParams(tileUrl).get('format');
+
+  return {
+    Layer: formatTiles === TILE_FORMATS.MVT ? MVTLayer : _CartoDynamicTileLayer,
+    propMap: sharedPropMap,
+    defaultProps: {
+      ...defaultProps,
+      pointRadiusScale: 0.3,
+      lineWidthScale: 2,
+      uniqueIdProperty: 'geoid',
+      formatTiles
+    }
+  };
 }
 
 function domainFromAttribute(attribute, scaleType) {

--- a/modules/carto/src/api/parseMap.js
+++ b/modules/carto/src/api/parseMap.js
@@ -24,12 +24,12 @@ export function parseMap(json) {
     mapStyle,
     layers: extractTextLayers(layers.reverse()).map(({id, type, config, visualChannels}) => {
       try {
-        const {Layer, propMap, defaultProps} = getLayer(type, config);
         const {dataId} = config;
         const dataset = datasets.find(d => d.id === dataId);
         log.assert(dataset, `No dataset matching dataId: ${dataId}`);
         const {data} = dataset;
         log.assert(data, `No data loaded for dataId: ${dataId}`);
+        const {Layer, propMap, defaultProps} = getLayer(type, config, dataset);
         return new Layer({
           id,
           data,

--- a/modules/carto/src/layers/carto-dynamic-tile-layer.js
+++ b/modules/carto/src/layers/carto-dynamic-tile-layer.js
@@ -6,7 +6,7 @@ import {MVTLayer, _getURLFromTemplate} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {geojsonToBinary} from '@loaders.gl/gis';
 import {Tile} from './schema/carto-dynamic-tile';
-import {encodeParameter, TILE_FORMATS} from '../api/maps-api-common';
+import {TILE_FORMATS} from '../api/maps-api-common';
 
 function parseJSON(arrayBuffer) {
   return JSON.parse(new TextDecoder().decode(arrayBuffer));
@@ -86,7 +86,10 @@ export default class CartoDynamicTileLayer extends MVTLayer {
         Object.values(TILE_FORMATS).includes(formatTiles),
         `Invalid value for formatTiles: ${formatTiles}. Use value from TILE_FORMATS`
       );
-      url += `&${encodeParameter('formatTiles', formatTiles)}`;
+      // eslint-disable-next-line no-undef
+      const newUrl = new URL(url);
+      newUrl.searchParams.set('formatTiles', formatTiles);
+      url = newUrl.toString();
       loadOptions.cartoDynamicTile = {formatTiles};
     }
 
@@ -103,7 +106,7 @@ export default class CartoDynamicTileLayer extends MVTLayer {
     const {
       bbox: {west, south, east, north}
     } = props.tile;
-    props.extensions = [new ClipExtension(), ...props.extensions];
+    props.extensions = [new ClipExtension(), ...(props.extensions || [])];
     props.clipBounds = [west, south, east, north];
 
     const subLayer = new GeoJsonLayer({

--- a/test/modules/carto/api/parseMap.spec.js
+++ b/test/modules/carto/api/parseMap.spec.js
@@ -2,6 +2,7 @@ import test from 'tape-catch';
 import VISSTATE_DATA from '../data/visState.json';
 import UNSUPPORTED_LAYER_TYPE_VISSTATE_DATA from '../data/unsupportedLayerTypeVisState.json';
 import {parseMap} from '@deck.gl/carto/api/parseMap';
+import {TILE_FORMATS} from '@deck.gl/carto';
 
 const METADATA = {
   id: 1234,
@@ -30,6 +31,59 @@ const DATASETS = [
   {
     id: 'DATA_TILESET_ID',
     data: {
+      tiles: [
+        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&format=${TILE_FORMATS.MVT}`
+      ],
+      tilestats: {
+        layers: [
+          {
+            attributes: [
+              {
+                attribute: 'STRING_ATTR',
+                categories: [{category: '1'}, {category: '2'}, {category: '3'}]
+              },
+              {
+                attribute: 'NUMBER_ATTR',
+                min: 0,
+                max: 10
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    id: 'DATA_TILESET_GEOJSON_FORMAT_ID',
+    data: {
+      tiles: [
+        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&format=${TILE_FORMATS.GEOJSON}`
+      ],
+      tilestats: {
+        layers: [
+          {
+            attributes: [
+              {
+                attribute: 'STRING_ATTR',
+                categories: [{category: '1'}, {category: '2'}, {category: '3'}]
+              },
+              {
+                attribute: 'NUMBER_ATTR',
+                min: 0,
+                max: 10
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    id: 'DATA_TILESET_BINARY_FORMAT_ID',
+    data: {
+      tiles: [
+        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&format=${TILE_FORMATS.BINARY}`
+      ],
       tilestats: {
         layers: [
           {
@@ -108,6 +162,12 @@ for (const {title, visState, layers} of VISSTATE_DATA) {
     layers.forEach(({props: layerProps}) => {
       if (layerProps.data === 'DATA_TILESET') {
         layerProps.data = DATASETS[1].data;
+      }
+      if (layerProps.data === 'DATA_TILESET_GEOJSON') {
+        layerProps.data = DATASETS[2].data;
+      }
+      if (layerProps.data === 'DATA_TILESET_BINARY') {
+        layerProps.data = DATASETS[3].data;
       }
     });
 

--- a/test/modules/carto/api/parseMap.spec.js
+++ b/test/modules/carto/api/parseMap.spec.js
@@ -32,7 +32,7 @@ const DATASETS = [
     id: 'DATA_TILESET_ID',
     data: {
       tiles: [
-        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&format=${TILE_FORMATS.MVT}`
+        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&formatTiles=${TILE_FORMATS.MVT}`
       ],
       tilestats: {
         layers: [
@@ -57,7 +57,7 @@ const DATASETS = [
     id: 'DATA_TILESET_GEOJSON_FORMAT_ID',
     data: {
       tiles: [
-        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&format=${TILE_FORMATS.GEOJSON}`
+        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&formatTiles=${TILE_FORMATS.GEOJSON}`
       ],
       tilestats: {
         layers: [
@@ -82,7 +82,7 @@ const DATASETS = [
     id: 'DATA_TILESET_BINARY_FORMAT_ID',
     data: {
       tiles: [
-        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&format=${TILE_FORMATS.BINARY}`
+        `https://gcp-us-east1.api.carto.com/v3/maps/my_connection/tileset/{z}/{x}/{y}?name=my_data&formatTiles=${TILE_FORMATS.BINARY}`
       ],
       tilestats: {
         layers: [

--- a/test/modules/carto/data/visState.json
+++ b/test/modules/carto/data/visState.json
@@ -286,7 +286,7 @@
           "config": {
             "color": [18, 147, 154],
             "label": "transmission lines",
-            "dataId": "DATA_ID",
+            "dataId": "DATA_TILESET_ID",
             "hidden": false,
             "columns": {},
             "isVisible": true,
@@ -544,7 +544,7 @@
         "props": {
           "id": "87swuny",
           "cartoLabel": "transmission lines",
-          "data": {"type": "FeatureCollection", "features": []},
+          "data": "DATA_TILESET",
           "lineMiterLimit": 2,
           "lineWidthUnits": "pixels",
           "pointRadiusScale": 0.3,
@@ -566,7 +566,8 @@
           "getPointRadius": 10,
           "wireframe": false,
           "highlightColor": [252, 242, 26, 255],
-          "uniqueIdProperty": "geoid"
+          "uniqueIdProperty": "geoid",
+          "formatTiles": "mvt"
         }
       }
     ]
@@ -789,7 +790,252 @@
           "getPointRadius": 10,
           "wireframe": false,
           "highlightColor": [252, 242, 26, 255],
-          "uniqueIdProperty": "geoid"
+          "uniqueIdProperty": "geoid",
+          "formatTiles": "mvt"
+        }
+      }
+    ]
+  },
+  {
+    "title": "Polygon tileset geojson format",
+    "visState": {
+      "layers": [
+        {
+          "id": "3btkipv",
+          "type": "tileset",
+          "config": {
+            "color": [18, 147, 154],
+            "label": "Layer 1",
+            "dataId": "DATA_TILESET_GEOJSON_FORMAT_ID",
+            "hidden": false,
+            "columns": {},
+            "isVisible": true,
+            "textLabel": [
+              {
+                "size": 18,
+                "color": [255, 255, 255],
+                "field": null,
+                "anchor": "start",
+                "offset": [0, 0],
+                "alignment": "center"
+              }
+            ],
+            "visConfig": {
+              "filled": true,
+              "radius": 10,
+              "opacity": 0.8,
+              "stroked": false,
+              "enable3d": false,
+              "sizeRange": [0, 10],
+              "thickness": 0.5,
+              "wireframe": false,
+              "colorRange": {
+                "name": "Global Warming",
+                "type": "sequential",
+                "colors": ["#5A1846", "#900C3F", "#C70039", "#E3611C", "#F1920E", "#FFC300"],
+                "category": "Uber"
+              },
+              "heightRange": [0, 500],
+              "radiusRange": [0, 50],
+              "strokeColor": [221, 178, 124],
+              "strokeOpacity": 0.8,
+              "elevationScale": 5,
+              "strokeColorRange": {
+                "name": "Global Warming",
+                "type": "sequential",
+                "colors": ["#5A1846", "#900C3F", "#C70039", "#E3611C", "#F1920E", "#FFC300"],
+                "category": "Uber"
+              }
+            },
+            "highlightColor": [252, 242, 26, 255]
+          },
+          "visualChannels": {
+            "sizeField": null,
+            "sizeScale": "linear",
+            "colorField": {"name": "STRING_ATTR", "type": "string"},
+            "colorScale": "ordinal",
+            "heightField": {"name": "NUMBER_ATTR", "type": "number"},
+            "heightScale": "log",
+            "radiusField": null,
+            "radiusScale": "log",
+            "strokeColorField": null,
+            "strokeColorScale": "quantile"
+          }
+        }
+      ],
+      "filters": [],
+      "splitMaps": [],
+      "layerBlending": "normal",
+      "animationConfig": {"speed": 1, "currentTime": null},
+      "interactionConfig": {
+        "brush": {"size": 0.5, "enabled": false},
+        "tooltip": {
+          "enabled": true,
+          "compareMode": false,
+          "compareType": "absolute",
+          "fieldsToShow": {
+            "4eebbc75-4331-409e-8c71-16ed67429177": [
+              {"name": "geoid", "format": null},
+              {"name": "construction_date", "format": null},
+              {"name": "current_use", "format": null},
+              {"name": "number_floors_above_ground", "format": null}
+            ]
+          }
+        },
+        "geocoder": {"enabled": false},
+        "coordinate": {"enabled": false}
+      }
+    },
+    "layers": [
+      {
+        "name": "CartoDynamicTileLayer({id: '3btkipv'})",
+        "props": {
+          "id": "3btkipv",
+          "cartoLabel": "Layer 1",
+          "data": "DATA_TILESET_GEOJSON",
+          "lineMiterLimit": 2,
+          "lineWidthUnits": "pixels",
+          "pointRadiusScale": 0.3,
+          "pointRadiusUnits": "pixels",
+          "rounded": true,
+          "wrapLongitude": false,
+          "lineWidthScale": 2,
+          "autoHighlight": true,
+          "pickable": true,
+          "visible": true,
+          "extruded": false,
+          "filled": true,
+          "opacity": 0.8,
+          "getLineColor": [221, 178, 124],
+          "stroked": false,
+          "getLineWidth": 0.5,
+          "getPointRadius": 10,
+          "wireframe": false,
+          "highlightColor": [252, 242, 26, 255],
+          "uniqueIdProperty": "geoid",
+          "formatTiles": "geojson"
+        }
+      }
+    ]
+  },
+  {
+    "title": "Polygon tileset binary format",
+    "visState": {
+      "layers": [
+        {
+          "id": "3btkipv",
+          "type": "tileset",
+          "config": {
+            "color": [18, 147, 154],
+            "label": "Layer 1",
+            "dataId": "DATA_TILESET_BINARY_FORMAT_ID",
+            "hidden": false,
+            "columns": {},
+            "isVisible": true,
+            "textLabel": [
+              {
+                "size": 18,
+                "color": [255, 255, 255],
+                "field": null,
+                "anchor": "start",
+                "offset": [0, 0],
+                "alignment": "center"
+              }
+            ],
+            "visConfig": {
+              "filled": true,
+              "radius": 10,
+              "opacity": 0.8,
+              "stroked": false,
+              "enable3d": false,
+              "sizeRange": [0, 10],
+              "thickness": 0.5,
+              "wireframe": false,
+              "colorRange": {
+                "name": "Global Warming",
+                "type": "sequential",
+                "colors": ["#5A1846", "#900C3F", "#C70039", "#E3611C", "#F1920E", "#FFC300"],
+                "category": "Uber"
+              },
+              "heightRange": [0, 500],
+              "radiusRange": [0, 50],
+              "strokeColor": [221, 178, 124],
+              "strokeOpacity": 0.8,
+              "elevationScale": 5,
+              "strokeColorRange": {
+                "name": "Global Warming",
+                "type": "sequential",
+                "colors": ["#5A1846", "#900C3F", "#C70039", "#E3611C", "#F1920E", "#FFC300"],
+                "category": "Uber"
+              }
+            },
+            "highlightColor": [252, 242, 26, 255]
+          },
+          "visualChannels": {
+            "sizeField": null,
+            "sizeScale": "linear",
+            "colorField": {"name": "STRING_ATTR", "type": "string"},
+            "colorScale": "ordinal",
+            "heightField": {"name": "NUMBER_ATTR", "type": "number"},
+            "heightScale": "log",
+            "radiusField": null,
+            "radiusScale": "log",
+            "strokeColorField": null,
+            "strokeColorScale": "quantile"
+          }
+        }
+      ],
+      "filters": [],
+      "splitMaps": [],
+      "layerBlending": "normal",
+      "animationConfig": {"speed": 1, "currentTime": null},
+      "interactionConfig": {
+        "brush": {"size": 0.5, "enabled": false},
+        "tooltip": {
+          "enabled": true,
+          "compareMode": false,
+          "compareType": "absolute",
+          "fieldsToShow": {
+            "4eebbc75-4331-409e-8c71-16ed67429177": [
+              {"name": "geoid", "format": null},
+              {"name": "construction_date", "format": null},
+              {"name": "current_use", "format": null},
+              {"name": "number_floors_above_ground", "format": null}
+            ]
+          }
+        },
+        "geocoder": {"enabled": false},
+        "coordinate": {"enabled": false}
+      }
+    },
+    "layers": [
+      {
+        "name": "CartoDynamicTileLayer({id: '3btkipv'})",
+        "props": {
+          "id": "3btkipv",
+          "cartoLabel": "Layer 1",
+          "data": "DATA_TILESET_BINARY",
+          "lineMiterLimit": 2,
+          "lineWidthUnits": "pixels",
+          "pointRadiusScale": 0.3,
+          "pointRadiusUnits": "pixels",
+          "rounded": true,
+          "wrapLongitude": false,
+          "lineWidthScale": 2,
+          "autoHighlight": true,
+          "pickable": true,
+          "visible": true,
+          "extruded": false,
+          "filled": true,
+          "opacity": 0.8,
+          "getLineColor": [221, 178, 124],
+          "stroked": false,
+          "getLineWidth": 0.5,
+          "getPointRadius": 10,
+          "wireframe": false,
+          "highlightColor": [252, 242, 26, 255],
+          "uniqueIdProperty": "geoid",
+          "formatTiles": "binary"
         }
       }
     ]


### PR DESCRIPTION
#### Background
With this PR the `fetchMap` method support tile layers in geojson and binary format
#### Change List
- The fetchMap will load a CartoDynamicTileLayer if the tile format is not MVT
