### PR TITLE
Improve logic to update auto highlight module settings

### DIFF
--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -1169,7 +1169,8 @@ export default abstract class Layer<PropsT = {}> extends Component<PropsT & Requ
       }
 
       // highlightedObjectIndex will overwrite any settings from auto highlighting.
-      if (Number.isInteger(highlightedObjectIndex)) {
+      // Do not reset unless the value has changed.
+      if (forceUpdate || highlightedObjectIndex !== oldProps.highlightedObjectIndex) {
         parameters.pickingSelectedColor =
           Number.isFinite(highlightedObjectIndex) && (highlightedObjectIndex as number) >= 0
             ? this.encodePickingColor(highlightedObjectIndex)


### PR DESCRIPTION
For #7560

#### Change List
- Update module settings if `highlightedObjectIndex` is switched from number to null
- Test cases for different highlighting props combinations
