### PR TITLE
Support MaskExtension with HeatmapLayer

### DIFF
--- a/modules/aggregation-layers/src/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/aggregation-layer.ts
@@ -53,7 +53,7 @@ export default abstract class AggregationLayer<
   updateState(opts: UpdateParameters<this>) {
     super.updateState(opts);
     const {changeFlags} = opts;
-    if (changeFlags.extensionsChanged) {
+    if (changeFlags.extensionsChanged || changeFlags.propsChanged) {
       const shaders = this.getShaders({});
       if (shaders && shaders.defines) {
         shaders.defines.NON_INSTANCED_MODEL = 1;

--- a/modules/aggregation-layers/src/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/aggregation-layer.ts
@@ -86,6 +86,16 @@ export default abstract class AggregationLayer<
       pickingActive: 0,
       devicePixelRatio: cssToDeviceRatio(gl)
     });
+
+    // @ts-ignore
+    const effects = this.context.deck?.effectManager?.getEffects();
+    // HACK needed to get maskChannels & maskMap
+    if (effects) {
+      for (const effect of effects) {
+        Object.assign(moduleSettings, effect.getModuleParameters?.(this));
+      }
+    }
+
     return moduleSettings;
   }
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -249,13 +249,6 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     const {props, oldProps} = opts;
     const changeFlags = this._getChangeFlags(opts);
 
-    const {maskRenderCount} = this.getModuleSettings();
-    if (maskRenderCount !== this.state.maskRenderCount) {
-      // Treat new mask as if data had changed
-      changeFlags.dataChanged = 'mask';
-      this.setState({maskRenderCount});
-    }
-
     if (changeFlags.dataChanged || changeFlags.viewportChanged) {
       // if data is changed, do not debounce and immediately update the weight map
       changeFlags.boundsChanged = this._updateBounds(changeFlags.dataChanged);

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -197,6 +197,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
   state!: AggregationLayer['state'] & {
     supported: boolean;
     colorDomain?: number[];
+    maskRenderCount: number;
     isWeightMapDirty?: boolean;
     weightsTexture?: Texture2D;
     zoom?: number;
@@ -239,6 +240,12 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     const {props, oldProps} = opts;
     const changeFlags = this._getChangeFlags(opts);
 
+    const {maskRenderCount} = this.getModuleSettings();
+    if (maskRenderCount !== this.state.maskRenderCount) {
+      changeFlags.dataChanged = 'mask';
+      this.setState({maskRenderCount});
+    }
+
     if (changeFlags.dataChanged || changeFlags.viewportChanged) {
       // if data is changed, do not debounce and immediately update the weight map
       changeFlags.boundsChanged = this._updateBounds(changeFlags.dataChanged);
@@ -259,6 +266,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
 
     if (this.state.isWeightMapDirty) {
+      console.log('updating weightmap');
       this._updateWeightmap();
     }
 
@@ -598,11 +606,6 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
 
     const uniforms = {
-      // Force mask (trouble is getting these from mask extension...
-      mask_enabled: true,
-      mask_bounds: [77.87691066740754, 304.98062194849194, 94.83216756252682, 321.93587884361136],
-
-      //
       radiusPixels,
       commonBounds,
       textureWidth: textureSize,

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -223,8 +223,10 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
   }
 
   shouldUpdateState({changeFlags}: UpdateParameters<this>) {
-    // Need to be updated when viewport changes
-    return changeFlags.somethingChanged;
+    // Need to be updated when viewport or mask changes
+    const {maskRenderCount} = this.getModuleSettings();
+    const maskChanged = maskRenderCount !== this.state.maskRenderCount;
+    return changeFlags.somethingChanged || maskChanged;
   }
 
   /* eslint-disable max-statements,complexity */
@@ -242,6 +244,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
 
     const {maskRenderCount} = this.getModuleSettings();
     if (maskRenderCount !== this.state.maskRenderCount) {
+      // Treat new mask as if data had changed
       changeFlags.dataChanged = 'mask';
       this.setState({maskRenderCount});
     }
@@ -266,7 +269,6 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
 
     if (this.state.isWeightMapDirty) {
-      console.log('updating weightmap');
       this._updateWeightmap();
     }
 
@@ -277,6 +279,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     if (!this.state.supported) {
       return [];
     }
+
     const {
       weightsTexture,
       triPositionBuffer,

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -276,6 +276,14 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
       colorTexture,
       colorDomain
     } = this.state;
+    console.log(
+      'weightsTexture',
+      weightsTexture.textureUnit,
+      'maxWeightsTexture',
+      maxWeightsTexture.textureUnit,
+      'colorTexture',
+      colorTexture.textureUnit
+    );
     const {updateTriggers, intensity, threshold, aggregation} = this.props;
 
     const TriangleLayerClass = this.getSubLayerClass('triangle', TriangleLayer);
@@ -299,7 +307,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
         maxTexture: maxWeightsTexture,
         colorTexture,
         aggregationMode: AGGREGATION_MODE[aggregation] || 0,
-        texture: weightsTexture,
+        texture: weightsTexture, /// <-- PROBLEM
         intensity,
         threshold,
         colorDomain

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -223,10 +223,8 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
   }
 
   shouldUpdateState({changeFlags}: UpdateParameters<this>) {
-    // Need to be updated when viewport or mask changes
-    const {maskRenderCount} = this.getModuleSettings();
-    const maskChanged = maskRenderCount !== this.state.maskRenderCount;
-    return changeFlags.somethingChanged || maskChanged;
+    // Need to be updated when viewport changes
+    return changeFlags.somethingChanged;
   }
 
   /* eslint-disable max-statements,complexity */
@@ -236,6 +234,15 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
     super.updateState(opts);
     this._updateHeatmapState(opts);
+  }
+
+  postEffect() {
+    const {maskRenderCount} = this.getModuleSettings();
+    const maskChanged = maskRenderCount !== this.state.maskRenderCount;
+    if (maskChanged) {
+      this.setState({maskRenderCount});
+      this._updateWeightmap();
+    }
   }
 
   _updateHeatmapState(opts: UpdateParameters<this>) {

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -241,7 +241,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     const maskChanged = maskRenderCount !== this.state.maskRenderCount;
     if (maskChanged) {
       this.setState({maskRenderCount});
-      this._updateWeightmap();
+      this._debouncedUpdateWeightmap();
     }
   }
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -311,7 +311,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
         maxTexture: maxWeightsTexture,
         colorTexture,
         aggregationMode: AGGREGATION_MODE[aggregation] || 0,
-        texture: weightsTexture, /// <-- PROBLEM
+        texture: weightsTexture,
         intensity,
         threshold,
         colorDomain

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -627,6 +627,9 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
 
     // Only instance-based masking affects the weights transform
+    // TODO: do we want to do this? On one hand it makes sense,
+    // but can result in starnge colors as the maxWeightValue is
+    // calculated on the unmasked dataset
     if (uniforms.mask_enabled) {
       uniforms.mask_enabled = uniforms.mask_maskByInstance;
     }

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -278,7 +278,6 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     if (!this.state.supported) {
       return [];
     }
-
     const {
       weightsTexture,
       triPositionBuffer,
@@ -607,7 +606,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
       this.state.colorDomain = colorDomain || DEFAULT_COLOR_DOMAIN;
     }
 
-    const uniforms = {
+    const uniforms: any = {
       radiusPixels,
       commonBounds,
       textureWidth: textureSize,
@@ -628,9 +627,7 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
 
     // Only instance-based masking affects the weights transform
-    // @ts-ignore
     if (uniforms.mask_enabled) {
-      // @ts-ignore
       uniforms.mask_enabled = uniforms.mask_maskByInstance;
     }
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 /* global setTimeout clearTimeout */
-import {readPixelsToArray} from '@luma.gl/core';
 import GL from '@luma.gl/constants';
 import {
   getBounds,
@@ -651,43 +650,12 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
       });
     });
     this._updateMaxWeightValue();
-    this._debug();
 
     // reset filtering parameters (TODO: remove once luma issue#1193 is fixed)
     weightsTexture.setParameters({
       [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
       [GL.TEXTURE_MIN_FILTER]: GL.LINEAR
     });
-  }
-
-  _debug() {
-    // Debug show FBO contents on screen
-    const {weightsTexture} = this.state;
-    const color = readPixelsToArray(weightsTexture);
-    let canvas = document.getElementById('weights-canvas') as HTMLCanvasElement;
-    if (!canvas) {
-      canvas = document.createElement('canvas');
-      canvas.id = 'weights-canvas';
-      canvas.width = weightsTexture.width;
-      canvas.height = weightsTexture.height;
-      canvas.style.zIndex = '100';
-      canvas.style.position = 'absolute';
-      canvas.style.right = '0';
-      canvas.style.top = '256px';
-      canvas.style.border = 'blue 1px solid';
-      canvas.style.width = '256px';
-      canvas.style.transform = 'scaleY(-1)';
-      document.body.appendChild(canvas);
-    }
-    const ctx = canvas.getContext('2d')!;
-    const imageData = ctx.createImageData(weightsTexture.width, weightsTexture.height);
-    for (let i = 0; i < color.length; i += 4) {
-      imageData.data[i + 0] = color[i + 0];
-      imageData.data[i + 1] = color[i + 1];
-      imageData.data[i + 2] = color[i + 2];
-      imageData.data[i + 3] = 255; //color[i + 3];
-    }
-    ctx.putImageData(imageData, 0, 0);
   }
 
   _debouncedUpdateWeightmap(fromTimer = false) {

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 /* global setTimeout clearTimeout */
+import {readPixelsToArray} from '@luma.gl/core';
 import GL from '@luma.gl/constants';
 import {
   getBounds,
@@ -605,6 +606,11 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
     }
 
     const uniforms = {
+      // Force mask (trouble is getting these from mask extension...
+      mask_enabled: true,
+      mask_bounds: [77.87691066740754, 304.98062194849194, 94.83216756252682, 321.93587884361136],
+
+      //
       radiusPixels,
       commonBounds,
       textureWidth: textureSize,
@@ -631,12 +637,43 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
       });
     });
     this._updateMaxWeightValue();
