### PR TITLE
Restrict h3-js version in scripting examples

### DIFF
--- a/docs/api-reference/geo-layers/h3-cluster-layer.md
+++ b/docs/api-reference/geo-layers/h3-cluster-layer.md
@@ -73,7 +73,7 @@ new H3ClusterLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/h3-js"></script>
+<script src="https://unpkg.com/h3-js@^3.0.0"></script>
 <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
 <script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>

--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -65,7 +65,7 @@ new H3HexagonLayer({});
 To use pre-bundled scripts:
 
 ```html
-<script src="https://unpkg.com/h3-js"></script>
+<script src="https://unpkg.com/h3-js@^3.0.0"></script>
 <script src="https://unpkg.com/deck.gl@^8.0.0/dist.min.js"></script>
 <!-- or -->
 <script src="https://unpkg.com/@deck.gl/core@^8.0.0/dist.min.js"></script>

--- a/website/src/doc-demos/geo-layers.js
+++ b/website/src/doc-demos/geo-layers.js
@@ -81,7 +81,7 @@ export const S2LayerDemo = makeLayerDemo({
 
 export const H3HexagonLayerDemo = makeLayerDemo({
   Layer: H3HexagonLayer,
-  dependencies: ['https://unpkg.com/h3-js'],
+  dependencies: ['https://unpkg.com/h3-js@3.7.2'],
   getTooltip: '({object}) => object && `${object.hex} count: ${object.count}`',
   props: `{
     data: '${DATA_URI}/sf.h3cells.json',
@@ -98,7 +98,7 @@ export const H3HexagonLayerDemo = makeLayerDemo({
 
 export const H3ClusterLayerDemo = makeLayerDemo({
   Layer: H3ClusterLayer,
-  dependencies: ['https://unpkg.com/h3-js'],
+  dependencies: ['https://unpkg.com/h3-js@3.7.2'],
   getTooltip: '({object}) => object && `density: ${object.mean}`',
   props: `{
     data: '${DATA_URI}/sf.h3clusters.json',


### PR DESCRIPTION
h3-js has published a new major version which contains breaking changes.

@nrabinowitz Unrelated but `4.0.0-rc1` should not be tagged `latest`?

#### Change List
- Documentations of H3 layers
- In-doc examples of H3 layers
