### PR TITLE
Fix MapboxLayer index resolution

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -963,6 +963,7 @@ export default class Deck {
       views?: {[viewId: string]: View};
       pass?: string;
       effects?: Effect[];
+      clearStack?: boolean;
       clearCanvas?: boolean;
     }
   ) {

--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -102,11 +102,13 @@ export function updateLayer(deck: Deck, layer: MapboxLayer<any>): void {
 
 export function drawLayer(deck: Deck, map: Map, layer: MapboxLayer<any>): void {
   let {currentViewport} = deck.userData as UserData;
+  let clearStack: boolean = false;
   if (!currentViewport) {
     // This is the first layer drawn in this render cycle.
     // Generate viewport from the current map state.
     currentViewport = getViewport(deck, map, true);
     (deck.userData as UserData).currentViewport = currentViewport;
+    clearStack = true;
   }
 
   if (!deck.isInitialized) {
@@ -116,6 +118,7 @@ export function drawLayer(deck: Deck, map: Map, layer: MapboxLayer<any>): void {
   deck._drawLayers('mapbox-repaint', {
     viewports: [currentViewport],
     layerFilter: ({layer: deckLayer}) => layer.id === deckLayer.id,
+    clearStack,
     clearCanvas: false
   });
 }
@@ -236,10 +239,9 @@ function updateLayers(deck: Deck): void {
   }
 
   const layers: Layer[] = [];
-  let layerIndex = 0;
   (deck.userData as UserData).mapboxLayers.forEach(deckLayer => {
     const LayerType = deckLayer.props.type;
-    const layer = new LayerType(deckLayer.props, {_offset: layerIndex++});
+    const layer = new LayerType(deckLayer.props);
     layers.push(layer);
   });
   deck.setProps({layers});

--- a/modules/mapbox/src/resolve-layers.ts
+++ b/modules/mapbox/src/resolve-layers.ts
@@ -39,7 +39,11 @@ export function resolveLayers(
 
   // Step 2: add missing layers
   for (const layer of layers) {
-    if (!map.getLayer(layer.id)) {
+    const mapboxLayer = map.getLayer(layer.id) as MapboxLayer<Layer>;
+    if (mapboxLayer) {
+      // @ts-expect-error not typed
+      mapboxLayer.implementation.setProps(layer.props);
+    } else {
       map.addLayer(
         new MapboxLayer({id: layer.id, deck}),
         // @ts-expect-error beforeId is not defined in LayerProps

--- a/test/modules/mapbox/mapbox-gl-mock/map.js
+++ b/test/modules/mapbox/mapbox-gl-mock/map.js
@@ -109,7 +109,7 @@ export default class Map extends Evented {
   removeLayer(layerId) {
     const layer = this.getLayer(layerId);
     if (layer.type === 'custom') {
-      layer.onRemove(this);
+      layer.implementation.onRemove(this);
     }
     this.style.removeLayer(layerId);
   }

--- a/test/modules/mapbox/mapbox-gl-mock/style.js
+++ b/test/modules/mapbox/mapbox-gl-mock/style.js
@@ -23,7 +23,9 @@ export default class Style {
   render() {
     for (const layerId of this._order) {
       const layer = this._layers[layerId];
-      if (layer.render) {
+      if (layer.implementation) {
+        layer.implementation.render();
+      } else if (layer.render) {
         layer.render();
       }
     }
@@ -50,6 +52,13 @@ export default class Style {
     const layerId = layer.id;
     if (layerId in this._layers) {
       throw new Error(`Layer with the id ${layerId} already exists`);
+    }
+    if (layer.type === 'custom') {
+      layer = {
+        id: layer.id,
+        type: 'custom',
+        implementation: layer
+      };
     }
     this._layers[layerId] = layer;
     if (beforeId) {


### PR DESCRIPTION
For #7139

A hack was put in https://github.com/visgl/deck.gl/pull/6565 to manually override the starting index of layers. This number is incorrect when composite layers are stacked.

This PR properly resolves layer z when multiple draw passes are used in the same render cycle.

#### Change List
- Add `clearStack` option to `LayersPass.render`
- Remove `_offset` hack from `MapboxLayer`