+    this._debug();
 
     // reset filtering parameters (TODO: remove once luma issue#1193 is fixed)
     weightsTexture.setParameters({
       [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
       [GL.TEXTURE_MIN_FILTER]: GL.LINEAR
     });
+  }
+
+  _debug() {
+    // Debug show FBO contents on screen
+    const {weightsTexture} = this.state;
+    const color = readPixelsToArray(weightsTexture);
+    let canvas = document.getElementById('weights-canvas') as HTMLCanvasElement;
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.id = 'weights-canvas';
+      canvas.width = weightsTexture.width;
+      canvas.height = weightsTexture.height;
+      canvas.style.zIndex = '100';
+      canvas.style.position = 'absolute';
+      canvas.style.right = '0';
+      canvas.style.top = '256px';
+      canvas.style.border = 'blue 1px solid';
+      canvas.style.width = '256px';
+      canvas.style.transform = 'scaleY(-1)';
+      document.body.appendChild(canvas);
+    }
+    const ctx = canvas.getContext('2d')!;
+    const imageData = ctx.createImageData(weightsTexture.width, weightsTexture.height);
+    for (let i = 0; i < color.length; i += 4) {
+      imageData.data[i + 0] = color[i + 0];
+      imageData.data[i + 1] = color[i + 1];
+      imageData.data[i + 2] = color[i + 2];
+      imageData.data[i + 3] = 255; //color[i + 3];
+    }
+    ctx.putImageData(imageData, 0, 0);
   }
 
   _debouncedUpdateWeightmap(fromTimer = false) {

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -628,6 +628,13 @@ export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends Aggrega
       extension.draw.call(this, opts, extension);
     }
 
