### PR TITLE
carto/fetchMap: support custom markers with original colors

### DIFF
--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -369,9 +369,8 @@ const FALLBACK_ICON =
 
 export function getIconUrlAccessor(
   field: VisualChannelField | null | undefined,
-  fallbackUrl: string | null | undefined,
   range: CustomMarkersRange | null | undefined,
-  maxIconSize: number,
+  {fallbackUrl, maxIconSize, useMaskedIcons},
   data: any
 ) {
   const urlToUnpackedIcon = (url: string) => ({
@@ -379,7 +378,7 @@ export function getIconUrlAccessor(
     url,
     width: maxIconSize,
     height: maxIconSize,
-    mask: true
+    mask: useMaskedIcons
   });
   let unknownValue = fallbackUrl || FALLBACK_ICON;
 

--- a/modules/carto/src/api/parseMap.ts
+++ b/modules/carto/src/api/parseMap.ts
@@ -254,11 +254,12 @@ function createChannelProps(
     const maxIconSize = getMaxMarkerSize(visConfig, visualChannels);
     const {getPointRadius, getFillColor} = result;
     result.pointType = 'icon';
+    const useMaskedIcons = visConfig.filled;
     result.getIcon = getIconUrlAccessor(
       visualChannels.customMarkersField,
-      visConfig.customMarkersUrl,
+
       visConfig.customMarkersRange,
-      maxIconSize,
+      {fallbackUrl: visConfig.customMarkersUrl, maxIconSize, useMaskedIcons},
       data
     );
     result._subLayerProps = {
@@ -276,7 +277,7 @@ function createChannelProps(
       }
     };
 
-    if (getFillColor) {
+    if (getFillColor && useMaskedIcons) {
       result.getIconColor = getFillColor;
     }
 

--- a/modules/carto/src/api/parseMap.ts
+++ b/modules/carto/src/api/parseMap.ts
@@ -253,13 +253,13 @@ function createChannelProps(
   } else if (visConfig.customMarkers) {
     const maxIconSize = getMaxMarkerSize(visConfig, visualChannels);
     const {getPointRadius, getFillColor} = result;
+    const {customMarkersUrl, customMarkersRange, filled: useMaskedIcons} = visConfig;
+
     result.pointType = 'icon';
-    const useMaskedIcons = visConfig.filled;
     result.getIcon = getIconUrlAccessor(
       visualChannels.customMarkersField,
-
-      visConfig.customMarkersRange,
-      {fallbackUrl: visConfig.customMarkersUrl, maxIconSize, useMaskedIcons},
+      customMarkersRange,
+      {fallbackUrl: customMarkersUrl, maxIconSize, useMaskedIcons},
       data
     );
     result._subLayerProps = {


### PR DESCRIPTION

#### Change List
- carto: fetchMap supports markers with original, not-masked colors
