### PR TITLE
[mapbox] Match base map camera when terrain is used

### DIFF
--- a/docs/api-reference/mapbox/overview.md
+++ b/docs/api-reference/mapbox/overview.md
@@ -62,5 +62,5 @@ The Mapbox ecosystem offers many well-designed controls, from the basic function
 * When using deck.gl's multi-view system, only one of the views can match the base map and receive interaction. See [using MapboxOverlay with multi-views](/docs/api-reference/mapbox/mapbox-overlay.md#multi-view-usage) for details.
 * When using deck.gl as Mapbox layers or controls, `Deck` only receives a subset of user inputs delegated by `Map`. Therefore, certain interactive callbacks like `onDrag`, `onInteractionStateChange` are not available.
 * WebGL2 based deck.gl features, such as attribute transitions and GPU accelerated aggregation layers cannot be used.
-* Mapbox 2.0's terrain feature is currently not supported.
+* Mapbox/Maplibre's terrain features are partially supported. When a terrain is used, the camera of deck.gl and the base map should synchronize, however the deck.gl data with z=0 are rendered at the sea level and not aligned with the terrain surface.
 

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -20,7 +20,7 @@
 
 // View and Projection Matrix calculations for mapbox-js style
 // map view properties
-import Viewport, {Padding} from './viewport';
+import Viewport from './viewport';
 
 import {
   pixelsToWorld,

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -20,12 +20,13 @@
 
 // View and Projection Matrix calculations for mapbox-js style
 // map view properties
-import Viewport from './viewport';
+import Viewport, {Padding} from './viewport';
 
 import {
   pixelsToWorld,
   getViewMatrix,
   addMetersToLngLat,
+  unitsPerMeter,
   getProjectionParameters,
   altitudeToFovy,
   fovyToAltitude,
@@ -36,11 +37,7 @@ import {Padding} from './viewport';
 
 // TODO - import from math.gl
 import * as vec2 from 'gl-matrix/vec2';
-import {Matrix4} from '@math.gl/core';
-
-const TILE_SIZE = 512;
-const EARTH_CIRCUMFERENCE = 40.03e6;
-const DEGREES_TO_RADIANS = Math.PI / 180;
+import {Matrix4, clamp} from '@math.gl/core';
 
 export type WebMercatorViewportOptions = {
   /** Name of the viewport */
@@ -69,6 +66,8 @@ export type WebMercatorViewportOptions = {
   position?: number[];
   /** Zoom level */
   zoom?: number;
+  /** Padding around the viewport, in pixels. */
+  padding?: Padding | null;
   /** Model matrix of viewport center */
   modelMatrix?: number[] | null;
   /** Custom projection matrix */
@@ -86,11 +85,6 @@ export type WebMercatorViewportOptions = {
   /** @deprecated Revert to approximated meter size calculation prior to v8.5 */
   legacyMeterSizes?: boolean;
 };
-
-function unitsPerMeter(latitude: number): number {
-  const latCosine = Math.cos(latitude * DEGREES_TO_RADIANS);
-  return TILE_SIZE / EARTH_CIRCUMFERENCE / latCosine;
-}
 
 /**
  * Manages transformations to/from WGS84 coordinates using the Web Mercator Projection.
@@ -126,6 +120,8 @@ export default class WebMercatorViewport extends Viewport {
 
       repeat = false,
       worldOffset = 0,
+      position,
+      padding,
 
       // backward compatibility
       // TODO: remove in v9
@@ -151,9 +147,19 @@ export default class WebMercatorViewport extends Viewport {
       } else {
         fovy = altitudeToFovy(altitude);
       }
+
+      let offset: [number, number] | undefined;
+      if (padding) {
+        const {top = 0, bottom = 0} = padding;
+        offset = [0, clamp((top + height - bottom) / 2, 0, height) - height / 2];
+      }
+
       projectionParameters = getProjectionParameters({
         width,
         height,
+        scale,
+        center: position && [0, 0, position[2] * unitsPerMeter(latitude)],
+        offset,
         pitch,
         fovy,
         nearZMultiplier,

--- a/modules/core/src/views/map-view.ts
+++ b/modules/core/src/views/map-view.ts
@@ -23,6 +23,8 @@ export type MapViewState = {
   minPitch?: number;
   /** Max pitch, default `60` */
   maxPitch?: number;
+  /** Viewport center offsets from lng, lat in meters */
+  position?: number[];
 } & CommonViewState;
 
 type MapViewProps = {

--- a/test/apps/multi-viewport/package.json
+++ b/test/apps/multi-viewport/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "@math.gl/core": "3.6.0-alpha.1",
+    "@math.gl/core": "3.6.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^4.1.2"


### PR DESCRIPTION
For #7064 

Note that this only matches the camera matrices between deck and the base map, so that positions are projected correctly. Any data with z=0 in deck layers will still be rendered at sea level and not align with the terrain surface.

#### Change List
- Upgrade math.gl dependency to include https://github.com/uber-web/math.gl/pull/295
- Calculate `viewState.position` if terrain is used
