### PR TITLE
CARTO fetchMap fix: parametrized queries are not working

### DIFF
--- a/modules/carto/src/api/maps-v3-client.ts
+++ b/modules/carto/src/api/maps-v3-client.ts
@@ -405,8 +405,7 @@ async function _fetchMapDataset(
   accessToken: string,
   credentials: CloudNativeCredentials,
   clientId?: string,
-  headers?: Headers,
-  queryParameters?: QueryParameters
+  headers?: Headers
 ) {
   const {
     aggregationExp,
@@ -416,7 +415,8 @@ async function _fetchMapDataset(
     format,
     geoColumn,
     source,
-    type
+    type,
+    queryParameters
   } = dataset;
   // First fetch metadata
   const {url, mapFormat} = await _fetchDataUrl({

--- a/test/modules/carto/api/maps-api-client.spec.js
+++ b/test/modules/carto/api/maps-api-client.spec.js
@@ -435,9 +435,7 @@ test(`getDataV2#versionError`, async t => {
   }
 ].forEach(({props, mapInstantiationUrl}) => {
   for (const useSetDefaultCredentials of [true, false]) {
-    test(`fetchLayerData#setDefaultCredentials(${String(
-      useSetDefaultCredentials
-    )})`, async t => {
+    test(`fetchLayerData#setDefaultCredentials(${String(useSetDefaultCredentials)})`, async t => {
       const geojsonURL = 'http://geojson';
       const ndjsonURL = 'http://ndjson';
       const accessToken = 'XXX';

--- a/test/modules/carto/api/maps-api-client.spec.js
+++ b/test/modules/carto/api/maps-api-client.spec.js
@@ -423,10 +423,21 @@ test(`getDataV2#versionError`, async t => {
     props: {geoColumn: 'geog', aggregationExp: 'sum(col) as v', aggregationResLevel: 7},
     mapInstantiationUrl:
       'http://carto-api/v3/maps/connection_name/table?client=deck-gl-carto&name=table&geo_column=geog&aggregationExp=sum(col)%20as%20v&aggregationResLevel=7'
+  },
+  {
+    props: {
+      type: MAP_TYPES.QUERY,
+      source: 'select * from table',
+      queryParameters: {end: '2021-09-17', start: '2021-09-15'}
+    },
+    mapInstantiationUrl:
+      'http://carto-api/v3/maps/connection_name/query?client=deck-gl-carto&q=select%20*%20from%20table&queryParameters=%7B%22end%22%3A%222021-09-17%22%2C%22start%22%3A%222021-09-15%22%7D'
   }
 ].forEach(({props, mapInstantiationUrl}) => {
   for (const useSetDefaultCredentials of [true, false]) {
-    test(`fetchLayerData#setDefaultCredentials(${String(useSetDefaultCredentials)})`, async t => {
+    test(`fetchLayerData#setDefaultCredentials(${String(
+      useSetDefaultCredentials
+    )})`, async t => {
       const geojsonURL = 'http://geojson';
       const ndjsonURL = 'http://ndjson';
       const accessToken = 'XXX';


### PR DESCRIPTION
#### Background
QueryParameters are not reading well in the fetchMap method
#### Change List
Read QueryParameters from the dataset object
