### PR TITLE
CARTO: Handle minZoom&maxZoom in H3TileLayer

### DIFF
--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -67,7 +67,6 @@ export default class H3TileLayer<DataT = any, ExtraPropsT = {}> extends Composit
     const {data, tileJSON} = this.state;
     let minresolution = parseInt(tileJSON.minresolution);
     let maxresolution = parseInt(tileJSON.maxresolution);
-    console.log(minresolution, maxresolution);
 
     // Convert Mercator zooms provided in props into H3 res levels
     // and clip into valid range provided from the tilejson
@@ -83,7 +82,6 @@ export default class H3TileLayer<DataT = any, ExtraPropsT = {}> extends Composit
         getHexagonResolution({zoom: this.props.maxZoom, latitude: 0})
       );
     }
-    console.log(minresolution, maxresolution);
 
     // The naming is unfortunate, but minZoom & maxZoom in the context
     // of a Tileset2D refer to the resolution levels, not the Mercator zooms

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -92,6 +92,7 @@ export default class H3TileLayer<DataT = any, ExtraPropsT = {}> extends Composit
         // @ts-expect-error Tileset2D should be generic over TileIndex
         TilesetClass: H3Tileset2D,
         renderSubLayers,
+        // minZoom and maxZoom are H3 resolutions, however we must use this naming as that is what the Tileset2D class expects
         minZoom: minresolution,
         maxZoom: maxresolution
       })

--- a/modules/carto/src/layers/h3-tileset-2d.ts
+++ b/modules/carto/src/layers/h3-tileset-2d.ts
@@ -59,7 +59,7 @@ function tileToBoundingBox(index: string): GeoBoundingBox {
 // similar
 // Relative scale factor (0 = no biasing, 2 = a few hexagons cover view)
 const BIAS = 2;
-function getHexagonResolution(viewport): number {
+export function getHexagonResolution(viewport): number {
   const hexagonScaleFactor = (2 / 3) * viewport.zoom;
   const latitudeScaleFactor = Math.log(1 / Math.cos((Math.PI * viewport.latitude) / 180));
 

--- a/modules/carto/src/layers/h3-tileset-2d.ts
+++ b/modules/carto/src/layers/h3-tileset-2d.ts
@@ -68,6 +68,11 @@ export function getHexagonResolution(viewport): number {
 }
 
 export default class H3Tileset2D extends Tileset2D {
+  /**
+   * Returns all tile indices in the current viewport. If the current zoom level is smaller
+   * than minZoom, return an empty array. If the current zoom level is greater than maxZoom,
+   * return tiles that are on maxZoom.
+   */
   // @ts-expect-error Tileset2D should be generic over TileIndex
   getTileIndices({viewport, minZoom, maxZoom}): H3TileIndex[] {
     const [east, south, west, north] = viewport.getBounds();
@@ -75,7 +80,7 @@ export default class H3Tileset2D extends Tileset2D {
     let z = getHexagonResolution(viewport);
     let indices: string[];
     if (typeof minZoom === 'number' && Number.isFinite(minZoom) && z < minZoom) {
-      z = minZoom;
+      return [];
     }
     if (typeof maxZoom === 'number' && Number.isFinite(maxZoom) && z > maxZoom) {
       z = maxZoom;

--- a/modules/carto/src/layers/h3-tileset-2d.ts
+++ b/modules/carto/src/layers/h3-tileset-2d.ts
@@ -80,6 +80,7 @@ export default class H3Tileset2D extends Tileset2D {
     let z = getHexagonResolution(viewport);
     let indices: string[];
     if (typeof minZoom === 'number' && Number.isFinite(minZoom) && z < minZoom) {
+      // TODO support `extent` prop
       return [];
     }
     if (typeof maxZoom === 'number' && Number.isFinite(maxZoom) && z > maxZoom) {

--- a/test/apps/carto-dynamic-tile/app.js
+++ b/test/apps/carto-dynamic-tile/app.js
@@ -7,22 +7,18 @@ import {CartoLayer, FORMATS, MAP_TYPES} from '@deck.gl/carto';
 import {GeoJsonLayer} from '@deck.gl/layers';
 
 const ZOOMS = {3: 3, 4: 4, 5: 5, 6: 6};
-const INITIAL_VIEW_STATE = {longitude: -108, latitude: 47, zoom: 2};
+const INITIAL_VIEW_STATE = {longitude: 18, latitude: 47, zoom: 2};
 const COUNTRIES =
   'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson';
 
 // Skip CDN
 // const apiBaseUrl = 'https://direct-gcp-us-east1.api.carto.com';
 // PROD US GCP
-const apiBaseUrl = 'https://gcp-us-east1-20.dev.api.carto.com';
+const apiBaseUrl = 'https://gcp-us-east1.api.carto.com';
 // Localhost
 // const apiBaseUrl = 'http://localhost:8002'
 
 const config = {
-  'dev-bigquery': {
-    quadbin:
-      'carto-dev-data.public.derived_spatialfeatures_usa_quadgrid15_v1_yearly_v2_quadbin_final'
-  },
   bigquery: {
     che15: 'carto-dev-data.public.derived_spatialfeatures_che_quadgrid15_v1_yearly_v2',
     che18: 'carto-dev-data.public.derived_spatialfeatures_che_quadgrid18_v1_yearly_v2',
@@ -58,8 +54,8 @@ const showBasemap = true;
 const showCarto = true;
 
 function Root() {
-  const [connection, setConnection] = useState('dev-bigquery');
-  const [dataset, setDataset] = useState('quadbin');
+  const [connection, setConnection] = useState('redshift');
+  const [dataset, setDataset] = useState('che15_h3');
   const [zoom, setZoom] = useState(5);
   const table = config[connection][dataset];
   return (
@@ -132,6 +128,10 @@ function createCarto(connection, zoom, table) {
     aggregationResLevel: zoom,
     geoColumn,
     getQuadkey: d => d.id,
+
+    // Visibilty (will be converted to H3 levels in the case of H3 tiles)
+    minZoom: 5,
+    maxZoom: 9,
 
     // autohighlight
     pickable: true,

--- a/test/modules/carto/layers/h3-tileset-2d.spec.js
+++ b/test/modules/carto/layers/h3-tileset-2d.spec.js
@@ -92,7 +92,7 @@ test('H3Tileset2D min zoom', async t => {
   let indices = tileset.getTileIndices({viewport});
   t.equal(indices.length, 28, 'without min zoom');
   indices = tileset.getTileIndices({viewport, minZoom: 1});
-  t.equal(indices.length, 157, 'min zoom added');
+  t.equal(indices.length, 0, 'min zoom added');
   t.end();
 });
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/6912
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Use `minZoom`&`maxZoom` props in addition to `min/maxresolution` when limiting H3 tile requests
