### PR TITLE
Fix maplibre-gl interleaving

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -9,7 +9,7 @@ type UserData = {
   isExternal: boolean;
   currentViewport?: WebMercatorViewport | null;
   mapboxLayers: Set<MapboxLayer<any>>;
-  mapboxVersion: {minor: number; major: number};
+  // mapboxVersion: {minor: number; major: number};
 };
 
 // Mercator constants
@@ -85,7 +85,7 @@ export function getDeckInstance({
   }
 
   (deckInstance.userData as UserData).mapboxLayers = new Set();
-  (deckInstance.userData as UserData).mapboxVersion = getMapboxVersion(map);
+  // (deckInstance.userData as UserData).mapboxVersion = getMapboxVersion(map);
   map.__deck = deckInstance;
   map.on('render', () => {
     if (deckInstance.isInitialized) afterRender(deckInstance, map);
@@ -210,47 +210,32 @@ function centerCameraOnTerrain(map: Map, viewState: MapViewState) {
   }
 }
 
-function getMapboxVersion(map: Map): {minor: number; major: number} {
-  // parse mapbox version string
-  let major = 0;
-  let minor = 0;
-  // @ts-ignore (2339) undefined property
-  const version: string = map.version;
-  if (version) {
-    [major, minor] = version.split('.').slice(0, 2).map(Number);
-  }
-  return {major, minor};
-}
+// function getMapboxVersion(map: Map): {minor: number; major: number} {
+//   // parse mapbox version string
+//   let major = 0;
+//   let minor = 0;
+//   // @ts-ignore (2339) undefined property
+//   const version: string = map.version;
+//   if (version) {
+//     [major, minor] = version.split('.').slice(0, 2).map(Number);
+//   }
+//   return {major, minor};
+// }
 
 function getViewport(deck: Deck, map: Map, useMapboxProjection = true): WebMercatorViewport {
-  const {mapboxVersion} = deck.userData as UserData;
-
-  return new WebMercatorViewport(
-    Object.assign(
-      {
-        id: 'mapbox',
-        x: 0,
-        y: 0,
-        width: deck.width,
-        height: deck.height
-      },
-      getViewState(map),
-      useMapboxProjection
-        ? {
-            // match mapbox's projection matrix
-            // A change of near plane was made in 1.3.0
-            // https://github.com/mapbox/mapbox-gl-js/pull/8502
-            nearZMultiplier:
-              (mapboxVersion.major === 1 && mapboxVersion.minor >= 3) || mapboxVersion.major >= 2
-                ? 0.02
-                : 1 / (deck.height || 1)
-          }
-        : {
-            // use deck.gl's own default
-            nearZMultiplier: 0.1
-          }
-    )
-  );
+  return new WebMercatorViewport({
+    id: 'mapbox',
+    x: 0,
+    y: 0,
+    width: deck.width,
+    height: deck.height,
+    ...getViewState(map),
+    nearZMultiplier: useMapboxProjection
+      ? // match mapbox's projection matrix
+        0.02
+      : // use deck.gl's own default
+        0.1
+  });
 }
 
 function afterRender(deck: Deck, map: Map): void {

--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -231,7 +231,7 @@ function getViewport(deck: Deck, map: Map, useMapboxProjection = true): WebMerca
     height: deck.height,
     ...getViewState(map),
     nearZMultiplier: useMapboxProjection
-      ? // match mapbox's projection matrix
+      ? // match mapbox-gl@>=1.3.0's projection matrix
         0.02
       : // use deck.gl's own default
         0.1

--- a/test/modules/mapbox/mapbox-layer.spec.js
+++ b/test/modules/mapbox/mapbox-layer.spec.js
@@ -51,7 +51,7 @@ test('MapboxLayer#onAdd, onRemove, setProps', t => {
       ),
       'Layer is added to deck'
     );
-    t.deepEqual(deck.userData.mapboxVersion, {major: 1, minor: 10}, 'Mapbox version is parsed');
+    // t.deepEqual(deck.userData.mapboxVersion, {major: 1, minor: 10}, 'Mapbox version is parsed');
     t.ok(deck.props.views[0].id === 'mapbox', 'mapbox view exists');
 
     t.ok(
@@ -125,7 +125,7 @@ test('MapboxLayer#external Deck', t => {
   map.on('load', () => {
     map.addLayer(layer);
     t.is(layer.deck, deck, 'Used external Deck instance');
-    t.ok(deck.userData.mapboxVersion, 'Mapbox version is parsed');
+    // t.ok(deck.userData.mapboxVersion, 'Mapbox version is parsed');
     t.ok(deck.props.views[0].id === 'mapbox', 'mapbox view exists');
 
     map.fire('render');


### PR DESCRIPTION
For #7128

maplibre 2.0 does not expose `map.version`, see issue at https://github.com/maplibre/maplibre-gl-js/issues/1426

I'm proposing to drop compatibility with mapbox-gl v0.50-1.2, which are more than 3 years old (mapbox v1's latest is 1.13 and maplibre v1's latest is 1.15). These versions are currently identified by the absence of `map.version`.

#### Change List
- Always use the most recent near plane value (technically a breaking change, for mapbox-gl <=1.2)
