### PR TITLE
Handle defaultProps of extensions

### DIFF
--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -208,7 +208,6 @@ export default abstract class CompositeLayer<PropsT = {}> extends Layer<
     const sublayerId = sublayerProps.id || 'sublayer';
 
     if (overridingSublayerProps) {
-      // @ts-ignore (TS2339) hidden property
       const propTypes = this.props[PROP_TYPES_SYMBOL];
       const subLayerPropTypes = sublayerProps.type ? sublayerProps.type._propTypes : {};
       for (const key in overridingSublayerProps) {

--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -27,6 +27,7 @@ import type {FilterContext} from '../passes/layers-pass';
 import type {LayersList, LayerContext} from './layer-manager';
 import type {CompositeLayerProps, Accessor, AccessorContext} from '../types/layer-props';
 import {ConstructorOf} from '../types/types';
+import {PROP_TYPES_SYMBOL} from '../lifecycle/constants';
 
 const TRACE_RENDER_LAYERS = 'compositeLayer.renderLayers';
 
@@ -208,7 +209,7 @@ export default abstract class CompositeLayer<PropsT = {}> extends Layer<
 
     if (overridingSublayerProps) {
       // @ts-ignore (TS2339) hidden property
-      const propTypes = this.constructor._propTypes;
+      const propTypes = this.props[PROP_TYPES_SYMBOL];
       const subLayerPropTypes = sublayerProps.type ? sublayerProps.type._propTypes : {};
       for (const key in overridingSublayerProps) {
         const propType = subLayerPropTypes[key] || propTypes[key];

--- a/modules/core/src/lifecycle/component-state.ts
+++ b/modules/core/src/lifecycle/component-state.ts
@@ -19,7 +19,12 @@
 // THE SOFTWARE.
 
 import {isAsyncIterable} from '../utils/iterable-utils';
-import {ASYNC_ORIGINAL_SYMBOL, ASYNC_RESOLVED_SYMBOL, ASYNC_DEFAULTS_SYMBOL} from './constants';
+import {
+  PROP_TYPES_SYMBOL,
+  ASYNC_ORIGINAL_SYMBOL,
+  ASYNC_RESOLVED_SYMBOL,
+  ASYNC_DEFAULTS_SYMBOL
+} from './constants';
 import type Component from './component';
 import {PropType} from './prop-types';
 
@@ -305,8 +310,7 @@ export default class ComponentState<ComponentT extends Component> {
   private _createAsyncPropData(propName: string, defaultValue: any) {
     const asyncProp = this.asyncProps[propName];
     if (!asyncProp) {
-      // @ts-expect-error
-      const propTypes = this.component && this.component.constructor._propTypes;
+      const propTypes = this.component && this.component.props[PROP_TYPES_SYMBOL];
       // assert(defaultValue !== undefined);
       this.asyncProps[propName] = {
         type: propTypes && propTypes[propName],

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -1,9 +1,11 @@
 import {
   COMPONENT_SYMBOL,
+  PROP_TYPES_SYMBOL,
   ASYNC_ORIGINAL_SYMBOL,
   ASYNC_RESOLVED_SYMBOL,
   ASYNC_DEFAULTS_SYMBOL
 } from './constants';
+import {PropType} from './prop-types';
 import {createProps} from './create-props';
 
 let counter = 0;
@@ -11,6 +13,7 @@ let counter = 0;
 export type StatefulComponentProps<PropsT> = PropsT & {
   id: string;
   [COMPONENT_SYMBOL]: Component<PropsT>;
+  [PROP_TYPES_SYMBOL]: Record<string, PropType>;
   [ASYNC_DEFAULTS_SYMBOL]: Partial<PropsT>;
   [ASYNC_ORIGINAL_SYMBOL]: Partial<PropsT>;
   [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;

--- a/modules/core/src/lifecycle/constants.ts
+++ b/modules/core/src/lifecycle/constants.ts
@@ -14,6 +14,8 @@ export type Lifecycle = typeof LIFECYCLE[keyof typeof LIFECYCLE];
 // but are copied with Object.assign ¯\_(ツ)_/¯
 // Supported everywhere except IE11, can be polyfilled with core-js
 export const COMPONENT_SYMBOL: unique symbol = Symbol.for('component');
+export const PROP_TYPES_SYMBOL: unique symbol = Symbol.for('propTypes');
+export const DEPRECATED_PROPS_SYMBOL: unique symbol = Symbol.for('deprecatedProps');
 export const ASYNC_DEFAULTS_SYMBOL: unique symbol = Symbol.for('asyncPropDefaults');
 export const ASYNC_ORIGINAL_SYMBOL: unique symbol = Symbol.for('asyncPropOriginal');
 export const ASYNC_RESOLVED_SYMBOL: unique symbol = Symbol.for('asyncPropResolved');

--- a/modules/core/src/lifecycle/props.ts
+++ b/modules/core/src/lifecycle/props.ts
@@ -1,8 +1,8 @@
-import {COMPONENT_SYMBOL} from './constants';
+import {PROP_TYPES_SYMBOL} from './constants';
 import {PropType} from './prop-types';
 
 export function validateProps(props) {
-  const propTypes = getPropTypes(props);
+  const propTypes = props[PROP_TYPES_SYMBOL];
 
   for (const propName in propTypes) {
     const propType = propTypes[propName];
@@ -28,7 +28,7 @@ export function diffProps(
   const propsChangedReason = compareProps({
     newProps: props,
     oldProps,
-    propTypes: getPropTypes(props),
+    propTypes: props[PROP_TYPES_SYMBOL],
     ignoreProps: {data: null, updateTriggers: null, extensions: null, transitions: null}
   });
 
@@ -56,7 +56,7 @@ function diffTransitions(props, oldProps): false | Record<string, true> {
     return false;
   }
   const result: Record<string, true> = {};
-  const propTypes = getPropTypes(props);
+  const propTypes = props[PROP_TYPES_SYMBOL];
   let changed = false;
 
   for (const key in props.transitions) {
@@ -256,10 +256,4 @@ function diffUpdateTrigger(props, oldProps, triggerName) {
     triggerName
   });
   return diffReason;
-}
-
-function getPropTypes(props): Record<string, PropType> {
-  const layer = props[COMPONENT_SYMBOL];
-  const LayerType = layer && layer.constructor;
-  return LayerType ? LayerType._propTypes : {};
 }

--- a/test/bench/create-props.bench.js
+++ b/test/bench/create-props.bench.js
@@ -31,6 +31,22 @@ TestLayer.defaultProps = {
   getColor: {deprecatedFor: ['getFillColor', 'getLineColor']}
 };
 
+class TestExtensionA {}
+TestExtensionA.extensionName = 'TestExtensionA';
+TestExtensionA.defaultProps = {
+  extAEnabled: true,
+  extAValue: {type: 'number', value: 10},
+  extARange: {type: 'array', value: [0, 1], compare: true}
+};
+
+class TestExtensionB {}
+TestExtensionB.extensionName = 'TestExtensionB';
+TestExtensionB.defaultProps = {
+  extBEnabled: true,
+  extBValue: {type: 'number', value: 10},
+  extBRange: {type: 'array', value: [0, 1], compare: true}
+};
+
 // eslint-disable-next-line
 let testInstance;
 
@@ -53,6 +69,22 @@ export default function comparePropsBench(suite) {
           data: 'http://deck.gl',
           getPosition: d => d.coordinates,
           getRadius: d => d.count
+        }
+      );
+    })
+    .add('createProps#with extensions', () => {
+      testInstance = new TestLayer(
+        {
+          stroked: true,
+          getFillColor: [255, 0, 0],
+          getLineColor: [255, 255, 255]
+        },
+        {
+          id: 'scatterplot',
+          data: 'http://deck.gl',
+          getPosition: d => d.coordinates,
+          getRadius: d => d.count,
+          extensions: [new TestExtensionA(), new TestExtensionB()]
         }
       );
     });

--- a/test/modules/core/lib/layer.spec.js
+++ b/test/modules/core/lib/layer.spec.js
@@ -21,6 +21,7 @@
 import test from 'tape-catch';
 import {
   Layer,
+  LayerExtension,
   AttributeManager,
   COORDINATE_SYSTEM,
   MapView,
@@ -107,6 +108,13 @@ class SubLayer3 extends Layer {
 
 SubLayer3.layerName = 'SubLayer2';
 
+class Extension extends LayerExtension {}
+Extension.extensionName = 'LayerExtension';
+Extension.defaultProps = {
+  extEnabled: true,
+  getExtValue: {type: 'accessor', value: 1}
+};
+
 test('Layer#constructor', t => {
   for (const tc of LAYER_CONSTRUCT_TEST_CASES) {
     const layer = Array.isArray(tc.props) ? new Layer(...tc.props) : new Layer(tc.props);
@@ -165,7 +173,7 @@ test('SubLayer3#constructor (no layerName, no defaultProps)', t => {
 
 test('Layer#getNumInstances', t => {
   for (const dataVariant of dataVariants) {
-    const layer = new Layer(Object.assign({}, LAYER_PROPS, {data: dataVariant.data}));
+    const layer = new Layer(LAYER_PROPS, {data: dataVariant.data});
     t.equal(layer.getNumInstances(), dataVariant.size);
   }
   t.end();
@@ -176,31 +184,31 @@ test('Layer#validateProps', t => {
   layer.validateProps();
   t.pass('Layer props are valid');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {sizeScale: 1}));
+  layer = new SubLayer(LAYER_PROPS, {sizeScale: 1});
   t.throws(() => layer.validateProps(), /sizeScale/, 'throws on invalid function prop');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {opacity: 'transparent'}));
+  layer = new SubLayer(LAYER_PROPS, {opacity: 'transparent'});
   t.throws(() => layer.validateProps(), /opacity/, 'throws on invalid numberic prop');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {opacity: 2}));
+  layer = new SubLayer(LAYER_PROPS, {opacity: 2});
   t.throws(() => layer.validateProps(), /opacity/, 'throws on numberic prop out of range');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {getColor: [255, 0, 0]}));
+  layer = new SubLayer(LAYER_PROPS, {getColor: [255, 0, 0]});
   layer.validateProps();
   t.pass('Layer props are valid');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {getColor: d => d.color}));
+  layer = new SubLayer(LAYER_PROPS, {getColor: d => d.color});
   layer.validateProps();
   t.pass('Layer props are valid');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {getColor: 3}));
+  layer = new SubLayer(LAYER_PROPS, {getColor: 3});
   t.throws(() => layer.validateProps(), /getColor/, 'throws on invalid accessor prop');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {sizeScale: null}));
+  layer = new SubLayer(LAYER_PROPS, {sizeScale: null});
   layer.validateProps();
   t.pass('Layer props are valid');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {sizeScale: [1, 10]}));
+  layer = new SubLayer(LAYER_PROPS, {sizeScale: [1, 10]});
   t.throws(() => layer.validateProps(), /sizeScale/, 'throws on invalid function prop');
 
   t.end();
@@ -211,64 +219,81 @@ test('Layer#diffProps', t => {
   let layer = new SubLayer(LAYER_PROPS);
   t.doesNotThrow(() => testInitializeLayer({layer, onError: t.notOk}), 'Layer initialized OK');
 
-  layer._diffProps(new SubLayer(Object.assign({}, LAYER_PROPS)).props, layer.props);
+  layer._diffProps(new SubLayer(LAYER_PROPS).props, layer.props);
   t.false(layer.getChangeFlags().somethingChanged, 'same props');
 
-  layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {data: dataVariants[0]})).props,
-    layer.props
-  );
+  layer._diffProps(new SubLayer(LAYER_PROPS, {data: dataVariants[0]}).props, layer.props);
   t.true(layer.getChangeFlags().dataChanged, 'data changed');
 
-  layer._diffProps(new SubLayer(Object.assign({}, LAYER_PROPS, {size: 0})).props, layer.props);
+  layer._diffProps(new SubLayer(LAYER_PROPS, {size: 0}).props, layer.props);
   t.true(layer.getChangeFlags().propsChanged, 'props changed');
 
   // Dummy attribute manager to avoid diffUpdateTriggers failure
-  layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 100}})).props,
-    layer.props
-  );
+  layer._diffProps(new SubLayer(LAYER_PROPS, {updateTriggers: {time: 100}}).props, layer.props);
   t.true(layer.getChangeFlags().propsOrDataChanged, 'props changed');
 
   const spy = makeSpy(AttributeManager.prototype, 'invalidate');
   layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: {version: 0}}})).props,
