### PR TITLE
DECKGL_FILTER_GL_POSITION hook consistency

### DIFF
--- a/modules/layers/src/arc-layer/arc-layer-vertex.glsl.ts
+++ b/modules/layers/src/arc-layer/arc-layer-vertex.glsl.ts
@@ -246,8 +246,8 @@ void main(void) {
     getExtrusionOffset((next.xy - curr.xy) * indexDir, positions.y, widthPixels),
     0.0);
   DECKGL_FILTER_SIZE(offset, geometry);
+  DECKGL_FILTER_GL_POSITION(curr, geometry);
   gl_Position = curr + vec4(project_pixel_size_to_clipspace(offset.xy), 0.0, 0.0);
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   vec4 color = mix(instanceSourceColors, instanceTargetColors, segmentRatio);
   vColor = vec4(color.rgb, color.a * opacity);

--- a/modules/layers/src/icon-layer/icon-layer-vertex.glsl.ts
+++ b/modules/layers/src/icon-layer/icon-layer-vertex.glsl.ts
@@ -80,6 +80,7 @@ void main(void) {
 
   if (billboard)  {
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
     vec3 offset = vec3(pixelOffset, 0.0);
     DECKGL_FILTER_SIZE(offset, geometry);
     gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
@@ -88,8 +89,8 @@ void main(void) {
     vec3 offset_common = vec3(project_pixel_size(pixelOffset), 0.0);
     DECKGL_FILTER_SIZE(offset_common, geometry);
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset_common, geometry.position); 
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
   }
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   vTextureCoords = mix(
     instanceIconFrames.xy,

--- a/modules/layers/src/line-layer/line-layer-vertex.glsl.ts
+++ b/modules/layers/src/line-layer/line-layer-vertex.glsl.ts
@@ -110,8 +110,8 @@ void main(void) {
     getExtrusionOffset(target.xy - source.xy, positions.y, widthPixels),
     0.0);
   DECKGL_FILTER_SIZE(offset, geometry);
+  DECKGL_FILTER_GL_POSITION(p, geometry);
   gl_Position = p + vec4(project_pixel_size_to_clipspace(offset.xy), 0.0, 0.0);
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   // Color
   vColor = vec4(instanceColors.rgb, instanceColors.a * opacity);

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer-vertex.glsl.ts
@@ -49,8 +49,8 @@ void main(void) {
   DECKGL_FILTER_SIZE(offset, geometry);
 
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.), geometry.position);
-  gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
+  gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
 
   // Apply lighting
   vec3 lightColor = lighting_getLightColor(instanceColors.rgb, project_uCameraPosition, geometry.position.xyz, geometry.normal);

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.ts
@@ -82,6 +82,7 @@ void main(void) {
   
   if (billboard) {
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
     vec3 offset = edgePadding * positions * outerRadiusPixels;
     DECKGL_FILTER_SIZE(offset, geometry);
     gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
@@ -89,9 +90,8 @@ void main(void) {
     vec3 offset = edgePadding * positions * project_pixel_size(outerRadiusPixels);
     DECKGL_FILTER_SIZE(offset, geometry);
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset, geometry.position);
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
   }
-
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   // Apply opacity to instance color, or return instance picking color
   vFillColor = vec4(instanceFillColors.rgb, instanceFillColors.a * opacity);

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
@@ -60,6 +60,7 @@ void main(void) {
 
   if (billboard)  {
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
     vec3 offset = vec3(pixelOffset, 0.0);
     DECKGL_FILTER_SIZE(offset, geometry);
     gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
@@ -67,8 +68,8 @@ void main(void) {
     vec3 offset_common = vec3(project_pixel_size(pixelOffset), 0.0);
     DECKGL_FILTER_SIZE(offset_common, geometry);
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset_common, geometry.position);
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
   }
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   // Apply opacity to instance color, or return instance picking color
   vFillColor = vec4(instanceFillColors.rgb, instanceFillColors.a * opacity);

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.ts
@@ -66,6 +66,7 @@ void main(void) {
     // when using globe mode, this branch does not re-orient the model to align with the surface of the earth
     // call project_normal before setting position to avoid rotation
     geometry.normal = project_normal(normal);
+    geometry.worldPosition += pos;
     gl_Position = project_position_to_clipspace(pos + instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
   }
   else {

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-vertex.glsl.ts
@@ -43,6 +43,7 @@ void main(void) {
     // when using globe mode, this branch does not re-orient the model to align with the surface of the earth
     // call project_normal before setting position to avoid rotation
     normals_commonspace = project_normal(instanceModelMatrix * normals);
+    geometry.worldPosition += pos;
     gl_Position = project_position_to_clipspace(pos + instancePositions, instancePositions64Low, vec3(0.0), position_commonspace);
     geometry.position = position_commonspace;
   }


### PR DESCRIPTION
For #7195

`TerrainExtension` rewrites gl_Position in the `DECKGL_FILTER_GL_POSITION` hook based on the common position. This breaks layers like `IconLayer`, `TextLayer`, `ScatterplotLayer`, `PathLayer` in billboard mode, where multiple vertices are offset from the same clipspace anchor.

`DECKGL_FILTER_GL_POSITION` is currently called after the last assignment of `gl_Position`.

This PR moves it to before any clipspace offset is applied, i.e. where `gl_Position` corresponds to `geometry.position`.

#### Change List
- Invoke `DECKGL_FILTER_GL_POSITION` hook before screen space offset is applied
