### PR TITLE
Cull TileLayer sub layers during picking

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -214,6 +214,7 @@ Receives arguments:
 - `layer` (Layer) - the layer to be drawn
 - `viewport` (Viewport) - the current viewport
 - `isPicking` (Boolean) - whether this is a picking pass
+- `cullRect` (Object) - if defined, indicates that only the content rendered to the given rectangle is needed.
 - `renderPass` (String) - the name of the current render pass. Some standard passes are:
   + `'screen'` - drawing to screen
   + `'picking:hover'` - drawing to offscreen picking buffer due to pointer move

--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -37,7 +37,7 @@ import {
 } from './picking/pick-info';
 
 import type {Framebuffer as LumaFramebuffer} from '@luma.gl/webgl';
-import type {FilterContext} from '../passes/layers-pass';
+import type {FilterContext, Rect} from '../passes/layers-pass';
 import type Layer from './layer';
 import type {Effect} from './effect';
 import type View from '../views/view';
@@ -68,8 +68,6 @@ type PickOperationContext = {
   onViewportActive: (viewport: Viewport) => void;
   effects: Effect[];
 };
-
-type Rect = {x: number; y: number; width: number; height: number};
 
 /** Manages picking in a Deck context */
 export default class DeckPicker {

--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -233,6 +233,13 @@ export default class DeckPicker {
       deviceHeight: height
     });
 
+    const cullRect: Rect = {
+      x: x - radius,
+      y: y - radius,
+      width: radius * 2 + 1,
+      height: radius * 2 + 1
+    };
+
     let infos: Map<string | null, PickingInfo>;
     const result: PickingInfo[] = [];
     const affectedLayers = new Set<Layer>();
@@ -247,6 +254,7 @@ export default class DeckPicker {
           viewports,
           onViewportActive,
           deviceRect,
+          cullRect,
           effects,
           pass: `picking:${mode}`
         });
@@ -279,6 +287,7 @@ export default class DeckPicker {
               width: 1,
               height: 1
             },
+            cullRect,
             effects,
             pass: `picking:${mode}:z`
           },
@@ -379,6 +388,7 @@ export default class DeckPicker {
       viewports,
       onViewportActive,
       deviceRect,
+      cullRect: {x, y, width, height},
       effects,
       pass: `picking:${mode}`
     });