+    // Only instance-based masking affects the weights transform
+    // @ts-ignore
+    if (uniforms.mask_enabled) {
+      // @ts-ignore
+      uniforms.mask_enabled = uniforms.mask_maskByInstance;
+    }
+
     // Attribute manager sets data array count as instaceCount on model
     // we need to set that as elementCount on 'weightsTransform'
     weightsTransform.update({

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-vertex.glsl.ts
@@ -38,6 +38,7 @@ varying float vIntensityMax;
 
 void main(void) {
   gl_Position = project_position_to_clipspace(positions, vec3(0.0), vec3(0.0));
+  geometry.position = project_position(vec4(positions, 1.0));
   vTexCoords = texCoords;
   vec4 maxTexture = texture2D(maxTexture, vec2(0.5));
   float maxValue = aggregationMode < 0.5 ? maxTexture.r : maxTexture.g;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -40,7 +40,6 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
 
   getShaders() {
     return super.getShaders({vs, fs, modules: [project32]});
-    // return {vs, fs, modules: [project32]};
   }
 
   initializeState({gl}: LayerContext): void {
@@ -57,7 +56,7 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
   updateState(opts: UpdateParameters<this>) {
     super.updateState(opts);
     const {changeFlags} = opts;
-    if (changeFlags.extensionsChanged) {
+    if (changeFlags.extensionsChanged || changeFlags.propsChanged) {
       this.setState({
         model: this._getModel(opts.context.gl)
       });

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -83,10 +83,14 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
     const {texture, maxTexture, colorTexture, intensity, threshold, aggregationMode, colorDomain} =
       this.props;
 
+    if (uniforms.mask_enabled) {
+      // Instance based masking happens in weightsTransform
+      uniforms.mask_enabled = !uniforms.mask_maskByInstance;
+    }
+
     model
       .setUniforms({
         ...uniforms,
-        mask_enabled: false, // <-- masking happens in weightsTransform
         colorTexture,
         texture, // <---- PROBLEM (put second to avoid warning :/)
         maxTexture,

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import GL from '@luma.gl/constants';
-import {Model, Geometry, Texture2D} from '@luma.gl/core';
+import {Model, Geometry, Texture2D, UpdateParameters} from '@luma.gl/core';
 import {Layer, LayerContext, project32} from '@deck.gl/core';
 import vs from './triangle-layer-vertex.glsl';
 import fs from './triangle-layer-fragment.glsl';
@@ -39,7 +39,8 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
   static layerName = 'TriangleLayer';
 
   getShaders() {
-    return {vs, fs, modules: [project32]};
+    return super.getShaders({vs, fs, modules: [project32]});
+    // return {vs, fs, modules: [project32]};
   }
 
   initializeState({gl}: LayerContext): void {
@@ -51,6 +52,16 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
     this.setState({
       model: this._getModel(gl)
     });
+  }
+
+  updateState(opts: UpdateParameters<this>) {
+    super.updateState(opts);
+    const {changeFlags} = opts;
+    if (changeFlags.extensionsChanged) {
+      this.setState({
+        model: this._getModel(opts.context.gl)
+      });
+    }
   }
 
   _getModel(gl: WebGLRenderingContext): Model {
@@ -75,9 +86,9 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
     model
       .setUniforms({
         ...uniforms,
-        texture,
-        maxTexture,
         colorTexture,
+        texture, // <---- PROBLEM (put second to avoid warning :/)
+        maxTexture,
         intensity,
         threshold,
         aggregationMode,

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -91,9 +91,9 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
     model
       .setUniforms({
         ...uniforms,
-        colorTexture,
-        texture, // <---- PROBLEM (put second to avoid warning :/)
+        texture,
         maxTexture,
+        colorTexture,
         intensity,
         threshold,
         aggregationMode,

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -86,6 +86,7 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
     model
       .setUniforms({
         ...uniforms,
+        mask_enabled: false, // <-- masking happens in weightsTransform
         colorTexture,
         texture, // <---- PROBLEM (put second to avoid warning :/)
         maxTexture,

--- a/modules/aggregation-layers/src/heatmap-layer/weights-vs.glsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/weights-vs.glsl.ts
@@ -15,6 +15,7 @@ void main()
   gl_PointSize = radiusTexels * 2.;
 
   vec3 commonPosition = project_position(positions, positions64Low);
+  geometry.position = vec4(commonPosition, 1.0);
 
   // map xy from commonBounds to [-1, 1]
   gl_Position.xy = (commonPosition.xy - commonBounds.xy) / (commonBounds.zw - commonBounds.xy) ;

--- a/modules/aggregation-layers/src/heatmap-layer/weights-vs.glsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/weights-vs.glsl.ts
@@ -15,7 +15,7 @@ void main()
   gl_PointSize = radiusTexels * 2.;
 
   vec3 commonPosition = project_position(positions, positions64Low);
-  geometry.position = vec4(commonPosition, 1.0);
+  geometry.worldPosition = positions;
 
   // map xy from commonBounds to [-1, 1]
   gl_Position.xy = (commonPosition.xy - commonBounds.xy) / (commonBounds.zw - commonBounds.xy) ;

--- a/modules/aggregation-layers/src/heatmap-layer/weights-vs.glsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/weights-vs.glsl.ts
@@ -14,11 +14,11 @@ void main()
   float radiusTexels  = project_pixel_size(radiusPixels) * textureWidth / (commonBounds.z - commonBounds.x);
   gl_PointSize = radiusTexels * 2.;
 
-  vec3 commonPosition = project_position(positions, positions64Low);
+  geometry.position = project_position(vec4(positions, 1.0), positions64Low);
   geometry.worldPosition = positions;
 
   // map xy from commonBounds to [-1, 1]
-  gl_Position.xy = (commonPosition.xy - commonBounds.xy) / (commonBounds.zw - commonBounds.xy) ;
+  gl_Position.xy = (geometry.position.xy - commonBounds.xy) / (commonBounds.zw - commonBounds.xy) ;
   gl_Position.xy = (gl_Position.xy * 2.) - (1.);
 }
 `;

--- a/modules/core/src/effects/mask/mask-effect.ts
+++ b/modules/core/src/effects/mask/mask-effect.ts
@@ -1,5 +1,5 @@
 import {Texture2D} from '@luma.gl/core';
-// import {readPixelsToArray} from '@luma.gl/core';
+import {readPixelsToArray} from '@luma.gl/core';
 import {equals} from '@math.gl/core';
 import MaskPass from '../../passes/mask-pass';
 import {OPERATION} from '../../lib/constants';
@@ -84,31 +84,32 @@ export default class MaskEffect implements Effect {
       });
     }
 
-    // // Debug show FBO contents on screen
-    // const color = readPixelsToArray(this.maskMap);
-    // let canvas = document.getElementById('fbo-canvas');
-    // if (!canvas) {
-    //   canvas = document.createElement('canvas');
-    //   canvas.id = 'fbo-canvas';
-    //   canvas.width = this.maskMap.width;
-    //   canvas.height = this.maskMap.height;
-    //   canvas.style.zIndex = 100;
-    //   canvas.style.position = 'absolute';
-    //   canvas.style.right = 0;
-    //   canvas.style.border = 'blue 1px solid';
-    //   canvas.style.width = '256px';
-    //   canvas.style.transform = 'scaleY(-1)';
-    //   document.body.appendChild(canvas);
-    // }
-    // const ctx = canvas.getContext('2d');
-    // const imageData = ctx.createImageData(this.maskMap.width, this.maskMap.height);
-    // for (let i = 0; i < color.length; i += 4) {
-    //   imageData.data[i + 0] = color[i + 0];
-    //   imageData.data[i + 1] = color[i + 1];
-    //   imageData.data[i + 2] = color[i + 2];
-    //   imageData.data[i + 3] = color[i + 3] + 128;
-    // }
-    // ctx.putImageData(imageData, 0, 0);
+    // Debug show FBO contents on screen
+    const color = readPixelsToArray(this.maskMap);
+    let canvas = document.getElementById('fbo-canvas');
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.id = 'fbo-canvas';
+      canvas.width = this.maskMap.width;
+      canvas.height = this.maskMap.height;
+      canvas.style.zIndex = 100;
+      canvas.style.position = 'absolute';
+      canvas.style.right = 0;
+      canvas.style.top = 0;
+      canvas.style.border = 'blue 1px solid';
+      canvas.style.width = '256px';
+      canvas.style.transform = 'scaleY(-1)';
+      document.body.appendChild(canvas);
+    }
+    const ctx = canvas.getContext('2d');
+    const imageData = ctx.createImageData(this.maskMap.width, this.maskMap.height);
+    for (let i = 0; i < color.length; i += 4) {
+      imageData.data[i + 0] = color[i + 0];
+      imageData.data[i + 1] = color[i + 1];
+      imageData.data[i + 2] = color[i + 2];
+      imageData.data[i + 3] = color[i + 3] + 128;
+    }
+    ctx.putImageData(imageData, 0, 0);
   }
 
   private _renderChannel(

--- a/modules/core/src/effects/mask/mask-effect.ts
+++ b/modules/core/src/effects/mask/mask-effect.ts
@@ -40,6 +40,7 @@ export default class MaskEffect implements Effect {
   private dummyMaskMap?: Texture2D;
   private channels: (Channel | null)[] = [];
   private masks: Record<string, Mask> | null = null;
+  private maskRenderCount: number = 0;
   private maskPass?: MaskPass;
   private maskMap?: Texture2D;
   private lastViewport?: Viewport;
@@ -86,22 +87,22 @@ export default class MaskEffect implements Effect {
 
     // Debug show FBO contents on screen
     const color = readPixelsToArray(this.maskMap);
-    let canvas = document.getElementById('fbo-canvas');
+    let canvas = document.getElementById('fbo-canvas') as HTMLCanvasElement;
     if (!canvas) {
       canvas = document.createElement('canvas');
       canvas.id = 'fbo-canvas';
       canvas.width = this.maskMap.width;
       canvas.height = this.maskMap.height;
-      canvas.style.zIndex = 100;
+      canvas.style.zIndex = '100';
       canvas.style.position = 'absolute';
-      canvas.style.right = 0;
-      canvas.style.top = 0;
+      canvas.style.right = '0';
+      canvas.style.top = '0';
       canvas.style.border = 'blue 1px solid';
       canvas.style.width = '256px';
       canvas.style.transform = 'scaleY(-1)';
       document.body.appendChild(canvas);
     }
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d')!;
     const imageData = ctx.createImageData(this.maskMap.width, this.maskMap.height);
     for (let i = 0; i < color.length; i += 4) {
       imageData.data[i + 0] = color[i + 0];
@@ -177,6 +178,7 @@ export default class MaskEffect implements Effect {
             devicePixelRatio: 1
           }
         });
+        this.maskRenderCount++;
       }
     }
 
@@ -242,10 +244,12 @@ export default class MaskEffect implements Effect {
 
   getModuleParameters(): {
     maskMap: Texture2D;
+    maskRenderCount: number;
     maskChannels: Record<string, Mask> | null;
   } {
     return {
       maskMap: this.masks ? this.maskMap : this.dummyMaskMap,
+      maskRenderCount: this.maskRenderCount,
       maskChannels: this.masks
     };
   }

--- a/modules/core/src/effects/mask/mask-effect.ts
+++ b/modules/core/src/effects/mask/mask-effect.ts
@@ -1,5 +1,5 @@
 import {Texture2D} from '@luma.gl/core';
-import {readPixelsToArray} from '@luma.gl/core';
+// import {readPixelsToArray} from '@luma.gl/core';
 import {equals} from '@math.gl/core';
 import MaskPass from '../../passes/mask-pass';
 import {OPERATION} from '../../lib/constants';
@@ -85,32 +85,32 @@ export default class MaskEffect implements Effect {
       });
     }
 
-    // Debug show FBO contents on screen
-    const color = readPixelsToArray(this.maskMap);
-    let canvas = document.getElementById('fbo-canvas') as HTMLCanvasElement;
-    if (!canvas) {
-      canvas = document.createElement('canvas');
-      canvas.id = 'fbo-canvas';
-      canvas.width = this.maskMap.width;
-      canvas.height = this.maskMap.height;
-      canvas.style.zIndex = '100';
-      canvas.style.position = 'absolute';
-      canvas.style.right = '0';
-      canvas.style.top = '0';
-      canvas.style.border = 'blue 1px solid';
-      canvas.style.width = '256px';
-      canvas.style.transform = 'scaleY(-1)';
-      document.body.appendChild(canvas);
-    }
-    const ctx = canvas.getContext('2d')!;
-    const imageData = ctx.createImageData(this.maskMap.width, this.maskMap.height);
-    for (let i = 0; i < color.length; i += 4) {
-      imageData.data[i + 0] = color[i + 0];
-      imageData.data[i + 1] = color[i + 1];
-      imageData.data[i + 2] = color[i + 2];
-      imageData.data[i + 3] = color[i + 3] + 128;
-    }
-    ctx.putImageData(imageData, 0, 0);
+    // // Debug show FBO contents on screen
+    // const color = readPixelsToArray(this.maskMap);
+    // let canvas = document.getElementById('fbo-canvas') as HTMLCanvasElement;
+    // if (!canvas) {
+    //   canvas = document.createElement('canvas');
+    //   canvas.id = 'fbo-canvas';
+    //   canvas.width = this.maskMap.width;
+    //   canvas.height = this.maskMap.height;
+    //   canvas.style.zIndex = '100';
+    //   canvas.style.position = 'absolute';
+    //   canvas.style.right = '0';
+    //   canvas.style.top = '0';
+    //   canvas.style.border = 'blue 1px solid';
+    //   canvas.style.width = '256px';
+    //   canvas.style.transform = 'scaleY(-1)';
+    //   document.body.appendChild(canvas);
+    // }
+    // const ctx = canvas.getContext('2d')!;
+    // const imageData = ctx.createImageData(this.maskMap.width, this.maskMap.height);
+    // for (let i = 0; i < color.length; i += 4) {
+    //   imageData.data[i + 0] = color[i + 0];
+    //   imageData.data[i + 1] = color[i + 1];
+    //   imageData.data[i + 2] = color[i + 2];
+    //   imageData.data[i + 3] = color[i + 3] + 128;
+    // }
+    // ctx.putImageData(imageData, 0, 0);
   }
 
   private _renderChannel(

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -209,6 +209,12 @@ export default class LayersPass extends Pass {
       if (shouldDrawLayer && layer.props.pickable) {
         renderStatus.pickableCount++;
       }
+
+      // Hack
+      if (layer.postEffect) {
+        layer.postEffect();
+      }
+
       if (layer.isComposite) {
         renderStatus.compositeCount++;
       } else if (shouldDrawLayer) {

--- a/modules/extensions/src/mask/mask.ts
+++ b/modules/extensions/src/mask/mask.ts
@@ -1,7 +1,7 @@
 import {COORDINATE_SYSTEM, LayerExtension, log} from '@deck.gl/core';
 import mask from './shader-module';
 
-import type {Layer} from '@deck.gl/core';
+import type {CompositeLayer, Layer} from '@deck.gl/core';
 
 const defaultProps = {
   maskId: ''
@@ -24,6 +24,17 @@ export type MaskExtensionProps = {
 export default class MaskExtension extends LayerExtension {
   static defaultProps = defaultProps;
   static extensionName = 'MaskExtension';
+
+  // @ts-ignore
+  getSubLayerProps(this: CompositeLayer, extension: this): any {
+    // @ts-ignore
+    const newProps = super.getSubLayerProps(extension);
+    if ('maskByInstance' in this.props) {
+      // @ts-ignore
+      newProps.maskByInstance = this.props.maskByInstance;
+    }
+    return newProps;
+  }
 
   getShaders(this: Layer<MaskExtensionProps>): any {
     // Infer by geometry if 'maskByInstance' prop isn't explictly set

--- a/modules/extensions/src/mask/mask.ts
+++ b/modules/extensions/src/mask/mask.ts
@@ -25,12 +25,9 @@ export default class MaskExtension extends LayerExtension {
   static defaultProps = defaultProps;
   static extensionName = 'MaskExtension';
 
-  // @ts-ignore
-  getSubLayerProps(this: CompositeLayer, extension: this): any {
-    // @ts-ignore
-    const newProps = super.getSubLayerProps(extension);
+  getSubLayerProps(this: CompositeLayer<MaskExtensionProps>, extension: this): any {
+    const newProps = super.getSubLayerProps.call(this, extension);
     if ('maskByInstance' in this.props) {
-      // @ts-ignore
       newProps.maskByInstance = this.props.maskByInstance;
     }
     return newProps;

--- a/modules/extensions/src/mask/shader-module.ts
+++ b/modules/extensions/src/mask/shader-module.ts
@@ -54,10 +54,12 @@ varying vec2 mask_texCoords;
     bool mask = mask_isInBounds(mask_texCoords);
 
     // Debug: show extent of render target
-    gl_FragColor = vec4(mask_texCoords, 0.0, 1.0);
+    // gl_FragColor = vec4(mask_texCoords, 0.0, 1.0);
     // gl_FragColor = vec4(1.0);
 
     // if (!mask) discard;
+    // Debug (mask out in blue, not discard)
+    if (!mask) gl_FragColor = vec4(0.0, 0.0, 1.0, 0.1);
   }
 `
 };

--- a/modules/extensions/src/mask/shader-module.ts
+++ b/modules/extensions/src/mask/shader-module.ts
@@ -49,17 +49,14 @@ varying vec2 mask_texCoords;
   'fs:#decl': `
 varying vec2 mask_texCoords;
 `,
-  'fs:#main-end': `
+  'fs:#main-start': `
   if (mask_enabled) {
     bool mask = mask_isInBounds(mask_texCoords);
 
     // Debug: show extent of render target
     // gl_FragColor = vec4(mask_texCoords, 0.0, 1.0);
-    // gl_FragColor = vec4(1.0);
 
     if (!mask) discard;
-    // Debug (mask out in blue, not discard)
-    // if (!mask) gl_FragColor = vec4(0.0, 0.0, 1.0, 0.1);
   }
 `
 };

--- a/modules/extensions/src/mask/shader-module.ts
+++ b/modules/extensions/src/mask/shader-module.ts
@@ -49,15 +49,15 @@ varying vec2 mask_texCoords;
   'fs:#decl': `
 varying vec2 mask_texCoords;
 `,
-  'fs:#main-start': `
+  'fs:#main-end': `
   if (mask_enabled) {
     bool mask = mask_isInBounds(mask_texCoords);
 
     // Debug: show extent of render target
-    // gl_FragColor = vec4(mask_texCoords, 0.0, 1.0);
-    gl_FragColor = texture2D(mask_texture, mask_texCoords);
+    gl_FragColor = vec4(mask_texCoords, 0.0, 1.0);
+    // gl_FragColor = vec4(1.0);
 
-    if (!mask) discard;
+    // if (!mask) discard;
   }
 `
 };

--- a/modules/extensions/src/mask/shader-module.ts
+++ b/modules/extensions/src/mask/shader-module.ts
@@ -57,9 +57,9 @@ varying vec2 mask_texCoords;
     // gl_FragColor = vec4(mask_texCoords, 0.0, 1.0);
     // gl_FragColor = vec4(1.0);
 
-    // if (!mask) discard;
+    if (!mask) discard;
     // Debug (mask out in blue, not discard)
-    if (!mask) gl_FragColor = vec4(0.0, 0.0, 1.0, 0.1);
+    // if (!mask) gl_FragColor = vec4(0.0, 0.0, 1.0, 0.1);
   }
 `
 };

--- a/test/apps/mask/app.js
+++ b/test/apps/mask/app.js
@@ -115,7 +115,7 @@ function getLayerData(data) {
 export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
   const {arcs, targets, sources} = useMemo(() => getLayerData(data), [data]);
   const [maskEnabled, setMaskEnabled] = useState(true);
-  const [showLayers, setShowLayers] = useState(true);
+  const [showLayers, setShowLayers] = useState(false);
   const [selectedCounty, selectCounty] = useState(null);
   const [selectedCounty2, selectCounty2] = useState(null);
 
@@ -181,35 +181,33 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
         highlightColor: [255, 255, 255, 150]
       }),
       // Rings around target (clipped by mask)
-      new ScatterplotLayer({
-        id: 'sources',
-        data: sources,
-        radiusScale: 3000,
-        radiusMinPixels: 10,
-        getFillColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
-        extensions: [new MaskExtension()],
-        maskId: maskEnabled && 'mask2'
-      }),
+      false &&
+        new ScatterplotLayer({
+          id: 'sources',
+          data: sources,
+          radiusScale: 3000,
+          radiusMinPixels: 10,
+          getFillColor: d => (d.gain > 0 ? TARGET_COLOR : SOURCE_COLOR),
+          extensions: [new MaskExtension()],
+          maskId: maskEnabled && 'mask2'
+        }),
       true &&
         new HeatmapLayer({
           id: 'sources-heatmap',
+          weightsTextureSize: 512,
           data: sources,
           radiusMinPixels: 10,
           getPosition: d => d.position,
           getWeight: d => Math.abs(d.gain),
           extensions: maskEnabled ? [new MaskExtension()] : [],
           maskId: maskEnabled && 'mask2',
-          maskByInstance: false
+          maskByInstance: showLayers
         })
     ];
 
   return (
     <>
-      <DeckGL
-        layers={showLayers ? layers : []}
-        initialViewState={INITIAL_VIEW_STATE}
-        controller={true}
-      >
+      <DeckGL layers={true ? layers : []} initialViewState={INITIAL_VIEW_STATE} controller={true}>
         <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
       </DeckGL>
       <div style={{position: 'absolute', background: 'white', padding: 10, userSelect: 'none'}}>
@@ -223,7 +221,7 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
         </label>
         <label>
           <input type="checkbox" checked={showLayers} onChange={() => setShowLayers(!showLayers)} />
-          Show layers
+          maskByInstance
         </label>
       </div>
     </>

--- a/test/apps/mask/app.js
+++ b/test/apps/mask/app.js
@@ -128,11 +128,13 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
   }, [selectedCounty2]);
 
   const onClickState = useCallback((info, evt) => {
-    if (evt.srcEvent.shiftKey) {
-      selectCounty2(info.object);
-    } else {
-      selectCounty(info.object);
-    }
+    // if (evt.srcEvent.shiftKey) {
+    //   selectCounty2(info.object);
+    // } else {
+    //   selectCounty(info.object);
+    // }
+    selectCounty(info.object);
+    selectCounty2(info.object);
   }, []);
 
   const onDataLoad = useCallback(geojson => {

--- a/test/apps/mask/app.js
+++ b/test/apps/mask/app.js
@@ -188,7 +188,7 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
         extensions: [new MaskExtension()],
         maskId: maskEnabled && 'mask2'
       }),
-      false &&
+      true &&
         new HeatmapLayer({
           id: 'sources-heatmap',
           data: sources,

--- a/test/apps/mask/index.html
+++ b/test/apps/mask/index.html
@@ -12,11 +12,6 @@
                 height: 100vh;
                 overflow: hidden;
             }
-            #app {
-                width: 80%;
-                height: 100%;
-                position: relative;
-            }
         </style>
     </head>
     <body>

--- a/test/apps/mask/index.html
+++ b/test/apps/mask/index.html
@@ -1,18 +1,29 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deck.gl Example</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
-  </style>
-</head>
-<body>
-<div id="app"></div>
-</body>
-<script type="text/javascript" src="app.js"></script>
-<script type="text/javascript">
-  App.renderToDOM(document.getElementById('app'));
-</script>
+    <head>
+        <meta charset="utf-8" />
+        <title>deck.gl Example</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <style>
+            body {
+                margin: 0;
+                font-family: sans-serif;
+                width: 100vw;
+                height: 100vh;
+                overflow: hidden;
+            }
+            #app {
+                width: 80%;
+                height: 100%;
+                position: relative;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="app"></div>
+    </body>
+    <script type="text/javascript" src="app.js"></script>
+    <script type="text/javascript">
+        App.renderToDOM(document.getElementById('app'));
+    </script>
 </html>


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/7184

#### Background

https://user-images.githubusercontent.com/453755/201100833-4ca2fcc3-0f99-4aaf-aef5-c96201ba7dd1.mov

Due to the aggregation the mask extension wasn't working with the `HeatmapLayer`. This PoC works well, but it doesn't fit cleanly with the deck architecture. @Pessimistress could you give some input on:

- How to cleanly access the `EffectManager` in `AggregationLayer.getModuleParameters`
- How best to get the `weightsTransform` to execute *after* the mask is rendered. I couldn't find a way without adding the `postEffect` hook

<!-- For all the PRs -->
#### Change List
- Provide correct uniforms to shaders in `weightsTransform` & `TriangleLayer`
- Update shaders to work with extension

#### TODO
- Agree on how to cleanly integrate
- Revert changes to test app
- Render tests
