### PR TITLE
feat(geo-layers): Tile3DLayers-async tileset traversal

### DIFF
--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.js
@@ -167,11 +167,12 @@ export default class Tile3DLayer extends CompositeLayer {
     if (!timeline || !viewportsNumber || !tileset3d) {
       return;
     }
-    const frameNumber = tileset3d.update(Object.values(viewports));
-    const tilesetChanged = this.state.frameNumber !== frameNumber;
-    if (tilesetChanged) {
-      this.setState({frameNumber});
-    }
+    tileset3d.selectTiles(Object.values(viewports)).then(frameNumber => {
+      const tilesetChanged = this.state.frameNumber !== frameNumber;
+      if (tilesetChanged) {
+        this.setState({frameNumber});
+      }
+    });
   }
 
   _getSubLayer(tileHeader, oldLayer) {


### PR DESCRIPTION
#### Background
  In "@loaders.gl/tiles@3.2.0-alpha.2" new method was added for async traversal of the tileset. This method includes debounce logic to mitigate spamming from the view.
#### Change List
- Replace sync `Tileset3D.update` to async `Tileset3D.selectTiles` method in Tile3DLayer.
