### PR TITLE
Prevent MVT tile downloads when layer not visible 

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -40,7 +40,7 @@ export default class MVTLayer extends TileLayer {
       this._updateTileData();
     }
 
-    if (this.state.data) {
+    if (this.state.data && this.props.visible) {
       super.updateState({props, oldProps, context, changeFlags});
       this._setWGS84PropertyForTiles();
     }
@@ -101,7 +101,7 @@ export default class MVTLayer extends TileLayer {
   /* eslint-disable complexity */
 
   renderLayers() {
-    if (!this.state.data) return null;
+    if (!this.state.data || !this.props.visible) return null;
     return super.renderLayers();
   }
 

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -101,7 +101,7 @@ export default class MVTLayer extends TileLayer {
   /* eslint-disable complexity */
 
   renderLayers() {
-    if (!this.state.data || !this.props.visible) return null;
+    if (!this.state.data) return null;
     return super.renderLayers();
   }
 

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -51,6 +51,7 @@ export default class TileLayer extends CompositeLayer {
   }
 
   updateState({props, changeFlags}) {
+    if (!props.visible) return;
     let {tileset} = this.state;
     const propsChanged = changeFlags.propsOrDataChanged || changeFlags.updateTriggersChanged;
     const dataChanged =
@@ -195,6 +196,9 @@ export default class TileLayer extends CompositeLayer {
   }
 
   renderLayers() {
+    if (!this.props.visible) {
+      return null;
+    }
     return this.state.tileset.tiles.map(tile => {
       const subLayerProps = this.getSubLayerPropsByTile(tile);
       // cache the rendered layer in the tile

--- a/modules/google-maps/src/utils.js
+++ b/modules/google-maps/src/utils.js
@@ -139,20 +139,28 @@ export function getViewPropsFromOverlay(map, overlay) {
   let bearing = (180 * delta.verticalAngle()) / Math.PI;
   if (bearing < 0) bearing += 360;
 
-  let zoom = map.getZoom() - 1;
+  // Maps sometimes returns undefined instead of 0
+  const heading = map.getHeading() || 0;
 
-  // Fractional zoom calculation only correct when bearing is not animating
-  if (bearing === map.getHeading()) {
+  let zoom = map.getZoom() - 1;
+  let scale;
+
+  if (bearing === 0) {
+    // At full world view (always unrotated) simply compare height, as diagonal
+    // is incorrect due to multiple world copies
+    scale = height ? (bottomLeft.y - topRight.y) / height : 1;
+  } else if (bearing === heading) {
+    // Fractional zoom calculation only correct when bearing is not animating
     const viewDiagonal = new Vector2([topRight.x, topRight.y])
       .sub([bottomLeft.x, bottomLeft.y])
       .len();
     const mapDiagonal = new Vector2([width, -height]).len();
-    const scale = mapDiagonal ? viewDiagonal / mapDiagonal : 1;
-
-    // When resizing aggressively, occasionally ne and sw are the same points
-    // See https://github.com/visgl/deck.gl/issues/4218
-    zoom += Math.log2(scale || 1);
+    scale = mapDiagonal ? viewDiagonal / mapDiagonal : 1;
   }
+
+  // When resizing aggressively, occasionally ne and sw are the same points
+  // See https://github.com/visgl/deck.gl/issues/4218
+  zoom += Math.log2(scale || 1);
 
   return {
     width,

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -102,8 +102,9 @@ export async function testLayerAsync(opts) {
 
     runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
 
-    let n = 0;
-    while (!newLayer.isLoaded && ++n < 10) {
+    let invocation = 0;
+    const maxInvocations = 10;
+    while (!newLayer.isLoaded && invocation++ < maxInvocations) {
       await update(resources);
       runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
     }
@@ -236,8 +237,9 @@ function runLayerTestUpdate(testCase, {layerManager, deckRenderer}, layer, spies
 
 /* global setTimeout */
 function update({layerManager, deckRenderer}) {
-  return new Promise((resolve, reject) => {
-    let n = 0;
+  return new Promise(resolve => {
+    let invocation = 0;
+    const maxInvocations = 10;
     const onAnimationFrame = () => {
       if (layerManager.needsUpdate()) {
         layerManager.updateLayers();
@@ -249,7 +251,7 @@ function update({layerManager, deckRenderer}) {
         });
         resolve();
         return;
-      } else if (++n > 10) {
+      } else if (++invocation >= maxInvocations) {
         resolve();
         return;
       }

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -102,7 +102,8 @@ export async function testLayerAsync(opts) {
 
     runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
 
-    while (!newLayer.isLoaded) {
+    let n = 0;
+    while (!newLayer.isLoaded && ++n < 10) {
       await update(resources);
       runLayerTestPostUpdateCheck(testCase, newLayer, oldState, spyMap);
     }
@@ -235,7 +236,8 @@ function runLayerTestUpdate(testCase, {layerManager, deckRenderer}, layer, spies
 
 /* global setTimeout */
 function update({layerManager, deckRenderer}) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
+    let n = 0;
     const onAnimationFrame = () => {
       if (layerManager.needsUpdate()) {
         layerManager.updateLayers();
@@ -245,6 +247,9 @@ function update({layerManager, deckRenderer}) {
           layers: layerManager.getLayers(),
           onViewportActive: layerManager.activateViewport
         });
+        resolve();
+        return;
+      } else if (++n > 10) {
         resolve();
         return;
       }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6747

<!-- For all the PRs -->
#### Change List
- Prevent tiles being fetched when `visible=false`
- Test

Note that the tileJSON will still be fetched if the `data` prop is a URL. This is intentional.
