### PR TITLE
React Google-maps example

### DIFF
--- a/examples/get-started/react/google-maps/README.md
+++ b/examples/get-started/react/google-maps/README.md
@@ -1,0 +1,31 @@
+<div align="center">
+   <img width="150" heigth="150" src="https://webpack.js.org/assets/icon-square-big.svg" />
+</div>
+
+## Example: Use deck.gl with React
+
+Uses [Webpack](https://github.com/webpack/webpack) to bundle files and serves it
+with [webpack-dev-server](https://webpack.js.org/guides/development/#webpack-dev-server).
+
+## Usage
+
+To run this example, you need a [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key) and a [map id](https://developers.google.com/maps/documentation/javascript/webgl#vector-id). You can either set an environment variable:
+
+```bash
+export GoogleMapsAPIKey=<google_maps_api_key>
+export GoogleMapsMapId=<google_maps_map_id>
+```
+
+Or set the `GOOGLE_MAPS_API_KEY` and `GOOGLE_MAP_ID` variables in `app.js`.
+
+To install dependencies:
+
+```bash
+npm install
+# or
+yarn
+```
+
+Commands:
+* `npm start` is the development target, to serve the app and hot reload.
+* `npm run build` is the production target, to create the final bundle and write to disk.

--- a/examples/get-started/react/google-maps/app.js
+++ b/examples/get-started/react/google-maps/app.js
@@ -1,0 +1,86 @@
+import React, {useEffect, useRef} from 'react';
+import {render} from 'react-dom';
+import {GeoJsonLayer, ArcLayer} from 'deck.gl';
+import {Wrapper, Status} from '@googlemaps/react-wrapper';
+import {GoogleMapsOverlay as DeckOverlay} from '@deck.gl/google-maps';
+
+// source: Natural Earth http://www.naturalearthdata.com/ via geojson.xyz
+const AIR_PORTS =
+  'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson';
+
+// Set your Google Maps API key here or via environment variable
+const GOOGLE_MAPS_API_KEY = process.env.GoogleMapsAPIKey; // eslint-disable-line
+const GOOGLE_MAP_ID = process.env.GoogleMapsMapId; // eslint-disable-line
+
+const overlay = new DeckOverlay({
+  layers: [
+    new GeoJsonLayer({
+      id: 'airports',
+      data: AIR_PORTS,
+      // Styles
+      filled: true,
+      pointRadiusMinPixels: 2,
+      pointRadiusScale: 2000,
+      getPointRadius: f => 11 - f.properties.scalerank,
+      getFillColor: [200, 0, 80, 180],
+      // Interactive props
+      pickable: true,
+      autoHighlight: true,
+      onClick: info =>
+        // eslint-disable-next-line
+        info.object && alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
+    }),
+    new ArcLayer({
+      id: 'arcs',
+      data: AIR_PORTS,
+      dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
+      // Styles
+      getSourcePosition: f => [-0.4531566, 51.4709959], // London
+      getTargetPosition: f => f.geometry.coordinates,
+      getSourceColor: [0, 128, 200],
+      getTargetColor: [200, 0, 80],
+      getWidth: 1
+    })
+  ]
+});
+
+const renderMap = status => {
+  if (status === Status.LOADING) return <h3>{status} ..</h3>;
+  if (status === Status.FAILURE) return <h3>{status} ...</h3>;
+  return null;
+};
+
+function MyMapComponent({center, zoom}) {
+  const ref = useRef();
+
+  useEffect(() => {
+    const map = new window.google.maps.Map(ref.current, {
+      center: center,
+      zoom: zoom,
+      mapId: GOOGLE_MAP_ID
+    });
+    overlay.setMap(map);
+  }, [center, zoom]);
+
+  return (
+    <>
+      <div ref={ref} id="map" style={{height: '100vh', width: '100wh'}} />
+    </>
+  );
+}
+
+function Root() {
+  const center = {lat: 51.47, lng: 0.45};
+  const zoom = 5;
+
+  return (
+    <>
+      <Wrapper apiKey={GOOGLE_MAPS_API_KEY} render={renderMap}>
+        <MyMapComponent center={center} zoom={zoom} />
+      </Wrapper>
+    </>
+  );
+}
+
+/* global document */
+render(<Root />, document.body.appendChild(document.createElement('div')));

--- a/examples/get-started/react/google-maps/app.js
+++ b/examples/get-started/react/google-maps/app.js
@@ -50,6 +50,25 @@ const renderMap = status => {
   return null;
 };
 
+// if using the create-react-app template try this
+// function MyMapComponent({center, zoom}) {
+//   const ref = useRef();
+//   const [map, setMap] = useState(null);
+  
+//   useEffect(() => {
+//     const map = new window.google.maps.Map(ref.current, {
+//       center: center,
+//       zoom: zoom,
+//       mapId: GOOGLE_MAP_ID
+//     });
+//     setMap(map);
+    
+//   }, [center, zoom]);
+
+//   useEffect(() => {
+//     overlay.setMap(map);
+//   }, [map]);
+
 function MyMapComponent({center, zoom}) {
   const ref = useRef();
 

--- a/examples/get-started/react/google-maps/app.js
+++ b/examples/get-started/react/google-maps/app.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState, useMemo} from 'react';
 import {render} from 'react-dom';
 import {GeoJsonLayer, ArcLayer} from 'deck.gl';
 import {Wrapper, Status} from '@googlemaps/react-wrapper';
@@ -12,75 +12,66 @@ const AIR_PORTS =
 const GOOGLE_MAPS_API_KEY = process.env.GoogleMapsAPIKey; // eslint-disable-line
 const GOOGLE_MAP_ID = process.env.GoogleMapsMapId; // eslint-disable-line
 
-const overlay = new DeckOverlay({
-  layers: [
-    new GeoJsonLayer({
-      id: 'airports',
-      data: AIR_PORTS,
-      // Styles
-      filled: true,
-      pointRadiusMinPixels: 2,
-      pointRadiusScale: 2000,
-      getPointRadius: f => 11 - f.properties.scalerank,
-      getFillColor: [200, 0, 80, 180],
-      // Interactive props
-      pickable: true,
-      autoHighlight: true,
-      onClick: info =>
-        // eslint-disable-next-line
-        info.object && alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
-    }),
-    new ArcLayer({
-      id: 'arcs',
-      data: AIR_PORTS,
-      dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
-      // Styles
-      getSourcePosition: f => [-0.4531566, 51.4709959], // London
-      getTargetPosition: f => f.geometry.coordinates,
-      getSourceColor: [0, 128, 200],
-      getTargetColor: [200, 0, 80],
-      getWidth: 1
-    })
-  ]
-});
-
 const renderMap = status => {
   if (status === Status.LOADING) return <h3>{status} ..</h3>;
   if (status === Status.FAILURE) return <h3>{status} ...</h3>;
   return null;
 };
 
-// if using the create-react-app template try this
-// function MyMapComponent({center, zoom}) {
-//   const ref = useRef();
-//   const [map, setMap] = useState(null);
-  
-//   useEffect(() => {
-//     const map = new window.google.maps.Map(ref.current, {
-//       center: center,
-//       zoom: zoom,
-//       mapId: GOOGLE_MAP_ID
-//     });
-//     setMap(map);
-    
-//   }, [center, zoom]);
-
-//   useEffect(() => {
-//     overlay.setMap(map);
-//   }, [map]);
-
 function MyMapComponent({center, zoom}) {
   const ref = useRef();
+  const [map, setMap] = useState(null);
+  const overlay = useMemo(
+    () =>
+      new DeckOverlay({
+        layers: [
+          new GeoJsonLayer({
+            id: 'airports',
+            data: AIR_PORTS,
+            // Styles
+            filled: true,
+            pointRadiusMinPixels: 2,
+            pointRadiusScale: 2000,
+            getPointRadius: f => 11 - f.properties.scalerank,
+            getFillColor: [200, 0, 80, 180],
+            // Interactive props
+            pickable: true,
+            autoHighlight: true,
+            onClick: info =>
+              // eslint-disable-next-line
+              info.object &&
+              alert(`${info.object.properties.name} (${info.object.properties.abbrev})`)
+          }),
+          new ArcLayer({
+            id: 'arcs',
+            data: AIR_PORTS,
+            dataTransform: d => d.features.filter(f => f.properties.scalerank < 4),
+            // Styles
+            getSourcePosition: f => [-0.4531566, 51.4709959], // London
+            getTargetPosition: f => f.geometry.coordinates,
+            getSourceColor: [0, 128, 200],
+            getTargetColor: [200, 0, 80],
+            getWidth: 1
+          })
+        ]
+      }),
+    []
+  );
+
+  useEffect(() => {
+    if (map) {
+      map.setCenter(center);
+      map.setZoom(zoom);
+      overlay.setMap(map);
+    }
+  }, [map, center, zoom, overlay]);
 
   useEffect(() => {
     const map = new window.google.maps.Map(ref.current, {
-      center: center,
-      zoom: zoom,
       mapId: GOOGLE_MAP_ID
     });
-    overlay.setMap(map);
-  }, [center, zoom]);
-
+    setMap(map);
+  }, []);
   return (
     <>
       <div ref={ref} id="map" style={{height: '100vh', width: '100wh'}} />

--- a/examples/get-started/react/google-maps/package.json
+++ b/examples/get-started/react/google-maps/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-basic",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open",
+    "build": "webpack -p"
+  },
+  "dependencies": {
+    "@googlemaps/react-wrapper": "^1.1.32",
+    "deck.gl": "^8.7.0-beta.6",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.5",
+    "html-webpack-plugin": "^3.0.7",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/examples/get-started/react/google-maps/webpack.config.js
+++ b/examples/get-started/react/google-maps/webpack.config.js
@@ -1,0 +1,32 @@
+// NOTE: To use this example standalone (e.g. outside of deck.gl repo)
+// delete the local development overrides at the bottom of this file
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: './app.js'
+  },
+
+  module: {
+    rules: [
+      {
+        // Transpile ES6 to ES5 with babel
+        // Remove if your app does not use JSX or you don't need to support old browsers
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: [/node_modules/],
+        options: {
+          presets: ['@babel/preset-react']
+        }
+      }
+    ]
+  },
+
+  plugins: [new HtmlWebpackPlugin({title: 'deck.gl example'})]
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../../../webpack.config.local')(CONFIG)(env) : CONFIG);


### PR DESCRIPTION
#### Background
I saw that react and google maps did not have an example so I created one. I used [@googlemaps/react-wrapper](https://www.npmjs.com/package/@googlemaps/react-wrapper) which is made by google maps and therefore should be stable.
#### Change List
- Create the google-maps example for react.

#### If Accepted Todo
- Update the docs with the new example
- [Base map doc](https://deck.gl/docs/get-started/using-with-map)
- [React doc](https://deck.gl/docs/get-started/using-with-react)
