### PR TITLE
[mapbox] Fix event handling when using external deck

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -31,11 +31,9 @@ export function getDeckInstance({map, gl, deck}) {
     }
   };
 
-  if (deck) {
-    deck.setProps(deckProps);
-    deck.props.userData.isExternal = true;
-  } else {
-    // Using external gl context - do not set css size
+  if (!deck || deck.props.gl === gl) {
+    // deck is using the WebGLContext created by mapbox
+    // block deck from setting the canvas size
     Object.assign(deckProps, {
       gl,
       width: false,
@@ -43,17 +41,22 @@ export function getDeckInstance({map, gl, deck}) {
       touchAction: 'unset',
       viewState: getViewState(map)
     });
-    deck = new Deck(deckProps);
-
-    // If deck is externally provided (React use case), we use deck's viewState to
-    // drive the map.
+    // If using the WebGLContext created by deck (React use case), we use deck's viewState to drive the map.
     // Otherwise (pure JS use case), we use the map's viewState to drive deck.
     map.on('move', () => onMapMove(deck, map));
+  }
+
+  if (deck) {
+    deck.setProps(deckProps);
+    deck.props.userData.isExternal = true;
+  } else {
+    deck = new Deck(deckProps);
     map.on('remove', () => {
       deck.finalize();
       map.__deck = null;
     });
   }
+
   deck.props.userData.mapboxVersion = getMapboxVersion(map);
   map.__deck = deck;
   map.on('render', () => {


### PR DESCRIPTION
For #6556

#### Background

When an external Deck instance is used to create a MapboxLayer, it could be one of two cases:

1. Deck driving Mapbox (React use case)
2. Mapbox driving Deck (pure JS, existing deck use case)

The current code always treat the external instance as if it's case 1.

#### Change List
- Deduce use case from deck's initialization props 
