### PR TITLE
pydeck: Rename `pydeck.Layer` param `type`

### DIFF
--- a/bindings/pydeck/pydeck/bindings/layer.py
+++ b/bindings/pydeck/pydeck/bindings/layer.py
@@ -15,7 +15,7 @@ QUOTE_CHARS = {"'", '"', "`"}
 
 
 class Layer(JSONMixin):
-    def __init__(self, type, data=None, id=None, use_binary_transport=None, **kwargs):
+    def __init__(self, class_type, data=None, id=None, use_binary_transport=None, **kwargs):
         """Configures a deck.gl layer for rendering on a map. Parameters passed
         here will be specific to the particular deck.gl layer that you are choosing to use.
 
@@ -27,7 +27,7 @@ class Layer(JSONMixin):
         Parameters
         ==========
 
-        type : str
+        class_type : str
             Type of layer to render, e.g., `HexagonLayer`
         id : str, default None
             Unique name for layer
@@ -74,7 +74,7 @@ class Layer(JSONMixin):
           >>>     extruded=True,
           >>>     coverage=1)
         """
-        self.type = type
+        self.type = class_type
         self.id = id or str(uuid.uuid4())
 
         # Add any other kwargs to the JSON output

--- a/bindings/pydeck/tests/bindings/pydeck_examples/hexagon_layer_function.py
+++ b/bindings/pydeck/tests/bindings/pydeck_examples/hexagon_layer_function.py
@@ -45,7 +45,7 @@ def create_heatmap_test_object():
     # Tries to detect if strings are being interpreted by the
     # expression parser in @deck.gl/json
     failed_hexagon_layer = Layer(
-        type="HexagonLayer",
+        "HexagonLayer",
         id="failed-heatmap",
         data=data,
         elevation_range=[0, 15],
@@ -57,7 +57,7 @@ def create_heatmap_test_object():
     )
     # This will render
     successful_heatmap_layer = Layer(
-        type="HeatmapLayer", id="successful-heatmap", data=data, get_position=["lon", "lat"], color_range=color_range,
+        "HeatmapLayer", id="successful-heatmap", data=data, get_position=["lon", "lat"], color_range=color_range,
     )
 
     return Deck(


### PR DESCRIPTION
#### Background
Rename `pydeck.Layer` param `type` to `class_type` to avoid collision with layer params called `type`, for example, with the [CartoLayer](https://deck.gl/docs/api-reference/carto/carto-layer).

#### Change List
- Rename `pydeck.Layer` param `type` to `class_type`
