### PR TITLE
Avoid mutating iconMapping value in autopacking

### DIFF
--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -226,7 +226,7 @@ export default class IconLayer<DataT = any, ExtraPropsT = {}> extends Layer<
       loadOptions: props.loadOptions,
       autoPacking: !prePacked,
       iconAtlas,
-      iconMapping: iconMapping as IconMapping
+      iconMapping: prePacked ? (iconMapping as IconMapping) : null
     });
 
     // prepacked iconAtlas from user


### PR DESCRIPTION
Fix a bug where auto-packed IconLayer mutates the default `iconMapping` object.

#### Change List
- Ignore `iconMapping` value if auto packing
