### PR TITLE
TerrainExtension (1/3)

### DIFF
--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -114,6 +114,7 @@ export type {
   AccessorFunction,
   LayerData,
   Unit,
+  Operation,
   Position,
   Color,
   Texture,

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -35,6 +35,7 @@ export {default as PostProcessEffect} from './effects/post-process-effect';
 
 // Passes
 export {default as _LayersPass} from './passes/layers-pass';
+export {default as _PickLayersPass} from './passes/pick-layers-pass';
 
 // Experimental Pure JS (non-React) bindings
 export {default as Deck} from './lib/deck';

--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -108,7 +108,7 @@ export const EVENTS = {
 } as const;
 
 /**
- * The rendering operation to perform with a layer, used in the `operation` prop
+ * @deprecated Use string constants directly
  */
 export const OPERATION = {
   DRAW: 'draw',

--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -112,5 +112,6 @@ export const EVENTS = {
  */
 export const OPERATION = {
   DRAW: 'draw',
-  MASK: 'mask'
+  MASK: 'mask',
+  TERRAIN: 'terrain'
 } as const;

--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -178,7 +178,9 @@ export default class DeckPicker {
     if (this._pickable === false) {
       return null;
     }
-    const pickableLayers = layers.filter(layer => layer.isPickable() && !layer.isComposite);
+    const pickableLayers = layers.filter(
+      layer => this.pickLayersPass.shouldDrawLayer(layer) && !layer.isComposite
+    );
     return pickableLayers.length ? pickableLayers : null;
   }
 

--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -481,8 +481,7 @@ export default class DeckPicker {
     decodePickingColor: PickingColorDecoder | null;
   } {
     const pickingFBO = pickZ ? this.depthFBO : this.pickingFBO;
-
-    const {decodePickingColor} = this.pickLayersPass.render({
+    const opts = {
       layers,
       layerFilter: this.layerFilter,
       views,
@@ -494,7 +493,15 @@ export default class DeckPicker {
       effects,
       pass,
       pickZ
-    });
+    };
+
+    for (const effect of effects) {
+      if (effect.useInPicking) {
+        effect.preRender(this.gl, opts);
+      }
+    }
+
+    const {decodePickingColor} = this.pickLayersPass.render(opts);
 
     // Read from an already rendered picking buffer
     // Returns an Uint8ClampedArray of picked pixels

--- a/modules/core/src/lib/layer-extension.ts
+++ b/modules/core/src/lib/layer-extension.ts
@@ -85,6 +85,10 @@ export default abstract class LayerExtension<OptionsT = undefined> {
 
   updateState(this: Layer, params: UpdateParameters<Layer>, extension: this): void {}
 
+  getNeedsRedraw(this: Layer, opts: {clearRedrawFlags: boolean}): boolean {
+    return false;
+  }
+
   draw(this: Layer, params: any, extension: this): void {}
 
   finalizeState(this: Layer, context: LayerContext, extension: this): void {}

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 /* eslint-disable react/no-direct-mutation-state */
-import {COORDINATE_SYSTEM, OPERATION} from './constants';
+import {COORDINATE_SYSTEM} from './constants';
 import AttributeManager from './attribute/attribute-manager';
 import UniformTransitionManager from './uniform-transition-manager';
 import {diffProps, validateProps} from '../lifecycle/props';
@@ -142,7 +142,7 @@ const defaultProps: DefaultProps<LayerProps> = {
   visible: true,
   pickable: false,
   opacity: {type: 'number', min: 0, max: 1, value: 1},
-  operation: OPERATION.DRAW,
+  operation: 'draw',
 
   onHover: {type: 'function', value: null, compare: false, optional: true},
   onClick: {type: 'function', value: null, compare: false, optional: true},
@@ -302,14 +302,9 @@ export default abstract class Layer<PropsT = {}> extends Component<PropsT & Requ
     return this.props.wrapLongitude;
   }
 
-  /** Returns true if the layer is visible in the picking pass */
+  /** @deprecated Returns true if the layer is visible in the picking pass */
   isPickable(): boolean {
-    const {operation} = this.props;
-    return (
-      this.props.visible &&
-      ((this.props.pickable && operation.includes(OPERATION.DRAW)) ||
-        operation.includes(OPERATION.TERRAIN))
-    );
+    return this.props.pickable && this.props.visible;
   }
 
   /** Returns an array of models used by this layer, can be overriden by layer subclass */

--- a/modules/core/src/passes/draw-layers-pass.ts
+++ b/modules/core/src/passes/draw-layers-pass.ts
@@ -3,6 +3,6 @@ import LayersPass from './layers-pass';
 
 export default class DrawLayersPass extends LayersPass {
   shouldDrawLayer(layer) {
-    return layer.props.operation === OPERATION.DRAW;
+    return layer.props.operation.includes(OPERATION.DRAW);
   }
 }

--- a/modules/core/src/passes/draw-layers-pass.ts
+++ b/modules/core/src/passes/draw-layers-pass.ts
@@ -1,8 +1,7 @@
-import {OPERATION} from '../lib/constants';
 import LayersPass from './layers-pass';
 
 export default class DrawLayersPass extends LayersPass {
   shouldDrawLayer(layer) {
-    return layer.props.operation.includes(OPERATION.DRAW);
+    return layer.props.operation.includes('draw');
   }
 }

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -118,8 +118,8 @@ export default class LayersPass extends Pass {
   protected _getDrawLayerParams(
     viewport: Viewport,
     {layers, pass, layerFilter, cullRect, effects, moduleParameters}: LayersPassRenderOptions,
-    /** Internal flag, false if only used to determine whether each layer should be drawn */
-    full: boolean = true
+    /** Internal flag, true if only used to determine whether each layer should be drawn */
+    evaluateShouldDrawOnly: boolean = false
   ): DrawLayerParameters[] {
     const drawLayerParams: DrawLayerParameters[] = [];
     const indexResolver = layerIndexResolver(this._lastRenderIndex + 1);
@@ -145,7 +145,7 @@ export default class LayersPass extends Pass {
         shouldDrawLayer
       };
 
-      if (shouldDrawLayer && full) {
+      if (shouldDrawLayer && !evaluateShouldDrawOnly) {
         // This is the "logical" index for ordering this layer in the stack
         // used to calculate polygon offsets
         // It can be the same as another layer
@@ -239,7 +239,7 @@ export default class LayersPass extends Pass {
   /* eslint-enable max-depth, max-statements */
 
   /* Methods for subclass overrides */
-  protected shouldDrawLayer(layer: Layer): boolean {
+  shouldDrawLayer(layer: Layer): boolean {
     return true;
   }
 
@@ -399,9 +399,9 @@ function getGLViewport(
   ];
 }
 
-function clearGLCanvas(gl: WebGLRenderingContext, target?: Framebuffer) {
-  const width = target ? target.width : gl.drawingBufferWidth;
-  const height = target ? target.height : gl.drawingBufferHeight;
+function clearGLCanvas(gl: WebGLRenderingContext, targetFramebuffer?: Framebuffer) {
+  const width = targetFramebuffer ? targetFramebuffer.width : gl.drawingBufferWidth;
+  const height = targetFramebuffer ? targetFramebuffer.height : gl.drawingBufferHeight;
   // clear depth and color buffers, restoring transparency
   setParameters(gl, {viewport: [0, 0, width, height]});
   gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -15,7 +15,7 @@ export type LayersPassRenderOptions = {
   pass: string;
   layers: Layer[];
   viewports: Viewport[];
-  onViewportActive: (viewport: Viewport) => void;
+  onViewportActive?: (viewport: Viewport) => void;
   cullRect?: Rect;
   views?: Record<string, View>;
   effects?: Effect[];
@@ -73,7 +73,7 @@ export default class LayersPass extends Pass {
 
     const gl = this.gl;
     if (clearCanvas) {
-      clearGLCanvas(gl);
+      clearGLCanvas(gl, target);
     }
 
     if (clearStack) {
@@ -86,7 +86,7 @@ export default class LayersPass extends Pass {
       const view = views && views[viewport.id];
 
       // Update context to point to this viewport
-      onViewportActive(viewport);
+      onViewportActive?.(viewport);
 
       const drawLayerParams = this._getDrawLayerParams(viewport, options);
 
@@ -112,12 +112,14 @@ export default class LayersPass extends Pass {
     return renderStats;
   }
 
-  // Resolve the parameters needed to draw each layer
   // When a viewport contains multiple subviewports (e.g. repeated web mercator map),
   // this is only done once for the parent viewport
-  private _getDrawLayerParams(
+  /* Resolve the parameters needed to draw each layer */
+  protected _getDrawLayerParams(
     viewport: Viewport,
-    {layers, pass, layerFilter, cullRect, effects, moduleParameters}: LayersPassRenderOptions
+    {layers, pass, layerFilter, cullRect, effects, moduleParameters}: LayersPassRenderOptions,
+    /** Internal flag, false if only used to determine whether each layer should be drawn */
+    full: boolean = true
   ): DrawLayerParameters[] {
     const drawLayerParams: DrawLayerParameters[] = [];
     const indexResolver = layerIndexResolver(this._lastRenderIndex + 1);
@@ -143,7 +145,7 @@ export default class LayersPass extends Pass {
         shouldDrawLayer
       };
 
-      if (shouldDrawLayer) {
+      if (shouldDrawLayer && full) {
         // This is the "logical" index for ordering this layer in the stack
         // used to calculate polygon offsets
         // It can be the same as another layer
@@ -397,9 +399,9 @@ function getGLViewport(
   ];
 }
 
-function clearGLCanvas(gl: WebGLRenderingContext) {
-  const width = gl.drawingBufferWidth;
-  const height = gl.drawingBufferHeight;
+function clearGLCanvas(gl: WebGLRenderingContext, target?: Framebuffer) {
+  const width = target ? target.width : gl.drawingBufferWidth;
+  const height = target ? target.height : gl.drawingBufferHeight;
   // clear depth and color buffers, restoring transparency
   setParameters(gl, {viewport: [0, 0, width, height]});
   gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -122,9 +122,9 @@ export type LayerProps<DataType = any> = {
    */
   updateTriggers?: Record<string, any>;
   /**
-   * The purpose of the layer
+   * The purpose of the layer. `+` separated list of OPERATION enums
    */
-  operation?: 'draw' | 'mask';
+  operation?: string;
   /**
    * If the layer should be rendered. Default true.
    */

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -62,6 +62,9 @@ export type Material = LightingModuleSettings['material'];
  */
 export type Unit = 'meters' | 'common' | 'pixels';
 
+/** Rendering operation of the layer. */
+export type Operation = 'draw' | 'mask' | 'terrain';
+
 export type Texture =
   | Texture2D
   | Texture2DProps
@@ -122,9 +125,9 @@ export type LayerProps<DataType = any> = {
    */
   updateTriggers?: Record<string, any>;
   /**
-   * The purpose of the layer. `+` separated list of OPERATION enums
+   * Rendering operation of the layer. `+` separated list of names.
    */
-  operation?: string;
+  operation?: Operation | `${Operation}+${Operation}`;
   /**
    * If the layer should be rendered. Default true.
    */

--- a/modules/extensions/src/mask/mask-effect.ts
+++ b/modules/extensions/src/mask/mask-effect.ts
@@ -1,12 +1,4 @@
-import {
-  Layer,
-  Viewport,
-  Effect,
-  PreRenderOptions,
-  OPERATION,
-  CoordinateSystem,
-  log
-} from '@deck.gl/core';
+import {Layer, Viewport, Effect, PreRenderOptions, CoordinateSystem, log} from '@deck.gl/core';
 import {Texture2D} from '@luma.gl/core';
 // import {readPixelsToArray} from '@luma.gl/core';
 import {equals} from '@math.gl/core';
@@ -61,9 +53,7 @@ export default class MaskEffect implements Effect {
       return;
     }
 
-    const maskLayers = layers.filter(
-      l => l.props.visible && l.props.operation.includes(OPERATION.MASK)
-    );
+    const maskLayers = layers.filter(l => l.props.visible && l.props.operation.includes('mask'));
     if (maskLayers.length === 0) {
       this.masks = null;
       this.channels.length = 0;

--- a/modules/extensions/src/mask/mask-effect.ts
+++ b/modules/extensions/src/mask/mask-effect.ts
@@ -47,7 +47,7 @@ export default class MaskEffect implements Effect {
 
   preRender(
     gl: WebGLRenderingContext,
-    {layers, layerFilter, viewports, onViewportActive, views}: PreRenderOptions
+    {layers, layerFilter, viewports, onViewportActive, views, pass}: PreRenderOptions
   ): void {
     if (!this.dummyMaskMap) {
       this.dummyMaskMap = new Texture2D(gl, {
@@ -56,7 +56,14 @@ export default class MaskEffect implements Effect {
       });
     }
 
-    const maskLayers = layers.filter(l => l.props.visible && l.props.operation === OPERATION.MASK);
+    if (pass.includes('picking')) {
+      // Do not update on picking pass
+      return;
+    }
+
+    const maskLayers = layers.filter(
+      l => l.props.visible && l.props.operation.includes(OPERATION.MASK)
+    );
     if (maskLayers.length === 0) {
       this.masks = null;
       this.channels.length = 0;

--- a/modules/extensions/src/mask/mask-effect.ts
+++ b/modules/extensions/src/mask/mask-effect.ts
@@ -48,7 +48,7 @@ export default class MaskEffect implements Effect {
       });
     }
 
-    if (pass.includes('picking')) {
+    if (pass.startsWith('picking')) {
       // Do not update on picking pass
       return;
     }

--- a/modules/extensions/src/mask/mask-pass.ts
+++ b/modules/extensions/src/mask/mask-pass.ts
@@ -1,5 +1,5 @@
 import {Framebuffer, Texture2D, withParameters} from '@luma.gl/core';
-import {OPERATION, _LayersPass as LayersPass, LayersPassRenderOptions} from '@deck.gl/core';
+import {_LayersPass as LayersPass, LayersPassRenderOptions} from '@deck.gl/core';
 
 type MaskPassRenderOptions = LayersPassRenderOptions & {
   /** The channel to render into, 0:red, 1:green, 2:blue, 3:alpha */
@@ -57,7 +57,7 @@ export default class MaskPass extends LayersPass {
   }
 
   shouldDrawLayer(layer) {
-    return layer.props.operation.includes(OPERATION.MASK);
+    return layer.props.operation.includes('mask');
   }
 
   delete() {

--- a/modules/extensions/src/mask/mask-pass.ts
+++ b/modules/extensions/src/mask/mask-pass.ts
@@ -57,7 +57,7 @@ export default class MaskPass extends LayersPass {
   }
 
   shouldDrawLayer(layer) {
-    return layer.props.operation === OPERATION.MASK;
+    return layer.props.operation.includes(OPERATION.MASK);
   }
 
   delete() {

--- a/test/modules/core/lib/deck-picker.spec.js
+++ b/test/modules/core/lib/deck-picker.spec.js
@@ -61,6 +61,7 @@ test('DeckPicker#pick empty', t => {
     layers: [],
     views: [view],
     viewports: [viewport],
+    effects: [],
     onViewportActive: layerManager.activateViewport,
     x: 1,
     y: 1

--- a/test/modules/extensions/mask/mask-effect.spec.js
+++ b/test/modules/extensions/mask/mask-effect.spec.js
@@ -40,6 +40,7 @@ test('MaskEffect#cleanup', t => {
   layerManager.updateLayers();
 
   maskEffect.preRender(gl, {
+    pass: 'screen',
     layers: layerManager.getLayers(),
     onViewportActive: layerManager.activateViewport,
     viewports: [testViewport]
@@ -79,6 +80,7 @@ test('MaskEffect#update', t => {
     layerManager.updateLayers();
 
     maskEffect.preRender(gl, {
+      pass: 'screen',
       layers: layerManager.getLayers(),
       onViewportActive: layerManager.activateViewport,
       viewports: [testViewport]
@@ -146,6 +148,7 @@ test('MaskEffect#coordinates', t => {
     layerManager.updateLayers();
 
     maskEffect.preRender(gl, {
+      pass: 'screen',
       layers: layerManager.getLayers(),
       onViewportActive: layerManager.activateViewport,
       viewports: [testViewport]


### PR DESCRIPTION
For #7195

This PR contains changes to the core module in preparation to support terrain. There should be no breaking change.

#### Change List
- Add `OPERATION.TERRAIN` enum
- `Layer`: `operation` prop supports any combination of operations, e.g. `draw+terrain`
- `DeckPicker`: invoke `effect.preRender()` in the picking pass as well as the screen render pass
- `LayerExtension`: add `getNeedsRedraw` lifecycle method
- Light refactor in `LayersPass` and `PickLayersPass` for easier subclassing
