### PR TITLE
Use default loader to load icons

### DIFF
--- a/modules/layers/src/icon-layer/icon-manager.ts
+++ b/modules/layers/src/icon-layer/icon-manager.ts
@@ -422,7 +422,7 @@ export default class IconManager {
 
     for (const icon of icons) {
       this._pendingCount++;
-      load(icon.url, ImageLoader, this._loadOptions)
+      load(icon.url, this._loadOptions)
         .then(imageData => {
           const id = getIconId(icon);
           const {x, y, width, height} = this._mapping[id];


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/discussions/7449
The discrepancy comes from loading images with and without premultiplication.

The default ImageLoader is registered with options: https://github.com/visgl/deck.gl/blob/691e3f5bce548aacbf00a16e65c87fae5501b4f2/modules/core/src/lib/init.ts#L56-L60

This is used for loading the `iconAtlas` prop.

When using auto packing, the `IconManager` calls `load` directly with `ImageLoader`, in which case the default options are not used.

#### Change List
- Use default loader to load individual icons
