### PR TITLE
Fix uniform transition for shader module props

### DIFF
--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -281,15 +281,18 @@ export default class LayersPass extends Pass {
     pass: string,
     overrides: any
   ): any {
-    const moduleParameters = Object.assign(Object.create(layer.props), {
-      autoWrapLongitude: layer.wrapLongitude,
-      // @ts-ignore
-      viewport: layer.context.viewport,
-      // @ts-ignore
-      mousePosition: layer.context.mousePosition,
-      pickingActive: 0,
-      devicePixelRatio: cssToDeviceRatio(this.gl)
-    });
+    const moduleParameters = Object.assign(
+      Object.create(layer.internalState?.propsInTransition || layer.props),
+      {
+        autoWrapLongitude: layer.wrapLongitude,
+        // @ts-ignore
+        viewport: layer.context.viewport,
+        // @ts-ignore
+        mousePosition: layer.context.mousePosition,
+        pickingActive: 0,
+        devicePixelRatio: cssToDeviceRatio(this.gl)
+      }
+    );
 
     if (effects) {
       for (const effect of effects) {

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -371,40 +371,68 @@ test('Layer#uniformTransitions', t => {
   class TestLayer extends Layer {
     initializeState() {}
 
+    setModuleParameters(params) {
+      super.setModuleParameters(params);
+      this.state.moduleParameters = params;
+    }
+
     draw() {
       drawCalls.push({
-        opacity: this.props.opacity
+        opacity: this.props.opacity,
+        modelMatrix: this.state.moduleParameters.modelMatrix
       });
     }
   }
+
+  const identityMat4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  const scale2Mat4 = [2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1];
+  const scale3Mat4 = [3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1];
 
   const testCases = [
     {
       props: {
         id: 'testLayer',
         data: [],
-        opacity: 0
+        opacity: 0,
+        modelMatrix: identityMat4
       },
       onBeforeUpdate: () => timeline.setTime(0),
-      onAfterUpdate: () => t.deepEquals(drawCalls.pop(), {opacity: 0}, 'layer drawn with opacity')
+      onAfterUpdate: () =>
+        t.deepEquals(
+          drawCalls.pop(),
+          {opacity: 0, modelMatrix: identityMat4},
+          'layer drawn with opacity'
+        )
     },
     {
       updateProps: {
-        opacity: 1
+        opacity: 1,
+        modelMatrix: scale3Mat4
       },
       onBeforeUpdate: () => timeline.setTime(100),
-      onAfterUpdate: () => t.deepEquals(drawCalls.pop(), {opacity: 1}, 'layer drawn with opacity')
+      onAfterUpdate: () =>
+        t.deepEquals(
+          drawCalls.pop(),
+          {opacity: 1, modelMatrix: scale3Mat4},
+          'layer drawn with opacity'
+        )
     },
     {
       updateProps: {
         opacity: 0,
+        modelMatrix: identityMat4,
         transitions: {
-          opacity: 200
+          opacity: 200,
+          modelMatrix: 200
         }
       },
       onBeforeUpdate: () => timeline.setTime(200),
       onAfterUpdate: () =>
-        t.deepEquals(drawCalls.pop(), {opacity: 1}, 'layer drawn with opacity in transition')
+        t.deepEquals(
+          drawCalls.pop(),
+          {opacity: 1, modelMatrix: scale3Mat4},
+          'layer drawn with opacity in transition'
+        )
     },
     {
       updateProps: {
@@ -412,7 +440,11 @@ test('Layer#uniformTransitions', t => {
       },
       onBeforeUpdate: () => timeline.setTime(300),
       onAfterUpdate: () =>
-        t.deepEquals(drawCalls.pop(), {opacity: 0.5}, 'layer drawn with opacity in transition')
+        t.deepEquals(
+          drawCalls.pop(),
+          {opacity: 0.5, modelMatrix: scale2Mat4},
+          'layer drawn with opacity in transition'
+        )
     },
     {
       updateProps: {
@@ -420,7 +452,11 @@ test('Layer#uniformTransitions', t => {
       },
       onBeforeUpdate: () => timeline.setTime(400),
       onAfterUpdate: () =>
-        t.deepEquals(drawCalls.pop(), {opacity: 0}, 'layer drawn with opacity in transition')
+        t.deepEquals(
+          drawCalls.pop(),
+          {opacity: 0, modelMatrix: identityMat4},
+          'layer drawn with opacity in transition'
+        )
     }
   ];
 


### PR DESCRIPTION
For #6830

#### Background

During uniform transition, we shadow `layer.props` with `internalState.propsInTransition` inside lifecycle calls (`_update` and `_drawLayer`. In `LayersPass`, module parameters are currently pre-calculated outside of these lifecycle methods, so they are not using the "real" props.

#### Change List
- Account for props in transition
- Unit tests
