### PR TITLE
Improve performance for `visible: false` layers

### DIFF
--- a/modules/core/src/effects/mask/mask-effect.ts
+++ b/modules/core/src/effects/mask/mask-effect.ts
@@ -55,7 +55,7 @@ export default class MaskEffect implements Effect {
       });
     }
 
-    const maskLayers = layers.filter(l => l.props.operation === OPERATION.MASK && l.props.visible);
+    const maskLayers = layers.filter(l => l.props.visible && l.props.operation === OPERATION.MASK);
     if (maskLayers.length === 0) {
       this.masks = null;
       this.channels.length = 0;

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -23,7 +23,7 @@ export type LayersPassRenderOptions = {
 
 type DrawLayerParameters = {
   shouldDrawLayer: boolean;
-  layerRenderIndex: number;
+  layerRenderIndex?: number;
   moduleParameters?: any;
   layerParameters?: any;
 };
@@ -125,17 +125,16 @@ export default class LayersPass extends Pass {
         layerFilterCache
       );
 
-      // This is the "logical" index for ordering this layer in the stack
-      // used to calculate polygon offsets
-      // It can be the same as another layer
-      const layerRenderIndex = indexResolver(layer, shouldDrawLayer);
-
       const layerParam: DrawLayerParameters = {
-        shouldDrawLayer,
-        layerRenderIndex
+        shouldDrawLayer
       };
 
       if (shouldDrawLayer) {
+        // This is the "logical" index for ordering this layer in the stack
+        // used to calculate polygon offsets
+        // It can be the same as another layer
+        layerParam.layerRenderIndex = indexResolver(layer, shouldDrawLayer);
+
         layerParam.moduleParameters = this._getModuleParameters(
           layer,
           effects,
@@ -241,7 +240,7 @@ export default class LayersPass extends Pass {
     layerFilter: ((params: FilterContext) => boolean) | undefined,
     layerFilterCache: Record<string, boolean>
   ) {
-    const shouldDrawLayer = this.shouldDrawLayer(layer) && layer.props.visible;
+    const shouldDrawLayer = layer.props.visible && this.shouldDrawLayer(layer);
 
     if (!shouldDrawLayer) {
       return false;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
I have a map with 600+ `visible: false` tile layers which resulted in almost 20k of sublayers where the visibility is `false`.

The performance is very slow due to some checks in the deck lifecycle.

These changes have shown 20-40% performance improvements for each render frame.
<!-- For all the PRs -->
#### Change List
- Prioritise checking visibility flag first
- Do not calculate render index if layer is not drawn

Edit: This is related to discussion #7021 