### PR TITLE
TextLayer: expand picking color attribute from per-point to per-icon

### DIFF
--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -221,6 +221,22 @@ export default class TextLayer extends CompositeLayer {
     });
   }
 
+  // Expands picking color attribute from per-point to per-icon
+  _expandPickingColors() {
+    const {startIndices, numInstances} = this.state;
+    const {instancePickingColors} = this.props.data.attributes;
+    const {value, size} = instancePickingColors;
+
+    const newValue = new value.constructor(numInstances * size);
+    for (let i = 0; i < startIndices.length - 1; i++) {
+      const color = value.subarray(size * i, size * (i + 1));
+      for (let j = startIndices[i]; j < startIndices[i + 1]; j++) {
+        newValue.set(color, size * j);
+      }
+    }
+    instancePickingColors.value = newValue;
+  }
+
   // Returns the x, y offsets of each character in a text string
   getBoundingRect(object, objectInfo) {
     const iconMapping = this.state.fontAtlasManager.mapping;
@@ -319,6 +335,10 @@ export default class TextLayer extends CompositeLayer {
 
     const CharactersLayerClass = this.getSubLayerClass('characters', MultiIconLayer);
     const BackgroundLayerClass = this.getSubLayerClass('background', TextBackgroundLayer);
+
+    if (data.attributes && data.attributes.instancePickingColors) {
+      this._expandPickingColors();
+    }
 
     return [
       background &&

--- a/modules/layers/src/text-layer/text-layer.js
+++ b/modules/layers/src/text-layer/text-layer.js
@@ -390,9 +390,7 @@ export default class TextLayer extends CompositeLayer {
             }
           }),
           {
-            data: data.attributes
-              ? {length: data.length, attributes: data.attributes.background || {}}
-              : data,
+            data,
             _dataDiff,
             // Maintain the same background behavior as <=8.3. Remove in v9?
             autoHighlight: false,

--- a/test/modules/layers/text-layer/text-layer.spec.js
+++ b/test/modules/layers/text-layer/text-layer.spec.js
@@ -150,6 +150,48 @@ test('TextLayer - binary unicode characters', t => {
   t.end();
 });
 
+test('TextLayer - binary picking colors', t => {
+  const p1 = [1, 2, 3];
+  const p2 = [4, 5, 6];
+  const c1 = [7, 8, 9];
+  const c2 = [10, 11, 12];
+  const testCases = [
+    {
+      props: {
+        data: {
+          length: 2,
+          attributes: {
+            getPosition: {value: new Float32Array([...p1, ...p2]), size: 3},
+            instancePickingColors: {value: new Uint8ClampedArray([...c1, ...c2]), size: 3}
+          }
+        },
+        getText: d => 'TEXT'
+      },
+      onAfterUpdate: ({layer, subLayer}) => {
+        t.is(subLayer.props.numInstances, 8, 'sublayer has correct numInstances');
+        t.deepEqual(subLayer.props.startIndices, [0, 4, 8], 'sublayer has correct startIndices');
+
+        const attributeManager = subLayer.getAttributeManager();
+        const {instancePositions, instancePickingColors} = attributeManager.attributes;
+        t.deepEqual(
+          [...instancePositions.value].slice(0, 24),
+          [...p1, ...p1, ...p1, ...p1, ...p2, ...p2, ...p2, ...p2],
+          'sublayer has correct instancePositions attribute'
+        );
+        t.deepEqual(
+          [...instancePickingColors.value].slice(0, 24),
+          [...c1, ...c1, ...c1, ...c1, ...c2, ...c2, ...c2, ...c2],
+          'sublayer has correct instancePickingColors attribute'
+        );
+      }
+    }
+  ];
+
+  testLayer({Layer: TextLayer, testCases, onError: t.notOk});
+
+  t.end();
+});
+
 test('TextLayer - fontAtlasCacheLimit', t => {
   TextLayer.fontAtlasCacheLimit = 5;
 


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/6457

#### Background

`MVTLayer` passes an explicit `instancePickingColors` attribute for points when using binary mode. For `pointType: 'circle'` this works fine, but for `pointType: 'text'` it breaks because the number of characters is not generally equal to the number of points rendered.

#### Change List
- Expand `instancePickingColors` attribute such that it matches the other attributes
- Pass expanded attribute to `TextBackgroundLayer` to fix background rendering on binary `MVTLayer`
- Test