@@ -422,6 +432,7 @@ export default class DeckPicker {
     views: Record<string, View>;
     viewports: Viewport[];
     onViewportActive: (viewport: Viewport) => void;
+    cullRect?: Rect;
     effects: Effect[];
   }): {
     pickedColors: Uint8Array;
@@ -437,6 +448,7 @@ export default class DeckPicker {
       views: Record<string, View>;
       viewports: Viewport[];
       onViewportActive: (viewport: Viewport) => void;
+      cullRect?: Rect;
       effects: Effect[];
     },
     pickZ: true
@@ -452,6 +464,7 @@ export default class DeckPicker {
       viewports,
       onViewportActive,
       deviceRect,
+      cullRect,
       effects,
       pass
     }: {
@@ -461,6 +474,7 @@ export default class DeckPicker {
       views: Record<string, View>;
       viewports: Viewport[];
       onViewportActive: (viewport: Viewport) => void;
+      cullRect?: Rect;
       effects: Effect[];
     },
     pickZ: boolean = false
@@ -478,6 +492,7 @@ export default class DeckPicker {
       onViewportActive,
       pickingFBO,
       deviceRect,
+      cullRect,
       effects,
       pass,
       pickZ

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -8,12 +8,15 @@ import type View from '../views/view';
 import type Layer from '../lib/layer';
 import type {Effect} from '../lib/effect';
 
+export type Rect = {x: number; y: number; width: number; height: number};
+
 export type LayersPassRenderOptions = {
   target?: Framebuffer;
   pass: string;
   layers: Layer[];
   viewports: Viewport[];
   onViewportActive: (viewport: Viewport) => void;
+  cullRect?: Rect;
   views?: Record<string, View>;
   effects?: Effect[];
   clearCanvas?: boolean;
@@ -33,6 +36,7 @@ export type FilterContext = {
   viewport: Viewport;
   isPicking: boolean;
   renderPass: string;
+  cullRect?: Rect;
 };
 
 export type RenderStats = {
@@ -104,7 +108,7 @@ export default class LayersPass extends Pass {
   // this is only done once for the parent viewport
   private _getDrawLayerParams(
     viewport: Viewport,
-    {layers, pass, layerFilter, effects, moduleParameters}: LayersPassRenderOptions
+    {layers, pass, layerFilter, cullRect, effects, moduleParameters}: LayersPassRenderOptions
   ): DrawLayerParameters[] {
     const drawLayerParams: DrawLayerParameters[] = [];
     const indexResolver = layerIndexResolver();
@@ -112,7 +116,8 @@ export default class LayersPass extends Pass {
       layer: layers[0],
       viewport,
       isPicking: pass.startsWith('picking'),
-      renderPass: pass
+      renderPass: pass,
+      cullRect
     };
     const layerFilterCache = {};
     for (let layerIndex = 0; layerIndex < layers.length; layerIndex++) {

--- a/modules/core/src/passes/pick-layers-pass.ts
+++ b/modules/core/src/passes/pick-layers-pass.ts
@@ -1,4 +1,4 @@
-import LayersPass, {LayersPassRenderOptions, RenderStats} from './layers-pass';
+import LayersPass, {LayersPassRenderOptions, RenderStats, Rect} from './layers-pass';
 import {withParameters} from '@luma.gl/core';
 import GL from '@luma.gl/constants';
 import {OPERATION} from '../lib/constants';
@@ -15,7 +15,7 @@ const PICKING_PARAMETERS = {
 
 type PickLayersPassRenderOptions = LayersPassRenderOptions & {
   pickingFBO: Framebuffer;
-  deviceRect: {x: number; y: number; width: number; height: number};
+  deviceRect: Rect;
   pickZ: boolean;
 };
 
@@ -60,6 +60,7 @@ export default class PickLayersPass extends LayersPass {
     onViewportActive,
     pickingFBO,
     deviceRect: {x, y, width, height},
+    cullRect,
     effects,
     pass = 'picking',
     pickZ
@@ -110,6 +111,7 @@ export default class PickLayersPass extends LayersPass {
           views,
           viewports,
           onViewportActive,
+          cullRect,
           effects: effects?.filter(e => e.useInPicking),
           pass
         })

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -8,8 +8,7 @@ import {
   GetPickingInfoParams,
   DefaultProps,
   FilterContext,
-  _flatten as flatten,
-  _memoize as memoize
+  _flatten as flatten
 } from '@deck.gl/core';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {LayersList} from 'modules/core/src/lib/layer-manager';
@@ -17,7 +16,7 @@ import Tile2DHeader from './tile-2d-header';
 
 import Tileset2D, {RefinementStrategy, STRATEGY_DEFAULT, Tileset2DProps} from './tileset-2d';
 import {TileLoadProps, ZRange} from './types';
-import {urlType, getURLFromTemplate, getCullBounds as _getCullBounds} from './utils';
+import {urlType, getURLFromTemplate} from './utils';
 
 const defaultProps: DefaultProps<TileLayerProps> = {
   TilesetClass: Tileset2D,
@@ -42,8 +41,6 @@ const defaultProps: DefaultProps<TileLayerProps> = {
   maxRequests: 6,
   zoomOffset: 0
 };
-
-const getCullBounds = memoize(_getCullBounds);
 
 /** All props supported by the TileLayer */
 export type TileLayerProps<DataT = any> = CompositeLayerProps<any> & _TileLayerProps<DataT>;
@@ -356,21 +353,8 @@ export default class TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeL
     });
   }
 
-  filterSubLayer({layer, viewport, cullRect}: FilterContext) {
+  filterSubLayer({layer, cullRect}: FilterContext) {
     const {tile} = (layer as Layer<{tile: Tile2DHeader}>).props;
-
-    if (!tile.isVisible) {
-      return false;
-    }
-
-    if (cullRect) {
-      const [minX, minY, maxX, maxY] = getCullBounds({viewport, z: this.props.zRange, cullRect});
-      const {bbox} = tile;
-      if ('west' in bbox) {
-        return bbox.west < maxX && bbox.east > minX && bbox.south < maxY && bbox.north > minY;
-      }
-      return bbox.left < maxX && bbox.right > minX && bbox.bottom < maxY && bbox.top > minY;
-    }
-    return true;
+    return this.state.tileset.isTileVisible(tile, cullRect);
   }
 }

--- a/modules/geo-layers/src/tile-layer/utils.ts
+++ b/modules/geo-layers/src/tile-layer/utils.ts
@@ -136,7 +136,7 @@ export function getCullBounds({
   /** Current viewport */
   viewport: Viewport;
   /** Current z range */
-  z: ZRange | number | null;
+  z: ZRange | number | undefined;
   /** Culling rectangle in screen space */
   cullRect: {x: number; y: number; width: number; height: number};
 }): [number, number, number, number] {

--- a/modules/geo-layers/src/tile-layer/utils.ts
+++ b/modules/geo-layers/src/tile-layer/utils.ts
@@ -127,6 +127,50 @@ function getBoundingBox(viewport: Viewport, zRange: number[] | null, extent: Bou
   ];
 }
 
+/** Get culling bounds in world space */
+export function getCullBounds({
+  viewport,
+  z,
+  cullRect
+}: {
+  /** Current viewport */
+  viewport: Viewport;
+  /** Current z range */
+  z: ZRange | number | null;
+  /** Culling rectangle in screen space */
+  cullRect: {x: number; y: number; width: number; height: number};
+}): [number, number, number, number] {
+  const x = cullRect.x - viewport.x;
+  const y = cullRect.y - viewport.y;
+  const {width, height} = cullRect;
+
+  if (!Array.isArray(z)) {
+    const unprojectOption = {targetZ: z || 0};
+
+    const topLeft = viewport.unproject([x, y], unprojectOption);
+    const topRight = viewport.unproject([x + width, y], unprojectOption);
+    const bottomLeft = viewport.unproject([x, y + height], unprojectOption);
+    const bottomRight = viewport.unproject([x + width, y + height], unprojectOption);
+
+    return [
+      Math.min(topLeft[0], topRight[0], bottomLeft[0], bottomRight[0]),
+      Math.min(topLeft[1], topRight[1], bottomLeft[1], bottomRight[1]),
+      Math.max(topLeft[0], topRight[0], bottomLeft[0], bottomRight[0]),
+      Math.max(topLeft[1], topRight[1], bottomLeft[1], bottomRight[1])
+    ];
+  }
+
+  const bounds0 = getCullBounds({viewport, z: z[0], cullRect});
+  const bounds1 = getCullBounds({viewport, z: z[1], cullRect});
+
+  return [
+    Math.min(bounds0[0], bounds1[0]),
+    Math.min(bounds0[1], bounds1[1]),
+    Math.max(bounds0[2], bounds1[2]),
+    Math.max(bounds0[3], bounds1[3])
+  ];
+}
+
 function getIndexingCoords(bbox: Bounds, scale: number, modelMatrixInverse?: Matrix4): Bounds {
   if (modelMatrixInverse) {
     const transformedTileIndex = transformBox(bbox, modelMatrixInverse).map(


### PR DESCRIPTION
Proof of concept for discussion #6729

Picking on hover draws 20 tiles before this PR, and only 1 tile after.

#### Change List
- Add `cullRect` to layer filter context
- `TileLayer.filterSubLayer` culls sub layers based on the scissor rectangle

#### TODO
- Test
- Culling for generic layers?