### PR TITLE
[ts] Handle nullable layer members in layer code

### DIFF
--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -165,10 +165,14 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
   static defaultProps: any = defaultProps;
   static layerName: string = 'Layer';
 
-  context: LayerContext | null = null; // Will reference layer manager's context, contains state shared by layers
   internalState: LayerState<PropsT> | null = null;
   lifecycle: Lifecycle = LIFECYCLE.NO_STATE; // Helps track and debug the life cycle of the layers
-  state: Record<string, any> | null = null; // Will be set to the shared layer state object during layer matching
+
+  // context and state can technically be null before a layer is initialized/matched.
+  // However, they are most extensively accessed in a layer's lifecycle methods, where they are always defined.
+  // Checking for null state constantly in layer implementation is unnecessarily verbose.
+  context!: LayerContext; // Will reference layer manager's context, contains state shared by layers
+  state!: Record<string, any>; // Will be set to the shared layer state object during layer matching
 
   toString(): string {
     const className = (this.constructor as typeof Layer).layerName || this.constructor.name;
@@ -179,7 +183,8 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
 
   /** Projects a point with current view state from the current layer's coordinate system to screen */
   project(xyz: number[]): number[] {
-    const viewport = this.internalState?.viewport || (this.context?.viewport as Viewport);
+    assert(this.internalState);
+    const viewport = this.internalState.viewport || this.context.viewport;
 
     const worldPosition = getWorldPosition(xyz, {
       viewport,
@@ -194,7 +199,8 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
   /** Unprojects a screen pixel to the current view's default coordinate system
       Note: this does not reverse `project`. */
   unproject(xy: number[]): number[] {
-    const viewport = this.internalState?.viewport || (this.context?.viewport as Viewport);
+    assert(this.internalState);
+    const viewport = this.internalState.viewport || this.context.viewport;
     return viewport.unproject(xy);
   }
 
@@ -210,7 +216,8 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
       fromCoordinateOrigin?: [number, number, number];
     }
   ): [number, number, number] {
-    const viewport = this.internalState?.viewport || (this.context?.viewport as Viewport);
+    assert(this.internalState);
+    const viewport = this.internalState.viewport || this.context.viewport;
 
     return projectPosition(xyz, {
       viewport,
@@ -244,7 +251,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
 
   /** Mark this layer as needs a deep update */
   setNeedsUpdate() {
-    if (this.context && this.internalState) {
+    if (this.internalState) {
       this.context.layerManager.setNeedsUpdate(String(this));
       this.internalState.needsUpdate = true;
     }
@@ -267,7 +274,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
 
   /** Returns an array of models used by this layer, can be overriden by layer subclass */
   getModels(): Model[] {
-    return this.state && (this.state.models || (this.state.model ? [this.state.model] : []));
+    return (this.state && (this.state.models || (this.state.model && [this.state.model]))) || [];
   }
 
   /** Update shader module parameters */
@@ -488,7 +495,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
 
   // / INTERNAL METHODS - called by LayerManager, DeckRenderer and DeckPicker
 
-  /** Propagate an error event through the system */
+  /** (Internal) Propagate an error event through the system */
   raiseError(error: Error, message: string): void {
     if (message) {
       error.message = `${message}: ${error.message}`;
@@ -498,7 +505,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     }
   }
 
-  /** Checks if this layer needs redraw */
+  /** (Internal) Checks if this layer needs redraw */
   getNeedsRedraw(
     opts: {
       /** Reset redraw flags to false after the check */
@@ -508,7 +515,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     return this._getNeedsRedraw(opts);
   }
 
-  /** Checks if this layer needs a deep update */
+  /** (Internal) Checks if this layer needs a deep update */
   needsUpdate(): boolean {
     if (!this.internalState) {
       return false;
@@ -735,7 +742,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
   /* eslint-disable max-statements */
   /* (Internal) Called by layer manager when a new layer is found */
   _initialize() {
-    assert(!this.internalState && !this.state); // finalized layer cannot be reused
+    assert(!this.internalState); // finalized layer cannot be reused
     assert(Number.isFinite(this.props.coordinateSystem)); // invalid coordinateSystem
 
     debug(TRACE_INITIALIZE, this);
@@ -777,16 +784,14 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     /* eslint-enable accessor-pairs */
 
     this.internalState.layer = this;
-    this.internalState.uniformTransitions = new UniformTransitionManager(
-      (this.context as LayerContext).timeline
-    );
+    this.internalState.uniformTransitions = new UniformTransitionManager(this.context.timeline);
     this.internalState.onAsyncPropUpdated = this._onAsyncPropUpdated.bind(this);
 
     // Ensure any async props are updated
     this.internalState.setAsyncProps(this.props);
 
     // Call subclass lifecycle methods
-    this.initializeState(this.context as LayerContext);
+    this.initializeState(this.context);
 
     // Initialize extensions
     for (const extension of this.props.extensions) {
@@ -842,7 +847,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     }
 
     const currentProps = this.props;
-    const context = this.context as LayerContext;
+    const context = this.context;
     const internalState = this.internalState as LayerState<PropsT>;
 
     const currentViewport = context.viewport;
@@ -894,7 +899,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     debug(TRACE_FINALIZE, this);
 
     // Call subclass lifecycle method
-    this.finalizeState(this.context as LayerContext);
+    this.finalizeState(this.context);
     // Finalize extensions
     for (const extension of this.props.extensions) {
       extension.finalizeState.call(this, extension);
@@ -914,7 +919,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     this._updateAttributeTransition();
 
     const currentProps = this.props;
-    const context = this.context as LayerContext;
+    const context = this.context;
     // Overwrite this.props during redraw to use in-transition prop values
     // `internalState.propsInTransition` could be missing if `updateState` failed
     // @ts-ignore (TS2339) internalState is alwasy defined when this method is called
@@ -1090,14 +1095,12 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
 
   /** Create new attribute manager */
   protected _getAttributeManager(): AttributeManager | null {
-    return (
-      this.context &&
-      new AttributeManager(this.context.gl, {
-        id: this.props.id,
-        stats: this.context.stats,
-        timeline: this.context.timeline
-      })
-    );
+    const context = this.context;
+    return new AttributeManager(context.gl, {
+      id: this.props.id,
+      stats: context.stats,
+      timeline: context.timeline
+    });
   }
 
   // Private methods
@@ -1111,7 +1114,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
     this._updateAttributes();
 
     // Note: Automatic instance count update only works for single layers
-    const {model} = this.state as any;
+    const {model} = this.state;
     model?.setInstanceCount(this.getNumInstances());
 
     // Set picking module parameters to match props
@@ -1147,7 +1150,7 @@ export default abstract class Layer<PropsT = any> extends Component<PropsT & Req
       props: this.props,
       // @ts-ignore TS2531 this method can only be called internally with internalState assigned
       oldProps: this.internalState.getOldProps() as PropsT,
-      context: this.context as LayerContext,
+      context: this.context,
       // @ts-ignore TS2531 this method can only be called internally with internalState assigned
       changeFlags: this.internalState.changeFlags
     };

--- a/modules/layers/src/geojson-layer/geojson-layer.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer.ts
@@ -361,7 +361,7 @@ export default class GeoJsonLayer<
     const featuresDiff = {};
 
     if (Array.isArray(changeFlags.dataChanged)) {
-      const oldFeatures = this.state!.features;
+      const oldFeatures = this.state.features;
       for (const key in oldFeatures) {
         newFeatures[key] = oldFeatures[key].slice();
         featuresDiff[key] = [];
@@ -397,7 +397,7 @@ export default class GeoJsonLayer<
     const info = super.getPickingInfo(params) as GeoJsonPickingInfo;
     const {index, sourceLayer} = info;
     info.featureType = FEATURE_TYPES.find(ft => sourceLayer!.id.startsWith(`${this.id}-${ft}-`));
-    if (index >= 0 && sourceLayer!.id.startsWith(`${this.id}-points-text`) && this.state!.binary) {
+    if (index >= 0 && sourceLayer!.id.startsWith(`${this.id}-points-text`) && this.state.binary) {
       info.index = (this.props.data as BinaryFeatures).points!.globalFeatureIds.value[index];
     }
     return info;
@@ -417,7 +417,7 @@ export default class GeoJsonLayer<
 
   private _renderPolygonLayer(): Layer | null {
     const {extruded, wireframe} = this.props;
-    const {layerProps} = this.state!;
+    const {layerProps} = this.state;
     const id = 'polygons-fill';
 
     const PolygonFillLayer =
@@ -448,7 +448,7 @@ export default class GeoJsonLayer<
 
   private _renderLineLayers(): (Layer | false)[] | null {
     const {extruded, stroked} = this.props;
-    const {layerProps} = this.state!;
+    const {layerProps} = this.state;
     const polygonStrokeLayerId = 'polygons-stroke';
     const lineStringsLayerId = 'linestrings';
 
@@ -491,7 +491,7 @@ export default class GeoJsonLayer<
 
   private _renderPointLayers(): Layer[] | null {
     const {pointType} = this.props;
-    const {layerProps, binary} = this.state!;
+    const {layerProps, binary} = this.state;
     let {highlightedObjectIndex} = this.props;
 
     if (!binary && Number.isFinite(highlightedObjectIndex)) {
@@ -559,7 +559,7 @@ export default class GeoJsonLayer<
   }
 
   protected getSubLayerAccessor<In, Out>(accessor: Accessor<In, Out>): Accessor<In, Out> {
-    const {binary} = this.state!;
+    const {binary} = this.state;
     if (!binary || typeof accessor !== 'function') {
       return super.getSubLayerAccessor(accessor);
     }

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -103,8 +103,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
   }
 
   initializeState() {
-    // @ts-ignore (TS2531) attributeManager is always defined for primitive layer
-    this.getAttributeManager().addInstanced({
+    this.getAttributeManager()!.addInstanced({
       instancePositions: {
         size: 3,
         type: GL.DOUBLE,
@@ -119,8 +118,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
         defaultValue: 1
       },
       instanceFillColors: {
-        // @ts-ignore (TS2322) colorFormat.length can only be 3 or 4
-        size: this.props.colorFormat.length,
+        size: this.props.colorFormat.length as 3 | 4,
         transition: true,
         normalized: true,
         type: GL.UNSIGNED_BYTE,
@@ -128,8 +126,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
         defaultValue: [0, 0, 0, 255]
       },
       instanceLineColors: {
-        // @ts-ignore (TS2322) colorFormat.length can only be 3 or 4
-        size: this.props.colorFormat.length,
+        size: this.props.colorFormat.length as 3 | 4,
         transition: true,
         normalized: true,
         type: GL.UNSIGNED_BYTE,
@@ -150,12 +147,9 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
 
     if (params.changeFlags.extensionsChanged) {
       const {gl} = this.context as LayerContext;
-      // @ts-ignore (TS2531) state is always defined
-      this.state.model?.delete();
-      // @ts-ignore (TS2531) state is always defined
-      this.state.model = this._getModel(gl);
-      // @ts-ignore (TS2531) attributeManager is always defined for primitive layer
-      this.getAttributeManager().invalidateAll();
+      this.state!.model?.delete();
+      this.state!.model = this._getModel(gl);
+      this.getAttributeManager()!.invalidateAll();
     }
   }
 
@@ -175,9 +169,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
       lineWidthMaxPixels
     } = this.props;
 
-    // @ts-ignore (TS2531) state is always defined
-    this.state.model
-      .setUniforms(uniforms)
+    this.state!.model.setUniforms(uniforms)
       .setUniforms({
         stroked: stroked ? 1 : 0,
         filled,

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -25,15 +25,7 @@ import {Model, Geometry} from '@luma.gl/core';
 import vs from './scatterplot-layer-vertex.glsl';
 import fs from './scatterplot-layer-fragment.glsl';
 
-import type {
-  LayerProps,
-  UpdateParameters,
-  LayerContext,
-  Accessor,
-  Unit,
-  Position,
-  Color
-} from '@deck.gl/core';
+import type {LayerProps, UpdateParameters, Accessor, Unit, Position, Color} from '@deck.gl/core';
 
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
@@ -142,13 +134,13 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
     });
   }
 
-  updateState(params: UpdateParameters<ScatterplotLayer>) {
+  updateState(params: UpdateParameters<ScatterplotLayer<DataT, ExtraPropsT>>) {
     super.updateState(params);
 
     if (params.changeFlags.extensionsChanged) {
-      const {gl} = this.context as LayerContext;
-      this.state!.model?.delete();
-      this.state!.model = this._getModel(gl);
+      const {gl} = this.context;
+      this.state.model?.delete();
+      this.state.model = this._getModel(gl);
       this.getAttributeManager()!.invalidateAll();
     }
   }
@@ -169,7 +161,8 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Lay
       lineWidthMaxPixels
     } = this.props;
 
-    this.state!.model.setUniforms(uniforms)
+    this.state.model
+      .setUniforms(uniforms)
       .setUniforms({
         stroked: stroked ? 1 : 0,
         filled,


### PR DESCRIPTION
For #5589 

This proposal replaces many `@ts-ignore` usage with the `!` pattern. I think it is a better approach because:
- `@ts-ignore` ignores ALL TS rules, not just 2531. The decorated line practically loses all type checks, which could be valuable in catching other bugs. `!` only tells TS to ignore one variable's possible null state.
- It's just less verbose to write.

I purposefully do not use this pattern in the core module - where things are more subject to unexpected states - I believe that it's better to explicitly document any assumptions there. For the layer implementations, however, the lifecycle methods are only ever invoked by the layer manager, where `state`, `context` and `internalState` are always defined. The risk that anything will break by forcing TypeScript to ignore the nullable members are extremely low.
