### PR TITLE
Fixed broken link in BitmapLayer doc

### DIFF
--- a/docs/api-reference/layers/bitmap-layer.md
+++ b/docs/api-reference/layers/bitmap-layer.md
@@ -64,7 +64,7 @@ The image to display.
 - If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 - One of the following, or a Promise that resolves to one of the following:
   + One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
-  + A luma.gl [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) instance
+  + A luma.gl [Texture2D](https://luma.gl/docs/api-reference-legacy/classes/texture-2d) instance
   + A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
 
 The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.


### PR DESCRIPTION
Link to Texture2D class was pointing to a broken link to luma.gl's documentation.

#### Change List
- Fixed broken link in BitmapLayer doc
