### PR TITLE
CARTO: Explicitly set geoColumn when requesting geoJSON

### DIFF
--- a/modules/carto/src/api/maps-v3-client.ts
+++ b/modules/carto/src/api/maps-v3-client.ts
@@ -586,7 +586,9 @@ export async function fetchMap({
   const geojsonDatasetIds = geojsonLayers.map(({config}) => config.dataId);
   map.datasets.forEach(dataset => {
     if (geojsonDatasetIds.includes(dataset.id)) {
+      const {config} = geojsonLayers.find(({config}) => config.dataId === dataset.id);
       dataset.format = 'geojson';
+      dataset.geoColumn = config.columns.geojson;
     }
   });
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

The maps API no longer guesses the geometry column, so it must be explicitly specified
<!-- For all the PRs -->
#### Change List
- Explicitly specify `geoColumn` for GeoJSON fetchMap datasets
