### PR TITLE
Include js files for ts-loader

### DIFF
--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -112,13 +112,13 @@ function makeLocalDevConfig(EXAMPLE_DIR = LIB_DIR, linkToLuma, linkToMath) {
           // Compile source using babel. This is not necessary for src to run in the browser
           // However class inheritance cannot happen between transpiled/non-transpiled code
           // Which affects some examples
-          test: /(\.ts|\.tsx)$/,
+          test: /(\.js|\.ts|\.tsx)$/,
           loader: 'ts-loader',
           options: {
-            configFile: resolve(ROOT_DIR, "tsconfig.build.json"),
+            configFile: resolve(ROOT_DIR, 'tsconfig.build.json'),
             transpileOnly: true,
             compilerOptions: {
-              target: "es2019",
+              target: 'es2019',
               noEmit: false
             }
           },


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

Fixes regression introduced by https://github.com/visgl/deck.gl/pull/7401. When trying to build test apps that include layers from the aggregation-layers an error is thrown due to a `.js` not being processed by the loader. Repro by running `yarn start-local` in `test/apps/carto-map`.


```
ERROR in deck.gl/modules/aggregation-layers/src/utils/gpu-grid-aggregation/gpu-grid-aggregator.js 185:25
Module parse failed: Unexpected token (185:25)
File was processed with these loaders:
 * ../../../node_modules/source-map-loader/index.js
You may need an additional loader to handle the result of these loaders.
|     } = this.state;
|
>     gridAggregationModel?.delete();
```

<!-- For all the PRs -->
#### Change List
- Include `.js` files in `ts-loader` config
