### PR TITLE
CARTO: fetchMap support for custom breaks

### DIFF
--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -7,7 +7,8 @@ import {
   scalePoint,
   scaleQuantile,
   scaleQuantize,
-  scaleSqrt
+  scaleSqrt,
+  scaleThreshold
 } from 'd3-scale';
 import {format as d3Format} from 'd3-format';
 import moment from 'moment-timezone';
@@ -27,9 +28,12 @@ const SCALE_FUNCS = {
   point: scalePoint,
   quantile: scaleQuantile,
   quantize: scaleQuantize,
-  sqrt: scaleSqrt
+  sqrt: scaleSqrt,
+  custom: scaleThreshold
 };
 export type SCALE_TYPE = keyof typeof SCALE_FUNCS;
+
+const UNKNOWN_COLOR = '#868d91';
 
 export const AGGREGATION = {
   average: 'MEAN',
@@ -179,7 +183,7 @@ function domainFromAttribute(attribute, scaleType: SCALE_TYPE) {
 
 function domainFromValues(values, scaleType: SCALE_TYPE) {
   if (scaleType === 'ordinal') {
-    return [...new Set(values)].sort();
+    return uniqueSortedByFrequency(values);
   } else if (scaleType === 'quantile') {
     return values.sort((a, b) => a - b);
   } else if (scaleType === 'log') {
@@ -187,6 +191,20 @@ function domainFromValues(values, scaleType: SCALE_TYPE) {
     return [d0 === 0 ? 1e-5 : d0, d1];
   }
   return extent(values);
+}
+
+function uniqueSortedByFrequency(values) {
+  const frequency = values.reduce((res, value) => {
+    if (value !== null && value !== undefined) {
+      if (!res[value]) {
+        res[value] = 0;
+      }
+      res[value] += 1;
+    }
+    return res;
+  }, {});
+
+  return Object.keys(frequency).sort((a, b) => frequency[b] - frequency[a]);
 }
 
 function calculateDomain(data, name, scaleType) {
@@ -226,13 +244,31 @@ export function getColorValueAccessor({name}, colorAggregation, data: any) {
 export function getColorAccessor(
   {name},
   scaleType: SCALE_TYPE,
-  {colors},
+  {colors, colorMap},
   opacity: number | undefined,
   data: any
 ) {
   const scale = SCALE_FUNCS[scaleType as any]();
-  scale.domain(calculateDomain(data, name, scaleType));
-  scale.range(colors);
+  let domain: (string | number)[] = [];
+  let scaleColor: string[] = [];
+
+  if (Array.isArray(colorMap)) {
+    colorMap.forEach(([value, color]) => {
+      domain.push(value);
+      scaleColor.push(color);
+    });
+  } else {
+    domain = calculateDomain(data, name, scaleType);
+    scaleColor = colors;
+  }
+
+  if (scaleType === 'ordinal') {
+    domain = domain.slice(0, scaleColor.length);
+  }
+
+  scale.domain(domain);
+  scale.range(scaleColor);
+  scale.unknown(UNKNOWN_COLOR);
   const alpha = opacity !== undefined ? Math.round(255 * Math.pow(opacity, 1 / 2.2)) : 255;
 
   const accessor = properties => {

--- a/test/modules/carto/api/layer-map.spec.js
+++ b/test/modules/carto/api/layer-map.spec.js
@@ -170,7 +170,7 @@ test('getHexagon', t => {
 });
 
 test('domainFromValues', t => {
-  t.deepEquals(_domainFromValues(['a', 'b', 'c', 'b'], 'ordinal'), ['a', 'b', 'c']);
+  t.deepEquals(_domainFromValues(['a', 'a', 'b', 'c', 'b'], 'ordinal'), ['a', 'b', 'c']);
   t.deepEquals(_domainFromValues([1, 4, 2, 3, 1], 'quantile'), [1, 1, 2, 3, 4]);
   t.deepEquals(_domainFromValues([1, 0, -3], 'log'), [-3, 1]);
   t.deepEquals(_domainFromValues([1, 0, 3], 'log'), [0.00001, 3]);


### PR DESCRIPTION
Background
Add support for layers colors custom breaks

Change List
- Read the colorMap from Kepler config
- For ordinal scales, order the categories by frequency instead of alphabetical 
