### PR TITLE
CARTO: fetchLayerData added support for spatial index parameters

### DIFF
--- a/modules/carto/src/api/maps-v3-client.ts
+++ b/modules/carto/src/api/maps-v3-client.ts
@@ -144,12 +144,12 @@ function getParameters({
   if (GEO_COLUMN_SUPPORT.includes(type)) {
     if (geoColumn) {
       parameters.push(encodeParameter('geo_column', geoColumn));
-    }
-    if (aggregationExp) {
-      parameters.push(encodeParameter('aggregationExp', aggregationExp));
-    }
-    if (aggregationResLevel) {
-      parameters.push(encodeParameter('aggregationResLevel', aggregationResLevel));
+      if (aggregationExp) {
+        parameters.push(encodeParameter('aggregationExp', aggregationExp));
+      }
+      if (aggregationExp && aggregationResLevel) {
+        parameters.push(encodeParameter('aggregationResLevel', aggregationResLevel));
+      }
     }
   }
   if (COLUMNS_SUPPORT.includes(type) && columns) {


### PR DESCRIPTION
#### Background
The Carto Maps API now supports spatial indices adding two new parameters: `aggregationExp` and `aggregationResLevel` in the map instantiation. This PR adds these parameters to the fetchLayerData method
#### Change List
- Added `aggregationExp` and `aggregationResLevel` to fetchLayerData method
