### PR TITLE
FillStyleExtension leverages new default props behavior

### DIFF
--- a/docs/developer-guide/custom-layers/prop-types.md
+++ b/docs/developer-guide/custom-layers/prop-types.md
@@ -128,6 +128,18 @@ MyLayerClass.defaultProps = {
 
 One of: URL string, [Texture2D](https://github.com/visgl/luma.gl/blob/8.5-release/modules/webgl/docs/api-reference/texture-2d.md) object, `Image`, `HTMLCanvasElement`, `HTMLVideoElement`, `ImageBitmap` or `ImageData`.
 
+- Options:
+  + `parameters` (object, optional) - custom [texture parameters](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) of the texture. If not specified, the following defaults are used:
+
+  ```js
+  {
+    [GL.TEXTURE_MIN_FILTER]: GL.LINEAR_MIPMAP_LINEAR,
+    [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
+    [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
+    [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE
+  }
+  ```
+
 - Default `transform`: converts to a `Texture2D` object
 
 ##### `array`

--- a/modules/core/src/lifecycle/prop-types.ts
+++ b/modules/core/src/lifecycle/prop-types.ts
@@ -3,6 +3,7 @@ import {deepEqual} from '../utils/deep-equal';
 
 import type Component from './component';
 import type {Color, Texture} from '../types/layer-props';
+import type Layer from '../lib/layer';
 
 type BasePropType<ValueT> = {
   value: ValueT;
@@ -68,6 +69,7 @@ type DataPropType<T = any> = BasePropType<T> & {
 };
 type ImagePropType = BasePropType<Texture | null> & {
   type: 'image';
+  parameters?: Record<number, number>;
 };
 type ObjectPropType<T = any> = BasePropType<T> & {
   type: 'object';
@@ -165,7 +167,14 @@ const TYPE_DEFINITIONS = {
   },
   image: {
     transform: (value, propType: ImagePropType, component) => {
-      return createTexture(component, value);
+      const context = (component as Layer).context;
+      if (!context || !context.gl) {
+        return null;
+      }
+      return createTexture(context.gl, value, {
+        ...propType.parameters,
+        ...component.props.textureParameters
+      });
     },
     release: value => {
       destroyTexture(value);

--- a/modules/core/src/utils/texture.ts
+++ b/modules/core/src/utils/texture.ts
@@ -1,8 +1,6 @@
 import {Texture2D} from '@luma.gl/core';
 import GL from '@luma.gl/constants';
 
-import type Layer from '../lib/layer';
-
 const DEFAULT_TEXTURE_PARAMETERS: Record<number, number> = {
   [GL.TEXTURE_MIN_FILTER]: GL.LINEAR_MIPMAP_LINEAR,
   [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
@@ -13,12 +11,11 @@ const DEFAULT_TEXTURE_PARAMETERS: Record<number, number> = {
 // Track the textures that are created by us. They need to be released when they are no longer used.
 const internalTextures: Record<string, Texture2D> = {};
 
-export function createTexture(layer: Layer, image: any): Texture2D | null {
-  const gl = layer.context && layer.context.gl;
-  if (!gl || !image) {
-    return null;
-  }
-
+export function createTexture(
+  gl: WebGLRenderingContext,
+  image: any,
+  parameters: Record<number, number>
+): Texture2D | null {
   // image could be one of:
   //  - Texture2D
   //  - Browser object: Image, ImageData, ImageData, HTMLCanvasElement, HTMLVideoElement, ImageBitmap
@@ -30,7 +27,7 @@ export function createTexture(layer: Layer, image: any): Texture2D | null {
     image = {data: image};
   }
 
-  let specialTextureParameters: Record<string, any> | null = null;
+  let specialTextureParameters: Record<number, number> | null = null;
   if (image.compressed) {
     specialTextureParameters = {
       [GL.TEXTURE_MIN_FILTER]: image.data.length > 1 ? GL.LINEAR_MIPMAP_NEAREST : GL.LINEAR
@@ -42,8 +39,7 @@ export function createTexture(layer: Layer, image: any): Texture2D | null {
     parameters: {
       ...DEFAULT_TEXTURE_PARAMETERS,
       ...specialTextureParameters,
-      // @ts-expect-error textureParameter may not be defined
-      ...layer.props.textureParameters
+      ...parameters
     }
   });
   // Track this texture

--- a/modules/extensions/src/fill-style/fill-style.ts
+++ b/modules/extensions/src/fill-style/fill-style.ts
@@ -1,6 +1,5 @@
 import {LayerExtension} from '@deck.gl/core';
 import {Texture2D} from '@luma.gl/core';
-import GL from '@luma.gl/constants';
 
 import {patternShaders} from './shaders.glsl';
 
@@ -15,8 +14,8 @@ import type {
 
 const defaultProps = {
   fillPatternEnabled: true,
-  fillPatternAtlas: null,
-  fillPatternMapping: null,
+  fillPatternAtlas: {type: 'image', value: null, async: true},
+  fillPatternMapping: {type: 'object', value: {}, async: true},
   fillPatternMask: true,
   getFillPattern: {type: 'accessor', value: d => d.pattern},
   getFillPatternScale: {type: 'accessor', value: 1},
@@ -29,7 +28,7 @@ export type FillStyleExtensionProps<DataT = any> = {
    */
   fillPatternEnabled?: boolean;
   /** Sprite image url or texture that packs all your patterns into one layout. */
-  fillPatternAtlas?: Texture;
+  fillPatternAtlas?: string | Texture;
   /** Pattern names mapped to pattern definitions, or a url that points to a JSON file. */
   fillPatternMapping?:
     | string
@@ -69,15 +68,6 @@ type FillStyleExtensionOptions = {
    * @default false
    */
   pattern: boolean;
-};
-
-const DEFAULT_TEXTURE_PARAMETERS = {
-  [GL.TEXTURE_MIN_FILTER]: GL.LINEAR,
-  // GL.LINEAR is the default value but explicitly set it here
-  [GL.TEXTURE_MAG_FILTER]: GL.LINEAR,
-  // for texture boundary artifact
-  [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
-  [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE
 };
 
 /** Adds selected features to layers that render a "fill", such as the `PolygonLayer` and `ScatterplotLayer`. */
@@ -170,11 +160,8 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
       return;
     }
 
-    if (props.fillPatternAtlas && props.fillPatternAtlas !== oldProps.fillPatternAtlas) {
-      extension.loadPatternAtlas.call(this);
-    }
     if (props.fillPatternMapping && props.fillPatternMapping !== oldProps.fillPatternMapping) {
-      extension.loadPatternMapping.call(this);
+      this.getAttributeManager()!.invalidate('getFillPattern');
     }
   }
 
@@ -183,9 +170,9 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
       return;
     }
 
-    const {patternTexture} = this.state;
+    const {fillPatternAtlas} = this.props;
     this.setModuleParameters({
-      fillPatternTexture: patternTexture || this.state.emptyTexture
+      fillPatternTexture: fillPatternAtlas || this.state.emptyTexture
     });
   }
 
@@ -195,42 +182,9 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
     emptyTexture?.delete();
   }
 
-  async loadPatternAtlas(this: Layer<FillStyleExtensionProps>) {
-    const {fillPatternAtlas, fetch} = this.props;
-    this.state.patternTexture?.delete();
-    this.setState({patternTexture: null});
-    let image = fillPatternAtlas;
-    if (typeof image === 'string') {
-      image = await fetch(image, {propName: 'fillPatternAtlas', layer: this});
-    }
-    const patternTexture =
-      image instanceof Texture2D
-        ? image
-        : new Texture2D(this.context.gl, {
-            data: image,
-            parameters: DEFAULT_TEXTURE_PARAMETERS
-          });
-    this.setState({patternTexture});
-  }
-
-  async loadPatternMapping(this: Layer<FillStyleExtensionProps>) {
-    const {fillPatternMapping, fetch} = this.props;
-    this.setState({patternMapping: null});
-    let patternMapping = fillPatternMapping;
-    if (typeof patternMapping === 'string') {
-      patternMapping = await fetch(patternMapping, {
-        propName: 'fillPatternMapping',
-        layer: this
-      });
-    }
-    this.setState({patternMapping});
-    this.getAttributeManager()!.invalidate('getFillPattern');
-    this.setNeedsUpdate();
-  }
-
   getPatternFrame(this: Layer<FillStyleExtensionProps>, name: string) {
-    const {patternMapping} = this.state;
-    const def = patternMapping && patternMapping[name];
+    const {fillPatternMapping} = this.getCurrentLayer()!.props;
+    const def = fillPatternMapping && fillPatternMapping[name];
     return def ? [def.x, def.y, def.width, def.height] : [0, 0, 0, 0];
   }
 }

--- a/modules/extensions/src/fill-style/fill-style.ts
+++ b/modules/extensions/src/fill-style/fill-style.ts
@@ -1,5 +1,6 @@
 import {LayerExtension} from '@deck.gl/core';
 import {Texture2D} from '@luma.gl/core';
+import GL from '@luma.gl/constants';
 
 import {patternShaders} from './shaders.glsl';
 
@@ -14,7 +15,14 @@ import type {
 
 const defaultProps = {
   fillPatternEnabled: true,
-  fillPatternAtlas: {type: 'image', value: null, async: true},
+  fillPatternAtlas: {
+    type: 'image',
+    value: null,
+    async: true,
+    parameters: {
+      [GL.TEXTURE_MIN_FILTER]: GL.LINEAR
+    }
+  },
   fillPatternMapping: {type: 'object', value: {}, async: true},
   fillPatternMask: true,
   getFillPattern: {type: 'accessor', value: d => d.pattern},

--- a/test/modules/extensions/fill-style.spec.js
+++ b/test/modules/extensions/fill-style.spec.js
@@ -27,11 +27,12 @@ test('FillStyleExtension#PolygonLayer', t => {
         extensions: [new FillStyleExtension({pattern: true})]
       },
       onAfterUpdate: ({layer, subLayers}) => {
-        t.notOk(layer.state.patternMapping, 'should not be enabled in composite layer');
+        t.notOk(layer.state.emptyTexture, 'should not be enabled in composite layer');
 
         const strokeLayer = subLayers.find(l => l.id.includes('stroke'));
         const fillLayer = subLayers.find(l => l.id.includes('fill'));
 
+        t.ok(fillLayer.state.emptyTexture, 'should be enabled in composite layer');
         let uniforms = fillLayer.getModels()[0].getUniforms();
         t.ok(uniforms.fill_patternMask, 'has fill_patternMask uniform');
         t.deepEqual(
@@ -46,7 +47,7 @@ test('FillStyleExtension#PolygonLayer', t => {
         );
 
         uniforms = strokeLayer.getModels()[0].getUniforms();
-        t.notOk(strokeLayer.state.patternMapping, 'should not be enabled in PathLayer');
+        t.notOk(strokeLayer.state.emptyTexture, 'should not be enabled in PathLayer');
         t.notOk('fill_patternMask' in uniforms, 'should not be enabled in PathLayer');
       }
     }


### PR DESCRIPTION
Follow up of #7496

#### Change List
- Remove ad-hoc prop handling in FillStyleExtension, use core async resolution system
- `image` prop type accepts a new option to override default texture parameters
- Tests
- Docs