### PR TITLE
[mapbox] Fix legacy React usage pattern

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -34,11 +34,13 @@ export function getDeckInstance({
 
   const deckProps: DeckProps = {
     useDevicePixels: true,
-    _customRender: (reason: string) => {
+    _customRender: () => {
       map.triggerRepaint();
       // customRender may be subscribed by DeckGL React component to update child props
       // make sure it is still called
-      customRender?.(reason);
+      // Hack - do not pass a redraw reason here to prevent the React component from clearing the context
+      // Rerender will be triggered by MapboxLayer's render()
+      customRender?.('');
     },
     // TODO: import these defaults from a single source of truth
     parameters: {


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/discussions/7170

Not super happy about the behaviors relying on `redrawReason` (a similar bug here https://github.com/visgl/deck.gl/pull/7092) but this will revert the breaking change for now.

#### Change List
- Avoid passing redraw reason to the React component