+    new SubLayer(LAYER_PROPS, {updateTriggers: {time: {version: 0}}}).props,
     layer.props
   );
   t.ok(spy.called, 'updateTriggers fired');
   spy.restore();
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 0}}));
+  layer = new SubLayer(LAYER_PROPS, {updateTriggers: {time: 0}});
   testInitializeLayer({layer, onError: t.notOk});
-  layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 0}})).props,
-    layer.props
-  );
+  layer._diffProps(new SubLayer(LAYER_PROPS, {updateTriggers: {time: 0}}).props, layer.props);
   t.false(layer.getChangeFlags().updateTriggersChanged, 'updateTriggers not fired');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 0}}));
+  layer = new SubLayer(LAYER_PROPS, {updateTriggers: {time: 0}});
+  testInitializeLayer({layer, onError: t.notOk});
+  layer._diffProps(new SubLayer(LAYER_PROPS, {updateTriggers: {time: 1}}).props, layer.props);
+  t.true(layer.getChangeFlags().updateTriggersChanged, 'updateTriggersChanged fired');
+
+  layer = new SubLayer(LAYER_PROPS, {updateTriggers: {time: 0}});
+  testInitializeLayer({layer, onError: t.notOk});
+  layer._diffProps(new SubLayer(LAYER_PROPS, {updateTriggers: {time: null}}).props, layer.props);
+  t.true(layer.getChangeFlags().updateTriggersChanged, 'updateTriggersChanged fired');
+
+  layer = new SubLayer(LAYER_PROPS, {updateTriggers: {time: 0}});
   testInitializeLayer({layer, onError: t.notOk});
   layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 1}})).props,
