### PR TITLE
Default format tiles to MVT to guarantee compatilibity with data cached in CDN

### DIFF
--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -107,7 +107,7 @@ function getTileLayer(dataset) {
   const formatTiles = new URLSearchParams(tileUrl).get('formatTiles');
 
   return {
-    Layer: formatTiles === TILE_FORMATS.MVT ? MVTLayer : _CartoDynamicTileLayer,
+    Layer: !formatTiles || formatTiles === TILE_FORMATS.MVT ? MVTLayer : _CartoDynamicTileLayer,
     propMap: sharedPropMap,
     defaultProps: {
       ...defaultProps,

--- a/modules/carto/src/api/layer-map.js
+++ b/modules/carto/src/api/layer-map.js
@@ -103,11 +103,11 @@ function getTileLayer(dataset) {
       tiles: [tileUrl]
     }
   } = dataset;
-  /* global URLSearchParams */
-  const formatTiles = new URLSearchParams(tileUrl).get('formatTiles');
+  /* global URL */
+  const formatTiles = new URL(tileUrl).searchParams.get('formatTiles') || TILE_FORMATS.MVT;
 
   return {
-    Layer: !formatTiles || formatTiles === TILE_FORMATS.MVT ? MVTLayer : _CartoDynamicTileLayer,
+    Layer: formatTiles === TILE_FORMATS.MVT ? MVTLayer : _CartoDynamicTileLayer,
     propMap: sharedPropMap,
     defaultProps: {
       ...defaultProps,

--- a/modules/carto/src/api/maps-v3-client.js
+++ b/modules/carto/src/api/maps-v3-client.js
@@ -255,7 +255,7 @@ export async function getData({
   return layerData.data;
 }
 
-/* global clearInterval, setInterval, URLSearchParams */
+/* global clearInterval, setInterval, URL */
 async function _fetchMapDataset(dataset, accessToken, credentials, clientId) {
   // First fetch metadata
   const {connectionName: connection, source, type} = dataset;
@@ -268,7 +268,7 @@ async function _fetchMapDataset(dataset, accessToken, credentials, clientId) {
   });
 
   // Extract the last time the data changed
-  const cache = parseInt(new URLSearchParams(url).get('cache'), 10);
+  const cache = parseInt(new URL(url).searchParams.get('cache'), 10);
   if (cache && dataset.cache === cache) {
     return false;
   }

--- a/modules/carto/src/layers/carto-dynamic-tile-layer.js
+++ b/modules/carto/src/layers/carto-dynamic-tile-layer.js
@@ -60,7 +60,8 @@ const CartoDynamicTileLoader = {
   parseSync: parseCartoDynamicTile,
   options: {
     cartoDynamicTile: {
-      formatTiles: TILE_FORMATS.BINARY
+      // TODO change to BINARY for 8.7 prod release
+      formatTiles: TILE_FORMATS.GEOJSON
     }
   }
 };

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -27,8 +27,8 @@ const defaultProps = {
   // (String, optional): format of data
   format: null,
 
-  // (String, optional): format of data
-  formatTiles: TILE_FORMATS.GEOJSON, // TODO: for 8.7 release switch to BINARY
+  // (String, optional): force format of data for tiles
+  formatTiles: null,
 
   // (String, optional): clientId identifier used for internal tracing, place here a string to identify the client who is doing the request.
   clientId: null,
@@ -134,9 +134,9 @@ export default class CartoLayer extends CompositeLayer {
     }
 
     if (format === FORMATS.TILEJSON) {
-      /* global URLSearchParams */
-      const formatTiles = new URLSearchParams(data.tiles[0]).get('formatTiles');
-      return !formatTiles || formatTiles === TILE_FORMATS.MVT ? MVTLayer : CartoDynamicTileLayer;
+      /* global URL */
+      const formatTiles = this.props.formatTiles || new URL(data.tiles[0]).searchParams.get('formatTiles') || TILE_FORMATS.MVT;
+      return formatTiles === TILE_FORMATS.MVT ? MVTLayer : CartoDynamicTileLayer;
     }
 
     // It's a geojson layer

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -136,7 +136,7 @@ export default class CartoLayer extends CompositeLayer {
     if (format === FORMATS.TILEJSON) {
       /* global URLSearchParams */
       const formatTiles = new URLSearchParams(data.tiles[0]).get('formatTiles');
-      return formatTiles === TILE_FORMATS.MVT ? MVTLayer : CartoDynamicTileLayer;
+      return !formatTiles || formatTiles === TILE_FORMATS.MVT ? MVTLayer : CartoDynamicTileLayer;
     }
 
     // It's a geojson layer

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -135,7 +135,10 @@ export default class CartoLayer extends CompositeLayer {
 
     if (format === FORMATS.TILEJSON) {
       /* global URL */
-      const formatTiles = this.props.formatTiles || new URL(data.tiles[0]).searchParams.get('formatTiles') || TILE_FORMATS.MVT;
+      const formatTiles =
+        this.props.formatTiles ||
+        new URL(data.tiles[0]).searchParams.get('formatTiles') ||
+        TILE_FORMATS.MVT;
       return formatTiles === TILE_FORMATS.MVT ? MVTLayer : CartoDynamicTileLayer;
     }
 

--- a/test/modules/carto/carto-layer.spec.js
+++ b/test/modules/carto/carto-layer.spec.js
@@ -1,6 +1,6 @@
 import {testLayerAsync} from '@deck.gl/test-utils';
 import {makeSpy} from '@probe.gl/test-utils';
-import {CartoLayer, API_VERSIONS, FORMATS, MAP_TYPES} from '@deck.gl/carto';
+import {CartoLayer, API_VERSIONS, FORMATS, MAP_TYPES, TILE_FORMATS} from '@deck.gl/carto';
 import {MVTLayer} from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import CartoDynamicTileLayer from '@deck.gl/carto/layers/carto-dynamic-tile-layer';
@@ -65,8 +65,6 @@ mockedV3Test('CartoLayer#v3', async t => {
       t.is(subLayers.length, 0, 'should no render subLayers');
     } else {
       t.is(subLayers.length, 1, 'should have only 1 sublayer');
-      /* global URLSearchParams */
-      const tilesFormat = data.tiles && new URLSearchParams(data.tiles[0]).get('format');
 
       switch (layer.props.type) {
         case MAP_TYPES.TILESET:
@@ -78,7 +76,7 @@ mockedV3Test('CartoLayer#v3', async t => {
           );
           break;
         case MAP_TYPES.TABLE:
-          if ((tilesFormat && tilesFormat !== 'mvt') || format === FORMATS.TILEJSON) {
+          if (format === FORMATS.TILEJSON) {
             t.ok(subLayer instanceof CartoDynamicTileLayer, 'should be a CartoDynamicTileLayer');
           } else {
             t.ok(subLayer instanceof GeoJsonLayer, 'should be a GeoJsonLayer');
@@ -129,6 +127,7 @@ mockedV3Test('CartoLayer#v3', async t => {
           connection: 'conn_name',
           type: MAP_TYPES.TABLE,
           format: FORMATS.TILEJSON,
+          formatTiles: TILE_FORMATS.BINARY,
           credentials: CREDENTIALS_V3
         },
         onAfterUpdate
@@ -509,7 +508,7 @@ mockedV3Test('CartoLayer#dynamic', async t => {
         data: 'tileset',
         type: MAP_TYPES.TABLE,
         format: FORMATS.TILEJSON,
-        formatTiles: 'binary',
+        formatTiles: TILE_FORMATS.BINARY,
         connection: 'connection_name',
         credentials: CREDENTIALS_V3,
 
@@ -518,10 +517,10 @@ mockedV3Test('CartoLayer#dynamic', async t => {
       onAfterUpdate: ({layer, subLayers}) => {
         if (layer.isLoaded) {
           t.is(counter, 1, 'should call once to onDataLoad');
-          t.is(subLayers.length, 1, 'Rendered mvt sublayer');
-          const mvtLayer = subLayers[0];
-          t.is(mvtLayer.internalState.subLayers.length, 4, 'Rendered mvt sublayers');
-          const geojsonLayer = mvtLayer.internalState.subLayers[0];
+          t.is(subLayers.length, 1, 'Rendered sublayer');
+          const dynLayer = subLayers[0];
+          t.is(dynLayer.internalState.subLayers.length, 4, 'Rendered right number of sublayers');
+          const geojsonLayer = dynLayer.internalState.subLayers[0];
           const {data} = geojsonLayer.props;
 
           // Test data taken from `cartobq.testtables.polygons_10k` table, tile: 15/9633/12341


### PR DESCRIPTION
Some data in the CDN is cached and it has not the `formatTiles` parameter, we're setting the default to MVT to guarantee compatibility with public maps.

It cannot be done by purging CDN because some customer could have it at the local browser cache.


