### PR TITLE
TileLayer exposes accurate picking info on pointer out

### DIFF
--- a/examples/website/map-tile/app.js
+++ b/examples/website/map-tile/app.js
@@ -34,8 +34,11 @@ const LINK_STYLE = {
 const devicePixelRatio = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
 
 function getTooltip({tile}) {
-  const {x, y, z} = tile.index;
-  return tile && `tile: x: ${x}, y: ${y}, z: ${z}`;
+  if (tile) {
+    const {x, y, z} = tile.index;
+    return `tile: x: ${x}, y: ${y}, z: ${z}`;
+  }
+  return null;
 }
 
 export default function App({showBorder = false, onTilesLoad = null}) {

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -310,7 +310,9 @@ export default class TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeL
   }
 
   getPickingInfo({info, sourceLayer}: GetPickingInfoParams): TiledPickingInfo<DataT> {
-    (info as any).tile = (sourceLayer as any).props.tile;
+    if (info.picked) {
+      (info as any).tile = (sourceLayer as any).props.tile;
+    }
     return info;
   }
 


### PR DESCRIPTION
#### Background

This fixes the following issue in the [map-tile example](https://deck.gl/examples/tile-layer/):

- tooltip shows nonsense content instead of disappearing when the pointer leaves the map

#### Change List
- `pickInfo.tile` should not be populated if nothing is picked. This might be lightly breaking if an application expects `tile` to be always present (like the example app) but arguably is the correct behavior.
