### PR TITLE
[mapbox] docs use getFillColor instead of getColor

### DIFF
--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -26,7 +26,7 @@ const overlay = new MapboxOverlay({
       ],
       getPosition: d => d.position,
       getRadius: d => d.size,
-      getColor: [255, 0, 0]
+      getFillColor: [255, 0, 0]
     })
   ]
 });
@@ -56,7 +56,7 @@ const overlay = new MapboxOverlay({
       ],
       getPosition: d => d.position,
       getRadius: d => d.size,
-      getColor: [255, 0, 0],
+      getFillColor: [255, 0, 0],
 
       beforeId: 'admin_labels' // Insert before this Mapbox layer
     })
@@ -91,7 +91,7 @@ export default function App() {
     ],
     getPosition: d => d.position,
     getRadius: d => d.size,
-    getColor: [255, 0, 0]
+    getFillColor: [255, 0, 0]
   });
 
   return (

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -77,7 +77,9 @@ import {useControl} from 'react-map-gl';
 
 import Map, {NavigationControl} from 'react-map-gl';
 
-function DeckGLOverlay(props: MapboxOverlayProps) {
+function DeckGLOverlay(props: MapboxOverlayProps & {
+  interleaved?: boolean;
+}) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
   overlay.setProps(props);
   return null;

--- a/docs/get-started/using-with-react.md
+++ b/docs/get-started/using-with-react.md
@@ -87,6 +87,8 @@ function App({data}) {
 
 ```
 
+For more detailed examples and options, see [using with Mapbox](/docs/developer-guide/base-maps/using-with-mapbox.md).
+
 ## Using JSX with deck.gl Layers
 
 It is possible to use JSX syntax to create deck.gl layers as React children of the `DeckGL` React components, instead of providing them as ES6 class instances to the `layers` prop. There are no performance advantages to this syntax but it can allow for a more consistent, React-like coding style.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -6,7 +6,6 @@
       "entries": [
         {"entry": "docs"},
         {"entry": "docs/whats-new"},
-        {"entry": "docs/get-started/using-with-map"},
         {"entry": "docs/upgrade-guide"},
         {"entry": "docs/contributing"},
         {"entry": "docs/faq"}
@@ -17,6 +16,7 @@
       "entries": [
         {"entry": "docs/get-started/getting-started"},
         {"entry": "docs/get-started/using-standalone"},
+        {"entry": "docs/get-started/using-with-map"},
         {"entry": "docs/get-started/using-with-react"},
         {"entry": "docs/get-started/using-with-typescript"},
         {"entry": "docs/get-started/learning-resources"}


### PR DESCRIPTION
Deprecation warning when following docs: 
```
getColor` is deprecated and will be removed in a later version. Use `getFillColor/getLineColor` instead
```

