### PR TITLE
[ts] main: re-export recently added typings

### DIFF
--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -149,5 +149,54 @@ export type {
   FirstPersonViewState,
   OrbitViewState,
   OrthographicViewState,
-  GlobeViewState
+  GlobeViewState,
+  CoordinateSystem,
+  ChangeFlags,
+  LayersList,
+  LayerContext,
+  UpdateParameters,
+  DeckProps,
+  LayerProps,
+  CompositeLayerProps,
+  Accessor,
+  AccessorFunction,
+  LayerData,
+  Unit,
+  Position,
+  Color,
+  Texture,
+  PickingInfo,
+  GetPickingInfoParams,
+  BinaryAttribute,
+  Effect
 } from '@deck.gl/core';
+
+export type {
+  ArcLayerProps,
+  BitmapLayerProps,
+  ColumnLayerProps,
+  ScatterplotLayerProps,
+  IconLayerProps,
+  LineLayerProps,
+  PolygonLayerProps,
+  GeoJsonLayerProps,
+  GridCellLayerProps,
+  TextLayerProps,
+  MultiIconLayerProps,
+  PointCloudLayerProps,
+  TextBackgroundLayerProps,
+  PathLayerProps,
+  SolidPolygonLayerProps
+} from '@deck.gl/layers';
+
+export type {
+  ContourLayerProps,
+  CPUGridLayerProps,
+  GridLayerProps,
+  GPUGridLayerProps,
+  HeatmapLayerProps,
+  HexagonLayerProps,
+  ScreenGridLayerProps
+} from '@deck.gl/aggregation-layers';
+
+export type {MVTLayerProps, QuadkeyLayerProps, TileLayerProps} from '@deck.gl/geo-layers';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,7 @@
     // {"path": "modules/json"},
     // {"path": "modules/jupyter-widget"},
     {"path": "modules/layers"},
-    // {"path": "modules/main"},
+    {"path": "modules/main"},
     {"path": "modules/mapbox"},
     {"path": "modules/mesh-layers"},
     {"path": "modules/react"},


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/5589 & https://github.com/visgl/deck.gl/issues/6967

Change List:

* [ts] main: re-export recently added typings from:
  * @deck.gl/core
  * @deck.gl/layers
  * @deck.gl/geo-layers
  * @deck.gl/aggregation-layers

* Add @deck.gl "main" module to tsbuild.