### PR TITLE
CARTO: fetchMap disable depthTest for point layers

### DIFF
--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -160,7 +160,7 @@ export function getLayer(
       Layer: GeoJsonLayer,
       propMap: {
         columns: {
-          altitude: x => ({parameters: {depthTest: x?.fieldIdx > -1}})
+          altitude: x => ({parameters: {depthTest: x !== null}})
         },
         visConfig: {outline: 'stroked'}
       }

--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -160,7 +160,7 @@ export function getLayer(
       Layer: GeoJsonLayer,
       propMap: {
         columns: {
-          altitude: x => ({parameters: {depthTest: x !== null}})
+          altitude: x => ({parameters: {depthTest: Boolean(x)}})
         },
         visConfig: {outline: 'stroked'}
       }

--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -78,14 +78,19 @@ const hexToRGBA = c => {
   return [r, g, b, 255 * opacity];
 };
 
-// Kepler -> Deck.gl
+// Kepler prop value -> Deck.gl prop value
+// Supports nested definitions, and function transforms:
+//   {keplerProp: 'deckProp'} is equivalent to:
+//   {keplerProp: x => ({deckProp: x})}
 const sharedPropMap = {
+  // Apply the value of Kepler `color` prop to the deck `getFillColor` prop
   color: 'getFillColor',
   isVisible: 'visible',
   label: 'cartoLabel',
   textLabel: {
     alignment: 'getTextAlignmentBaseline',
     anchor: 'getTextAnchor',
+    // Apply the value of Kepler `textLabel.color` prop to the deck `getTextColor` prop
     color: 'getTextColor',
     size: 'getTextSize'
   },
@@ -153,7 +158,12 @@ export function getLayer(
   > = {
     point: {
       Layer: GeoJsonLayer,
-      propMap: {visConfig: {outline: 'stroked'}}
+      propMap: {
+        columns: {
+          altitude: x => ({parameters: {depthTest: x?.fieldIdx > -1}})
+        },
+        visConfig: {outline: 'stroked'}
+      }
     },
     geojson: {
       Layer: GeoJsonLayer

--- a/modules/carto/src/api/parseMap.ts
+++ b/modules/carto/src/api/parseMap.ts
@@ -199,6 +199,21 @@ function createChannelProps(
     );
   }
 
+  if (type === 'point') {
+    const altitude = config.columns?.altitude;
+    if (altitude) {
+      result.dataTransform = data => {
+        data.features.forEach(({geometry, properties}) => {
+          const {type, coordinates} = geometry;
+          if (type === 'Point') {
+            coordinates[2] = properties[altitude];
+          }
+        });
+        return data;
+      };
+    }
+  }
+
   if (radiusField || sizeField) {
     result.getPointRadius = getSizeAccessor(
       // @ts-ignore

--- a/modules/carto/src/api/parseMap.ts
+++ b/modules/carto/src/api/parseMap.ts
@@ -40,14 +40,15 @@ export function parseMap(json) {
         const {data} = dataset;
         assert(data, `No data loaded for dataId: ${dataId}`);
         const {Layer, propMap, defaultProps} = getLayer(type, config, dataset);
+        const styleProps = createStyleProps(config, propMap);
         return new Layer({
           id,
           data,
           ...defaultProps,
-          ...createParametersProp(layerBlending),
           ...(!config.textLabel && createInteractionProps(interactionConfig)),
-          ...createStyleProps(config, propMap),
+          ...styleProps,
           ...createChannelProps(visualChannels, type, config, data), // Must come after style
+          ...createParametersProp(layerBlending, styleProps.parameters || {}), // Must come after style
           ...createLoadOptions(token)
         });
       } catch (e: any) {
@@ -86,8 +87,7 @@ function extractTextLayers(layers) {
   );
 }
 
-function createParametersProp(layerBlending) {
-  const parameters: Record<string, any> = {};
+function createParametersProp(layerBlending, parameters: Record<string, any>) {
   if (layerBlending === 'additive') {
     parameters.blendFunc = [GL.SRC_ALPHA, GL.DST_ALPHA];
     parameters.blendEquation = GL.FUNC_ADD;

--- a/modules/carto/src/api/parseMap.ts
+++ b/modules/carto/src/api/parseMap.ts
@@ -44,7 +44,7 @@ export function parseMap(json) {
           id,
           data,
           ...defaultProps,
-          ...createBlendingProps(layerBlending),
+          ...createParametersProp(layerBlending),
           ...(!config.textLabel && createInteractionProps(interactionConfig)),
           ...createStyleProps(config, propMap),
           ...createChannelProps(visualChannels, type, config, data), // Must come after style
@@ -86,24 +86,17 @@ function extractTextLayers(layers) {
   );
 }
 
-function createBlendingProps(layerBlending) {
+function createParametersProp(layerBlending) {
+  const parameters: Record<string, any> = {};
   if (layerBlending === 'additive') {
-    return {
-      parameters: {
-        blendFunc: [GL.SRC_ALPHA, GL.DST_ALPHA],
-        blendEquation: GL.FUNC_ADD
-      }
-    };
+    parameters.blendFunc = [GL.SRC_ALPHA, GL.DST_ALPHA];
+    parameters.blendEquation = GL.FUNC_ADD;
   } else if (layerBlending === 'subtractive') {
-    return {
-      parameters: {
-        blendFunc: [GL.ONE, GL.ONE_MINUS_DST_COLOR, GL.SRC_ALPHA, GL.DST_ALPHA],
-        blendEquation: [GL.FUNC_SUBTRACT, GL.FUNC_ADD]
-      }
-    };
+    parameters.blendFunc = [GL.ONE, GL.ONE_MINUS_DST_COLOR, GL.SRC_ALPHA, GL.DST_ALPHA];
+    parameters.blendEquation = [GL.FUNC_SUBTRACT, GL.FUNC_ADD];
   }
 
-  return {};
+  return Object.keys(parameters).length ? {parameters} : {};
 }
 
 function createInteractionProps(interactionConfig) {

--- a/test/apps/carto-map/app.js
+++ b/test/apps/carto-map/app.js
@@ -87,11 +87,12 @@ document.body.appendChild(iframe);
 
 for (const e of examples) {
   const btn = document.createElement('button');
-  btn.innerHTML = e.slice(0, 8);
+  btn.innerHTML = e.slice(0, 4);
   btn.style.position = 'relative';
-  btn.style.bottom = '40px';
-  btn.style.padding = '4px';
-  btn.style.float = 'left';
+  btn.style.bottom = '80px';
+  btn.style.padding = '8px 0px';
+  btn.style.opacity = '0.8';
+  btn.style.width = '40px';
   if (e === id) {
     btn.style.background = '#e3f6ff';
   }

--- a/test/apps/carto-map/app.js
+++ b/test/apps/carto-map/app.js
@@ -45,10 +45,7 @@ const examples = [
   // Spatial index layers
   '202252d8-5647-424a-9317-9e392be59d65', // dynamic spatial index
   '907ee05f-b05c-4784-8226-c59e34773be5', // dynamic tiling
-  'a29d4941-a683-4516-9479-9db05a5b6bd9', // dynamic spatial index h3 ana (table)
   '38255824-e1d5-4a8f-b803-324aa75ef08a', // dynamic spatial index h3 ana (tileset)
-  'bee8c9c4-f12a-4cec-87f6-021bd52df942', // dynamic spatial index h3 ana (query)
-  '465f9b51-8256-4582-a9f0-a23757aefc39', // dynamic spatial index quadbin ana (table)
   '433b5f7e-af50-4da3-8803-26dfe58972d8', // dynamic tiling ana
   'ab8cc16b-e6b2-409a-8e0a-39ad6f6dfc12', // dynamic tiling snowflake
   'a42992e9-df58-451e-ad71-d7e91fe4a0df', // No aggregationExp provided
@@ -59,20 +56,20 @@ const examples = [
   'b45bb22f-6b2e-4a35-8d46-c8272251f450', // heatmap
 
   // Layers
-  '86094c6b-16f7-44fa-aca9-c3dc0617c362',
-  '420acda4-088f-448b-82f4-dcaaaf18d5a1',
-  'e787df8e-7459-46ea-ade3-55462a44131a',
-  'ff6ac53f-741a-49fb-b615-d040bc5a96b8',
-  'ba2ef0ba-e7bb-4a9a-a2a0-e8ade556b3d2',
-  '20c51f51-dedb-4cc2-b0c0-151137977a19',
-  '3b47f2df-b4af-4505-a586-c4ac0ded4e14',
-  'ae3ab696-3992-4d46-bdd2-b137ef9715d6',
-  '968c03bd-375c-4ec1-92e4-a4caef6efbfb',
-  '7537fa69-ce7b-4242-9db1-2de8c8526808',
-  '6a447e5b-9bb8-41f0-99aa-2e081371b7da',
-  'eb6fa89b-d8d1-4431-ab40-73b0c4b290bd',
-  '12119dd2-0ddb-4fd2-b48a-15a1b7511e52',
-  '3c892452-3806-4ebf-821b-a76f4562dd0c',
+  'b874e2d9-7896-4a9e-a0ba-42bdaf8730f5', // Points with altitude column
+  '86094c6b-16f7-44fa-aca9-c3dc0617c362', // SF extruded hex
+  '420acda4-088f-448b-82f4-dcaaaf18d5a1', // Points with multiple labels
+  'ff6ac53f-741a-49fb-b615-d040bc5a96b8', // NYC extruded buildings
+  'ba2ef0ba-e7bb-4a9a-a2a0-e8ade556b3d2', // Blended Texas tilesets
+  '20c51f51-dedb-4cc2-b0c0-151137977a19', // Europe railways
+  '3b47f2df-b4af-4505-a586-c4ac0ded4e14', // Dense point tileset
+  'ae3ab696-3992-4d46-bdd2-b137ef9715d6', // Cordoba colored buildings
+  '968c03bd-375c-4ec1-92e4-a4caef6efbfb', // Galapagos contours
+  '7537fa69-ce7b-4242-9db1-2de8c8526808', // SF point layer
+  '6a447e5b-9bb8-41f0-99aa-2e081371b7da', // Minnesota huge circles
+  'eb6fa89b-d8d1-4431-ab40-73b0c4b290bd', // Galapagos colored
+  '12119dd2-0ddb-4fd2-b48a-15a1b7511e52', // Overlapping empty circles
+  '3c892452-3806-4ebf-821b-a76f4562dd0c', // points and lines
   '21cc8261-e626-4778-a78b-76fe8b808214', // markers tilesets
   '4e8f215f-97b4-4f4e-8b53-465c3908c317' // markers points
 ];

--- a/test/modules/carto/data/visState.json
+++ b/test/modules/carto/data/visState.json
@@ -97,7 +97,8 @@
           "getPointRadius": 20.2,
           "stroked": true,
           "highlightColor": [252, 242, 26, 255],
-          "loadOptions": {"fetch": {"headers": {"Authorization": "Bearer API_TOKEN"}}}
+          "loadOptions": {"fetch": {"headers": {"Authorization": "Bearer API_TOKEN"}}},
+          "parameters": {"depthTest": false}
         }
       }
     ]
@@ -203,7 +204,7 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [770, 772], "blendEquation": 32774},
+          "parameters": {"depthTest": false, "blendFunc": [770, 772], "blendEquation": 32774},
           "autoHighlight": true,
           "pickable": true,
           "getFillColor": [18, 147, 154, 172],
@@ -226,7 +227,7 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [770, 772], "blendEquation": 32774},
+          "parameters": {"depthTest": false, "blendFunc": [770, 772], "blendEquation": 32774},
           "getFillColor": [18, 147, 154, 255],
           "visible": true,
           "getTextAlignmentBaseline": "top",
@@ -253,7 +254,7 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [770, 772], "blendEquation": 32774},
+          "parameters": {"depthTest": false, "blendFunc": [770, 772], "blendEquation": 32774},
           "getFillColor": [18, 147, 154, 255],
           "visible": true,
           "getTextAlignmentBaseline": "center",
@@ -366,7 +367,7 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [770, 772], "blendEquation": 32774},
+          "parameters": {"depthTest": false, "blendFunc": [770, 772], "blendEquation": 32774},
           "autoHighlight": true,
           "pickable": true,
           "getIconColor": [18, 147, 154],
@@ -405,7 +406,7 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [770, 772], "blendEquation": 32774},
+          "parameters": {"depthTest": false, "blendFunc": [770, 772], "blendEquation": 32774},
           "getFillColor": [18, 147, 154, 255],
           "visible": true,
           "cartoLabel": "Stores-label-city",
@@ -519,7 +520,7 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [770, 772], "blendEquation": 32774},
+          "parameters": {"depthTest": false, "blendFunc": [770, 772], "blendEquation": 32774},
           "autoHighlight": true,
           "pickable": true,
           "getIconColor": [18, 147, 154],
@@ -770,7 +771,11 @@
           "pointRadiusUnits": "pixels",
           "rounded": true,
           "wrapLongitude": false,
-          "parameters": {"blendFunc": [1, 775, 770, 772], "blendEquation": [32778, 32774]},
+          "parameters": {
+            "depthTest": false,
+            "blendFunc": [1, 775, 770, 772],
+            "blendEquation": [32778, 32774]
+          },
           "autoHighlight": true,
           "pickable": true,
           "getFillColor": [87, 173, 87, 230],

--- a/test/modules/carto/data/visState.json
+++ b/test/modules/carto/data/visState.json
@@ -16,7 +16,7 @@
             "label": "Stores",
             "dataId": "DATA_ID",
             "hidden": false,
-            "columns": {"lat": "latitude", "lng": "longitude", "altitude": null},
+            "columns": {"lat": "latitude", "lng": "longitude", "altitude": 100},
             "isVisible": true,
             "textLabel": [],
             "visConfig": {
@@ -98,7 +98,7 @@
           "stroked": true,
           "highlightColor": [252, 242, 26, 255],
           "loadOptions": {"fetch": {"headers": {"Authorization": "Bearer API_TOKEN"}}},
-          "parameters": {"depthTest": false}
+          "parameters": {"depthTest": true}
         }
       }
     ]

--- a/test/modules/carto/data/visState.json
+++ b/test/modules/carto/data/visState.json
@@ -16,7 +16,7 @@
             "label": "Stores",
             "dataId": "DATA_ID",
             "hidden": false,
-            "columns": {"lat": "latitude", "lng": "longitude", "altitude": 100},
+            "columns": {"lat": "latitude", "lng": "longitude", "altitude": "altitude"},
             "isVisible": true,
             "textLabel": [],
             "visConfig": {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

To match behavior in Kepler, `depthTest: false` needs to be set on point layers

<!-- For all the PRs -->
#### Change List
- disable depthTest for point layers
- test updates
