### PR TITLE
CARTO: Append formatTiles to TileJSON URL when requested

### DIFF
--- a/modules/carto/src/api/maps-v3-client.ts
+++ b/modules/carto/src/api/maps-v3-client.ts
@@ -10,7 +10,9 @@ import {
   MapInstantiation,
   MapType,
   MAP_TYPES,
-  SchemaField
+  SchemaField,
+  TileFormat,
+  TILE_FORMATS
 } from './maps-api-common';
 import {parseMap} from './parseMap';
 import {log} from '@deck.gl/core';
@@ -111,6 +113,7 @@ type FetchLayerDataParams = {
   schema?: boolean;
   clientId?: string;
   format?: Format;
+  formatTiles?: TileFormat;
 };
 
 /**
@@ -208,6 +211,7 @@ export async function fetchLayerData({
   geoColumn,
   columns,
   format,
+  formatTiles,
   schema,
   clientId
 }: FetchLayerDataParams): Promise<FetchLayerDataResult> {
@@ -221,6 +225,7 @@ export async function fetchLayerData({
     geoColumn,
     columns,
     format,
+    formatTiles,
     schema,
     clientId
   });
@@ -242,6 +247,7 @@ async function _fetchDataUrl({
   geoColumn,
   columns,
   format,
+  formatTiles,
   schema,
   clientId
 }: FetchLayerDataParams) {
@@ -286,6 +292,14 @@ async function _fetchDataUrl({
       }
     }
     assert(url && mapFormat, 'Unsupported data formats received from backend.');
+  }
+
+  if (format === FORMATS.TILEJSON && formatTiles) {
+    log.assert(
+      Object.values(TILE_FORMATS).includes(formatTiles),
+      `Invalid value for formatTiles: ${formatTiles}. Use value from TILE_FORMATS`
+    );
+    url += `&${encodeParameter('formatTiles', formatTiles)}`;
   }
 
   const {accessToken} = localCreds;

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -92,8 +92,10 @@ export default class CartoLayer extends CompositeLayer {
       changeFlags.dataChanged ||
       props.connection !== oldProps.connection ||
       props.geoColumn !== oldProps.geoColumn ||
-      JSON.stringify(props.columns) !== JSON.stringify(oldProps.columns) ||
+      props.format !== oldProps.format ||
+      props.formatTiles !== oldProps.formatTiles ||
       props.type !== oldProps.type ||
+      JSON.stringify(props.columns) !== JSON.stringify(oldProps.columns) ||
       JSON.stringify(props.credentials) !== JSON.stringify(oldProps.credentials);
 
     if (shouldUpdateData) {

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -139,10 +139,10 @@ export default class CartoLayer extends CompositeLayer {
 
     if (format === FORMATS.TILEJSON) {
       /* global URL */
+      const tileUrl = new URL(data.tiles[0]);
+
       props.formatTiles =
-        props.formatTiles ||
-        new URL(data.tiles[0]).searchParams.get('formatTiles') ||
-        TILE_FORMATS.MVT;
+        props.formatTiles || tileUrl.searchParams.get('formatTiles') || TILE_FORMATS.MVT;
 
       return props.formatTiles === TILE_FORMATS.MVT ? [MVTLayer, props] : [CartoTileLayer, props];
     }

