### PR TITLE
Carto: support for attributes aggregated by count

### DIFF
--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -435,7 +435,9 @@ export function getSizeAccessor(
 ) {
   const scale = scaleType ? SCALE_FUNCS[scaleType as any]() : identity;
   if (scaleType) {
-    scale.domain(calculateDomain(data, name, scaleType));
+    if (aggregation !== 'count') {
+      scale.domain(calculateDomain(data, name, scaleType));
+    }
     scale.range(range);
   }
 


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background

When aggregating via `count`, we there is no need to calculate domain of input data.

<!-- For all the PRs -->
#### Change List
- support for aggregation type `count` in `fetchMap`
