### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/bindings/pydeck/requirements/requirements.txt
+++ b/bindings/pydeck/requirements/requirements.txt
@@ -1,3 +1,3 @@
 ipykernel>=5.1.2;python_version>="3.4"
 Jinja2>=2.10.1
-numpy>=1.16.4
+numpy>=1.22.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.16.4
- [CVE-2021-33430](https://www.oscs1024.com/hd/CVE-2021-33430)


### What did I do？
Upgrade numpy from 1.16.4 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>