+    new SubLayer(LAYER_PROPS, {updateTriggers: {time: undefined}}).props,
     layer.props
   );
   t.true(layer.getChangeFlags().updateTriggersChanged, 'updateTriggersChanged fired');
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 0}}));
-  testInitializeLayer({layer, onError: t.notOk});
-  layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: null}})).props,
-    layer.props
-  );
-  t.true(layer.getChangeFlags().updateTriggersChanged, 'updateTriggersChanged fired');
+  t.end();
+});
 
-  layer = new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: 0}}));
+test('Layer#diffProps#extensions', t => {
+  let layer = new SubLayer(LAYER_PROPS);
   testInitializeLayer({layer, onError: t.notOk});
+
   layer._diffProps(
-    new SubLayer(Object.assign({}, LAYER_PROPS, {updateTriggers: {time: undefined}})).props,
+    new SubLayer(LAYER_PROPS, {getExtValue: _ => 1, extensions: [new Extension()]}).props,
     layer.props
   );
-  t.true(layer.getChangeFlags().updateTriggersChanged, 'updateTriggersChanged fired');
+  t.true(layer.getChangeFlags().extensionsChanged, 'extensionsChanged');
+  layer.finalizeState();
+
+  layer = new SubLayer(LAYER_PROPS, {getExtValue: _ => 1, extensions: [new Extension()]});
+  testInitializeLayer({layer, onError: t.notOk});
+
+  layer._diffProps(
+    new SubLayer(LAYER_PROPS, {randomProp: _ => 2, extensions: [new Extension()]}).props,
+    layer.props
+  );
+  t.true(layer.getChangeFlags().propsChanged, 'undefined prop changed');
+  layer._clearChangeFlags();
+
+  layer._diffProps(
+    new SubLayer(LAYER_PROPS, {getExtValue: _ => 2, extensions: [new Extension()]}).props,
+    layer.props
+  );
+  t.false(layer.getChangeFlags().somethingChanged, 'extension accessor change ignored');
+
+  layer.finalizeState();
 
   t.end();
 });

