### PR TITLE
ComponentState should dereference component on finalize

### DIFF
--- a/modules/core/src/lib/layer-state.ts
+++ b/modules/core/src/lib/layer-state.ts
@@ -58,32 +58,35 @@ export default class LayerState<LayerT extends Layer> extends ComponentState<Lay
     this.usesPickingColorCache = false;
   }
 
-  get layer(): LayerT {
+  get layer(): LayerT | null {
     return this.component;
-  }
-
-  set layer(layer: LayerT) {
-    this.component = layer;
   }
 
   /* Override base Component methods with Layer-specific handling */
 
   protected _fetch(propName, url: string) {
-    const fetch = this.component.props.fetch;
+    const layer = this.layer;
+    const fetch = layer?.props.fetch;
     if (fetch) {
-      return fetch(url, {propName, layer: this.layer});
+      return fetch(url, {propName, layer});
     }
     return super._fetch(propName, url);
   }
 
   protected _onResolve(propName: string, value: any) {
-    const onDataLoad = this.component.props.onDataLoad;
-    if (propName === 'data' && onDataLoad) {
-      onDataLoad(value, {propName, layer: this.layer});
+    const layer = this.layer;
+    if (layer) {
+      const onDataLoad = layer.props.onDataLoad;
+      if (propName === 'data' && onDataLoad) {
+        onDataLoad(value, {propName, layer});
+      }
     }
   }
 
   protected _onError(propName: string, error: Error) {
-    this.layer.raiseError(error, `loading ${propName} of ${this.layer}`);
+    const layer = this.layer;
+    if (layer) {
+      layer.raiseError(error, `loading ${propName} of ${this.layer}`);
+    }
   }
 }

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -818,7 +818,6 @@ export default abstract class Layer<PropsT = {}> extends Component<PropsT & Requ
     });
     /* eslint-enable accessor-pairs */
 
-    this.internalState.layer = this;
     this.internalState.uniformTransitions = new UniformTransitionManager(this.context.timeline);
     this.internalState.onAsyncPropUpdated = this._onAsyncPropUpdated.bind(this);
 
@@ -857,7 +856,6 @@ export default abstract class Layer<PropsT = {}> extends Component<PropsT & Requ
 
     // Move internalState
     this.internalState = internalState as LayerState<this>;
-    this.internalState.layer = this;
 
     // Move state
     this.state = state;

--- a/modules/core/src/lifecycle/component-state.ts
+++ b/modules/core/src/lifecycle/component-state.ts
@@ -31,11 +31,17 @@ import {PropType} from './prop-types';
 
 const EMPTY_PROPS = Object.freeze({});
 
+/** Internal state of an async prop */
 type AsyncPropState = {
+  /** The prop type definition from component.defaultProps, if exists */
   type: PropType | null;
+  /** Supplied prop value (can be url/promise, not visible to the component) */
   lastValue: any;
+  /** Resolved prop value (valid data, can be "shown" to the component) */
   resolvedValue: any;
+  /** How many loads have been issued */
   pendingLoadCount: number;
+  /** Latest resolved load, (earlier loads will be ignored) */
   resolvedLoadCount: number;
 };
 
@@ -330,10 +336,10 @@ export default class ComponentState<ComponentT extends Component> {
       // assert(defaultValue !== undefined);
       this.asyncProps[propName] = {
         type: propTypes && propTypes[propName],
-        lastValue: null, // Supplied prop value (can be url/promise, not visible to layer)
-        resolvedValue: defaultValue, // Resolved prop value (valid data, can be "shown" to layer)
-        pendingLoadCount: 0, // How many loads have been issued
-        resolvedLoadCount: 0 // Latest resolved load, (earlier loads will be ignored)
+        lastValue: null,
+        resolvedValue: defaultValue,
+        pendingLoadCount: 0,
+        resolvedLoadCount: 0
       };
     }
   }

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -47,6 +47,9 @@ function initializeLayerManager({layer, viewport = testViewport, onError = defau
 
 export function testInitializeLayer(opts) {
   const layerManager = initializeLayerManager(opts);
+  if (opts.finalize === false) {
+    return () => layerManager.finalize();
+  }
   layerManager.finalize();
   return null;
 }
@@ -56,6 +59,9 @@ export async function testInitializeLayerAsync(opts) {
   const deckRenderer = new DeckRenderer(gl);
   while (!opts.layer.isLoaded) {
     await update({layerManager, deckRenderer});
+  }
+  if (opts.finalize === false) {
+    return () => layerManager.finalize();
   }
   layerManager.finalize();
   return null;

--- a/modules/test-utils/src/lifecycle-test.js
+++ b/modules/test-utils/src/lifecycle-test.js
@@ -48,7 +48,9 @@ function initializeLayerManager({layer, viewport = testViewport, onError = defau
 export function testInitializeLayer(opts) {
   const layerManager = initializeLayerManager(opts);
   if (opts.finalize === false) {
-    return () => layerManager.finalize();
+    return {
+      finalize: () => layerManager.finalize()
+    };
   }
   layerManager.finalize();
   return null;
@@ -61,7 +63,9 @@ export async function testInitializeLayerAsync(opts) {
     await update({layerManager, deckRenderer});
   }
   if (opts.finalize === false) {
-    return () => layerManager.finalize();
+    return {
+      finalize: () => layerManager.finalize()
+    };
   }
   layerManager.finalize();
   return null;

--- a/test/modules/core/lib/composite-layer.spec.js
+++ b/test/modules/core/lib/composite-layer.spec.js
@@ -351,11 +351,12 @@ test('CompositeLayer#isLoaded', t => {
     data: Promise.resolve([]),
     onDataLoad: () => {
       t.ok(layer.isLoaded, 'data is loaded');
+      finalize();
       t.end();
     }
   });
 
-  testInitializeLayer({layer});
+  const finalize = testInitializeLayer({layer, finalize: false});
 
   t.notOk(layer.isLoaded, 'is loading data');
 });

--- a/test/modules/core/lib/composite-layer.spec.js
+++ b/test/modules/core/lib/composite-layer.spec.js
@@ -356,7 +356,7 @@ test('CompositeLayer#isLoaded', t => {
     }
   });
 
-  const finalize = testInitializeLayer({layer, finalize: false});
+  const {finalize} = testInitializeLayer({layer, finalize: false});
 
   t.notOk(layer.isLoaded, 'is loading data');
 });


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/pull/7605#discussion_r1091946791

`layer.getCurrentLayer()` should return `null` if the layer has been removed.

#### Change List
- `ComponentState` clears component reference when finalized
- test-utils `testInitializeLayer` adds option to defer finalization
- Unit tests
