### PR TITLE
Handle undefined heading for raster Google maps

### DIFF
--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -139,10 +139,13 @@ export function getViewPropsFromOverlay(map, overlay) {
   let bearing = (180 * delta.verticalAngle()) / Math.PI;
   if (bearing < 0) bearing += 360;
 
+  // Maps sometimes returns undefined instead of 0
+  const heading = map.getHeading() || 0;
+
   let zoom = map.getZoom() - 1;
 
   // Fractional zoom calculation only correct when bearing is not animating
-  if (bearing === map.getHeading()) {
+  if (bearing === heading) {
     const viewDiagonal = new Vector2([topRight.x, topRight.y])
       .sub([bottomLeft.x, bottomLeft.y])
       .len();

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -143,19 +143,24 @@ export function getViewPropsFromOverlay(map, overlay) {
   const heading = map.getHeading() || 0;
 
   let zoom = map.getZoom() - 1;
+  let scale = 1;
 
-  // Fractional zoom calculation only correct when bearing is not animating
-  if (bearing === heading) {
+  if (bearing === 0) {
+    // At full world view (always unrotated) simply compare height, as diagonal
+    // is incorrect due to multiple world copies
+    scale = height ? (bottomLeft.y - topRight.y) / height : 1;
+  } else if (bearing === heading) {
+    // Fractional zoom calculation only correct when bearing is not animating
     const viewDiagonal = new Vector2([topRight.x, topRight.y])
       .sub([bottomLeft.x, bottomLeft.y])
       .len();
     const mapDiagonal = new Vector2([width, -height]).len();
-    const scale = mapDiagonal ? viewDiagonal / mapDiagonal : 1;
-
-    // When resizing aggressively, occasionally ne and sw are the same points
-    // See https://github.com/visgl/deck.gl/issues/4218
-    zoom += Math.log2(scale || 1);
+    scale = mapDiagonal ? viewDiagonal / mapDiagonal : 1;
   }
+
+  // When resizing aggressively, occasionally ne and sw are the same points
+  // See https://github.com/visgl/deck.gl/issues/4218
+  zoom += Math.log2(scale || 1);
 
   return {
     width,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6731
<!-- For other PRs without open issue -->
#### Background

[getHeading](https://developers.google.com/maps/documentation/javascript/reference/map?hl=en#Map.getHeading) sometimes returns undefined instead of 0.

<!-- For all the PRs -->
#### Change List
- Handle case of `heading = undefined`
- Correct zoom calculation for mulitple world copies (use map height rather than diagonal)
