### PR TITLE
Fix Python CI

### DIFF
--- a/bindings/pydeck/pyproject.toml
+++ b/bindings/pydeck/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "pydeck"
-version = "0.3.0"
+version = "0.7.1"
+requires-python = ">=3.7"
 
+[build-system]
 requires = [
-    "setuptools",
-    "wheel",
+  "setuptools",
+  "wheel",
 ]
 
 [tool.black]


### PR DESCRIPTION
The latest version of `setuptools` broke our CI, see: https://github.com/visgl/deck.gl/runs/5687413943?check_suite_focus=true, but it turns out our `pyproject.toml` file is invalid anyways. The `requires` array should be under the `[build-system]` header.

#### Change List

- Update `pyproject.toml` in line with [PEP 621](https://peps.python.org/pep-0621/)
