### PR TITLE
Fix website "Edit on Codepen" link

### DIFF
--- a/modules/core/src/lifecycle/constants.ts
+++ b/modules/core/src/lifecycle/constants.ts
@@ -16,4 +16,4 @@ export type Lifecycle = typeof LIFECYCLE[keyof typeof LIFECYCLE];
 export const COMPONENT_SYMBOL: unique symbol = Symbol.for('component');
 export const ASYNC_DEFAULTS_SYMBOL: unique symbol = Symbol.for('asyncPropDefaults');
 export const ASYNC_ORIGINAL_SYMBOL: unique symbol = Symbol.for('asyncPropOriginal');
-export const ASYNC_RESOLVED_SYMBOL: unique symbol = Symbol.for('ASYNC_RESOLVED');
+export const ASYNC_RESOLVED_SYMBOL: unique symbol = Symbol.for('asyncPropResolved');


### PR DESCRIPTION
#### Background

This was a typo introduced by https://github.com/visgl/deck.gl/pull/6454
The library itself is not affected, since all references of the symbol are directly imported from this file. However, the production website's "Edit on Codepen" feature crashes due to the symbol id `asyncPropResolved` being hard coded.

#### Change List
- Fix symbol id.
