### PR TITLE
Resolve async prop to null if fetch is undefined

### DIFF
--- a/modules/core/src/lifecycle/component-state.ts
+++ b/modules/core/src/lifecycle/component-state.ts
@@ -135,7 +135,7 @@ export default class ComponentState<ComponentT extends Component> {
   /* Placeholder methods for subclassing */
 
   protected _fetch(propName: string, url: string): any {
-    return url;
+    return null;
   }
 
   protected _onResolve(propName: string, value: any) {} // eslint-disable-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
See https://github.com/visgl/deck.gl/issues/6981

#### Change List
- If `props.fetch` is specified as null/undefined, async prop resolves to null
