### PR TITLE
Fix disablePickingColor with externally supplied startIndices

### DIFF
--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -323,7 +323,11 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
 
   getVertexOffset(row: number): number {
     const {startIndices} = this;
-    const vertexIndex = startIndices ? startIndices[row] : row;
+    const vertexIndex = startIndices
+      ? row < startIndices.length
+        ? startIndices[row]
+        : this.numInstances
+      : row;
     return vertexIndex * this.size;
   }
 

--- a/test/modules/core/lib/attribute/attribute-manager.spec.js
+++ b/test/modules/core/lib/attribute/attribute-manager.spec.js
@@ -285,6 +285,10 @@ test('AttributeManager.update - external logical buffers', t => {
   let attribute = attributeManager.getAttributes()['positions'];
   t.deepEqual(attribute.value, [1, 1, 2, 2], 'positions attribute has value');
 
+  t.is(attribute.getVertexOffset(0), 0, 'getVertexOffset returns correct result');
+  t.is(attribute.getVertexOffset(1), 2, 'getVertexOffset returns correct result');
+  t.is(attribute.getVertexOffset(2), 4, 'getVertexOffset returns correct result');
+
   attribute = attributeManager.getAttributes()['colors'];
   t.deepEqual(attribute.value, [255, 0, 0, 0, 255, 0], 'colors attribute has value');
   t.is(attribute.getAccessor().size, 3, 'colors attribute has correct size');
@@ -326,6 +330,10 @@ test('AttributeManager.update - external logical buffers - variable width', t =>
 
   let attribute = attributeManager.getAttributes()['positions'];
   t.deepEqual(attribute.value.slice(0, 6), [1, 1, 1, 1, 2, 2], 'positions attribute has value');
+
+  t.is(attribute.getVertexOffset(0), 0, 'getVertexOffset returns correct result');
+  t.is(attribute.getVertexOffset(1), 4, 'getVertexOffset returns correct result');
+  t.is(attribute.getVertexOffset(2), 6, 'getVertexOffset returns correct result');
 
   attribute = attributeManager.getAttributes()['colors'];
   t.deepEqual(


### PR DESCRIPTION
For #7504

Internally generated `startIndices` always have `data.length + 1` elements, with the last one indicating the end of the attribute buffer. This may not be true with user-supplied `startIndices`.

#### Change List
- Add a safety check to `attribute.getVertexOffset`, which is used by `layer.disablePickingColor`
- Unit tests