### PR TITLE
Do not access viewports before viewManager initialization

### DIFF
--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -195,11 +195,18 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
     return forwardProps;
   }, [props]);
 
+  const [isWebGLInitialized, setIsWebGLInitialized] = useState(false);
+
   useEffect(() => {
     thisRef.deck = createDeckInstance(thisRef, {
       ...deckProps,
       parent: containerRef.current,
-      canvas: canvasRef.current
+      canvas: canvasRef.current,
+      onWebGLInitialized: () => {
+        setTimeout(() => {
+          setIsWebGLInitialized(true);
+        });
+      }
     });
 
     return () => thisRef.deck?.finalize();
@@ -223,7 +230,8 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
 
   useImperativeHandle(ref, () => getRefHandles(thisRef), []);
 
-  const currentViewports = thisRef.deck && thisRef.deck.getViewports();
+  const currentViewports =
+    thisRef.deck && isWebGLInitialized ? thisRef.deck.getViewports() : undefined;
 
   const {ContextProvider, width, height, id, style} = props;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fix for regression introduced in https://github.com/visgl/deck.gl/pull/7016 

<!-- For other PRs without open issue -->
#### Background

https://github.com/visgl/deck.gl/pull/7016#discussion_r897819653

<!-- For all the PRs -->
#### Change List
- Do not access `getViewports` before `viewManager` is initialized
