### PR TITLE
[ts] Fix prop types of Polygon, GeoCell and Queadkey layers.

### DIFF
--- a/modules/geo-layers/src/geo-cell-layer/GeoCellLayer.ts
+++ b/modules/geo-layers/src/geo-cell-layer/GeoCellLayer.ts
@@ -1,11 +1,12 @@
-import {CompositeLayer, Layer, LayersList} from '@deck.gl/core';
+import {CompositeLayer, CompositeLayerProps, Layer, LayersList} from '@deck.gl/core';
 import {PolygonLayer, PolygonLayerProps} from '@deck.gl/layers';
 
 const defaultProps = {
   ...PolygonLayer.defaultProps
 };
 
-export type GeoCellLayerProps<DataT = any> = PolygonLayerProps<DataT>;
+/** All properties supported by GeoCellLayer. */
+export type GeoCellLayerProps<DataT = any> = PolygonLayerProps<DataT> & CompositeLayerProps<DataT>;
 
 export default class GeoCellLayer<DataT = any, ExtraProps = {}> extends CompositeLayer<
   Required<GeoCellLayerProps<DataT>> & ExtraProps

--- a/modules/geo-layers/src/quadkey-layer/quadkey-layer.ts
+++ b/modules/geo-layers/src/quadkey-layer/quadkey-layer.ts
@@ -1,15 +1,16 @@
 import {AccessorFunction} from '@deck.gl/core';
-import GeoCellLayer from '../geo-cell-layer/GeoCellLayer';
+import GeoCellLayer, {GeoCellLayerProps} from '../geo-cell-layer/GeoCellLayer';
 import {getQuadkeyPolygon} from './quadkey-utils';
 
 const defaultProps = {
   getQuadkey: {type: 'accessor', value: d => d.quadkey}
 };
 
-/**
- * Properties of `QuadkeyLayer`.
- */
-type QuadkeyLayerProps<DataT = any> = {
+/** All properties supported by QuadkeyLayer. */
+export type QuadkeyLayerProps<DataT = any> = _QuadkeyLayerProps<DataT> & GeoCellLayerProps<DataT>;
+
+/** Properties added by QuadkeyLayer. */
+type _QuadkeyLayerProps<DataT = any> = {
   /**
    * Called for each data object to retrieve the quadkey string identifier.
    *
@@ -20,7 +21,7 @@ type QuadkeyLayerProps<DataT = any> = {
 
 export default class QuadkeyLayer<DataT = any, ExtraProps = {}> extends GeoCellLayer<
   DataT,
-  Required<QuadkeyLayerProps> & ExtraProps
+  Required<_QuadkeyLayerProps> & ExtraProps
 > {
   static layerName = 'QuadkeyLayer';
   static defaultProps: any = defaultProps;

--- a/modules/layers/src/polygon-layer/polygon-layer.ts
+++ b/modules/layers/src/polygon-layer/polygon-layer.ts
@@ -45,7 +45,7 @@ export type PolygonLayerProps<DataT = any> = _PolygonLayerProps<DataT> & Composi
 /**
  * Properties added by `PolygonLayer`.
  */
-export type _PolygonLayerProps<DataT = any> = {
+type _PolygonLayerProps<DataT = any> = {
   /**
    * Whether to draw an outline around the polygon (solid fill).
    *


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/5589

Change List:
* fix wrong typing introduced in (#6822)  for in Polygon, GeoCell and Quadkey layers.