### PR TITLE
Fix z fighting in ColumnLayer when using 2d stroke

### DIFF
--- a/modules/layers/src/column-layer/column-layer-vertex.glsl.ts
+++ b/modules/layers/src/column-layer/column-layer-vertex.glsl.ts
@@ -40,6 +40,7 @@ uniform float radius;
 uniform float angle;
 uniform vec2 offset;
 uniform bool extruded;
+uniform bool stroked;
 uniform bool isStroke;
 uniform float coverage;
 uniform float elevationScale;
@@ -71,11 +72,16 @@ void main(void) {
 
   if (extruded) {
     elevation = instanceElevations * (positions.z + 1.0) / 2.0 * elevationScale;
-  } else if (isStroke) {
+  } else if (stroked) {
     float widthPixels = clamp(
       project_size_to_pixel(instanceStrokeWidths * widthScale, widthUnits),
       widthMinPixels, widthMaxPixels) / 2.0;
-    strokeOffsetRatio -= sign(positions.z) * project_pixel_size(widthPixels) / project_size(edgeDistance * coverage * radius);
+    float halfOffset = project_pixel_size(widthPixels) / project_size(edgeDistance * coverage * radius);
+    if (isStroke) {
+      strokeOffsetRatio -= sign(positions.z) * halfOffset;
+    } else {
+      strokeOffsetRatio -= halfOffset;
+    }
   }
 
   // if alpha == 0.0 or z < 0.0, do not render element

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -387,6 +387,7 @@ export default class ColumnLayer<DataT = any, ExtraPropsT = {}> extends Layer<
       angle: (angle / 180) * Math.PI,
       offset,
       extruded,
+      stroked,
       coverage,
       elevationScale,
       edgeDistance,


### PR DESCRIPTION
For #6966

Before:
![Screen Shot 2022-07-01 at 10 20 49 AM](https://user-images.githubusercontent.com/2059298/176941629-bbc63fc5-bfdc-411e-bcc6-9cc58e515ee1.png)

After:
![Screen Shot 2022-07-01 at 10 20 37 AM](https://user-images.githubusercontent.com/2059298/176941622-a7b85a1e-99c1-4819-aa6d-8a1a91a80ddd.png)


#### Change List
- Shrink the fill area of `stroked: true`
