### PR TITLE
Fix arcgis integration

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -520,7 +520,9 @@ export default class Deck {
       return;
     }
     // Check if we need to redraw
-    const redrawReason = this.needsRedraw({clearRedrawFlags: true}) || reason;
+    let redrawReason = this.needsRedraw({clearRedrawFlags: true});
+    // User-supplied should take precedent, however the redraw flags get cleared regardless
+    redrawReason = reason || redrawReason;
 
     if (!redrawReason) {
       return;


### PR DESCRIPTION
For #7081

This is a regression due to a change in `redraw` from

```js
const redrawReason = reason || this.needsRedraw({clearRedrawFlags: true});
```

to 

```js
const redrawReason = this.needsRedraw({clearRedrawFlags: true}) || reason;
```

The intention is to always clear the dirty flags when redraw is forced by the user. However, this changed the `reason` received by `_customRender`, which the ArcGIS integration is relying on.

#### Change List
- `redraw` always invoke `_customRender` with user-supplied reason, if any
