### PR TITLE
[docs] `fitBounds` requires width and height

### DIFF
--- a/docs/api-reference/core/web-mercator-viewport.md
+++ b/docs/api-reference/core/web-mercator-viewport.md
@@ -134,7 +134,9 @@ Parameters:
 * `bounds` (Array) - Bounding box in `[[longitude, latitude], [longitude, latitude]]`.
 * `opts` (Object) - See additional options in [@math.gl/web-mercator](https://math.gl/modules/web-mercator/docs/api-reference/web-mercator-utils#fitboundsopts)
   + `width` (Number) - If not supplied, will use the current width of the viewport (default `1`)
-  + `height` (Number) - Required unless set on viewport.
+  + `height` (Number) - If not supplied, will use the current height of the viewport (default `1`)
+  + `minExtent` (Number) - In degrees, 0.01 would be about 1000 meters
+  + `maxZoom` (Number) - Max zoom level
   + `padding` (Number) - The amount of padding in pixels to add to the given bounds.
   + `offset` (Array) - The center in `[x, y]` of the given bounds relative to the map's center measured in pixels.
   

--- a/docs/api-reference/core/web-mercator-viewport.md
+++ b/docs/api-reference/core/web-mercator-viewport.md
@@ -133,7 +133,7 @@ Parameters:
 
 * `bounds` (Array) - Bounding box in `[[longitude, latitude], [longitude, latitude]]`.
 * `opts` (Object) - See additional options in [@math.gl/web-mercator](https://math.gl/modules/web-mercator/docs/api-reference/web-mercator-utils#fitboundsopts)
-  + `width` (Number) - Required unless set on viewport.
+  + `width` (Number) - If not supplied, will use the current width of the viewport (default `1`)
   + `height` (Number) - Required unless set on viewport.
   + `padding` (Number) - The amount of padding in pixels to add to the given bounds.
   + `offset` (Array) - The center in `[x, y]` of the given bounds relative to the map's center measured in pixels.

--- a/docs/api-reference/core/web-mercator-viewport.md
+++ b/docs/api-reference/core/web-mercator-viewport.md
@@ -127,12 +127,14 @@ Returns:
 
 ##### `fitBounds`
 
-Returns a new viewport that fit around the given bounding box. Only supports non-perspective mode.
+Returns a new viewport that fit around the given bounding box. Viewport `width` and `height` must be either set or provided as options. Only supports non-perspective mode.
 
 Parameters:
 
 * `bounds` (Array) - Bounding box in `[[longitude, latitude], [longitude, latitude]]`.
-* `opts` (Object)
+* `opts` (Object) - See additional options in [@math.gl/web-mercator](https://math.gl/modules/web-mercator/docs/api-reference/web-mercator-utils#fitboundsopts)
+  + `width` (Number) - Required unless set on viewport.
+  + `height` (Number) - Required unless set on viewport.
   + `padding` (Number) - The amount of padding in pixels to add to the given bounds.
   + `offset` (Array) - The center in `[x, y]` of the given bounds relative to the map's center measured in pixels.
   

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -32,6 +32,7 @@ import {
   fitBounds,
   getBounds
 } from '@math.gl/web-mercator';
+import {Padding} from './viewport';
 
 // TODO - import from math.gl
 import * as vec2 from 'gl-matrix/vec2';
@@ -294,13 +295,25 @@ export default class WebMercatorViewport extends Viewport {
   /**
    * Returns a new viewport that fit around the given rectangle.
    * Only supports non-perspective mode.
-   * @param {Array} bounds - [[lon, lat], [lon, lat]]
-   * @param {Number} [options.padding] - The amount of padding in pixels to add to the given bounds.
-   * @param {Array} [options.offset] - The center of the given bounds relative to the map's center,
-   *    [x, y] measured in pixels.
-   * @returns {WebMercatorViewport}
    */
-  fitBounds(bounds: [[number, number], [number, number]], options = {}) {
+  fitBounds(
+    /** [[lon, lat], [lon, lat]] */
+    bounds: [[number, number], [number, number]],
+    options: {
+      /** If not supplied, will use the current width of the viewport (default `1`) */
+      width?: number;
+      /** If not supplied, will use the current height of the viewport (default `1`) */
+      height?: number;
+      /** In degrees, 0.01 would be about 1000 meters */
+      minExtent?: number;
+      /** Max zoom level */
+      maxZoom?: number;
+      /** Extra padding in pixels */
+      padding?: number | Required<Padding>;
+      /** Center shift in pixels */
+      offset?: number[];
+    } = {}
+  ) {
     const {width, height} = this;
     const {longitude, latitude, zoom} = fitBounds({width, height, bounds, ...options});
     return new WebMercatorViewport({width, height, longitude, latitude, zoom});


### PR DESCRIPTION
Without this clarification `fitBounds` doesn't behave correctly because the default value for `width` and `height` is `1`.