### PR TITLE
CARTO: document use of spatial indices

### DIFF
--- a/docs/api-reference/carto/carto-layer.md
+++ b/docs/api-reference/carto/carto-layer.md
@@ -80,9 +80,7 @@ Required. Data type. Possible values are:
 
 ##### `connection` (String, optional)
 
-Required when `apiVersion` is `API_VERSIONS.V3`.
-
-Name of the connection registered in the CARTO workspace.
+Required. Name of the connection registered in the CARTO workspace.
 
 ##### `formatTiles` (String, optional)
 

--- a/docs/api-reference/carto/carto-layer.md
+++ b/docs/api-reference/carto/carto-layer.md
@@ -154,6 +154,14 @@ Optional. A string pointing to a unique attribute at the result of the query. A 
 
 Optional. Overrides the configuration to connect with CARTO. Check the parameters [here](overview#carto-credentials).
 
+##### `aggregationExp` (String, optional)
+
+Optional. Aggregration SQL expression. Only used for spatial index datasets.
+
+##### `aggregationResLevel` (Number, optional)
+
+Optional. Aggregration resolution level. Only used for spatial index datasets, defaults to 6 for quadbins, 4 for h3.
+
 ### Callbacks
 
 #### `onDataLoad` (Function, optional)

--- a/docs/api-reference/carto/carto-layer.md
+++ b/docs/api-reference/carto/carto-layer.md
@@ -43,7 +43,7 @@ The CARTO platform supports storing data using a spatial index. The `geoColumn` 
 Tiled data will be used, with the layer created depending on the spatial index used:
 
 - `h3` [`H3HexagonLayer`](/docs/api-reference/geo-layers/h3-hexagon-layer.md) will be created and all properties will be inherited.
-- `quadbin` [`QuadkeyLayer`](/docs/api-reference/geo-layers/quadkey-layer.md) will be created and all properties will be inherited. Note the `getQuadkey` accessor is replaced with `getQuadbin`.
+- `quadbin` [`QuadkeyLayer`](/docs/api-reference/geo-layers/quadkey-layer.md) will be created and all properties will be inherited. _Note the `getQuadkey` accessor is replaced with `getQuadbin`_.
 
 ```js
 import DeckGL from '@deck.gl/react';
@@ -103,9 +103,12 @@ new deck.carto.CartoLayer({});
 
 ## Properties
 
-Inherits the properties of the [`GeoJsonLayer`](/docs/api-reference/layers/geojson-layer.md).
+Depending on the datasource, different properties will be inherited from the created sublayer:
 
-Additional properties may be available depending on the configuration. For details see: [Sublayer details](/docs/api-reference/carto/carto-layer#sublayer-details).
+- For the `h3` spatial index: [`H3HexagonLayer`](/docs/api-reference/geo-layers/h3-hexagon-layer.md).
+- For the `quadbin` spatial index: [`QuadkeyLayer`](/docs/api-reference/geo-layers/quadkey-layer.md). _Note the `getQuadkey` accessor is replaced with `getQuadbin`_.
+- Otherwise (longitude/latitude): [`MVTLayer`](/docs/api-reference/geo-layers/mvt-layer.md).
+
 
 ##### `data` (String)
 
@@ -172,12 +175,6 @@ Receives arguments:
 Receives arguments:
 
 - `error` (`Error`)
-
-### SubLayers
-
-The `CartoLayer` is a [`CompositeLayer`](/docs/api-reference/core/composite-layer.md), and will generate different sublayers depending on the configuration. In all cases, properties of the [`GeoJsonLayer`](/docs/api-reference/layers/geojson-layer.md) will be inherited.
-
-Tiled data will be used, depending on `formatTiles`. A [`MVTLayer`](/docs/api-reference/geo-layers/mvt-layer.md) will be created and all properties will be inherited.
 
 ## Source
 

--- a/docs/api-reference/carto/carto-layer.md
+++ b/docs/api-reference/carto/carto-layer.md
@@ -2,7 +2,12 @@
 
 `CartoLayer` is the layer to visualize data using the CARTO Maps API.
 
-## Usage
+## Usage 
+
+### Geometry data
+
+By default the `CartoLayer` expects the data to be described using longitude & latitude. Tiled data will be used, with the format depending on `formatTiles`.
+A [`MVTLayer`](/docs/api-reference/geo-layers/mvt-layer.md) will be created and all properties will be inherited.
 
 ```js
 import DeckGL from '@deck.gl/react';
@@ -22,6 +27,42 @@ function App({viewState}) {
     getLineColor: [0, 0, 0, 200],
     getFillColor: [238, 77, 90],
     lineWidthMinPixels: 1
+  })
+
+  return <DeckGL viewState={viewState} layers={[layer]} />;
+}
+```
+
+### Spatial index data
+
+The CARTO platform supports storing data using a spatial index. The `geoColumn` prop is used to specify a database column that contains geographic data. When `geoColumn` has one of the following values, the data will be interpreted as a spatial index:
+
+- `h3` [H3](https://h3geo.org/) indexing system will be used
+- `quadbin` Quadbin indexing system will be used
+
+Tiled data will be used, with the layer created depending on the spatial index used:
+
+- `h3` [`H3HexagonLayer`](/docs/api-reference/geo-layers/h3-hexagon-layer.md) will be created and all properties will be inherited.
+- `quadbin` [`QuadkeyLayer`](/docs/api-reference/geo-layers/quadkey-layer.md) will be created and all properties will be inherited. Note the `getQuadkey` accessor is replaced with `getQuadbin`.
+
+```js
+import DeckGL from '@deck.gl/react';
+import {CartoLayer, setDefaultCredentials, MAP_TYPES, API_VERSIONS} from '@deck.gl/carto';
+
+setDefaultCredentials({
+  accessToken: 'XXX'
+  apiBaseUrl: 'https://gcp-us-east1.api.carto.com' // Default value (optional)
+});
+
+function App({viewState}) {
+  const layer = new CartoLayer({
+    type: MAP_TYPES.TABLE,
+    connection: 'bigquery',
+    data: 'cartobq.testtables.h3',
+    geoColumn: 'h3',
+    aggregationExp: 'AVG(population) as population',
+    getFillColor: [238, 77, 90],
+    getElevation: d => d.properties.population
   })
 
   return <DeckGL viewState={viewState} layers={[layer]} />;

--- a/docs/api-reference/carto/carto-layer.md
+++ b/docs/api-reference/carto/carto-layer.md
@@ -80,7 +80,9 @@ Required. Data type. Possible values are:
 
 ##### `connection` (String, optional)
 
-Required. Name of the connection registered in the CARTO workspace.
+Required when `apiVersion` is `API_VERSIONS.V3`.
+
+Name of the connection registered in the CARTO workspace.
 
 ##### `formatTiles` (String, optional)
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6912
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Example in `CartoLayer` docs on displaying a spatial index dataset
- Document `aggregationExp` & `aggregationResLevel` props
