### PR TITLE
QuadkeyTileset2D add missing metadata

### DIFF
--- a/modules/carto/src/layers/quadkey-tileset-2d.ts
+++ b/modules/carto/src/layers/quadkey-tileset-2d.ts
@@ -13,6 +13,23 @@ function tileToQuadkey(tile): QuadkeyTileIndex {
   return {i: index};
 }
 
+function quadkeyToTile(index: QuadkeyTileIndex) {
+  const quadkey = index.i;
+  const tile = {x: 0, y: 0, z: quadkey.length};
+
+  for (let i = tile.z; i > 0; i--) {
+    const mask = 1 << (i - 1);
+    const q = +quadkey[tile.z - i];
+    if (q === 1) tile.x |= mask;
+    if (q === 2) tile.y |= mask;
+    if (q === 3) {
+      tile.x |= mask;
+      tile.y |= mask;
+    }
+  }
+  return tile;
+}
+
 export default class QuadkeyTileset2D extends Tileset2D {
   // @ts-expect-error for spatial indices, TileSet2d should be parametrized by TileIndexT
   getTileIndices(opts): QuadkeyTileIndex[] {
@@ -24,8 +41,9 @@ export default class QuadkeyTileset2D extends Tileset2D {
     return i;
   }
 
-  getTileMetadata() {
-    return {};
+  // @ts-expect-error TileIndex must be generic
+  getTileMetadata(index: QuadkeyTileIndex) {
+    return super.getTileMetadata(quadkeyToTile(index));
   }
 
   // @ts-expect-error TileIndex must be generic

--- a/modules/carto/src/layers/quadkey-tileset-2d.ts
+++ b/modules/carto/src/layers/quadkey-tileset-2d.ts
@@ -19,7 +19,7 @@ function quadkeyToTile(index: QuadkeyTileIndex) {
 
   for (let i = tile.z; i > 0; i--) {
     const mask = 1 << (i - 1);
-    const q = +quadkey[tile.z - i];
+    const q = Number(quadkey[tile.z - i]);
     if (q === 1) tile.x |= mask;
     if (q === 2) tile.y |= mask;
     if (q === 3) {

--- a/test/modules/carto/layers/quadkey-tileset-2d.spec.js
+++ b/test/modules/carto/layers/quadkey-tileset-2d.spec.js
@@ -11,6 +11,8 @@ test('QuadkeyTileset2D', async t => {
     width: 300,
     height: 200
   });
+  // Required for getTileMetadata to function
+  tileset._viewport = viewport;
 
   const indices = tileset.getTileIndices({viewport});
   t.deepEqual(
@@ -19,7 +21,13 @@ test('QuadkeyTileset2D', async t => {
     'indices in viewport'
   );
   t.equal(tileset.getTileId({i: '0132'}), '0132', 'tile id');
-  t.deepEqual(tileset.getTileMetadata({i: '0132'}), {}, 'tile metadata');
+  t.deepEqual(
+    tileset.getTileMetadata({i: '0132'}),
+    {
+      bbox: {west: -45, north: 74.01954331150226, east: -22.5, south: 66.51326044311186}
+    },
+    'tile metadata'
+  );
   t.equal(tileset.getTileZoom({i: '0132'}), 4, 'tile zoom');
   t.deepEqual(tileset.getParentIndex({i: '0132'}), {i: '013'}, 'tile parent');
   t.end();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Followup to https://github.com/visgl/deck.gl/issues/6912
<!-- For other PRs without open issue -->
#### Background
`Tileset2D` now relies on tiles providing their bbox, which was missing from the `QuadkeyTileset2D`

https://github.com/visgl/deck.gl/blob/master/modules/geo-layers/src/tile-layer/tileset-2d.ts#L244-L257


#### Change List
- Provide bbox in metadata
