### PR TITLE
CARTO: set default formatTiles to binary at CartoTileLayer

### DIFF
--- a/modules/carto/src/layers/carto-tile-layer.js
+++ b/modules/carto/src/layers/carto-tile-layer.js
@@ -61,7 +61,7 @@ const CartoTileLoader = {
   options: {
     cartoTile: {
       // TODO change to BINARY for 8.7 prod release
-      formatTiles: TILE_FORMATS.GEOJSON
+      formatTiles: TILE_FORMATS.BINARY
     }
   }
 };


### PR DESCRIPTION
This PR set `formatTiles` to `binary` as default for `CartoTileLayer`
