### PR TITLE
Fix picking in non-geospatial TileLayer

### DIFF
--- a/modules/geo-layers/src/tile-layer/tileset-2d.ts
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.ts
@@ -251,7 +251,7 @@ export default class Tileset2D {
       if ('west' in bbox) {
         return bbox.west < maxX && bbox.east > minX && bbox.south < maxY && bbox.north > minY;
       }
-      return bbox.left < maxX && bbox.right > minX && bbox.bottom < maxY && bbox.top > minY;
+      return bbox.left < maxX && bbox.right > minX && bbox.top < maxY && bbox.bottom > minY;
     }
     return true;
   }

--- a/modules/geo-layers/src/tile-layer/tileset-2d.ts
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.ts
@@ -251,7 +251,10 @@ export default class Tileset2D {
       if ('west' in bbox) {
         return bbox.west < maxX && bbox.east > minX && bbox.south < maxY && bbox.north > minY;
       }
-      return bbox.left < maxX && bbox.right > minX && bbox.top < maxY && bbox.bottom > minY;
+      // top/bottom could be swapped depending on the indexing system
+      const y0 = Math.min(bbox.top, bbox.bottom);
+      const y1 = Math.max(bbox.top, bbox.bottom);
+      return bbox.left < maxX && bbox.right > minX && y0 < maxY && y1 > minY;
     }
     return true;
   }


### PR DESCRIPTION
For #7050

#### Change List
- Fix `Tileset2D.isTileVisible` culling in non-geo case
