### PR TITLE
[feat] Add a _full3d prop that uses the plane with the maximum area to tesselate

### DIFF
--- a/docs/api-reference/layers/geojson-layer.md
+++ b/docs/api-reference/layers/geojson-layer.md
@@ -266,6 +266,20 @@ This is an object that contains material props for [lighting effect](/docs/api-r
 Check [the lighting guide](/docs/developer-guide/using-lighting.md#constructing-a-material-instance) for configurable settings.
 
 
+##### `_full3d` (Boolean, optional)
+
+* Default: `false`
+
+> Note: This prop is experimental
+
+When true, polygon tesselation will be performed on the plane with the largest area, instead of the xy plane.
+
+Remarks:
+
+* Only use this if you experience issues rendering features that only change on the z axis.
+* This prop is only effective with `XYZ` data.
+
+
 ### pointType:circle Options
 
 The following props are forwarded to a `ScatterplotLayer` if `pointType` is `'circle'`.

--- a/docs/api-reference/layers/solid-polygon-layer.md
+++ b/docs/api-reference/layers/solid-polygon-layer.md
@@ -134,6 +134,18 @@ This prop is only effective with `_normalize: false`. It specifies the winding o
 
 The proper value depends on the source of your data. Most geometry formats [enforce a specific winding order](https://gis.stackexchange.com/a/147971). Incorrectly set winding order will cause an extruded polygon's surfaces to be flipped, affecting culling and the lighting effect.
 
+##### `_full3d` (Boolean, optional)
+
+* Default: `false`
+
+> Note: This prop is experimental
+
+When true, polygon tesselation will be performed on the plane with the largest area, instead of the xy plane.
+
+Remarks:
+
+* Only use this if you experience issues rendering features that only change on the z axis.
+* This prop is only effective with `XYZ` data.
 
 ### Data Accessors
 

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -36,7 +36,7 @@
     "@math.gl/core": "^3.6.2",
     "@math.gl/polygon": "^3.6.2",
     "@math.gl/web-mercator": "^3.6.2",
-    "earcut": "^2.0.6"
+    "earcut": "^2.2.4"
   },
   "peerDependencies": {
     "@deck.gl/core": "^8.0.0",

--- a/modules/layers/src/geojson-layer/geojson-layer.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer.ts
@@ -198,6 +198,13 @@ type _GeoJsonLayer3DProps<DataT> = {
   wireframe?: boolean;
 
   /**
+   * (Experimental) This prop is only effective with `XYZ` data.
+   * When true, polygon tesselation will be performed on the plane with the largest area, instead of the xy plane.
+   * @default false
+   */
+  _full3d?: boolean;
+
+  /**
    * Elevation valur or accessor.
    *
    * Only used if `extruded: true`.
@@ -300,6 +307,7 @@ const defaultProps: DefaultProps<GeoJsonLayerProps> = {
   filled: true,
   extruded: false,
   wireframe: false,
+  _full3d: false,
   iconAtlas: {type: 'object', value: null},
   iconMapping: {type: 'object', value: {}},
   getIcon: {type: 'accessor', value: f => f.properties.icon},

--- a/modules/layers/src/geojson-layer/sub-layer-map.ts
+++ b/modules/layers/src/geojson-layer/sub-layer-map.ts
@@ -110,6 +110,7 @@ export const POLYGON_LAYER = {
     wireframe: 'wireframe',
     elevationScale: 'elevationScale',
     material: 'material',
+    _full3d: '_full3d',
 
     getElevation: 'getElevation',
     getFillColor: 'getFillColor',

--- a/modules/layers/src/solid-polygon-layer/polygon-tesselator.ts
+++ b/modules/layers/src/solid-polygon-layer/polygon-tesselator.ts
@@ -56,6 +56,7 @@ export default class PolygonTesselator extends Tesselator<
     resolution?: number;
     wrapLongitude?: boolean;
     preproject?: (xy: number[]) => number[];
+    full3d?: boolean;
   }
 > {
   constructor(opts) {
@@ -180,7 +181,12 @@ export default class PolygonTesselator extends Tesselator<
     let i = indexStart;
 
     // 1. get triangulated indices for the internal areas
-    const indices = Polygon.getSurfaceIndices(polygon, this.positionSize, this.opts.preproject);
+    const indices = Polygon.getSurfaceIndices(
+      polygon,
+      this.positionSize,
+      this.opts.preproject,
+      this.opts.full3d
+    );
 
     // make sure the buffer is large enough
     target = typedArrayManager.allocate(target, indexStart + indices.length, {

--- a/modules/layers/src/solid-polygon-layer/polygon.ts
+++ b/modules/layers/src/solid-polygon-layer/polygon.ts
@@ -332,6 +332,8 @@ export function getSurfaceIndices(
 
   let positions = getPositions(polygon);
 
+  const is3d = full3d && positionSize === 3;
+
   if (preproject) {
     // When tesselating lnglat coordinates, project them to the common space for accuracy
     const n = positions.length;
@@ -344,7 +346,7 @@ export function getSurfaceIndices(
       p[0] = positions[i];
       p[1] = positions[i + 1];
 
-      if (full3d && positionSize === 3) {
+      if (is3d) {
         p[2] = positions[i + 2];
       }
 
@@ -353,13 +355,13 @@ export function getSurfaceIndices(
       positions[i] = xy[0];
       positions[i + 1] = xy[1];
 
-      if (full3d && positionSize === 3) {
+      if (is3d) {
         positions[i + 2] = xy[2];
       }
     }
   }
 
-  if (full3d && positionSize === 3) {
+  if (is3d) {
     // calculate plane with largest area
     const xyArea = getPlaneArea(positions, 0, 1);
     const xzArea = getPlaneArea(positions, 0, 2);

--- a/modules/layers/src/solid-polygon-layer/polygon.ts
+++ b/modules/layers/src/solid-polygon-layer/polygon.ts
@@ -331,22 +331,8 @@ export function getSurfaceIndices(
   }
 
   let positions = getPositions(polygon);
+  let positionsCloned = false;
 
-  if (preproject) {
-    // When tesselating lnglat coordinates, project them to the common space for accuracy
-    const n = positions.length;
-    // Clone the array
-    positions = positions.slice();
-    const p: number[] = [];
-    for (let i = 0; i < n; i += positionSize) {
-      p[0] = positions[i];
-      p[1] = positions[i + 1];
-      const xy = preproject(p);
-      positions[i] = xy[0];
-      positions[i + 1] = xy[1];
-    }
-  }
-  
   if (full3d && positionSize === 3) {
     // calculate plane with largest area
     const xyArea = getPlaneArea(positions, 0, 1);
@@ -362,16 +348,33 @@ export function getSurfaceIndices(
       // xy plane largest, nothing to do
     } else if (xzArea > yzArea) {
       // xz plane largest, permute to make xyz -> xzy
-      if (!preproject) {
-        positions = positions.slice();
-      }
+      positions = positions.slice();
+      positionsCloned = true;
       permutePositions(positions, 0, 2, 1);
     } else {
       // yz plane largest, permute to make xyz -> yzx
-      if (!preproject) {
-        positions = positions.slice();
-      }
+      positions = positions.slice();
+      positionsCloned = true;
       permutePositions(positions, 1, 2, 0);
+    }
+  }
+
+  if (preproject) {
+    // When tesselating lnglat coordinates, project them to the common space for accuracy
+    const n = positions.length;
+
+    if (positionsCloned) {
+      // Clone the array
+      positions = positions.slice();
+    }
+
+    const p: number[] = [];
+    for (let i = 0; i < n; i += positionSize) {
+      p[0] = positions[i];
+      p[1] = positions[i + 1];
+      const xy = preproject(p);
+      positions[i] = xy[0];
+      positions[i + 1] = xy[1];
     }
   }
 

--- a/modules/layers/src/solid-polygon-layer/polygon.ts
+++ b/modules/layers/src/solid-polygon-layer/polygon.ts
@@ -344,7 +344,7 @@ export function getSurfaceIndices(
       p[0] = positions[i];
       p[1] = positions[i + 1];
 
-      if (full3d) {
+      if (full3d && positionSize === 3) {
         p[2] = positions[i + 2];
       }
 
@@ -353,7 +353,7 @@ export function getSurfaceIndices(
       positions[i] = xy[0];
       positions[i + 1] = xy[1];
 
-      if (full3d) {
+      if (full3d && positionSize === 3) {
         positions[i + 2] = xy[2];
       }
     }

--- a/modules/layers/src/solid-polygon-layer/polygon.ts
+++ b/modules/layers/src/solid-polygon-layer/polygon.ts
@@ -331,7 +331,33 @@ export function getSurfaceIndices(
   }
 
   let positions = getPositions(polygon);
-  let positionsCloned = false;
+
+  if (preproject) {
+    // When tesselating lnglat coordinates, project them to the common space for accuracy
+    const n = positions.length;
+
+    // Clone the array
+    positions = positions.slice();
+
+    const p: number[] = [];
+    for (let i = 0; i < n; i += positionSize) {
+      p[0] = positions[i];
+      p[1] = positions[i + 1];
+
+      if (full3d) {
+        p[2] = positions[i + 2];
+      }
+
+      const xy = preproject(p);
+
+      positions[i] = xy[0];
+      positions[i + 1] = xy[1];
+
+      if (full3d) {
+        positions[i + 2] = xy[2];
+      }
+    }
+  }
 
   if (full3d && positionSize === 3) {
     // calculate plane with largest area
@@ -348,33 +374,16 @@ export function getSurfaceIndices(
       // xy plane largest, nothing to do
     } else if (xzArea > yzArea) {
       // xz plane largest, permute to make xyz -> xzy
-      positions = positions.slice();
-      positionsCloned = true;
+      if (!preproject) {
+        positions = positions.slice();
+      }
       permutePositions(positions, 0, 2, 1);
     } else {
       // yz plane largest, permute to make xyz -> yzx
-      positions = positions.slice();
-      positionsCloned = true;
+      if (!preproject) {
+        positions = positions.slice();
+      }
       permutePositions(positions, 1, 2, 0);
-    }
-  }
-
-  if (preproject) {
-    // When tesselating lnglat coordinates, project them to the common space for accuracy
-    const n = positions.length;
-
-    if (positionsCloned) {
-      // Clone the array
-      positions = positions.slice();
-    }
-
-    const p: number[] = [];
-    for (let i = 0; i < n; i += positionSize) {
-      p[0] = positions[i];
-      p[1] = positions[i + 1];
-      const xy = preproject(p);
-      positions[i] = xy[0];
-      positions[i + 1] = xy[1];
     }
   }
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -186,9 +186,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT = {}> extends La
         // Provide a preproject function if the coordinates are in lnglat
         preproject,
         fp64: this.use64bitPositions(),
-        IndexType:
-          !gl || hasFeatures(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array,
-        full3d: _full3d
+        IndexType: !gl || hasFeatures(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
       })
     });
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -66,6 +66,13 @@ type _SolidPolygonLayerProps<DataT> = {
    */
   _windingOrder?: 'CW' | 'CCW';
 
+  /**
+   * (Experimental) This prop is only effective with `XYZ` data.
+   * When true, polygon tesselation will be performed on the plane with the largest area, instead of the xy plane.
+   * @default false
+   */
+  _full3d?: boolean;
+
   /** Elevation multiplier.
    * @default 1
    */
@@ -107,6 +114,7 @@ const defaultProps: DefaultProps<SolidPolygonLayerProps> = {
   wireframe: false,
   _normalize: true,
   _windingOrder: 'CW',
+  _full3d: false,
 
   elevationScale: {type: 'number', min: 0, value: 1},
 
@@ -155,7 +163,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT = {}> extends La
 
   initializeState() {
     const {gl, viewport} = this.context;
-    let {coordinateSystem} = this.props;
+    let {coordinateSystem, _full3d} = this.props;
     if (viewport.isGeospatial && coordinateSystem === COORDINATE_SYSTEM.DEFAULT) {
       coordinateSystem = COORDINATE_SYSTEM.LNGLAT;
     }
@@ -168,7 +176,8 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT = {}> extends La
         preproject:
           coordinateSystem === COORDINATE_SYSTEM.LNGLAT && viewport.projectFlat.bind(viewport),
         fp64: this.use64bitPositions(),
-        IndexType: !gl || hasFeatures(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array
+        IndexType: !gl || hasFeatures(gl, FEATURES.ELEMENT_INDEX_UINT32) ? Uint32Array : Uint16Array,
+        full3d: _full3d
       })
     });
 
@@ -383,7 +392,8 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT = {}> extends La
         // TODO - move the flag out of the viewport
         resolution: this.context.viewport.resolution,
         fp64: this.use64bitPositions(),
-        dataChanged: changeFlags.dataChanged
+        dataChanged: changeFlags.dataChanged,
+        full3d: props._full3d
       });
 
       this.setState({

--- a/test/modules/layers/polygon-tesselation.spec.js
+++ b/test/modules/layers/polygon-tesselation.spec.js
@@ -274,6 +274,54 @@ test('PolygonTesselator#tesselation', t => {
   t.end();
 });
 
+test('PolygonTesselator#3dtesselation', t => {
+  const tesselator = new PolygonTesselator({
+    data: [
+      {
+        polygon: [
+          [1, 0, 1],
+          [2, 0, 2],
+          [3, 0, 0],
+          [1, 0, 1]
+        ],
+        name: 'simple loop'
+      },
+      {
+        polygon: [
+          [
+            [0, 0, 0],
+            [2, 0, 0],
+            [2, 0, 2],
+            [0, 0, 2]
+          ],
+          [
+            [0.5, 0, 0.5],
+            [1, 0, 0.5],
+            [0.5, 0, 1]
+          ]
+        ],
+        name: 'with 1 hole'
+      }
+    ],
+    getGeometry: d => d.polygon,
+    positionFormat: 'XYZ',
+    full3d: true
+  });
+
+  t.deepEquals(
+    tesselator.get('indices').slice(0, 24),
+    [2, 0, 1, 8, 9, 10, 11, 9, 8, 7, 6, 5, 5, 8, 10, 11, 8, 7, 7, 5, 10, 10, 11, 7],
+    'returned correct indices'
+  );
+  t.deepEquals(
+    tesselator.get('vertexValid').slice(0, 13),
+    [1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0],
+    'returned correct vertexValid'
+  );
+
+  t.end();
+});
+
 /* eslint-disable max-statements */
 test('PolygonTesselator#partial update', t => {
   const accessorCalled = new Set();


### PR DESCRIPTION
This should fix rendering of full 3d data (data that changes only on the z plane). See https://github.com/visgl/deck.gl/issues/7203

As per the suggested solution to the issue https://github.com/mapbox/earcut/issues/21#issuecomment-98119437 this should calculate the plane with the maximum area, then use that plane to tesselate on.

I've also bumped the earcut version to the latest as it was a few behind, and according to the patch notes there have been a lot of performance improvements made.