### PR TITLE
MVTLayer: force binary to false for GlobeView

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -4,6 +4,7 @@ import {MVTWorkerLoader} from '@loaders.gl/mvt';
 import {binaryToGeojson} from '@loaders.gl/gis';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {ClipExtension} from '@deck.gl/extensions';
+import {_GlobeViewport as GlobeViewport} from '@deck.gl/core';
 
 import TileLayer from '../tile-layer/tile-layer';
 import {getURLFromTemplate, isURLTemplate} from '../tile-layer/utils';
@@ -25,7 +26,9 @@ const defaultProps = {
 export default class MVTLayer extends TileLayer {
   initializeState() {
     super.initializeState();
+    const binary = this.context.viewport instanceof GlobeViewport ? false : this.props.binary;
     this.setState({
+      binary,
       data: null,
       tileJSON: null
     });
@@ -111,7 +114,8 @@ export default class MVTLayer extends TileLayer {
       return Promise.reject('Invalid URL');
     }
     let loadOptions = this.getLoadOptions();
-    const {binary, fetch} = this.props;
+    const {binary} = this.state;
+    const {fetch} = this.props;
     const {signal, x, y, z} = tile;
     loadOptions = {
       ...loadOptions,
@@ -153,7 +157,7 @@ export default class MVTLayer extends TileLayer {
 
     const subLayers = super.renderSubLayers(props);
 
-    if (this.props.binary && !(subLayers instanceof GeoJsonLayer)) {
+    if (this.state.binary && !(subLayers instanceof GeoJsonLayer)) {
       log.warn('renderSubLayers() must return GeoJsonLayer when using binary:true')();
     }
 
@@ -194,7 +198,7 @@ export default class MVTLayer extends TileLayer {
 
     const isWGS84 = this.context.viewport.resolution;
 
-    if (this.props.binary && info.index !== -1) {
+    if (this.state.binary && info.index !== -1) {
       const {data} = params.sourceLayer.props;
       info.object = binaryToGeojson(data, {globalFeatureId: info.index});
     }
@@ -213,8 +217,8 @@ export default class MVTLayer extends TileLayer {
   }
 
   getHighlightedObjectIndex(tile) {
-    const {hoveredFeatureId, hoveredFeatureLayerName} = this.state;
-    const {uniqueIdProperty, highlightedFeatureId, binary} = this.props;
+    const {hoveredFeatureId, hoveredFeatureLayerName, binary} = this.state;
+    const {uniqueIdProperty, highlightedFeatureId} = this.props;
     const data = tile.content;
 
     const isHighlighted = isFeatureIdDefined(highlightedFeatureId);
@@ -294,7 +298,7 @@ export default class MVTLayer extends TileLayer {
               return null;
             }
 
-            if (this.props.binary && Array.isArray(tile.content) && !tile.content.length) {
+            if (this.state.binary && Array.isArray(tile.content) && !tile.content.length) {
               // TODO: @loaders.gl/mvt returns [] when no content. It should return a valid empty binary.
               // https://github.com/visgl/loaders.gl/pull/1137
               return [];
@@ -302,7 +306,7 @@ export default class MVTLayer extends TileLayer {
 
             if (tile._contentWGS84 === undefined) {
               // Create a cache to transform only once
-              const content = this.props.binary ? binaryToGeojson(tile.content) : tile.content;
+              const content = this.state.binary ? binaryToGeojson(tile.content) : tile.content;
               tile._contentWGS84 = content.map(feature =>
                 transformTileCoordsToWGS84(feature, tile.bbox, this.context.viewport)
               );

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -242,7 +242,7 @@ test('MVTLayer#transformCoordsToWGS84', t => {
 test('MVTLayer#autoHighlight', async t => {
   class TestMVTLayer extends MVTLayer {
     getTileData() {
-      return this.props.binary ? geoJSONBinaryData : geoJSONData;
+      return this.state.binary ? geoJSONBinaryData : geoJSONData;
     }
   }
 
@@ -300,7 +300,7 @@ for (const binary of [true, false]) {
   test(`MVTLayer#picking binary:${binary}`, async t => {
     class TestMVTLayer extends MVTLayer {
       getTileData() {
-        return this.props.binary ? geoJSONBinaryData : geoJSONData;
+        return this.state.binary ? geoJSONBinaryData : geoJSONData;
       }
     }
 
@@ -425,7 +425,7 @@ test('MVTLayer#TileJSON', async t => {
 test('MVTLayer#dataInWGS84', async t => {
   class TestMVTLayer extends MVTLayer {
     getTileData() {
-      return this.props.binary ? geoJSONBinaryData : geoJSONData;
+      return this.state.binary ? geoJSONBinaryData : geoJSONData;
     }
   }
 
@@ -495,7 +495,7 @@ test('MVTLayer#triangulation', async t => {
     }
     const geoJsonLayer = layer.internalState.subLayers[0];
     const data = geoJsonLayer.props.data;
-    if (layer.props.binary) {
+    if (layer.state.binary) {
       // Triangulated binary data should be passed
       t.ok(data.polygons.triangles, 'should triangulate');
     } else {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/discussions/6717#discussioncomment-2269006
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Store `binary` in `state` in `MVTLayer`
- Override `prop` value when `viewport` is `GlobeViewport`
