### PR TITLE
Font Atlas Manager: Always update the atlas with the cached version

### DIFF
--- a/modules/layers/src/text-layer/font-atlas-manager.ts
+++ b/modules/layers/src/text-layer/font-atlas-manager.ts
@@ -172,7 +172,6 @@ export default class FontAtlasManager {
     Object.assign(this.props, props);
 
     // update cache key
-    const oldKey = this._key;
     this._key = this._getKey();
 
     const charSet = getNewChars(this._key, this.props.characterSet);
@@ -182,7 +181,7 @@ export default class FontAtlasManager {
     // there are no new chars
     if (cachedFontAtlas && charSet.size === 0) {
       // update texture with cached fontAtlas
-      if (this._key !== oldKey) {
+      if (this._atlas !== cachedFontAtlas) {
         this._atlas = cachedFontAtlas;
       }
       return;


### PR DESCRIPTION
#### Background

When you have 2 `TextLayer` instances using the same fontFamily, fontWeight, ... (all the properties used in the `_getKey()` method are the same) and the `charSet` is set to `auto`, you could end up in a situation where the atlas of 1 of the text layers doesn't contain all the characters.

In my application I have the following scenario:
- 2 `TextLayer` instances with the same font settings (hence the `_getKey()` method would return the same String)
- Extra data is added to 1 `TextLayer` where the text contains new characters, not previously present
- Later, the same data is added to the other `TextLayer`. However, the drawn text for this second layer only shows the characters that were already present on the map and not the new characters. This indicates those new characters are not present in the atlas

Looking at the code, what I suspect happens is the following.

The moment `TextLayer` 2 triggers the `setProps` method:

The 

```
const charSet = getNewChars(this._key, this.props.characterSet);
```
will return an empty `Set` because the atlas in the `cache` is already updated with all the new characters thanks to `TextLayer` 1 (remember that both layers have the same `_getKey()`)

Then the code checks whether to update the `this._atlas`:
```
    // if a fontAtlas associated with the new settings is cached and
    // there are no new chars
    if (cachedFontAtlas && charSet.size === 0) {
      // update texture with cached fontAtlas
      if (this._key !== oldKey) {
        this._atlas = cachedFontAtlas;
      }
      return;
    }
```
The problem with the check above is that the `this._atlas` is only replaced when the keys are different. However, it is perfectly possible that `cachedFontAtlas` is completely different from `this._atlas` because another layer with the same key has changed the cache entry.

As such, I think the additional check on the key ` if (this._key !== oldKey) ` should be replaced, and we should always replace `this._atlas` with the cached atlas.

An alternative fix would be to replace the global `cache` variable with a cache per `FontAtlasManager` instance, but that felt like too big of a change with unknown memory/performance impacts.