--- a/modules/carto/src/layers/carto-tile-layer.js
+++ b/modules/carto/src/layers/carto-tile-layer.js
@@ -75,7 +75,7 @@ const defaultProps = {
 
 export default class CartoTileLayer extends MVTLayer {
   getTileData(tile) {
-    let url = _getURLFromTemplate(this.state.data, tile);
+    const url = _getURLFromTemplate(this.state.data, tile);
     if (!url) {
       return Promise.reject('Invalid URL');
     }

--- a/modules/carto/src/layers/carto-tile-layer.js
+++ b/modules/carto/src/layers/carto-tile-layer.js
@@ -48,6 +48,8 @@ function parseCartoTile(arrayBuffer, options) {
   return data;
 }
 
+const defaultTileFormat = TILE_FORMATS.BINARY;
+
 const CartoTileLoader = {
   name: 'CARTO Tile',
   id: 'cartoTile',
@@ -60,10 +62,15 @@ const CartoTileLoader = {
   parseSync: parseCartoTile,
   options: {
     cartoTile: {
-      // TODO change to BINARY for 8.7 prod release
-      formatTiles: TILE_FORMATS.BINARY
+      formatTiles: defaultTileFormat
     }
   }
+};
+
+const defaultProps = {
+  ...MVTLayer.defaultProps,
+  formatTiles: defaultTileFormat,
+  loaders: [CartoTileLoader]
 };
 
 export default class CartoTileLayer extends MVTLayer {
@@ -87,10 +94,6 @@ export default class CartoTileLayer extends MVTLayer {
         Object.values(TILE_FORMATS).includes(formatTiles),
         `Invalid value for formatTiles: ${formatTiles}. Use value from TILE_FORMATS`
       );
-      // eslint-disable-next-line no-undef
-      const newUrl = new URL(url);
-      newUrl.searchParams.set('formatTiles', formatTiles);
-      url = newUrl.toString();
       loadOptions.cartoTile = {formatTiles};
     }
 
@@ -118,4 +121,4 @@ export default class CartoTileLayer extends MVTLayer {
 }
 
 CartoTileLayer.layerName = 'CartoTileLayer';
-CartoTileLayer.defaultProps = {...MVTLayer.defaultProps, loaders: [CartoTileLoader]};
+CartoTileLayer.defaultProps = defaultProps;

--- a/test/apps/carto-dynamic-tile/app.js
+++ b/test/apps/carto-dynamic-tile/app.js
@@ -57,20 +57,43 @@ const config = {
   }
 };
 
-const connection = 'redshift';
-const table = config[connection]['zipcodes'];
 const accessToken = 'XXXX';
 
 const showBasemap = true;
 const showCarto = true;
 
 function Root() {
+  const [connection, setConnection] = useState('bigquery');
+  const [dataset, setDataset] = useState('points_1M');
+  const [formatTiles, setFormatTiles] = useState(TILE_FORMATS.BINARY);
+  const table = config[connection][dataset];
   return (
     <>
       <DeckGL
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}
-        layers={[showBasemap && createBasemap(), showCarto && createCarto()]}
+        layers={[
+          showBasemap && createBasemap(),
+          showCarto && createCarto(connection, formatTiles, table)
+        ]}
+      />
+      <ObjectSelect
+        title="formatTiles"
+        obj={TILE_FORMATS}
+        value={formatTiles}
+        onSelect={setFormatTiles}
+      />
+      <ObjectSelect
+        title="connection"
+        obj={Object.keys(config)}
+        value={connection}
+        onSelect={setConnection}
+      />
+      <ObjectSelect
+        title="dataset"
+        obj={Object.keys(config[connection])}
+        value={dataset}
+        onSelect={setDataset}
       />
     </>
   );
@@ -90,7 +113,7 @@ function createBasemap() {
   });
 }
 
-function createCarto() {
+function createCarto(connection, formatTiles, table) {
   return new CartoLayer({
     id: 'carto',
     connection,
@@ -100,6 +123,7 @@ function createCarto() {
     // Dynamic tiling. Request TILEJSON format with TABLE
     type: MAP_TYPES.TABLE,
     format: FORMATS.TILEJSON,
+    formatTiles,
 
     // Styling
     getFillColor: [233, 71, 251],
@@ -113,6 +137,27 @@ function createCarto() {
     getPointRadius: 1.5,
     getLineColor: [0, 0, 200]
   });
+}
+
+function ObjectSelect({title, obj, value, onSelect}) {
+  const keys = Object.values(obj).sort();
+  return (
+    <>
+      <select
+        onChange={e => onSelect(e.target.value)}
+        style={{position: 'relative', padding: 4, margin: 2, width: 200}}
+        value={value}
+      >
+        <option hidden>{title}</option>
+        {keys.map(f => (
+          <option key={f} value={f}>
+            {`${title}: ${f}`}
+          </option>
+        ))}
+      </select>
+      <br></br>
+    </>
+  );
 }
 
 render(<Root />, document.body.appendChild(document.createElement('div')));


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6508

Tiles were being requested in binary format even when `formatTiles: 'mvt'`

<!-- For all the PRs -->
#### Change List
- Append formatTiles to TileJSON URL when requested
- Better `shouldUpdateData` check
- Improve test app to allow easy selection of dataset & tile format
