### PR TITLE
add type for viewState

### DIFF
--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -110,14 +110,34 @@ export type InteractionState = {
   isZooming?: boolean;
 }
 
+export type ViewState = {
+  zoom: number;
+  longitude: number;
+  latitude: number;
+  bearing?: number;
+  pitch?: number;
+  transitionDuration?: number;
+  width?: number;
+  height?: number;
+  altitude?: number;
+  maxPitch?: number;
+  maxZoom?: number;
+  minPitch?: number;
+  minZoom?: number;
+  normalize?: any;
+  position?: number[];
+  transitionEasing?: any;
+  transitionInterpolator?: any;
+}
+
 /** Parameters passed to the onViewStateChange callback */
 export type ViewStateChangeParameters = {
   /** The next view state, either from user input or transition */
-  viewState: Record<string, any>;
+  viewState: ViewState;
   /** Object describing the nature of the view state change */
   interactionState: InteractionState;
   /** The current view state */
-  oldViewState?: Record<string, any>;
+  oldViewState?: ViewState;
 }
 
 const pinchEventWorkaround: any = {};


### PR DESCRIPTION
Add type definition for viewState, which causes type warnings when setting the state of a predefined object, even when that object has correct parameters

Used "any" type for the following properties: normalize, position, transitionEasing,  transitionInterpolator; which should probably be defined.

TS Warning Example:
```
Argument of type 'Record<string, any>' is not assignable to parameter of type 'SetStateAction<{ longitude: number; latitude: number; zoom: number; pitch: number; minZoom: number; }>'.
  Type 'Record<string, any>' is missing the following properties from type '{ longitude: number; latitude: number; zoom: number; pitch: number; minZoom: number; }': longitude, latitude, zoom, pitch, minZoomts(2345)
```
