### PR TITLE
Extensibility of `TileLayer` and `Tileset2D`

### DIFF
--- a/modules/geo-layers/src/index.ts
+++ b/modules/geo-layers/src/index.ts
@@ -31,3 +31,4 @@ export {default as TerrainLayer} from './terrain-layer/terrain-layer';
 export {default as MVTLayer} from './mvt-layer/mvt-layer';
 
 export {getURLFromTemplate as _getURLFromTemplate} from './tile-layer/utils';
+export {Tileset2D} from './tile-layer/tileset-2d';

--- a/modules/geo-layers/src/tile-layer/tile-layer.js
+++ b/modules/geo-layers/src/tile-layer/tile-layer.js
@@ -59,7 +59,7 @@ export default class TileLayer extends CompositeLayer {
         (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getTileData));
 
     if (!tileset) {
-      tileset = new Tileset2D(this._getTilesetOptions(props));
+      tileset = new (this._getTileset2DClass())(this._getTilesetOptions(props));
       this.setState({tileset});
     } else if (propsChanged) {
       tileset.setOptions(this._getTilesetOptions(props));
@@ -77,6 +77,10 @@ export default class TileLayer extends CompositeLayer {
     }
 
     this._updateTileset();
+  }
+
+  _getTileset2DClass () {
+    return Tileset2D;
   }
 
   _getTilesetOptions(props) {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
As a developer working with tile layer for different projections, I would appreciate if the `TileLayer` can be extended easily with custom `Tileset2D`.
<!-- For all the PRs -->
#### Change List
* Allow `TileLayer` to be extended with custom `Tileset2D`
* Expose `Tileset2D` for developers to extend