### PR TITLE
chore: update caniuse-lite

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4523,9 +4523,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001254:
-  version "1.0.30001283"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz"
-  integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
+  version "1.0.30001346"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz"
+  integrity sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==
 
 canvas@^2.6.0:
   version "2.6.1"


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background
Running `yarn test` on _clean_ checkout currently fails in `test-browser` stage with following error:

```
browser-driver: Browser Test failed: Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
```

(`ocular-bootstrap` somehow manages to update it locally, but we're left with dirty workspace)

<!-- For all the PRs -->
#### Change List
- update `caniuse-lite` in yarn.lock
