### PR TITLE
chore(docs): Update luma.gl docs links

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -153,7 +153,7 @@ Expects an object with WebGL settings. Before each frame is rendered, this objec
 }
 ```
 
-Refer to the luma.gl [setParameters](https://luma.gl/docs/api-reference-legacy/context/parameter-setting) API for documentation on supported parameters and values.
+Refer to the luma.gl [setParameters](https://github.com/visgl/luma.gl/blob/8.5-release/modules/gltools/docs/api-reference/parameter-setting.md) API for documentation on supported parameters and values.
 
 ```js
 import GL from '@luma.gl/constants';

--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -70,10 +70,10 @@ The keys in `data.attributes` correspond to the [accessor](/docs/developer-guide
 
 Each value in `data.attributes` may be one of the following formats:
 
-- luma.gl [Buffer](https://luma.gl/docs/api-reference-legacy/classes/buffer) instance
+- luma.gl [Buffer](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/buffer.md) instance
 - A typed array, which will be used to create a `Buffer`
 - An object containing the following optional fields. For more information, see [WebGL vertex attribute API](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer).
-  + `buffer` ([Buffer](https://luma.gl/docs/api-reference/webgl/buffer))
+  + `buffer` ([Buffer](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/buffer.md))
   + `value` (TypedArray)
   + `type` (GLenum) - A WebGL data type, see [vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer#Parameters).
   + `size` (Number) - the number of elements per vertex attribute.
@@ -472,7 +472,7 @@ The function receives two arguments:
 
 The `parameters` allows applications to specify values for WebGL parameters such as blending mode, depth testing etc. Any `parameters` will be applied temporarily while rendering this layer only.
 
-To get access to static parameter values, applications can `import GL from 'luma.gl'`. Please refer to the luma.gl [setParameters](https://luma.gl/docs/api-reference-legacy/context/parameter-setting) API for documentation on supported parameters and values.
+To get access to static parameter values, applications can `import GL from 'luma.gl'`. Please refer to the luma.gl [setParameters](https://github.com/visgl/luma.gl/blob/8.5-release/modules/gltools/docs/api-reference/parameter-setting.md) API for documentation on supported parameters and values.
 
 
 ##### `getPolygonOffset` (Function, optional)

--- a/docs/api-reference/layers/bitmap-layer.md
+++ b/docs/api-reference/layers/bitmap-layer.md
@@ -64,10 +64,10 @@ The image to display.
 - If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 - One of the following, or a Promise that resolves to one of the following:
   + One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
-  + A luma.gl [Texture2D](https://luma.gl/docs/api-reference-legacy/classes/texture-2d) instance
+  + A luma.gl [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) instance
   + A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
 
-The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference/webgl/texture-2d) object. See `textureParameters` prop for advanced customization.
+The image data will be converted to a [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) object. See `textureParameters` prop for advanced customization.
 
 ##### `bounds` (Array)
 

--- a/docs/api-reference/layers/icon-layer.md
+++ b/docs/api-reference/layers/icon-layer.md
@@ -148,10 +148,10 @@ The atlas image.
 - If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 - One of the following, or a Promise that resolves to one of the following:
   + One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
-  + A luma.gl [Texture2D](https://luma.gl/docs/api-reference-legacy/classes/texture-2d) instance
+  + A luma.gl [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) instance
   + A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
 
-The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference-legacy/classes/texture-2d) object. See `textureParameters` prop for advanced customization.
+The image data will be converted to a [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) object. See `textureParameters` prop for advanced customization.
 
 If you go with pre-packed strategy, this prop is required.
 

--- a/docs/api-reference/mesh-layers/scenegraph-layer.md
+++ b/docs/api-reference/mesh-layers/scenegraph-layer.md
@@ -82,7 +82,7 @@ Inherits from all [Base Layer](/docs/api-reference/core/layer.md) properties.
 
 The geometry to render for each data object.
 Can be a URL of an object. You need to provide the `fetch` function to load the object.
-Can also be a luma.gl [ScenegraphNode](https://luma.gl/docs/modules/experimental/scenegraph/scenegraph-node), or a `Promise` that resolves to one.
+Can also be a luma.gl [ScenegraphNode](https://github.com/visgl/luma.gl/blob/8.5-release/modules/experimental/docs/api-reference/scenegraph/scenegraph-node.md), or a `Promise` that resolves to one.
 The layer calls _delete()_ on _scenegraph_ when a new one is provided or the layer is finalized.
 
 

--- a/docs/api-reference/mesh-layers/simple-mesh-layer.md
+++ b/docs/api-reference/mesh-layers/simple-mesh-layer.md
@@ -99,7 +99,7 @@ Inherits from all [Base Layer](/docs/api-reference/core/layer.md) properties.
 The geometry to render for each data object. One of:
 
 - An URL to a mesh description file in a format supported by [loaders.gl](https://loaders.gl/docs/specifications/category-mesh). The appropriate loader will have to be registered via the loaders.gl `registerLoaders` function for this usage.
-- A luma.gl [Geometry](https://luma.gl/docs/modules/engine/geometry) instance
+- A luma.gl [Geometry](https://github.com/visgl/luma.gl/blob/8.5-release/modules/engine/docs/api-reference/geometry.md) instance
 - An object containing the following fields:
   + `positions` (Float32Array) - 3d vertex offset from the object center, in meters
   + `normals` (Float32Array) - 3d normals
@@ -115,10 +115,10 @@ The texture of the geometries.
 - If a string is supplied, it is interpreted as a URL or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 - One of the following, or a Promise that resolves to one of the following:
   + One of the valid [pixel sources for WebGL texture](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D)
-  + A luma.gl [Texture2D](https://luma.gl/docs/api-reference-legacy/classes/texture-2d) instance
+  + A luma.gl [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) instance
   + A plain object that can be passed to the `Texture2D` constructor, e.g. `{width: <number>, height: <number>, data: <Uint8Array>}`. Note that whenever this object shallowly changes, a new texture will be created.
 
-The image data will be converted to a [Texture2D](https://luma.gl/docs/api-reference-legay/classes/texture-2d) object. See `textureParameters` prop for advanced customization.
+The image data will be converted to a [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) object. See `textureParameters` prop for advanced customization.
 
 If `texture` is supplied, texture is used to render the geometries. Otherwise, object color obtained via the `getColor` accessor is used.
 

--- a/docs/developer-guide/custom-layers/layer-extensions.md
+++ b/docs/developer-guide/custom-layers/layer-extensions.md
@@ -116,7 +116,7 @@ When a layer extension is used, it injects itself into a layer. This means that 
 
 ##### `getShaders`
 
-Called to retrieve the *additional* shader parameters. Returns an object that will be merged with the layer's own `getShaders` result before sending to luma.gl's [shader assembly](https://luma.gl/docs/modules/shadertools/assemble-shaders). See [writing shaders](/docs/developer-guide/custom-layers/writing-shaders.md) for deck.gl-specific modules and hooks.
+Called to retrieve the *additional* shader parameters. Returns an object that will be merged with the layer's own `getShaders` result before sending to luma.gl's [shader assembly](https://github.com/visgl/luma.gl/blob/8.5-release/modules/shadertools/docs/api-reference/assemble-shaders.md). See [writing shaders](/docs/developer-guide/custom-layers/writing-shaders.md) for deck.gl-specific modules and hooks.
 
 When this method is executed, `this` points to the layer.
 

--- a/docs/developer-guide/custom-layers/picking.md
+++ b/docs/developer-guide/custom-layers/picking.md
@@ -99,7 +99,7 @@ By default, the `object` field of the picking `info` object is indexed from the 
 
 ### Model object creation
 
-If your layer creates its own [Model](https://luma.gl/docs/api-reference/engine/model) object, add picking module to `modules` array.
+If your layer creates its own [Model](https://github.com/visgl/luma.gl/blob/8.5-release/modules/engine/docs/api-reference/model.md) object, add picking module to `modules` array.
 
 ```js
 import {Model} from '@luma.gl/core';
@@ -144,4 +144,4 @@ void main(void) {
 }
 ```
 
-For more details refer to luma.gl's [`Picking Module`](https://luma.gl/docs/modules/shadertools/core-shader-modules).
+For more details refer to luma.gl's [`Picking Module`](https://github.com/visgl/luma.gl/blob/8.5-release/modules/shadertools/docs/api-reference/core-shader-modules.md#picking).

--- a/docs/developer-guide/custom-layers/prop-types.md
+++ b/docs/developer-guide/custom-layers/prop-types.md
@@ -126,7 +126,7 @@ MyLayerClass.defaultProps = {
 
 ##### `image`
 
-One of: URL string, [Texture2D](https://luma.gl/docs/api-reference-legacy/classes/texture-2d) object, `Image`, `HTMLCanvasElement`, `HTMLVideoElement`, `ImageBitmap` or `ImageData`.
+One of: URL string, [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) object, `Image`, `HTMLCanvasElement`, `HTMLVideoElement`, `ImageBitmap` or `ImageData`.
 
 - Default `transform`: converts to a `Texture2D` object
 

--- a/docs/developer-guide/tips-and-tricks.md
+++ b/docs/developer-guide/tips-and-tricks.md
@@ -7,7 +7,8 @@
 
 The base `Layer` class (which is inherited by all layers) supports a `parameters` property that allows applications to specify the state of WebGL parameters such as blending mode, depth testing etc. This can provide signigicant extra control over rendering.
 
-The new `parameters` prop leverages the luma.gl v4 [setParameters](https://luma.gl/docs/api-reference-legacy/context/parameter-setting) API, which allows all WebGL parameters to be specified as keys in a single parameter object.
+The new `parameters` prop leverages the luma.gl v4 [setParameters](https://github.com/visgl/luma.gl/blob/8.5-release/modules/gltools/docs/api-reference/parameter-setting.md) API, which allows all WebGL parameters to be specified as keys in a single parameter object.
+
 
 ### z-fighting and Depth Testing
 


### PR DESCRIPTION
Follow up of #6681

Per discussion with @ibgreen, given that luma.gl site is prioritizing v9 preview, deck.gl docs will point luma.gl links to the current release branch on GitHub.
