### PR TITLE
Fix controller bug when view props change

### DIFF
--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -297,7 +297,7 @@ export default class ViewManager {
       onViewStateChange: this._onViewStateChange.bind(this, props.id),
       onStateChange: this._eventCallbacks.onInteractionStateChange,
       makeViewport: viewState =>
-        view.makeViewport({
+        this.getView(view.id)?.makeViewport({
           viewState,
           width: this.width,
           height: this.height

--- a/test/modules/core/lib/view-manager.spec.js
+++ b/test/modules/core/lib/view-manager.spec.js
@@ -183,3 +183,62 @@ test('ViewManager#controllers', t => {
 
   t.end();
 });
+
+test('ViewManager#update view props', t => {
+  let viewStateChangedEvent;
+
+  const viewManager = new ViewManager({
+    views: [new MapView({id: 'main', controller: true, width: '50%'})],
+    onViewStateChange: evt => (viewStateChangedEvent = evt),
+    viewState: {
+      longitude: -122,
+      latitude: 38,
+      zoom: 1
+    },
+    width: 100,
+    height: 100
+  });
+
+  // Scroll at the viewport center
+  viewManager.controllers.main.handleEvent(
+    mockControllerEvent('wheel', 25, 50, {
+      delta: 10
+    })
+  );
+
+  t.ok(
+    equals(viewStateChangedEvent.viewState.longitude, -122),
+    'Map center is calculated correctly'
+  );
+
+  viewManager.setProps({
+    views: [new MapView({id: 'main', controller: true, width: '100%'})]
+  });
+
+  // Scroll at the viewport center
+  viewManager.controllers.main.handleEvent(
+    mockControllerEvent('wheel', 50, 50, {
+      delta: 10
+    })
+  );
+
+  t.ok(
+    equals(viewStateChangedEvent.viewState.longitude, -122),
+    'Map center is calculated correctly'
+  );
+
+  viewManager.finalize();
+  t.end();
+});
+
+function mockControllerEvent(type, x, y, details) {
+  return {
+    type,
+    offsetCenter: {x, y},
+    ...details,
+    stopPropagation: () => {},
+    srcEvent: {
+      preventDefault: () => {}
+    }
+  };
+}


### PR DESCRIPTION
For #7156

`Controller.makeViewport` currently assumes that the associated `view` never changes.

#### Change List
- Always use the latest view to calculate view states
