### PR TITLE
GoogleMapsOverlay: Force useDevicePixels to true in interleaved mode

### DIFF
--- a/modules/google-maps/src/utils.ts
+++ b/modules/google-maps/src/utils.ts
@@ -35,6 +35,7 @@ export function createDeckInstance(
 
   const newDeck = new Deck({
     ...props,
+    useDevicePixels: props.interleaved ? true : props.useDevicePixels,
     style: props.interleaved ? null : {pointerEvents: 'none'},
     parent: getContainer(overlay, props.style),
     initialViewState: {

--- a/test/modules/google-maps/google-maps-overlay.spec.js
+++ b/test/modules/google-maps/google-maps-overlay.spec.js
@@ -51,7 +51,7 @@ test('GoogleMapsOverlay#interleaved prop', t => {
   t.end();
 });
 
-test.only('GoogleMapsOverlay#useDevicePixels prop', t => {
+test('GoogleMapsOverlay#useDevicePixels prop', t => {
   const map = new mapsApi.Map({width: 1, height: 1, longitude: 0, latitude: 0, zoom: 1});
 
   let overlay = new GoogleMapsOverlay({useDevicePixels: 3, layers: []});

--- a/test/modules/google-maps/google-maps-overlay.spec.js
+++ b/test/modules/google-maps/google-maps-overlay.spec.js
@@ -51,6 +51,29 @@ test('GoogleMapsOverlay#interleaved prop', t => {
   t.end();
 });
 
+test.only('GoogleMapsOverlay#useDevicePixels prop', t => {
+  const map = new mapsApi.Map({width: 1, height: 1, longitude: 0, latitude: 0, zoom: 1});
+
+  let overlay = new GoogleMapsOverlay({useDevicePixels: 3, layers: []});
+  overlay.setMap(map);
+  map.emit({type: 'renderingtype_changed'});
+  t.ok(
+    overlay._deck.props.useDevicePixels,
+    'useDevicePixels is forced to true in interleaved mode'
+  );
+
+  overlay = new GoogleMapsOverlay({interleaved: false, useDevicePixels: 3, layers: []});
+  overlay.setMap(map);
+  map.emit({type: 'renderingtype_changed'});
+  t.equals(
+    overlay._deck.props.useDevicePixels,
+    3,
+    'useDevicePixels is overridden when not interleaved'
+  );
+
+  t.end();
+});
+
 test('GoogleMapsOverlay#raster lifecycle', t => {
   const map = new mapsApi.Map({
     width: 1,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6993
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Override `useDevicePixels` in `GoogleMapsOverlay` (as is done in `MapboxOverlay`)
- Tests
