### PR TITLE
GoogleMapsOverlay: HeatmapLayer weightsTransform uses correct clearColor

### DIFF
--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -28,7 +28,15 @@ import {
   getTextureCoordinates,
   getTextureParams
 } from './heatmap-layer-utils';
-import {Buffer, Texture2D, Transform, getParameters, FEATURES, hasFeatures} from '@luma.gl/core';
+import {
+  Buffer,
+  Texture2D,
+  Transform,
+  getParameters,
+  withParameters,
+  FEATURES,
+  hasFeatures
+} from '@luma.gl/core';
 import {
   Accessor,
   AccessorFunction,
@@ -598,17 +606,20 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     weightsTransform.update({
       elementCount: this.getNumInstances()
     });
-    weightsTransform.run({
-      uniforms,
-      parameters: {
-        blend: true,
-        depthTest: false,
-        blendFunc: [GL.ONE, GL.ONE],
-        blendEquation: GL.FUNC_ADD
-      },
-      clearRenderTarget: true,
-      attributes: this.getAttributes(),
-      moduleSettings: this.getModuleSettings()
+    // Need to explictly specify clearColor as external context may have modified it
+    withParameters(this.context.gl, {clearColor: [0, 0, 0, 0]}, () => {
+      weightsTransform.run({
+        uniforms,
+        parameters: {
+          blend: true,
+          depthTest: false,
+          blendFunc: [GL.ONE, GL.ONE],
+          blendEquation: GL.FUNC_ADD
+        },
+        clearRenderTarget: true,
+        attributes: this.getAttributes(),
+        moduleSettings: this.getModuleSettings()
+      });
     });
     this._updateMaxWeightValue();
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6994
<!-- For other PRs without open issue -->
#### Background

The render of the weights texture in the `HeatmapLayer` was giving incorrect results as the GL state had the incorrect `clearColor` (set on the shared context by Google Maps).

<!-- For all the PRs -->
#### Change List
- When performing the `weightsTransform` explicitly set `clearColor`
