### PR TITLE
Base Layer type signature

### DIFF
--- a/modules/carto/src/layers/carto-layer.ts
+++ b/modules/carto/src/layers/carto-layer.ts
@@ -240,7 +240,7 @@ export default class CartoLayer<DataT = any> extends CompositeLayer<CartoLayerPr
           source,
           clientId,
           credentials: credentials as CloudNativeCredentials,
-          connection: connection as string,
+          connection,
           ...rest
         });
       }

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -116,3 +116,4 @@ export type {OrthographicViewState} from './views/orthographic-view';
 export type {GlobeViewState} from './views/globe-view';
 export type {ChangeFlags} from './lib/layer-state';
 export type {LayersList} from './lib/layer-manager';
+export type {LayerContext} from './lib/layer-manager';

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -100,6 +100,15 @@ export {mergeShaders as _mergeShaders} from './utils/shader';
 export {compareProps as _compareProps} from './lifecycle/props';
 
 // Types
+export type {MapViewState} from './views/map-view';
+export type {FirstPersonViewState} from './views/first-person-view';
+export type {OrbitViewState} from './views/orbit-view';
+export type {OrthographicViewState} from './views/orthographic-view';
+export type {GlobeViewState} from './views/globe-view';
+export type {ChangeFlags} from './lib/layer-state';
+export type {LayersList} from './lib/layer-manager';
+export type {LayerContext} from './lib/layer-manager';
+export type {UpdateParameters} from './lib/layer';
 export type {
   LayerProps,
   CompositeLayerProps,
@@ -109,11 +118,3 @@ export type {
   Position,
   Color
 } from './types/layer-props';
-export type {MapViewState} from './views/map-view';
-export type {FirstPersonViewState} from './views/first-person-view';
-export type {OrbitViewState} from './views/orbit-view';
-export type {OrthographicViewState} from './views/orthographic-view';
-export type {GlobeViewState} from './views/globe-view';
-export type {ChangeFlags} from './lib/layer-state';
-export type {LayersList} from './lib/layer-manager';
-export type {LayerContext} from './lib/layer-manager';

--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -21,14 +21,19 @@ import Layer, {UpdateParameters} from './layer';
 import debug from '../debug';
 import {flatten} from '../utils/flatten';
 
+import type AttributeManager from './attribute/attribute-manager';
 import type {PickingInfo} from './picking/pick-info';
 import type {FilterContext} from '../passes/layers-pass';
 import type {LayersList, LayerContext} from './layer-manager';
-import type {Accessor, AccessorContext} from '../types/layer-props';
+import type {CompositeLayerProps, Accessor, AccessorContext} from '../types/layer-props';
 
 const TRACE_RENDER_LAYERS = 'compositeLayer.renderLayers';
 
-export default abstract class CompositeLayer<PropsT = any> extends Layer<PropsT> {
+export default abstract class CompositeLayer<PropsT = any> extends Layer<
+  PropsT & Required<CompositeLayerProps>
+> {
+  static layerName: string = 'CompositeLayer';
+
   /** `true` if this layer renders other layers */
   get isComposite(): boolean {
     return true;
@@ -243,7 +248,7 @@ export default abstract class CompositeLayer<PropsT = any> extends Layer<PropsT>
   }
 
   /** Override base Layer method */
-  protected _getAttributeManager(): null {
+  protected _getAttributeManager(): AttributeManager | null {
     return null;
   }
 
@@ -266,9 +271,7 @@ export default abstract class CompositeLayer<PropsT = any> extends Layer<PropsT>
     // populate reference to parent layer (this layer)
     // NOTE: needs to be done even when reusing layers as the parent may have changed
     for (const layer of subLayers) {
-      layer.parent = this as Layer;
+      layer.parent = this;
     }
   }
 }
-
-CompositeLayer.layerName = 'CompositeLayer';

--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -17,22 +17,18 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-import Layer from './layer';
+import Layer, {UpdateParameters} from './layer';
 import debug from '../debug';
 import {flatten} from '../utils/flatten';
 
-import type AttributeManager from './attribute/attribute-manager';
 import type {PickingInfo} from './picking/pick-info';
-import type {ChangeFlags} from './layer-state';
 import type {FilterContext} from '../passes/layers-pass';
 import type {LayersList, LayerContext} from './layer-manager';
-import type {CompositeLayerProps, Accessor, AccessorContext} from '../types/layer-props';
+import type {Accessor, AccessorContext} from '../types/layer-props';
 
 const TRACE_RENDER_LAYERS = 'compositeLayer.renderLayers';
 
-export default abstract class CompositeLayer<
-  PropsT extends CompositeLayerProps = CompositeLayerProps
-> extends Layer<PropsT> {
+export default abstract class CompositeLayer<PropsT = any> extends Layer<PropsT> {
   /** `true` if this layer renders other layers */
   get isComposite(): boolean {
     return true;
@@ -247,20 +243,12 @@ export default abstract class CompositeLayer<
   }
 
   /** Override base Layer method */
-  protected _getAttributeManager(): AttributeManager | null {
+  protected _getAttributeManager(): null {
     return null;
   }
 
   /** (Internal) Called after an update to rerender sub layers */
-  protected _postUpdate(
-    updateParams: {
-      props: PropsT;
-      oldProps: PropsT;
-      context: LayerContext;
-      changeFlags: ChangeFlags;
-    },
-    forceUpdate: boolean
-  ) {
+  protected _postUpdate(updateParams: UpdateParameters<PropsT>, forceUpdate: boolean) {
     // @ts-ignore (TS2531) this method is only called internally when internalState is defined
     let subLayers = this.internalState.subLayers as Layer[];
     const shouldUpdate = !subLayers || this.needsUpdate();
@@ -278,7 +266,7 @@ export default abstract class CompositeLayer<
     // populate reference to parent layer (this layer)
     // NOTE: needs to be done even when reusing layers as the parent may have changed
     for (const layer of subLayers) {
-      layer.parent = this;
+      layer.parent = this as Layer;
     }
   }
 }

--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -253,7 +253,7 @@ export default abstract class CompositeLayer<PropsT = any> extends Layer<
   }
 
   /** (Internal) Called after an update to rerender sub layers */
-  protected _postUpdate(updateParams: UpdateParameters<PropsT>, forceUpdate: boolean) {
+  protected _postUpdate(updateParams: UpdateParameters<CompositeLayer>, forceUpdate: boolean) {
     // @ts-ignore (TS2531) this method is only called internally when internalState is defined
     let subLayers = this.internalState.subLayers as Layer[];
     const shouldUpdate = !subLayers || this.needsUpdate();

--- a/modules/core/src/lib/layer-manager.ts
+++ b/modules/core/src/lib/layer-manager.ts
@@ -48,7 +48,7 @@ export type LayerContext = {
   timeline: Timeline;
   mousePosition: [number, number] | null;
   userData: any;
-  onError?: (error: Error, source: Layer) => void;
+  onError?: <PropsT>(error: Error, source: Layer<PropsT>) => void;
 };
 
 export type LayersList = (Layer | undefined | false | null | LayersList)[];

--- a/modules/core/src/lib/layer-state.ts
+++ b/modules/core/src/lib/layer-state.ts
@@ -3,7 +3,6 @@ import {StatefulComponentProps} from '../lifecycle/component';
 
 import type Layer from './layer';
 import type AttributeManager from './attribute/attribute-manager';
-import type {LayerProps} from '../types/layer-props';
 import type Viewport from '../viewports/viewport';
 import type UniformTransitionManager from './uniform-transition-manager';
 
@@ -21,7 +20,7 @@ export type ChangeFlags = {
   somethingChanged: boolean;
 };
 
-export default class LayerState<PropsT extends LayerProps> extends ComponentState<PropsT> {
+export default class LayerState<PropsT> extends ComponentState<PropsT> {
   attributeManager: AttributeManager | null;
   needsRedraw: boolean;
   needsUpdate: boolean;

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -398,18 +398,13 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
   }
 
   /** Controls if updateState should be called. By default returns true if any prop has changed */
-  shouldUpdateState(params: {
-    oldProps: PropsT;
-    props: PropsT;
-    context: any;
-    changeFlags: ChangeFlags;
-  }): boolean {
+  shouldUpdateState<T>(params: UpdateParameters<T>): boolean {
     return params.changeFlags.propsOrDataChanged;
   }
 
   /* eslint-disable-next-line complexity */
   /** Default implementation, all attributes will be invalidated and updated when data changes */
-  updateState(params: UpdateParameters<PropsT>): void {
+  updateState<T>(params: UpdateParameters<T>): void {
     const attributeManager = this.getAttributeManager();
     const {dataChanged} = params.changeFlags;
     if (dataChanged && attributeManager) {

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -153,9 +153,9 @@ const defaultProps = {
   highlightColor: {type: 'accessor', value: [0, 0, 128, 128]}
 };
 
-export type UpdateParameters<PropsT> = {
-  props: StatefulComponentProps<PropsT>;
-  oldProps: StatefulComponentProps<PropsT>;
+export type UpdateParameters<LayerT extends Layer> = {
+  props: LayerT['props'];
+  oldProps: LayerT['props'];
   context: LayerContext;
   changeFlags: ChangeFlags;
 };
@@ -398,13 +398,13 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
   }
 
   /** Controls if updateState should be called. By default returns true if any prop has changed */
-  shouldUpdateState(params: UpdateParameters<PropsT>): boolean {
+  shouldUpdateState(params: UpdateParameters<Layer>): boolean {
     return params.changeFlags.propsOrDataChanged;
   }
 
   /* eslint-disable-next-line complexity */
   /** Default implementation, all attributes will be invalidated and updated when data changes */
-  updateState(params: UpdateParameters<PropsT>): void {
+  updateState(params: UpdateParameters<Layer>): void {
     const attributeManager = this.getAttributeManager();
     const {dataChanged} = params.changeFlags;
     if (dataChanged && attributeManager) {
@@ -1100,7 +1100,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
   // Private methods
 
   /** Called after updateState to perform common tasks */
-  protected _postUpdate(updateParams: UpdateParameters<PropsT>, forceUpdate: boolean) {
+  protected _postUpdate(updateParams: UpdateParameters<Layer>, forceUpdate: boolean) {
     const {props, oldProps} = updateParams;
 
     this.setNeedsRedraw();
@@ -1139,7 +1139,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
     }
   }
 
-  private _getUpdateParams(): UpdateParameters<PropsT> {
+  private _getUpdateParams(): UpdateParameters<Layer> {
     return {
       props: this.props,
       // @ts-ignore TS2531 this method can only be called internally with internalState assigned

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -345,8 +345,8 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
     - Auto-deduction via arrays */
   getNumInstances(props: StatefulComponentProps<PropsT> = this.props): number {
     // First Check if app has provided an explicit value
-    if (props.numInstances !== undefined) {
-      return props.numInstances;
+    if (Number.isFinite(props.numInstances)) {
+      return props.numInstances as number;
     }
 
     // Second check if the layer has set its own value
@@ -364,7 +364,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
       is in the form of [L0, L1, L2, ...] */
   getStartIndices(props: StatefulComponentProps<PropsT> = this.props): NumericArray | null {
     // First Check if startIndices is provided as an explicit value
-    if (props.startIndices !== undefined) {
+    if (props.startIndices) {
       return props.startIndices;
     }
 
@@ -398,13 +398,13 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT> {
   }
 
   /** Controls if updateState should be called. By default returns true if any prop has changed */
-  shouldUpdateState<T>(params: UpdateParameters<T>): boolean {
+  shouldUpdateState(params: UpdateParameters<PropsT>): boolean {
     return params.changeFlags.propsOrDataChanged;
   }
 
   /* eslint-disable-next-line complexity */
   /** Default implementation, all attributes will be invalidated and updated when data changes */
-  updateState<T>(params: UpdateParameters<T>): void {
+  updateState(params: UpdateParameters<PropsT>): void {
     const attributeManager = this.getAttributeManager();
     const {dataChanged} = params.changeFlags;
     if (dataChanged && attributeManager) {

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -10,21 +10,19 @@ import {createProps} from './create-props';
 
 import type {LayerContext} from '../lib/layer-manager';
 import type LayerState from '../lib/layer-state';
+import type {LayerProps} from '../types/layer-props';
 
 let counter = 0;
 
-export type ComponentProps = {
-  id: string;
-};
+export type StatefulComponentProps<PropsT> = Required<PropsT> &
+  Required<LayerProps> & {
+    [COMPONENT_SYMBOL]: Component<PropsT>;
+    [ASYNC_DEFAULTS_SYMBOL]: Partial<PropsT>;
+    [ASYNC_ORIGINAL_SYMBOL]: Partial<PropsT>;
+    [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;
+  };
 
-export type StatefulComponentProps<PropsT extends ComponentProps> = PropsT & {
-  [COMPONENT_SYMBOL]: Component<PropsT>;
-  [ASYNC_DEFAULTS_SYMBOL]: Partial<PropsT>;
-  [ASYNC_ORIGINAL_SYMBOL]: Partial<PropsT>;
-  [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;
-};
-
-export default class Component<PropsT extends ComponentProps> {
+export default class Component<PropsT = any> {
   static componentName: string = 'Component';
   static defaultProps: Readonly<{}> = {};
 
@@ -32,10 +30,9 @@ export default class Component<PropsT extends ComponentProps> {
   props: StatefulComponentProps<PropsT>;
   count: number;
   lifecycle: Lifecycle;
-  parent: Component<any> | null;
+  parent: Component | null;
   context: LayerContext | null;
   state: Record<string, any> | null;
-  // @ts-expect-error (TS2344) PropsT does not extend LayerProps
   internalState: LayerState<PropsT> | null;
 
   constructor(...propObjects: Partial<PropsT>[]) {
@@ -57,9 +54,9 @@ export default class Component<PropsT extends ComponentProps> {
     Object.seal(this);
   }
 
-  get root() {
+  get root(): Component {
     // eslint-disable-next-line
-    let component: Component<any> = this;
+    let component = this as Component;
     while (component.parent) {
       component = component.parent;
     }
@@ -67,7 +64,7 @@ export default class Component<PropsT extends ComponentProps> {
   }
 
   // clone this layer with modified props
-  clone(newProps) {
+  clone(newProps: Partial<PropsT>) {
     const {props} = this;
 
     // Async props cannot be copied with Object.assign, copy them separately

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -14,7 +14,7 @@ import type {LayerProps} from '../types/layer-props';
 
 let counter = 0;
 
-export type StatefulComponentProps<PropsT> = Required<PropsT> &
+export type StatefulComponentProps<PropsT> = PropsT &
   Required<LayerProps> & {
     [COMPONENT_SYMBOL]: Component<PropsT>;
     [ASYNC_DEFAULTS_SYMBOL]: Partial<PropsT>;
@@ -56,7 +56,7 @@ export default class Component<PropsT = any> {
 
   get root(): Component {
     // eslint-disable-next-line
-    let component = this as Component;
+    let component: Component = this;
     while (component.parent) {
       component = component.parent;
     }

--- a/modules/core/src/lifecycle/create-props.ts
+++ b/modules/core/src/lifecycle/create-props.ts
@@ -7,11 +7,11 @@ import {
   ASYNC_RESOLVED_SYMBOL,
   ASYNC_DEFAULTS_SYMBOL
 } from './constants';
-import {ComponentProps, StatefulComponentProps} from './component';
+import {StatefulComponentProps} from './component';
 import type Component from './component';
 
 // Create a property object
-export function createProps<T extends ComponentProps>(
+export function createProps<T>(
   component: Component<T>,
   propObjects: Partial<T>[]
 ): StatefulComponentProps<T> {

--- a/modules/core/src/shaderlib/project/project-functions.ts
+++ b/modules/core/src/shaderlib/project/project-functions.ts
@@ -37,14 +37,14 @@ function normalizeParameters(opts: {
   viewport: Viewport;
   coordinateSystem: CoordinateSystem;
   coordinateOrigin: [number, number, number];
-  modelMatrix?: NumericArray;
+  modelMatrix?: NumericArray | null;
   fromCoordinateSystem?: CoordinateSystem;
   fromCoordinateOrigin?: [number, number, number];
 }): {
   viewport: Viewport;
   coordinateSystem: CoordinateSystem;
   coordinateOrigin: [number, number, number];
-  modelMatrix?: NumericArray;
+  modelMatrix?: NumericArray | null;
   fromCoordinateSystem: CoordinateSystem;
   fromCoordinateOrigin: [number, number, number];
 } {
@@ -85,7 +85,7 @@ export function getWorldPosition(
     offsetMode
   }: {
     viewport: Viewport;
-    modelMatrix?: NumericArray;
+    modelMatrix?: NumericArray | null;
     coordinateSystem: CoordinateSystem;
     coordinateOrigin: [number, number, number];
     offsetMode?: boolean;
@@ -138,7 +138,7 @@ export function projectPosition(
     /** The reference coordinate origin used to align world position */
     coordinateOrigin: [number, number, number];
     /** The model matrix of the supplied position */
-    modelMatrix?: NumericArray;
+    modelMatrix?: NumericArray | null;
     /** The coordinate system that the supplied position is in. Default to the same as `coordinateSystem`. */
     fromCoordinateSystem?: CoordinateSystem;
     /** The coordinate origin that the supplied position is in. Default to the same as `coordinateOrigin`. */

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -87,29 +87,32 @@ export type LayerProps<DataType = any> = {
   /**
    * Callback to determine if two data values are equal.
    */
-  dataComparator?: (newData: LayerData<DataType>, oldData?: LayerData<DataType>) => boolean;
+  dataComparator?:
+    | ((newData: LayerData<DataType>, oldData?: LayerData<DataType>) => boolean)
+    | null;
   /**
    * Callback to determine the difference between two data values, in order to perform a partial update.
    */
-  _dataDiff?: (
-    newData: LayerData<DataType>,
-    oldData?: LayerData<DataType>
-  ) => {startRow: number; endRow?: number}[];
+  _dataDiff?:
+    | ((
+        newData: LayerData<DataType>,
+        oldData?: LayerData<DataType>
+      ) => {startRow: number; endRow?: number}[])
+    | null;
   /**
    * Callback to manipulate remote data when it's fetched and parsed.
    */
-  dataTransform?: (
-    data: LayerData<DataType>,
-    previousData?: LayerData<DataType>
-  ) => LayerData<DataType>;
+  dataTransform?:
+    | ((data: LayerData<DataType>, previousData?: LayerData<DataType>) => LayerData<DataType>)
+    | null;
   /**
    * Custom implementation to fetch and parse content from URLs.
    */
-  fetch: (
+  fetch?: <PropsT>(
     url: string,
     context: {
       propName: string;
-      layer: Layer;
+      layer: Layer<PropsT>;
       loaders?: any[];
       loadOptions?: any;
       signal?: AbortSignal;
@@ -122,43 +125,43 @@ export type LayerProps<DataType = any> = {
   /**
    * The purpose of the layer
    */
-  operation: 'draw' | 'mask';
+  operation?: 'draw' | 'mask';
   /**
    * If the layer should be rendered. Default true.
    */
-  visible: boolean;
+  visible?: boolean;
   /**
    * If the layer can be picked on pointer events. Default false.
    */
-  pickable: boolean;
+  pickable?: boolean;
   /**
    * Opacity of the layer, between 0 and 1. Default 1.
    */
-  opacity: number;
+  opacity?: number;
   /**
    * The coordinate system of the data. Default to COORDINATE_SYSTEM.LNGLAT in a geospatial view or COORDINATE_SYSTEM.CARTESIAN in a non-geospatial view.
    */
-  coordinateSystem: CoordinateSystem;
+  coordinateSystem?: CoordinateSystem;
   /**
    * The coordinate origin of the data.
    */
-  coordinateOrigin: [number, number, number];
+  coordinateOrigin?: [number, number, number];
   /**
    * A 4x4 matrix to transform local coordianates to the world space.
    */
-  modelMatrix?: NumericArray;
+  modelMatrix?: NumericArray | null;
   /**
    * (Geospatial only) normalize geometries that cross the 180th meridian. Default false.
    */
-  wrapLongitude: boolean;
+  wrapLongitude?: boolean;
   /**
    * The format of positions, default 'XYZ'.
    */
-  positionFormat: 'XYZ' | 'XY';
+  positionFormat?: 'XYZ' | 'XY';
   /**
    * The format of colors, default 'RGBA'.
    */
-  colorFormat: 'RGBA' | 'RGB';
+  colorFormat?: 'RGBA' | 'RGB';
   /**
    * Override the WebGL parameters used to draw this layer. See https://luma.gl/modules/gltools/docs/api-reference/parameter-setting#parameters
    */
@@ -170,7 +173,7 @@ export type LayerProps<DataType = any> = {
   /**
    * Add additional functionalities to this layer.
    */
-  extensions: any[];
+  extensions?: any[];
   /**
    * Add support for additional data formats.
    */
@@ -182,65 +185,68 @@ export type LayerProps<DataType = any> = {
   /**
    * Callback to calculate the polygonOffset WebGL parameter.
    */
-  getPolygonOffset?: (params: {layerIndex: number}) => [number, number] | null;
+  getPolygonOffset?: ((params: {layerIndex: number}) => [number, number]) | null;
 
   /**
    * Enable GPU-based object highlighting. Default false.
    */
-  autoHighlight: boolean;
+  autoHighlight?: boolean;
   /**
    * The index of the data object to highlight. If unspecified, the currently hoverred object is highlighted.
    */
-  highlightedObjectIndex: number | null;
+  highlightedObjectIndex?: number | null;
   /**
    * The color of the highlight.
    */
-  highlightColor: number[] | ((pickingInfo: PickingInfo) => number[]);
+  highlightColor?: number[] | ((pickingInfo: PickingInfo) => number[]);
 
   /**
    * Called when remote data is fetched and parsed.
    */
-  onDataLoad?: (data: LayerData<DataType>, context: {propName: string; layer: Layer}) => void;
+  onDataLoad?:
+    | (<PropsT>(
+        data: LayerData<DataType>,
+        context: {propName: string; layer: Layer<PropsT>}
+      ) => void)
+    | null;
   /**
    * Called when the layer encounters an error.
    */
-  onError?: (error: Error) => boolean | void;
+  onError?: ((error: Error) => boolean | void) | null;
   /**
    * Called when the mouse enters/leaves an object of this layer.
    */
-  onHover?: (pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void;
+  onHover?: ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null;
   /**
    * Called when the mouse clicks over an object of this layer.
    */
-  onClick?: (pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void;
+  onClick?: ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null;
   /**
    * Called when the mouse starts dragging an object of this layer.
    */
-  onDragStart?: (pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void;
+  onDragStart?: ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null;
   /**
    * Called when the mouse drags an object of this layer.
    */
-  onDrag?: (pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void;
+  onDrag?: ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null;
   /**
    * Called when the mouse releases an object of this layer.
    */
-  onDragEnd?: (pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void;
+  onDragEnd?: ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null;
 
   /** (Advanced) supply attribute size externally */
-  numInstances?: number;
+  numInstances?: number | undefined;
 
   /** (Advanced) supply variable-width attribute size externally */
-  startIndices?: NumericArray;
-};
+  startIndices?: NumericArray | undefined;
 
-/**
- * Base CompositeLayer prop types
- */
-export type CompositeLayerProps<DataType = any> = LayerProps<DataType> & {
-  _subLayerProps: {
-    [subLayerId: string]: {
-      type?: typeof Layer;
-      [propName: string]: any;
-    };
-  };
+  /** (Experimental) override sub layer props. Only works on a composite layer. */
+  _subLayerProps?:
+    | {
+        [subLayerId: string]: {
+          type?: typeof Layer;
+          [propName: string]: any;
+        };
+      }
+    | undefined;
 };

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -239,7 +239,9 @@ export type LayerProps<DataType = any> = {
 
   /** (Advanced) supply variable-width attribute size externally */
   startIndices?: NumericArray | undefined;
+};
 
+export type CompositeLayerProps = {
   /** (Experimental) override sub layer props. Only works on a composite layer. */
   _subLayerProps?:
     | {

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -235,20 +235,18 @@ export type LayerProps<DataType = any> = {
   onDragEnd?: ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null;
 
   /** (Advanced) supply attribute size externally */
-  numInstances?: number | undefined;
+  numInstances?: number | null;
 
   /** (Advanced) supply variable-width attribute size externally */
-  startIndices?: NumericArray | undefined;
+  startIndices?: NumericArray | null;
 };
 
-export type CompositeLayerProps = {
+export type CompositeLayerProps<DataType = any> = LayerProps<DataType> & {
   /** (Experimental) override sub layer props. Only works on a composite layer. */
-  _subLayerProps?:
-    | {
-        [subLayerId: string]: {
-          type?: typeof Layer;
-          [propName: string]: any;
-        };
-      }
-    | undefined;
+  _subLayerProps?: {
+    [subLayerId: string]: {
+      type?: typeof Layer;
+      [propName: string]: any;
+    };
+  } | null;
 };

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.js
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.js
@@ -82,18 +82,19 @@ export default class MVTLayer extends TileLayer {
     this.setState({data, tileJSON});
   }
 
-  _getTilesetOptions(props) {
-    const opts = super._getTilesetOptions(props);
+  _getTilesetOptions() {
+    const opts = super._getTilesetOptions();
     const {tileJSON} = this.state;
+    const {minZoom, maxZoom} = this.props;
 
     if (tileJSON) {
-      if (Number.isFinite(tileJSON.minzoom) && tileJSON.minzoom > props.minZoom) {
+      if (Number.isFinite(tileJSON.minzoom) && tileJSON.minzoom > minZoom) {
         opts.minZoom = tileJSON.minzoom;
       }
 
       if (
         Number.isFinite(tileJSON.maxzoom) &&
-        (!Number.isFinite(props.maxZoom) || tileJSON.maxzoom < props.maxZoom)
+        (!Number.isFinite(maxZoom) || tileJSON.maxzoom < maxZoom)
       ) {
         opts.maxZoom = tileJSON.maxzoom;
       }

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -1,10 +1,10 @@
 import {
   assert,
-  ChangeFlags,
   CompositeLayer,
   CompositeLayerProps,
   Layer,
   LayerProps,
+  UpdateParameters,
   _flatten as flatten
 } from '@deck.gl/core';
 import {GeoJsonLayer} from '@deck.gl/layers';
@@ -39,12 +39,20 @@ const defaultProps = {
   zoomOffset: 0
 };
 
-export type TileLayerProps<DataT = any> = CompositeLayerProps<DataT> & {
+/** All props supported by the TileLayer */
+export type TileLayerProps<DataT> = _TileLayerProps<DataT> & CompositeLayerProps<DataT>;
+
+/** Props added by the TileLayer */
+type _TileLayerProps<DataT> = {
+  /**
+   * Optionally implement a custom indexing scheme.
+   */
+  TilesetClass: typeof Tileset2D;
   /**
    * Renders one or an array of Layer instances.
    */
-  renderSubLayers: (
-    props: TileLayerProps & {
+  renderSubLayers?: (
+    props: TileLayerProps<DataT> & {
       id: string;
       data: any;
       _offset: number;
@@ -54,58 +62,62 @@ export type TileLayerProps<DataT = any> = CompositeLayerProps<DataT> & {
   /**
    * If supplied, `getTileData` is called to retrieve the data of each tile.
    */
-  getTileData: (props: TileLoadProps) => Promise<any> | any;
+  getTileData?: (props: TileLoadProps) => Promise<DataT> | DataT;
 
   /** Called when all tiles in the current viewport are loaded. */
   onViewportLoad?: (tiles: Tile2DHeader[]) => void;
 
   /** Called when a tile successfully loads. */
-  onTileLoad: (tile: Tile2DHeader) => void;
+  onTileLoad?: (tile: Tile2DHeader) => void;
 
   /** Called when a tile is cleared from cache. */
-  onTileUnload: (tile: Tile2DHeader) => void;
+  onTileUnload?: (tile: Tile2DHeader) => void;
 
   /** Called when a tile failed to load. */
-  onTileError: (err: any) => void;
+  onTileError?: (err: any) => void;
 
   /** The bounding box of the layer's data. */
-  extent: number[] | undefined | null;
+  extent?: number[] | null;
 
   /** The pixel dimension of the tiles, usually a power of 2. */
-  tileSize: number;
+  tileSize?: number;
 
-  /** The max zoom level of the layer's data.  */
-  maxZoom: number;
+  /** The max zoom level of the layer's data.
+   * @default null
+   */
+  maxZoom?: number | null;
 
-  /** The min zoom level of the layer's data.  */
-  minZoom: number;
+  /** The min zoom level of the layer's data.
+   * @default 0
+   */
+  minZoom?: number | null;
 
   /** The maximum number of tiles that can be cached. */
-  maxCacheSize: number | undefined | null;
+  maxCacheSize?: number | null;
 
   /**
    * The maximum memory used for caching tiles.
    *
    * @default null
    */
-  maxCacheByteSize: number | undefined;
+  maxCacheByteSize?: number | null;
 
   /**
    * How the tile layer refines the visibility of tiles.
    *
    * @default 'best-available'
    */
-  refinementStrategy: RefinementStrategy;
+  refinementStrategy?: RefinementStrategy;
 
   /** Range of minimum and maximum heights in the tile. */
-  zRange: ZRange | null;
+  zRange?: ZRange | null;
 
   /**
    * The maximum number of concurrent getTileData calls.
    *
    * @default 6
    */
-  maxRequests: number;
+  maxRequests?: number;
 
   /**
    * This offset changes the zoom level at which the tiles are fetched.
@@ -114,7 +126,7 @@ export type TileLayerProps<DataT = any> = CompositeLayerProps<DataT> & {
    *
    * @default 0
    */
-  zoomOffset: number;
+  zoomOffset?: number;
 };
 
 /**
@@ -122,10 +134,9 @@ export type TileLayerProps<DataT = any> = CompositeLayerProps<DataT> & {
  *
  * Instead of fetching the entire dataset, it only loads and renders what's visible in the current viewport.
  */
-export default class TileLayer<
-  DataT = any,
-  PropsT extends TileLayerProps<DataT> = TileLayerProps<DataT>
-> extends CompositeLayer<PropsT> {
+export default class TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+  ExtraPropsT & Required<_TileLayerProps<DataT>>
+> {
   static defaultProps = defaultProps as any;
   static layerName = 'TileLayer';
 
@@ -150,15 +161,7 @@ export default class TileLayer<
     return changeFlags.somethingChanged;
   }
 
-  updateState({
-    props,
-    changeFlags
-  }: {
-    props: TileLayerProps;
-    oldProps: TileLayerProps;
-    context: any;
-    changeFlags: ChangeFlags;
-  }) {
+  updateState({changeFlags}: UpdateParameters<ExtraPropsT & Required<_TileLayerProps<DataT>>>) {
     assert(this.state);
 
     let {tileset} = this.state;
@@ -169,10 +172,10 @@ export default class TileLayer<
         (changeFlags.updateTriggersChanged.all || changeFlags.updateTriggersChanged.getTileData));
 
     if (!tileset) {
-      tileset = new this.props.TilesetClass(this._getTilesetOptions(props));
+      tileset = new this.props.TilesetClass(this._getTilesetOptions());
       this.setState({tileset});
     } else if (propsChanged) {
-      tileset.setOptions(this._getTilesetOptions(props));
+      tileset.setOptions(this._getTilesetOptions());
 
       if (dataChanged) {
         // reload all tiles
@@ -189,7 +192,7 @@ export default class TileLayer<
     this._updateTileset();
   }
 
-  _getTilesetOptions(props: TileLayerProps): Tileset2DProps {
+  _getTilesetOptions(): Tileset2DProps {
     const {
       tileSize,
       maxCacheSize,
@@ -200,7 +203,7 @@ export default class TileLayer<
       minZoom,
       maxRequests,
       zoomOffset
-    } = props;
+    } = this.props;
 
     return {
       maxCacheSize,
@@ -290,7 +293,7 @@ export default class TileLayer<
   }
 
   renderSubLayers(
-    props: TileLayerProps & {
+    props: _TileLayerProps<DataT> & {
       id: string;
       data: any;
       _offset: number;
@@ -330,7 +333,7 @@ export default class TileLayer<
           _offset: 0,
           tile
         });
-        tile.layers = flatten(layers, Boolean).map(layer =>
+        tile.layers = (flatten(layers, Boolean) as Layer[]).map(layer =>
           layer.clone({
             tile,
             ...subLayerProps

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -161,7 +161,7 @@ export default class TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeL
     return changeFlags.somethingChanged;
   }
 
-  updateState({changeFlags}: UpdateParameters<ExtraPropsT & Required<_TileLayerProps<DataT>>>) {
+  updateState({changeFlags}: UpdateParameters<TileLayer>) {
     assert(this.state);
 
     let {tileset} = this.state;

--- a/modules/geo-layers/src/tile-layer/utils.ts
+++ b/modules/geo-layers/src/tile-layer/utils.ts
@@ -1,6 +1,5 @@
 import {Viewport} from '@deck.gl/core';
 import {Matrix4} from '@math.gl/core';
-import Tile2DHeader from './tile-2d-header';
 import {getOSMTileIndices} from './tile-2d-traversal';
 import {Bounds, TileBoundingBox, TileIndex, ZRange} from './types';
 
@@ -62,7 +61,13 @@ function stringHash(s: string): number {
   return s.split('').reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0);
 }
 
-export function getURLFromTemplate(template: string | string[], tile: Tile2DHeader): string | null {
+export function getURLFromTemplate(
+  template: string | string[],
+  tile: {
+    index: TileIndex;
+    id: string;
+  }
+): string | null {
   if (!template || !template.length) {
     return null;
   }

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -30,26 +30,26 @@ import type {LayerProps, LayerContext, Accessor, Unit, Position, Color} from '@d
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 export type ScatterplotLayerProps<DataT> = LayerProps<DataT> & {
-  radiusUnits: Unit;
-  radiusScale: number;
-  radiusMinPixels: number;
-  radiusMaxPixels: number;
+  radiusUnits?: Unit;
+  radiusScale?: number;
+  radiusMinPixels?: number;
+  radiusMaxPixels?: number;
 
-  lineWidthUnits: Unit;
-  lineWidthScale: number;
-  lineWidthMinPixels: number;
-  lineWidthMaxPixels: number;
+  lineWidthUnits?: Unit;
+  lineWidthScale?: number;
+  lineWidthMinPixels?: number;
+  lineWidthMaxPixels?: number;
 
-  stroked: boolean;
-  filled: boolean;
-  billboard: boolean;
-  antialiasing: boolean;
+  stroked?: boolean;
+  filled?: boolean;
+  billboard?: boolean;
+  antialiasing?: boolean;
 
-  getPosition: Accessor<DataT, Position>;
-  getRadius: Accessor<DataT, number>;
-  getFillColor: Accessor<DataT, Color>;
-  getLineColor: Accessor<DataT, Color>;
-  getLineWidth: Accessor<DataT, number>;
+  getPosition?: Accessor<DataT, Position>;
+  getRadius?: Accessor<DataT, number>;
+  getFillColor?: Accessor<DataT, Color>;
+  getLineColor?: Accessor<DataT, Color>;
+  getLineWidth?: Accessor<DataT, number>;
 };
 
 const defaultProps = {

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -25,11 +25,23 @@ import {Model, Geometry} from '@luma.gl/core';
 import vs from './scatterplot-layer-vertex.glsl';
 import fs from './scatterplot-layer-fragment.glsl';
 
-import type {LayerProps, LayerContext, Accessor, Unit, Position, Color} from '@deck.gl/core';
+import type {
+  LayerProps,
+  UpdateParameters,
+  LayerContext,
+  Accessor,
+  Unit,
+  Position,
+  Color
+} from '@deck.gl/core';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
-export type ScatterplotLayerProps<DataT> = LayerProps<DataT> & {
+/** All props supported by the ScatterplotLayer */
+export type ScatterplotLayerProps<DataT> = _ScatterplotLayerProps<DataT> & LayerProps<DataT>;
+
+/** Props added by the ScatterplotLayer */
+type _ScatterplotLayerProps<DataT> = {
   radiusUnits?: Unit;
   radiusScale?: number;
   radiusMinPixels?: number;
@@ -80,10 +92,9 @@ const defaultProps = {
   getColor: {deprecatedFor: ['getFillColor', 'getLineColor']}
 };
 
-export default class ScatterplotLayer<
-  DataT = any,
-  PropsT extends ScatterplotLayerProps<DataT> = ScatterplotLayerProps<DataT>
-> extends Layer<PropsT> {
+export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+  ExtraPropsT & Required<_ScatterplotLayerProps<DataT>>
+> {
   static defaultProps: any = defaultProps;
   static layerName: string = 'ScatterplotLayer';
 
@@ -134,7 +145,7 @@ export default class ScatterplotLayer<
     });
   }
 
-  updateState(params) {
+  updateState<T extends _ScatterplotLayerProps<DataT>>(params: UpdateParameters<T>) {
     super.updateState(params);
 
     if (params.changeFlags.extensionsChanged) {

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -145,7 +145,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
     });
   }
 
-  updateState<T extends _ScatterplotLayerProps<DataT>>(params: UpdateParameters<T>) {
+  updateState(params: UpdateParameters<ExtraPropsT & Required<_ScatterplotLayerProps<DataT>>>) {
     super.updateState(params);
 
     if (params.changeFlags.extensionsChanged) {

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -145,7 +145,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
     });
   }
 
-  updateState(params: UpdateParameters<ExtraPropsT & Required<_ScatterplotLayerProps<DataT>>>) {
+  updateState(params: UpdateParameters<ScatterplotLayer>) {
     super.updateState(params);
 
     if (params.changeFlags.extensionsChanged) {


### PR DESCRIPTION
For #5589 

Continue discussion from https://github.com/visgl/deck.gl/pull/6803#discussion_r846417620

In this proposal, we no longer require the generic type `PropsT` to extend `LayerProps`. The type of `layer.props` is instead enforced with `PropsT & Required<LayerProps>`. This removes TypeScript's complaint that `PropsT` may override some of `LayerProps` fields.

See proof-of-concept in [this Playground snippet](https://www.typescriptlang.org/play?#code/C4TwDgpgBAMghiCAnACkg9mAzlAvFAbwCgpSpM4BjAS1AH4AuKAOwFcBbAI2QG4iBfIkQD0AKlFQAQnCzQANgmRRRwopQVYc8REgA8aTFgAqAPkIkyYDNiYHsRqADIoAJQgBHVtSQQAJru1kOywTITIoSnRmLGAkVkpgdCQACgA6dKtDWzgkYGo4OX1rYxMAbQBdAEpzcPDgAAtqLFTM7DwoAHlOACsIBNSZLGoAc2Zkgn4AGih0luLKi1JBRahhiGAOsCpaEGTKpjYuJWJash9gViRmKAamucNUihpQFcFl0EgoI2o5CEDUYrtE5kdjUZgALXQ6HYjBYHG4SD4yzEEgAyqxOBENDgAIzKVTqQZfH5-RR6ACiAA9YnBgg58BMzBBqRBmL4tGTdFSaXSnK4PF4fP5vr9-sETGZgaQ1sAALJgyHQvYHeHHFbhc6Xa63ZqtZqgiFQ9ivARCD7QWUANSMYsBDJW1F8dmQ9CYMSQYOGSKEKKg6MxhM0UAATPi1NioFabZzuUhacV6YR+EyWWycCLSToudS47znG5PN4-Loo7bDBKamQZQBJJ3WF27fZQd2eyunTVXG6NXXFVKO525EAm97gC0gADCrBi0LLbXt4UiciSsMOCIqppE4j9GKxRIAzFAALQsdDAKDM4CsoacX5hwM4WUTqeJdj-c+p9mR63-XQFwXFx9J2nV8yXFSUVhlcd0CXFIm1XZAKjbWoO21bt7mwVJFySPhwjeIggA)

`ScatterplotLayerProps` still extends `LayerProps` in case the user needs to use the type outside of the constructor. However, it is no longer necessary.