### PR TITLE
Add missing props to ClipExtension and MaskExtension

### DIFF
--- a/modules/extensions/src/clip/clip.ts
+++ b/modules/extensions/src/clip/clip.ts
@@ -23,7 +23,8 @@ import {LayerExtension, _ShaderModule as ShaderModule} from '@deck.gl/core';
 import type {Layer} from '@deck.gl/core';
 
 const defaultProps = {
-  clipBounds: [0, 0, 1, 1]
+  clipBounds: [0, 0, 1, 1],
+  clipByInstance: undefined
 };
 
 export type ClipExtensionProps = {

--- a/modules/extensions/src/mask/mask.ts
+++ b/modules/extensions/src/mask/mask.ts
@@ -4,7 +4,8 @@ import mask from './shader-module';
 import type {Layer} from '@deck.gl/core';
 
 const defaultProps = {
-  maskId: ''
+  maskId: '',
+  maskByInstance: undefined
 };
 
 export type MaskExtensionProps = {


### PR DESCRIPTION
#### Background

All extension prop names must be present in `deffaultProps` for `getSubLayerProps` to pass them down.

#### Change List
- Add missing prop names to ClipExtension and MaskExtension
