### PR TITLE
Fix position precision in CPU aggregation layers

### DIFF
--- a/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.js
+++ b/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.js
@@ -25,6 +25,8 @@ import {pointToDensityGridDataCPU} from './grid-aggregator';
 import CPUAggregator from '../utils/cpu-aggregator';
 import AggregationLayer from '../aggregation-layer';
 
+import GL from '@luma.gl/constants';
+
 function nop() {}
 
 const defaultProps = {
@@ -79,7 +81,7 @@ export default class CPUGridLayer extends AggregationLayer {
     };
     const attributeManager = this.getAttributeManager();
     attributeManager.add({
-      positions: {size: 3, accessor: 'getPosition'}
+      positions: {size: 3, type: GL.DOUBLE, accessor: 'getPosition'}
     });
     // color and elevation attributes can't be added as attributes
     // they are calcualted using 'getValue' accessor that takes an array of pints.

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js
@@ -27,6 +27,8 @@ import {pointToHexbin} from './hexagon-aggregator';
 import CPUAggregator from '../utils/cpu-aggregator';
 import AggregationLayer from '../aggregation-layer';
 
+import GL from '@luma.gl/constants';
+
 function nop() {}
 
 const defaultProps = {
@@ -79,7 +81,7 @@ export default class HexagonLayer extends AggregationLayer {
     };
     const attributeManager = this.getAttributeManager();
     attributeManager.add({
-      positions: {size: 3, accessor: 'getPosition'}
+      positions: {size: 3, type: GL.DOUBLE, accessor: 'getPosition'}
     });
     // color and elevation attributes can't be added as attributes
     // they are calculated using 'getValue' accessor that takes an array of pints.


### PR DESCRIPTION
For #6813

#### Change List
- Use double precision for positions in `CPUGridLayer` and `HexagonLayer`