--- a/test/modules/core/lifecycle/props.spec.js
+++ b/test/modules/core/lifecycle/props.spec.js
@@ -219,7 +219,9 @@ test('createProps', t => {
   class ExtB extends ExtA {}
   ExtB.extensionName = 'ExtB';
   ExtB.defaultProps = {
-    extValue: 1
+    extValue: 1,
+    extRange: [0, 1],
+    extRange0: {deprecatedFor: 'extRange'}
   };
 
   let mergedProps = createProps(new B(), [{data: [0, 1]}]);
@@ -243,11 +245,13 @@ test('createProps', t => {
 
   mergedProps = createProps(new B(), [
     {
+      extRange0: [1, 100],
       extensions: [new ExtB()]
     }
   ]);
   t.equal(mergedProps.extValue, 1, 'extension default props merged');
   t.equal(mergedProps.extEnabled, true, 'base extension default props merged');
+  t.deepEqual(mergedProps.extRange, [1, 100], 'user props merged');
   t.ok(mergedProps[PROP_TYPES_SYMBOL].extValue, 'prop types defined');
 
   mergedProps = createProps(new B(), [{}]);

--- a/test/modules/core/lifecycle/props.spec.js
+++ b/test/modules/core/lifecycle/props.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-promise/tape';
 import {createProps} from '@deck.gl/core/lifecycle/create-props';
 import {compareProps} from '@deck.gl/core/lifecycle/props';
+import {PROP_TYPES_SYMBOL} from '@deck.gl/core/lifecycle/constants';
 import {Vector2} from '@math.gl/core';
 
 const SAME = 'equal';
@@ -197,6 +198,7 @@ test('compareProps#tests', t => {
 
 test('createProps', t => {
   class A {}
+  A.componentName = 'A';
   A.defaultProps = {
     a: 1,
     data: [],
@@ -205,7 +207,20 @@ test('createProps', t => {
   };
 
   class B extends A {}
+  B.componentName = 'B';
   B.defaultProps = {b: 2};
+
+  class ExtA {}
+  ExtA.extensionName = 'ExtA';
+  ExtA.defaultProps = {
+    extEnabled: true
+  };
+
+  class ExtB extends ExtA {}
+  ExtB.extensionName = 'ExtB';
+  ExtB.defaultProps = {
+    extValue: 1
+  };
 
   let mergedProps = createProps(new B(), [{data: [0, 1]}]);
 
@@ -213,10 +228,30 @@ test('createProps', t => {
   t.equal(mergedProps.b, 2, 'sub class props merged');
   t.deepEqual(mergedProps.data, [0, 1], 'user props merged');
   t.equal(mergedProps.c, 0, 'default prop value used');
+  t.ok(mergedProps[PROP_TYPES_SYMBOL].a, 'prop types defined');
 
   mergedProps = createProps(new B(), [{c0: 4}]);
+  t.equal(mergedProps.c, 4, 'user props merged');
 
-  t.deepEqual(mergedProps.c, 4, 'user props merged');
+  mergedProps = createProps(new B(), [
+    {
+      extensions: [new ExtA()]
+    }
+  ]);
+  t.equal(mergedProps.extEnabled, true, 'extension default props merged');
+  t.ok(mergedProps[PROP_TYPES_SYMBOL].extEnabled, 'prop types defined');
+
+  mergedProps = createProps(new B(), [
+    {
+      extensions: [new ExtB()]
+    }
+  ]);
+  t.equal(mergedProps.extValue, 1, 'extension default props merged');
+  t.equal(mergedProps.extEnabled, true, 'base extension default props merged');
+  t.ok(mergedProps[PROP_TYPES_SYMBOL].extValue, 'prop types defined');
+
+  mergedProps = createProps(new B(), [{}]);
+  t.notOk(mergedProps.extEnabled, 'default props without extensions not affected');
 
   t.end();
 });


### PR DESCRIPTION
For #7496

Before this change, we parse the static `defaultProps` object once for each layer class, and then merge it recursively with parent class defaults once for each layer class as well. The result is stored in e.g. `ScatterplotLayer["_mergedDefaultProps"]`.

After this change, we parse the static `defaultProps` object once for each layer class and layer extension class, and merge them recursively with parent class defaults for each layer class + extension class list combination. The result is stored in e.g. `ScatterplotLayer["_mergedDefaultProps:DataFilterExtension:FillStyleExtension"]`.

This approach ensures that `ExtensionClass.defaultProps` behave the same as `LayerClass.defaultProps` when used together.

My main concern about merging this is the perf impact. Here are the resulting `createProp` benchmarks:

| Test | Before (iterations/s) | After (iterations/s) |
|---|---|---|
| empty | 3.20M | 3.20M |
| with props | 117K  | 118K |
| props with extensions | 117K  | 104K |

#### Change List
- Update `createProps` to consider extensions
- Unit tests
- Bench tests
