### PR TITLE
[mapbox] documentations

### DIFF
--- a/docs/api-reference/mapbox/mapbox-layer.md
+++ b/docs/api-reference/mapbox/mapbox-layer.md
@@ -2,15 +2,9 @@
 
 `MapboxLayer` is an implementation of [Mapbox GL JS](https://www.npmjs.com/package/mapbox-gl)'s [CustomLayerInterface](https://docs.mapbox.com/mapbox-gl-js/api/properties/#customlayerinterface) API. By adding a `MapboxLayer` instance to an mapbox map, one can render any deck.gl layer inside the mapbox canvas / WebGL context. This is in contrast to the traditional deck.gl/mapbox integration where the deck.gl layers are rendered into a separate canvas over the base map.
 
-See [mapbox documentation](https://www.mapbox.com/mapbox-gl-js/api/#map#addlayer) for how to add a layer to an existing layer stack.
+See the Mapbox [`map.addLayer(layer, before?)`](https://www.mapbox.com/mapbox-gl-js/api/#map#addlayer) API for how to add a layer to an existing layer stack.
 
 ## Example
-
-There are two options to construct a `MapboxLayer`.
-
-### Make a Layer from Scratch
-
-This option works best for static layers that do not require advanced interaction controls, or frequent adding/removing/updating.
 
 ```js
 import {MapboxLayer} from '@deck.gl/mapbox';
@@ -19,127 +13,28 @@ import {ScatterplotLayer} from '@deck.gl/layers';
 const map = new mapboxgl.Map({...});
 
 const myScatterplotLayer = new MapboxLayer({
-    id: 'my-scatterplot',
-    type: ScatterplotLayer,
-    data: [
-        {position: [-74.5, 40], size: 100}
-    ],
-    getPosition: d => d.position,
-    getRadius: d => d.size,
-    getColor: [255, 0, 0]
+  id: 'my-scatterplot',
+  type: ScatterplotLayer,
+  data: [
+      {position: [-74.5, 40], size: 100}
+  ],
+  getPosition: d => d.position,
+  getRadius: d => d.size,
+  getColor: [255, 0, 0]
 });
 
 // wait for map to be ready
 map.on('load', () => {
-    // add to mapbox
-    map.addLayer(myScatterplotLayer);
+  // insert before the mapbox layer "waterway_label"
+  map.addLayer(myScatterplotLayer, 'waterway_label');
 
-    // update the layer
-    myScatterplotLayer.setProps({
-      getColor: [0, 0, 255]
-    });
-}
-```
-
-### Use a Layer from an Existing Deck's Layer Stack
-
-This option allows one to take full advantage of the `Deck` API, e.g. top-level props such as `pickingRadius`, `onHover`, and adding/removing/updating layers in a reactive fashion by setting the `layers` array.
-
-```js
-import {MapboxLayer} from '@deck.gl/mapbox';
-import {Deck} from '@deck.gl/core';
-import {ScatterplotLayer} from '@deck.gl/layers';
-
-const map = new mapboxgl.Map({...});
-
-const deck = new Deck({
-    gl: map.painter.context.gl,
-    layers: [
-        new ScatterplotLayer({
-            id: 'my-scatterplot',
-            data: [
-                {position: [-74.5, 40], size: 100}
-            ],
-            getPosition: d => d.position,
-            getRadius: d => d.size,
-            getFillColor: [255, 0, 0]
-        })
-    ]
-});
-
-// wait for map to be ready
-map.on('load', () => {
-    // add to mapbox
-    map.addLayer(new MapboxLayer({id: 'my-scatterplot', deck}));
-
-    // update the layer
-    deck.setProps({
-        layers: [
-            new ScatterplotLayer({
-                id: 'my-scatterplot',
-                data: [
-                    {position: [-74.5, 40], size: 100}
-                ],
-                getPosition: d => d.position,
-                getRadius: d => d.size,
-                getFillColor: [0, 0, 255]
-            })
-        ]
-    });
-}
-```
-
-### Using Multiple Views from an Existing Deck Instance
-
-This option allows one to take advantage of deck's multi-view system and render a mapbox base map onto any one MapView of your choice by setting the `views` array and a `layerFilter` callback.
-
-- To use multiple views, define a `MapView` with the id `“mapbox”`. This view will receive the state that matches the base map at each render.
-- If views are provided but the array does not contain this id, then a `MapView({id: 'mapbox'})` will be inserted at the bottom of the stack.
-- If the views prop is not provided, then the default is a single `MapView({id: 'mapbox'})`.
-
-```js
-import {MapboxLayer} from '@deck.gl/mapbox';
-import {Deck, MapView, OrthographicView} from '@deck.gl/core';
-import {ScatterplotLayer} from '@deck.gl/layers';
-
-const map = new mapboxgl.Map({...});
-
-const deck = new Deck({
-    gl: map.painter.context.gl,
-    views: [new MapView({id: 'mapbox'}), new OrthographicView({id: 'widget'})],
-    layerFilter: ({layer, viewport}) => {
-        const shouldDrawInWidget = layer.id.startsWith('widget');
-        if (viewport.id === 'widget') return shouldDrawInWidget;
-        return !shouldDrawInWidget;
-    },
-    layers: [
-        new ScatterplotLayer({
-            id: 'my-scatterplot',
-            data: [
-                {position: [-74.5, 40], size: 100}
-            ],
-            getPosition: d => d.position,
-            getRadius: d => d.size,
-            getFillColor: [255, 0, 0]
-        }),
-        new ScatterplotLayer({
-            id: 'widget-scatterplot',
-            data: [
-                {position: [0, 0], size: 100}
-            ],
-            getPosition: d => d.position,
-            getRadius: d => d.size,
-            getFillColor: [255, 0, 0]
-        })
-    ]
-});
-
-// wait for map to be ready
-map.on('load', () => {
-    // add to mapbox
-    map.addLayer(new MapboxLayer({id: 'my-scatterplot', deck}));
+  // update the layer
+  myScatterplotLayer.setProps({
+    getColor: [0, 0, 255]
+  });
 });
 ```
+
 
 ## Constructor
 
@@ -152,8 +47,8 @@ Parameters:
 
 - `props` (Object)
   + `props.id` (String) - an unique id is required for each layer.
-  + `props.deck` (`Deck`, optional) - a `Deck` instance that controls the rendering of this layer. If provided, the layer will be looked up from its layer stack by `id` at render time, and all other props are ignored.
   + `props.type` (`Layer`, optional) - a class that extends deck.gl's base `Layer` class. Required if `deck` is not provided.
+  + `props.deck` (`Deck`, optional) - a `Deck` instance that controls the rendering of this layer. If provided, the layer will be looked up from its layer stack by `id` at render time, and all other props are ignored. It's recommended that you use the [MapboxOverlay](/docs/api-reference/mapbox/mapbox-overlay.md) class where a `Deck` instance is automatically managed.
   + Optional: any other prop needed by this type of layer. See deck.gl's [layer catalog](/docs/api-reference/layers/README.md) for documentation and examples on how to create layers.
 
 
@@ -167,6 +62,8 @@ const layer = new MapboxLayer({
     type: ScatterplotLayer,
     ...
 });
+
+map.addLayer(layer);
 
 layer.setProps({
     radiusScale: 2

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -66,6 +66,53 @@ const overlay = new MapboxOverlay({
 map.addControl(overlay);
 ```
 
+### Using with react-map-gl
+
+The following code demonstrates how to create a React component from `MapboxOverlay` with `react-map-gl@7.x`:
+
+```tsx
+import {ScatterplotLayer} from '@deck.gl/layers/typed';
+import {MapboxOverlay, MapboxOverlayProps} from '@deck.gl/mapbox/typed';
+import {useControl} from 'react-map-gl';
+
+import Map, {NavigationControl} from 'react-map-gl';
+
+function DeckGLOverlay(props: MapboxOverlayProps) {
+  const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
+  overlay.setProps(props);
+  return null;
+}
+
+export default function App() {
+  const scatterplotLayer = new ScatterplotLayer({
+    id: 'my-scatterplot',
+    data: [
+      {position: [-74.5, 40], size: 100}
+    ],
+    getPosition: d => d.position,
+    getRadius: d => d.size,
+    getColor: [255, 0, 0]
+  });
+
+  return (
+    <Map
+      initialViewState={{
+        latitude: 37.78,
+        longitude: -122.45,
+        zoom: 12
+      }}
+      mapStyle="mapbox://styles/mapbox/light-v9"
+      mapboxAccessToken=""
+    >
+      <DeckGLOverlay layers={[scatterplotLayer]} />
+      <NavigationControl />
+    </Map>
+  );
+}
+```
+
+See react-map-gl's [useControl](https://visgl.github.io/react-map-gl/docs/api-reference/use-control) hook.
+
 
 ## Constructor
 

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -1,16 +1,23 @@
 # MapboxOverlay
 
-`MapboxOverlay` is an implementation of [Mapbox GL JS](https://www.npmjs.com/package/mapbox-gl)'s [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) API. When adding a `MapboxOverlay` instance to an mapbox map, a deck.gl canvas overlaid on top of the base map, and synchronized with the map's camera.
+`MapboxOverlay` is an implementation of [Mapbox GL JS](https://www.npmjs.com/package/mapbox-gl)'s [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) API. When adding a `MapboxOverlay` control to an mapbox map, deck.gl layers are rendered in synchronization with the base map layers. This control supports both [overlaid and interleaved](/docs/get-started/using-with-map.md) rendering modes.
 
 ## Example
+
+### Overlaid
 
 ```js
 import {MapboxOverlay} from '@deck.gl/mapbox';
 import {ScatterplotLayer} from '@deck.gl/layers';
 
-const map = new mapboxgl.Map({...});
+const map = new mapboxgl.Map({
+  center: [-74.5, 40],
+  zoom: 14,
+  antialis: true // Improves the rendering quality
+});
 
 const overlay = new MapboxOverlay({
+  interleaved: false,
   layers: [
     new ScatterplotLayer({
       id: 'my-scatterplot',
@@ -27,6 +34,39 @@ const overlay = new MapboxOverlay({
 map.addControl(overlay);
 ```
 
+### Interleaved
+
+```js
+import {MapboxOverlay} from '@deck.gl/mapbox';
+import {ScatterplotLayer} from '@deck.gl/layers';
+
+const map = new mapboxgl.Map({
+  center: [-74.5, 40],
+  zoom: 14,
+  antialis: true // Improves the rendering quality
+});
+
+const overlay = new MapboxOverlay({
+  interleaved: true,
+  layers: [
+    new ScatterplotLayer({
+      id: 'my-scatterplot',
+      data: [
+        {position: [-74.5, 40], size: 100}
+      ],
+      getPosition: d => d.position,
+      getRadius: d => d.size,
+      getColor: [255, 0, 0],
+
+      beforeId: 'admin_labels' // Insert before this Mapbox layer
+    })
+  ]
+});
+
+map.addControl(overlay);
+```
+
+
 ## Constructor
 
 ```js
@@ -36,13 +76,34 @@ new MapboxOverlay(props);
 
 `MapboxOverlay` accepts the same props as the [Deck](/docs/api-reference/core/deck.md) class, with the following exceptions:
 
-- `views` - multi-view is not supported. There is only one `MapView` that synchronizes with the base map.
-- `viewState` - managed internally.
+- `views` - multi-view support is limited. There is only one `MapView` that can synchronize with the base map. See the [using with multi-views](#multi-view-usage) section for details.
+- `parent` / `canvas` / `gl` - context creation is managed internally.
+- `viewState` / `initialViewState` - camera state is managed internally.
 - `controller` - always disabled (to use Mapbox's interaction handlers).
+
+The constructor additionally accepts the following option:
+
+- `interleaved` (Boolean) - If `false`, a dedicated deck.gl canvas is added on top of the base map. If `true`, deck.gl layers are inserted into mapbox-gl's layer stack, and share the same WebGLRenderingContext as the base map.
+
+When using `interleaved: true`, you may optionally add a `beforeId` prop to a layer to specify its position in the Mapbox layer stack. If multiple deck.gl layers have the same `beforeId`, they are rendered in the order that is passed into the `layers` array.
 
 ## Methods
 
 ##### setProps
+
+```js
+const overlay = new MapboxOverlay({
+  interleaved: true,
+  layers: []
+});
+
+map.addControl(overlay);
+
+// Update layers
+overlay.setProps({
+  layers: [new ScatterplotLayer({...})]
+})
+```
 
 Updates (partial) props of the underlying `Deck` instance. See [Deck.setProps](/docs/api-reference/core/deck.md#setprops).
 
@@ -61,3 +122,59 @@ See [Deck.pickMultipleObjects](/docs/api-reference/core/deck.md#pickmultipleobje
 ##### finalize
 
 Removes the control and deletes all resources.
+
+
+## Remarks
+
+### Multi-view usage
+
+When using `MapboxOverlay` with multiple views passed to the `views` prop, only one of the views can match the base map and receive interaction.
+
+With that said, it is still possible to take advantage of deck's multi-view system and render a mapbox base map onto any one MapView of your choice by setting the `views` array and a `layerFilter` callback.
+
+- To use multiple views, define a `MapView` with the id `“mapbox”`. This view will receive the state that matches the base map at each render.
+- If views are provided but the array does not contain this id, then a `MapView({id: 'mapbox'})` will be inserted at the bottom of the stack.
+
+```js
+import {MapboxOverlay} from '@deck.gl/mapbox';
+import {Deck, MapView, OrthographicView} from '@deck.gl/core';
+import {ScatterplotLayer} from '@deck.gl/layers';
+
+const map = new mapboxgl.Map({...});
+
+const overlay = new MapboxOverlay({
+  views: [
+    // This view will be synchronized with the base map
+    new MapView({id: 'mapbox'}),
+    // This view will not be interactive
+    new OrthographicView({id: 'widget'})
+  ],
+  layerFilter: ({layer, viewport}) => {
+    const shouldDrawInWidget = layer.id.startsWith('widget');
+    if (viewport.id === 'widget') return shouldDrawInWidget;
+    return !shouldDrawInWidget;
+  },
+  layers: [
+    new ScatterplotLayer({
+      id: 'my-scatterplot',
+      data: [
+        {position: [-74.5, 40], size: 100}
+      ],
+      getPosition: d => d.position,
+      getRadius: d => d.size,
+      getFillColor: [255, 0, 0]
+    }),
+    new ScatterplotLayer({
+      id: 'widget-scatterplot',
+      data: [
+        {position: [0, 0], size: 100}
+      ],
+      getPosition: d => d.position,
+      getRadius: d => d.size,
+      getFillColor: [255, 0, 0]
+    })
+  ]
+});
+
+map.addControl(overlay);
+```

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -13,7 +13,7 @@ import {ScatterplotLayer} from '@deck.gl/layers';
 const map = new mapboxgl.Map({
   center: [-74.5, 40],
   zoom: 14,
-  antialis: true // Improves the rendering quality
+  antialias: true // Improves the rendering quality
 });
 
 const overlay = new MapboxOverlay({
@@ -43,7 +43,7 @@ import {ScatterplotLayer} from '@deck.gl/layers';
 const map = new mapboxgl.Map({
   center: [-74.5, 40],
   zoom: 14,
-  antialis: true // Improves the rendering quality
+  antialias: true // Improves the rendering quality
 });
 
 const overlay = new MapboxOverlay({
@@ -130,7 +130,7 @@ new MapboxOverlay(props);
 
 The constructor additionally accepts the following option:
 
-- `interleaved` (Boolean) - If `false`, a dedicated deck.gl canvas is added on top of the base map. If `true`, deck.gl layers are inserted into mapbox-gl's layer stack, and share the same WebGLRenderingContext as the base map.
+- `interleaved` (Boolean) - If `false`, a dedicated deck.gl canvas is added on top of the base map. If `true`, deck.gl layers are inserted into mapbox-gl's layer stack, and share the same WebGLRenderingContext as the base map. Default is `false`.
 
 When using `interleaved: true`, you may optionally add a `beforeId` prop to a layer to specify its position in the Mapbox layer stack. If multiple deck.gl layers have the same `beforeId`, they are rendered in the order that is passed into the `layers` array.
 

--- a/docs/api-reference/mapbox/overview.md
+++ b/docs/api-reference/mapbox/overview.md
@@ -59,6 +59,7 @@ The Mapbox ecosystem offers many well-designed controls, from the basic function
 ## Limitations
 
 * When using deck.gl's multi-view system, only one of the views can match the base map and receive interaction. See [using MapboxOverlay with multi-views](/docs/api-reference/mapbox/mapbox-overlay.md#multi-view-usage) for details.
+* When using deck.gl as Mapbox layers or controls, `Deck` only receives a subset of user inputs delegated by `Map`. Therefore, certain interactive callbacks like `onDrag`, `onInteractionStateChange` are not available.
 * WebGL2 based deck.gl features, such as attribute transitions and GPU accelerated aggregation layers cannot be used.
 * Mapbox 2.0's terrain feature is currently not supported.
 

--- a/docs/api-reference/mapbox/overview.md
+++ b/docs/api-reference/mapbox/overview.md
@@ -33,8 +33,9 @@ import {MapboxOverlay} from '@deck.gl/mapbox';
 
 ## Use Cases
 
-One should note that this module is *not required* to use mapbox-gl as a base map for deck.gl. It is easier to understand the concepts of the module if you are already a mapbox-gl developer. Visit the [mapbox base map developer guide](/docs/developer-guide/base-maps/using-with-mapbox.md) for a complete list of your options.
+One should note that this module is *not required* to use mapbox-gl as a base map for deck.gl. When you use this module, Mapbox is the root element and deck.gl is the child, with Mapbox handling all user inputs. Some of deck.gl's features are therefore unavailable due to limitations of mapbox-gl's API, see [limitations](#limitations) below. If you just want the base map as a back drop, and do not need mapbox-gl's UI controls or mixing deck and Mapbox layers, it is recommended that you use deck.gl as the root element. Visit the [mapbox base map developer guide](/docs/developer-guide/base-maps/using-with-mapbox.md) for examples of each option.
 
+It may be easier to understand the concepts of the module if you are already a mapbox-gl developer.
 
 ### Mixing deck.gl layers and Mapbox layers
 

--- a/docs/developer-guide/base-maps/using-with-mapbox.md
+++ b/docs/developer-guide/base-maps/using-with-mapbox.md
@@ -6,10 +6,11 @@
 
 [mapbox-gl](https://github.com/mapbox/mapbox-gl-js) is a powerful open-source map renderer from [Mapbox](https://mapbox.com). deck.gl's `MapView` is designed to sync perfectly with the camera of Mapbox, at every zoom level and rotation angle.
 
-When using deck.gl and Mapbox, there are two options you can choose from:
+When using deck.gl and Mapbox, there are three options you can choose from:
 
-- Using the Deck canvas as a overlay on top of the Mapbox map, in [pure JS](https://github.com/visgl/deck.gl/tree/master/examples/get-started/pure-js/mapbox) or [React](https://github.com/visgl/deck.gl/tree/master/examples/get-started/react/mapbox). This is the most tested and robust use case.
-- Using deck.gl layers as custom Mapbox layers, using the [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) module. This allows you to interleave deck.gl layers with base map layers, e.g. below text labels or occlude each other correctly in 3D. Be cautious that this feature is experimental: we are working closely with Mapbox to evolve the API.
+- Using the Deck canvas as a overlay on top of the Mapbox map, and deck.gl drives the base map. The [React get-started example](/examples/get-started/react/mapbox/) illustrates the basic pattern. In this option, deck.gl handles all user input, and holds the source of truth of the camera state. This is the most tested and robust use case, as you can find in all the [examples on this website](/examples/website). It supports all the features of Deck.
+- Using the Deck canvas as a overlay on top of the Mapbox map, and Mapbox drives deck.gl. In this option, mapbox-gl handles all user input, and holds the source of truth of the camera state. The [vanilla JS get-started example](/examples/get-started/pure-js/mapbox) illustrates this pattern. The [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) module implements a mapbox-gl control that inserts deck into the map container. This is favorable if you need to use other mapbox-gl controls and plugins in addition to deck.gl.
+- Using deck.gl layers as Mapbox layers, also using the [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) module. This allows you to interleave deck.gl layers with base map layers, e.g. below text labels or occlude each other correctly in 3D. Be cautious that this feature subjects to bugs and limitations of mapbox-gl's custom layer interface.
 
 ![deck.gl interleaved with Mapbox layers](https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/mapbox-layers.jpg)
 

--- a/docs/developer-guide/base-maps/using-with-mapbox.md
+++ b/docs/developer-guide/base-maps/using-with-mapbox.md
@@ -4,13 +4,13 @@
 | ----- | ----- | ----- | ----- |
 |  ✓ | ✓ | [example](https://github.com/visgl/deck.gl/tree/master/examples/get-started/pure-js/mapbox) | [example](https://deck.gl/gallery/mapbox-layer) |
 
-[mapbox-gl](https://github.com/mapbox/mapbox-gl-js) is a powerful open-source map renderer from [Mapbox](https://mapbox.com). deck.gl's `MapView` is designed to sync perfectly with the camera of Mapbox, at every zoom level and rotation angle.
+[Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) is a powerful open-source map renderer from [Mapbox](https://mapbox.com). deck.gl's `MapView` is designed to sync perfectly with the camera of Mapbox, at every zoom level and rotation angle.
 
 When using deck.gl and Mapbox, there are three options you can choose from:
 
-- Using the Deck canvas as a overlay on top of the Mapbox map, and deck.gl drives the base map. The [React get-started example](/examples/get-started/react/mapbox/) illustrates the basic pattern. In this option, deck.gl handles all user input, and holds the source of truth of the camera state. This is the most tested and robust use case, as you can find in all the [examples on this website](/examples/website). It supports all the features of Deck.
-- Using the Deck canvas as a overlay on top of the Mapbox map, and Mapbox drives deck.gl. In this option, mapbox-gl handles all user input, and holds the source of truth of the camera state. The [vanilla JS get-started example](/examples/get-started/pure-js/mapbox) illustrates this pattern. The [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) module implements a mapbox-gl control that inserts deck into the map container. This is favorable if you need to use other mapbox-gl controls and plugins in addition to deck.gl.
-- Using deck.gl layers as Mapbox layers, also using the [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) module. This allows you to interleave deck.gl layers with base map layers, e.g. below text labels or occlude each other correctly in 3D. Be cautious that this feature subjects to bugs and limitations of mapbox-gl's custom layer interface.
+- Using the Deck canvas as a overlay on top of the Mapbox map, and Deck as the root element. In this option, deck.gl handles all user input, and holds the source of truth of the camera state. The [React get-started example](/examples/get-started/react/mapbox/) illustrates the basic pattern. This is the most tested and robust use case, as you can find in all the [examples on this website](/examples/website). It supports all the features of Deck.
+- Using the Deck canvas as a overlay on top of the Mapbox map, and Mapbox as the root element. In this option, mapbox-gl handles all user input, and holds the source of truth of the camera state. The [vanilla JS get-started example](/examples/get-started/pure-js/mapbox) illustrates this pattern. The `MapboxOverlay` class in [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) implements the mapbox-gl control interface to insert deck into the map container. This is favorable if you need to use other mapbox-gl controls and plugins in addition to deck.gl.
+- Using deck.gl layers interleaved with Mapbox layers in the same WebGL context, using either the `MapboxOverlay` or `MapboxLayer` from the [@deck.gl/mapbox](/docs/api-reference/mapbox/overview.md) module. This allows you to mix deck.gl layers with base map layers, e.g. below text labels or occlude each other correctly in 3D. Be cautious that this feature subjects to bugs and limitations of mapbox-gl's custom layer interface.
 
 ![deck.gl interleaved with Mapbox layers](https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/mapbox-layers.jpg)
 
@@ -30,7 +30,7 @@ If you are using react-map-gl, there are several ways to provide a token to your
 
 * Set the `MapboxAccessToken` environment variable. You may need to add additional set up to the bundler ([example](https://webpack.js.org/plugins/environment-plugin/)) so that `process.env.MapboxAccessToekn` is accessible at runtime.
 * Provide it in the URL, e.g `?access_token=TOKEN`
-* Pass it as a prop to the ReactMapGL instance `<ReactMapGL mapboxApiAccessToken={TOKEN} />`
+* Pass it as a prop to the ReactMapGL instance `<ReactMapGL mapboxAccessToken={TOKEN} />`
 
 ## Compatibility with Mapbox GL JS forks
 


### PR DESCRIPTION
For #6773

#### Change List
- Update mapbox module documentation. Most notably I am removing the old nested-dependency React usage pattern for `MapboxLayer`. The old pattern is hard to understand, causes many bugs and should be replaced by `MapboxOverlay` and `interleaved: true`.
- Update base map developer guide
