### PR TITLE
[ts] Improve carto/style typings.

### DIFF
--- a/modules/carto/src/style/color-bins-style.ts
+++ b/modules/carto/src/style/color-bins-style.ts
@@ -1,18 +1,40 @@
 import {scaleThreshold} from 'd3-scale';
+import {AccessorFunction} from '@deck.gl/core';
+import {Feature} from 'geojson';
 import getPalette, {Color, DEFAULT_PALETTE, NULL_COLOR} from './palette';
 import {assert, AttributeSelector, getAttrValue} from './utils';
 
-export default function colorBins({
+/**
+ * Helper function for quickly creating a color bins style based on `d3` `scaleThreshold`.
+ *
+ * Data values of each attribute are rounded down to the nearest value in the domain and are then
+ * styled with the corresponding color.
+ *
+ * @return accessor that maps objects to `Color` values
+ */
+export default function colorBins<DataT = Feature>({
   attr,
   domain,
   colors = DEFAULT_PALETTE,
   nullColor = NULL_COLOR
 }: {
-  attr: AttributeSelector;
+  /** Attribute or column to symbolize by. */
+  attr: AttributeSelector<DataT, number>;
+
+  /** Category list. Must be a valid list of categories. */
   domain: number[];
+
+  /**
+   * Color assigned to each domain value.
+   *
+   * Either Array of colors in RGBA or valid named CARTOColors palette.
+   * @default `PurpOr`
+   */
   colors?: string | Color[];
+
+  /** Color for null values. @default: [204, 204, 204] */
   nullColor?: Color;
-}): AttributeSelector {
+}): AccessorFunction<DataT, Color> {
   assert(Array.isArray(domain), 'Expected "domain" to be an array of numbers');
 
   const palette = typeof colors === 'string' ? getPalette(colors, domain.length + 1) : colors;

--- a/modules/carto/src/style/color-categories-style.ts
+++ b/modules/carto/src/style/color-categories-style.ts
@@ -1,19 +1,43 @@
+import {AccessorFunction} from '@deck.gl/core';
+import {Feature} from 'geojson';
 import getPalette, {Color, DEFAULT_PALETTE, NULL_COLOR, OTHERS_COLOR} from './palette';
 import {assert, AttributeSelector, getAttrValue} from './utils';
 
-export default function colorCategories({
+/**
+ * Helper function for quickly creating a color category style.
+ *
+ * Data values of each attribute listed in the domain are mapped one to one
+ * with corresponding colors in the range.
+ *
+ * @return accessor that maps objects to `Color` values
+ */
+export default function colorCategories<DataT = Feature>({
   attr,
   domain,
   colors = DEFAULT_PALETTE,
   nullColor = NULL_COLOR,
   othersColor = OTHERS_COLOR
 }: {
-  attr: AttributeSelector;
-  domain: number[];
+  /** Attribute or column to symbolize by */
+  attr: string | AttributeSelector<DataT, number | string>;
+
+  /** Category list. Must be a valid list of categories. */
+  domain: number[] | string[];
+
+  /**
+   * Color assigned to each domain value.
+   *
+   * Either Array of colors in RGBA or valid named CARTOColors palette.
+   * @default `PurpOr`
+   */
   colors: string | Color[];
+
+  /** Color for null values. @default: [204, 204, 204] */
   nullColor?: Color;
+
+  /** Fallback color for a category not correctly assigned. @default: [119, 119, 119] */
   othersColor?: Color;
-}): AttributeSelector {
+}): AccessorFunction<DataT, Color> {
   assert(Array.isArray(domain), 'Expected "domain" to be an array of numbers or strings');
 
   const colorsByCategory = {};

--- a/modules/carto/src/style/color-continuous-style.ts
+++ b/modules/carto/src/style/color-continuous-style.ts
@@ -1,18 +1,40 @@
+import {AccessorFunction} from '@deck.gl/core';
 import {scaleLinear} from 'd3-scale';
+import {Feature} from 'geojson';
 import getPalette, {Color, DEFAULT_PALETTE, NULL_COLOR} from './palette';
 import {assert, AttributeSelector, getAttrValue} from './utils';
 
-export default function colorContinuous({
+/**
+ * Helper function for quickly creating a color continuous style.
+ *
+ * Data values of each field are interpolated linearly across values in the domain and
+ * are then styled with a blend of the corresponding color in the range.
+ *
+ * @return accessor that maps objects to `Color` values
+ */
+export default function colorContinuous<DataT = Feature>({
   attr,
   domain,
   colors = DEFAULT_PALETTE,
   nullColor = NULL_COLOR
 }: {
-  attr: AttributeSelector;
+  /** Attribute or column to symbolize by. */
+  attr: AttributeSelector<DataT, number>;
+
+  /** Attribute domain to define the data range. */
   domain: number[];
+
+  /**
+   * Color assigned to each domain value.
+   *
+   * Either Array of colors in RGBA or valid named CARTOColors palette.
+   * @default `PurpOr`
+   */
   colors?: string | Color[];
+
+  /** Color for null values. @default: [204, 204, 204]*/
   nullColor?: Color;
-}): AttributeSelector {
+}): AccessorFunction<DataT, Color> {
   assert(Array.isArray(domain), 'Expected "domain" to be an array of numbers');
 
   const palette = typeof colors === 'string' ? getPalette(colors, domain.length) : colors;

--- a/modules/carto/src/style/utils.ts
+++ b/modules/carto/src/style/utils.ts
@@ -1,9 +1,13 @@
+import {Feature} from 'geojson';
+
 const ALLOWED_ATTR_TYPES = Object.freeze(['function', 'string']);
 
-type Row = {properties: Record<string, unknown>};
-export type AttributeSelector = string | ((d: Row) => unknown);
+export type AttributeSelector<DataT = Feature, OutT = any> = string | ((d: DataT) => OutT);
 
-export function getAttrValue(attr: AttributeSelector, d: Row): unknown {
+export function getAttrValue<DataT = Feature, OutT = any>(
+  attr: string | AttributeSelector<DataT, OutT>,
+  d: DataT
+): OutT {
   assert(typeof d === 'object', 'Expected "data" to be an object');
   assert(ALLOWED_ATTR_TYPES.includes(typeof attr), 'Expected "attr" to be a function or string');
 
@@ -11,7 +15,7 @@ export function getAttrValue(attr: AttributeSelector, d: Row): unknown {
   if (typeof attr === 'function') {
     return attr(d);
   }
-  return d.properties[attr];
+  return (d as unknown as Feature)?.properties?.[attr] as OutT;
 }
 
 export function assert(condition, message = ''): asserts condition {


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/5589

#### Change List
- Improve `carto/style` typings for `color*` functions - improve typings and and use types from `@deck.gl/core`