### PR TITLE
Fix Tileset2D cache pruning

### DIFF
--- a/modules/geo-layers/src/tile-layer/tileset-2d.ts
+++ b/modules/geo-layers/src/tile-layer/tileset-2d.ts
@@ -419,7 +419,7 @@ export default class Tileset2D {
 
     if (overflown) {
       for (const [id, tile] of _cache) {
-        if (!tile.isVisible) {
+        if (!tile.isVisible && !tile.isSelected) {
           // delete tile
           this._cacheByteSize -= opts.maxCacheByteSize ? tile.byteLength : 0;
           _cache.delete(id);

--- a/test/modules/geo-layers/tile-layer/tileset-2d.spec.js
+++ b/test/modules/geo-layers/tile-layer/tileset-2d.spec.js
@@ -133,14 +133,17 @@ test('Tileset2D#maxCacheSize', t => {
   tileset.update(
     new WebMercatorViewport(
       Object.assign({}, testViewState, {
+        width: 300,
+        height: 100,
         longitude: -100,
         latitude: 80
       })
     )
   );
-
-  t.equal(tileset._cache.size, 1, 'cache is resized');
+  t.equal(tileset._cache.size, 2, 'cache is resized');
+  t.notOk(tileset._cache.get('1171-1566-12'), 'old tile is deleted from cache');
   t.ok(tileset._cache.get('910-459-12'), 'expected tile is in cache');
+  t.ok(tileset._cache.get('909-459-12'), 'expected tile is in cache');
 
   t.end();
 });


### PR DESCRIPTION
For #7396

#### Change List
- Tileset2D never prunes selected tiles from cache
- Test
