### PR TITLE
Add docs to clarify layer updates in React

### DIFF
--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -597,6 +597,9 @@ Create a copy of this layer, optionally change some prop values.
 Arguments:
 - `overrideProps` (Object, optional) - layer props to update.
 
+Remarks:
+- When using React, instead of calling `layer.clone(...)` you should construct a new layer instance on every render. Instead of the above, use `const updatedLayer = new ScatterPlotlayer({...props, ...overrideProps})` each time (both initialization and re-rendering).
+
 ##### `setState`
 
 Used to update the layers [`state`](/docs/api-reference/core/layer.md#state) object. Calling this method will also cause the layer to rerender.

--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -598,7 +598,11 @@ Arguments:
 - `overrideProps` (Object, optional) - layer props to update.
 
 Remarks:
-- When using React, instead of calling `layer.clone(...)` you should construct a new layer instance on every render. Instead of the above, use `const updatedLayer = new ScatterPlotlayer({...props, ...overrideProps})` each time (both initialization and re-rendering).
+- When using React, instead of calling `layer.clone(...)` you should construct a new layer instance on every render. Instead of the above, use the following each time (both initialization and re-rendering):
+
+    ```typescript
+    const updatedLayer = new ScatterPlotlayer({...props, ...overrideProps})
+    ```
 
 ##### `setState`
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #7598

#### Change List
- Added docs to clarify layer instantiation updates & in React, and discourage use of `layer.clone(...)`
