### PR TITLE
Minor fix in widget-tooltip: reset value on every iteration

### DIFF
--- a/modules/jupyter-widget/src/playground/widget-tooltip.js
+++ b/modules/jupyter-widget/src/playground/widget-tooltip.js
@@ -138,6 +138,8 @@ export function substituteIn(template, json) {
       value = json[key];
     } else if (json[propsKey] && json[propsKey].hasOwnProperty(key)) {
       value = json[propsKey][key];
+    } else {
+      value = undefined;
     }
     if (value) {
       output = output.replaceAll(`{${key}}`, value);

--- a/modules/jupyter-widget/src/playground/widget-tooltip.js
+++ b/modules/jupyter-widget/src/playground/widget-tooltip.js
@@ -132,6 +132,9 @@ export function substituteIn(template, json) {
       for (const subkey of subkeys) {
         if (value.hasOwnProperty(subkey)) {
           value = value[subkey];
+        } else {
+          value = undefined;
+          break;
         }
       }
     } else if (json.hasOwnProperty(key)) {
@@ -141,9 +144,7 @@ export function substituteIn(template, json) {
     } else {
       value = undefined;
     }
-    if (value) {
-      output = output.replaceAll(`{${key}}`, value);
-    }
+    output = output.replaceAll(`{${key}}`, value);
   }
 
   return output;

--- a/test/modules/jupyter-widget/widget-tooltip.spec.js
+++ b/test/modules/jupyter-widget/widget-tooltip.spec.js
@@ -111,6 +111,15 @@ test('jupyter-widget: tooltip', t0 => {
         expected: 'Total population (Madrid): 3305408'
       },
       {
+        template: 'Total population ({city}): {pop}',
+        json: {
+          properties: {
+            city: 'Madrid'
+          }
+        },
+        expected: 'Total population (Madrid): {pop}'
+      },
+      {
         template:
           'The Answer to the Ultimate Question of Life, The Universe, and Everything: {a.b.c}',
         json: {

--- a/test/modules/jupyter-widget/widget-tooltip.spec.js
+++ b/test/modules/jupyter-widget/widget-tooltip.spec.js
@@ -111,13 +111,13 @@ test('jupyter-widget: tooltip', t0 => {
         expected: 'Total population (Madrid): 3305408'
       },
       {
-        template: 'Total population ({city}): {pop}',
+        template: '{true} {false} {null} {undefined}',
         json: {
-          properties: {
-            city: 'Madrid'
-          }
+          true: true,
+          false: false,
+          null: null
         },
-        expected: 'Total population (Madrid): {pop}'
+        expected: 'true false null undefined'
       },
       {
         template:
@@ -130,6 +130,15 @@ test('jupyter-widget: tooltip', t0 => {
           }
         },
         expected: 'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42'
+      },
+      {
+        template:
+          'The Answer to the Ultimate Question of Life, The Universe, and Everything: {a.b.c}',
+        json: {
+          a: {}
+        },
+        expected:
+          'The Answer to the Ultimate Question of Life, The Universe, and Everything: undefined'
       }
     ];
     for (const kv of TESTING_TABLE) {


### PR DESCRIPTION
Minor fix in widget-tooltip variables replacement: reset the value to avoid replacing non-existing variables in the template.
