### PR TITLE
[react] Fix padding compatibility with react-map-gl v7

### DIFF
--- a/modules/core/src/viewports/viewport.ts
+++ b/modules/core/src/viewports/viewport.ts
@@ -151,6 +151,7 @@ export default class Viewport {
   y: number;
   width: number;
   height: number;
+  padding?: Padding | null;
   isGeospatial: boolean;
   zoom: number;
   focalDistance: number;
@@ -187,6 +188,7 @@ export default class Viewport {
     this.width = opts.width || 1;
     this.height = opts.height || 1;
     this.zoom = opts.zoom || 0;
+    this.padding = opts.padding;
     this.distanceScales = opts.distanceScales || DEFAULT_DISTANCE_SCALES;
     this.focalDistance = opts.focalDistance || 1;
     this.position = opts.position || ZERO_VECTOR;

--- a/modules/react/src/utils/position-children-under-views.ts
+++ b/modules/react/src/utils/position-children-under-views.ts
@@ -57,6 +57,7 @@ export default function positionChildrenUnderViews({
 
     // Drop (auto-hide) elements with viewId that are not matched by any current view
     if (viewport) {
+      viewState.padding = viewport.padding;
       const {x, y, width, height} = viewport;
       // Resolve potentially relative dimensions using the deck.gl container size
       viewChildren = evaluateChildren(viewChildren, {


### PR DESCRIPTION
For #7382

react-map-gl v7 ignores top-level `padding` prop if `viewState` is passed.

#### Change List
- Store original `padding` value in Viewport class
- Pass down `padding` as part of `viewState` to React children
