### PR TITLE
Remove layer-specific logic from Component class

### DIFF
--- a/modules/core/src/lib/layer-state.ts
+++ b/modules/core/src/lib/layer-state.ts
@@ -1,7 +1,6 @@
 import ComponentState from '../lifecycle/component-state';
 
 import type Layer from './layer';
-import type {ResolvedLayerProps} from './layer';
 import type AttributeManager from './attribute/attribute-manager';
 import type Viewport from '../viewports/viewport';
 import type UniformTransitionManager from './uniform-transition-manager';
@@ -43,7 +42,7 @@ export default class LayerState<PropsT> extends ComponentState<PropsT & Required
 
   uniformTransitions!: UniformTransitionManager;
   /** Populated during uniform transition to replace user-supplied values */
-  propsInTransition?: ResolvedLayerProps<PropsT>;
+  propsInTransition?: Layer<PropsT>['props'];
 
   constructor({
     attributeManager,

--- a/modules/core/src/lib/layer-state.ts
+++ b/modules/core/src/lib/layer-state.ts
@@ -1,10 +1,11 @@
 import ComponentState from '../lifecycle/component-state';
-import {StatefulComponentProps} from '../lifecycle/component';
 
 import type Layer from './layer';
+import type {ResolvedLayerProps} from './layer';
 import type AttributeManager from './attribute/attribute-manager';
 import type Viewport from '../viewports/viewport';
 import type UniformTransitionManager from './uniform-transition-manager';
+import type {LayerProps} from '../types/layer-props';
 
 export type ChangeFlags = {
   // Primary changeFlags, can be strings stating reason for change
@@ -20,7 +21,7 @@ export type ChangeFlags = {
   somethingChanged: boolean;
 };
 
-export default class LayerState<PropsT> extends ComponentState<PropsT> {
+export default class LayerState<PropsT> extends ComponentState<PropsT & Required<LayerProps>> {
   attributeManager: AttributeManager | null;
   needsRedraw: boolean;
   needsUpdate: boolean;
@@ -42,7 +43,7 @@ export default class LayerState<PropsT> extends ComponentState<PropsT> {
 
   uniformTransitions!: UniformTransitionManager;
   /** Populated during uniform transition to replace user-supplied values */
-  propsInTransition?: StatefulComponentProps<PropsT>;
+  propsInTransition?: ResolvedLayerProps<PropsT>;
 
   constructor({
     attributeManager,

--- a/modules/core/src/lifecycle/component-state.ts
+++ b/modules/core/src/lifecycle/component-state.ts
@@ -267,6 +267,7 @@ export default class ComponentState<PropsT> {
     let count = 0;
 
     for await (const chunk of iterable) {
+      // @ts-expect-error (2339) dataTransform is not decared in base component props
       const {dataTransform} = this.component.props;
       if (dataTransform) {
         data = dataTransform(chunk, data) as any[];

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -1,6 +1,4 @@
 import {
-  LIFECYCLE,
-  Lifecycle,
   COMPONENT_SYMBOL,
   ASYNC_ORIGINAL_SYMBOL,
   ASYNC_RESOLVED_SYMBOL,
@@ -8,19 +6,15 @@ import {
 } from './constants';
 import {createProps} from './create-props';
 
-import type {LayerContext} from '../lib/layer-manager';
-import type LayerState from '../lib/layer-state';
-import type {LayerProps} from '../types/layer-props';
-
 let counter = 0;
 
-export type StatefulComponentProps<PropsT> = PropsT &
-  Required<LayerProps> & {
-    [COMPONENT_SYMBOL]: Component<PropsT>;
-    [ASYNC_DEFAULTS_SYMBOL]: Partial<PropsT>;
-    [ASYNC_ORIGINAL_SYMBOL]: Partial<PropsT>;
-    [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;
-  };
+export type StatefulComponentProps<PropsT> = PropsT & {
+  id: string;
+  [COMPONENT_SYMBOL]: Component<PropsT>;
+  [ASYNC_DEFAULTS_SYMBOL]: Partial<PropsT>;
+  [ASYNC_ORIGINAL_SYMBOL]: Partial<PropsT>;
+  [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;
+};
 
 export default class Component<PropsT = any> {
   static componentName: string = 'Component';
@@ -29,11 +23,7 @@ export default class Component<PropsT = any> {
   id: string;
   props: StatefulComponentProps<PropsT>;
   count: number;
-  lifecycle: Lifecycle;
   parent: Component | null;
-  context: LayerContext | null;
-  state: Record<string, any> | null;
-  internalState: LayerState<PropsT> | null;
 
   constructor(...propObjects: Partial<PropsT>[]) {
     // Merge supplied props with default props and freeze them.
@@ -41,17 +31,9 @@ export default class Component<PropsT = any> {
     this.props = createProps<PropsT>(this, propObjects);
     /* eslint-enable prefer-spread */
 
-    // Define all members before layer is sealed
     this.id = this.props.id; // The layer's id, used for matching with layers from last render cycle
     this.count = counter++; // Keep track of how many layer instances you are generating
-    this.lifecycle = LIFECYCLE.NO_STATE; // Helps track and debug the life cycle of the layers
     this.parent = null; // reference to the composite layer parent that rendered this layer
-    this.context = null; // Will reference layer manager's context, contains state shared by layers
-    this.state = null; // Will be set to the shared layer state object during layer matching
-    this.internalState = null;
-
-    // Seal the layer
-    Object.seal(this);
   }
 
   get root(): Component {


### PR DESCRIPTION
My understanding of the Component/ComponentState inheritance hierarchy is that they are intended to extract the props resolution logic out of the Layer class. As we transition to TypeScript, the `Object.seal` call in the Component constructor forces the Component to reference many layer-specific types, which breaks that abstraction. This refactor moves the sealing into the Layer constructor instead.
