### PR TITLE
CARTO: Cartolayer h3 maxresolution tile limit

### DIFF
--- a/modules/carto/src/layers/h3-tile-layer.js
+++ b/modules/carto/src/layers/h3-tile-layer.js
@@ -28,14 +28,17 @@ export default class H3TileLayer extends CompositeLayer {
   }
 
   renderLayers() {
-    const {data} = this.state;
+    const {data, tileJSON} = this.state;
+    const {maxresolution} = tileJSON;
+    const maxZoom = maxresolution - this.props.aggregationResLevel;
     return [
       new TileLayer(this.props, {
         id: 'h3-tile-layer',
         data,
         getHexagon: d => d.id,
         TilesetClass: H3Tileset2D,
-        renderSubLayers
+        renderSubLayers,
+        maxZoom
       })
     ];
   }

--- a/modules/carto/src/layers/h3-tile-layer.js
+++ b/modules/carto/src/layers/h3-tile-layer.js
@@ -29,8 +29,7 @@ export default class H3TileLayer extends CompositeLayer {
 
   renderLayers() {
     const {data, tileJSON} = this.state;
-    const {maxresolution} = tileJSON;
-    const maxZoom = maxresolution - this.props.aggregationResLevel;
+    const maxZoom = parseInt(tileJSON.maxresolution);
     return [
       new TileLayer(this.props, {
         id: 'h3-tile-layer',

--- a/modules/carto/src/layers/quadkey-tile-layer.js
+++ b/modules/carto/src/layers/quadkey-tile-layer.js
@@ -24,8 +24,7 @@ export default class QuadkeyTileLayer extends CompositeLayer {
 
   renderLayers() {
     const {data, tileJSON} = this.state;
-    const {maxresolution} = tileJSON;
-    const maxZoom = maxresolution - this.props.aggregationResLevel;
+    const maxZoom = parseInt(tileJSON.maxresolution);
     return [
       new TileLayer(this.props, {
         id: 'quadkey-tile-layer',


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6912
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Read out maxresolution from tilejson
- Limit data fetching by resolution not zoom level
- Improve `getTileIndices` for H3 when zoomed in
