### PR TITLE
[mapbox] restrict longitude returned by map.getCenter()

### DIFF
--- a/modules/mapbox/src/deck-utils.js
+++ b/modules/mapbox/src/deck-utils.js
@@ -106,7 +106,9 @@ export function drawLayer(deck, map, layer) {
 export function getViewState(map) {
   const {lng, lat} = map.getCenter();
   return {
-    longitude: lng,
+    // Longitude returned by getCenter can be outside of [-180, 180] when zooming near the anti meridian
+    // https://github.com/visgl/deck.gl/issues/6894
+    longitude: ((lng + 540) % 360) - 180,
     latitude: lat,
     zoom: map.getZoom(),
     bearing: map.getBearing(),

--- a/test/modules/mapbox/mapbox-layer.spec.js
+++ b/test/modules/mapbox/mapbox-layer.spec.js
@@ -4,6 +4,7 @@ import {Deck, MapView} from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {MapboxLayer} from '@deck.gl/mapbox';
 import {gl} from '@deck.gl/test-utils';
+import {equals} from '@math.gl/core';
 
 class MockMapboxMap {
   constructor(opts) {
@@ -107,16 +108,15 @@ test('MapboxLayer#onAdd, onRemove, setProps', t => {
   t.deepEqual(deck.props.userData.mapboxVersion, {major: 1, minor: 10}, 'Mapbox version is parsed');
   t.ok(deck.props.views[0].id === 'mapbox', 'mapbox view exists');
 
-  t.deepEqual(
-    deck.props.viewState,
-    {
+  t.ok(
+    objectEqual(deck.props.viewState, {
       longitude: -122.45,
       latitude: 37.78,
       zoom: 12,
       bearing: 0,
       pitch: 0,
       repeat: true
-    },
+    }),
     'viewState is set correctly'
   );
 
@@ -305,3 +305,17 @@ test('MapboxLayer#external Deck custom views', t => {
     t.end();
   });
 });
+
+function objectEqual(actual, expected) {
+  const keys0 = Object.keys(actual);
+  const keys1 = Object.keys(expected);
+  if (keys0.length !== keys1.length) {
+    return false;
+  }
+  for (const key of keys1) {
+    if (!equals(actual[key], expected[key])) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
For #6894

Normally viewstates are normalized by deck.gl's controller. In the MapboxLayer use case, it is extracted from mapbox's methods. `map.getCenter()` could apparently return longitude that is out of range.

#### Change List
- Normalize longitude into `[-180, 180]`
