### PR TITLE
CARTO: Recreate tileset if aggregationResLevel changes

### DIFF
--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -1,10 +1,12 @@
 import {registerLoaders} from '@loaders.gl/core';
+import {DefaultProps, UpdateParameters} from '@deck.gl/core';
 import CartoSpatialTileLoader from './schema/carto-spatial-tile-loader';
 registerLoaders([CartoSpatialTileLoader]);
 
 import {PickingInfo} from '@deck.gl/core';
 import {
   TileLayer,
+  TileLayerProps,
   _getURLFromTemplate,
   _Tile2DHeader as Tile2DHeader,
   _TileLoadProps as TileLoadProps
@@ -15,8 +17,25 @@ function isFeatureIdDefined(value: unknown): boolean {
   return value !== undefined && value !== null && value !== '';
 }
 
-export default class SpatialIndexTileLayer<ExtraProps = {}> extends TileLayer<any, ExtraProps> {
+const defaultProps: DefaultProps<SpatialIndexTileLayerProps> = {
+  aggregationResLevel: 4
+};
+
+/** All properties supported by SpatialIndexTileLayer. */
+export type SpatialIndexTileLayerProps<DataT = any> = _SpatialIndexTileLayerProps<DataT> &
+  TileLayer<DataT>;
+
+/** Properties added by SpatialIndexTileLayer. */
+type _SpatialIndexTileLayerProps<DataT> = {
+  aggregationResLevel?: number;
+};
+
+export default class SpatialIndexTileLayer<DataT = any, ExtraProps = {}> extends TileLayer<
+  DataT,
+  ExtraProps & Required<_SpatialIndexTileLayerProps<DataT>>
+> {
   static layerName = 'SpatialIndexTileLayer';
+  static defaultProps = defaultProps;
 
   getTileData(tile: TileLoadProps) {
     const {data, getTileData, fetch} = this.props;
@@ -46,6 +65,15 @@ export default class SpatialIndexTileLayer<ExtraProps = {}> extends TileLayer<an
     }
 
     return fetch(tile.url, {propName: 'data', layer: this, loadOptions, signal});
+  }
+
+  updateState(params: UpdateParameters<this>) {
+    const {props, oldProps} = params;
+    if (props.aggregationResLevel !== oldProps.aggregationResLevel) {
+      // Tileset cache is invalid when resLevel changes
+      this.setState({tileset: null});
+    }
+    super.updateState(params);
   }
 
   protected _updateAutoHighlight(info: PickingInfo): void {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Edge case where changing the `aggregationResLevel` leads to invalid tiles being requested

<!-- For all the PRs -->
#### Change List
- Recreate `Tileset` whenever `aggregationResLevel` is changed
