### PR TITLE
Preparation for CollideExtension

### DIFF
--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -494,12 +494,13 @@ export default class DeckPicker {
       cullRect,
       effects,
       pass,
-      pickZ
+      pickZ,
+      preRenderStats: {}
     };
 
     for (const effect of effects) {
       if (effect.useInPicking) {
-        effect.preRender(this.gl, opts);
+        opts.preRenderStats[effect.id] = effect.preRender(this.gl, opts);
       }
     }
 

--- a/modules/core/src/lib/deck-renderer.js
+++ b/modules/core/src/lib/deck-renderer.js
@@ -48,6 +48,7 @@ export default class DeckRenderer {
     opts.layerFilter = opts.layerFilter || this.layerFilter;
     opts.effects = opts.effects || [];
     opts.target = opts.target || Framebuffer.getDefaultFramebuffer(this.gl);
+    opts.preRenderStats = {};
 
     this._preRender(opts.effects, opts);
 
@@ -82,7 +83,7 @@ export default class DeckRenderer {
     let lastPostProcessEffect = null;
 
     for (const effect of effects) {
-      effect.preRender(this.gl, opts);
+      opts.preRenderStats[effect.id] = effect.preRender(this.gl, opts);
       if (effect.postRender) {
         lastPostProcessEffect = effect;
       }

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -636,10 +636,10 @@ export default class Deck {
   }
 
   /** Experimental
-   * Register a default effect
+   * Register a default effect. Effects will be sorted by order, those with a low order will be rendered first
    */
-  _addDefaultEffect(effect: Effect) {
-    this.effectManager!.addDefaultEffect(effect);
+  _addDefaultEffect(effect: Effect, order?: number) {
+    this.effectManager!.addDefaultEffect(effect, order);
   }
 
   // Private Methods

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -638,8 +638,8 @@ export default class Deck {
   /** Experimental
    * Register a default effect. Effects will be sorted by order, those with a low order will be rendered first
    */
-  _addDefaultEffect(effect: Effect, order?: number) {
-    this.effectManager!.addDefaultEffect(effect, order);
+  _addDefaultEffect(effect: Effect) {
+    this.effectManager!.addDefaultEffect(effect);
   }
 
   // Private Methods

--- a/modules/core/src/lib/effect-manager.ts
+++ b/modules/core/src/lib/effect-manager.ts
@@ -7,7 +7,8 @@ const DEFAULT_LIGHTING_EFFECT = new LightingEffect();
 export default class EffectManager {
   effects: Effect[];
   private _resolvedEffects: Effect[] = [];
-  private _defaultEffects: Effect[] = [];
+  /** Effect instances and order preference pairs, sorted by order */
+  private _defaultEffects: {effect: Effect; order: number}[] = [];
   private _needsRedraw: false | string;
 
   constructor() {
@@ -16,9 +17,24 @@ export default class EffectManager {
     this._setEffects([]);
   }
 
-  addDefaultEffect(effect: Effect) {
-    if (!this._defaultEffects.find(e => e.constructor === effect.constructor)) {
-      this._defaultEffects.push(effect);
+  // TODO - better Effect API, may be cleaner to add `order` to `Effect` class
+  /**
+   * Register a new default effect, i.e. an effect present regardless of user supplied props.effects
+   */
+  addDefaultEffect(
+    /** Effect instance. The same effect can only be added once. */
+    effect: Effect,
+    /** Used to sort effects. In case of conflict, effects will be used in the order of registration. */
+    order: number = Infinity
+  ) {
+    const defaultEffects = this._defaultEffects;
+    if (!defaultEffects.find(e => e.effect.constructor === effect.constructor)) {
+      const index = defaultEffects.findIndex(e => e.order > order);
+      if (index < 0) {
+        defaultEffects.push({effect, order});
+      } else {
+        defaultEffects.splice(index, 0, {effect, order});
+      }
       this._setEffects(this.effects);
     }
   }
@@ -74,7 +90,7 @@ export default class EffectManager {
     }
     this.effects = nextEffects;
 
-    this._resolvedEffects = nextEffects.concat(this._defaultEffects);
+    this._resolvedEffects = nextEffects.concat(this._defaultEffects.map(e => e.effect));
     // Special case for lighting: only add default instance if no LightingEffect is specified
     if (!effects.some(effect => effect instanceof LightingEffect)) {
       this._resolvedEffects.push(DEFAULT_LIGHTING_EFFECT);

--- a/modules/core/src/lib/effect.ts
+++ b/modules/core/src/lib/effect.ts
@@ -12,8 +12,9 @@ export interface Effect {
   id: string;
   props: any;
   useInPicking?: boolean;
+  order?: number;
 
-  preRender: (gl: WebGLRenderingContext, opts: PreRenderOptions) => any;
+  preRender: (gl: WebGLRenderingContext, opts: PreRenderOptions) => unknown;
   postRender?: (gl: WebGLRenderingContext, opts: PostRenderOptions) => Framebuffer;
   getModuleParameters?: (layer: Layer) => any;
 

--- a/modules/core/src/lib/effect.ts
+++ b/modules/core/src/lib/effect.ts
@@ -13,7 +13,7 @@ export interface Effect {
   props: any;
   useInPicking?: boolean;
 
-  preRender: (gl: WebGLRenderingContext, opts: PreRenderOptions) => void;
+  preRender: (gl: WebGLRenderingContext, opts: PreRenderOptions) => any;
   postRender?: (gl: WebGLRenderingContext, opts: PostRenderOptions) => Framebuffer;
   getModuleParameters?: (layer: Layer) => any;
 

--- a/modules/core/src/lib/layer-extension.ts
+++ b/modules/core/src/lib/layer-extension.ts
@@ -89,6 +89,10 @@ export default abstract class LayerExtension<OptionsT = undefined> {
     return false;
   }
 
+  getNeedsPickingBuffer(this: Layer, extension: this): boolean {
+    return false;
+  }
+
   draw(this: Layer, params: any, extension: this): void {}
 
   finalizeState(this: Layer, context: LayerContext, extension: this): void {}

--- a/modules/core/src/lib/layer-state.ts
+++ b/modules/core/src/lib/layer-state.ts
@@ -32,6 +32,10 @@ export default class LayerState<LayerT extends Layer> extends ComponentState<Lay
    */
   usesPickingColorCache: boolean;
   /**
+   * If the layer has picking buffer (pickingColors or instancePickingColors)
+   */
+  hasPickingBuffer?: boolean;
+  /**
    * Dirty flags of the layer's props and state
    */
   changeFlags!: ChangeFlags;

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -473,7 +473,7 @@ export default abstract class Layer<PropsT = {}> extends Component<PropsT & Requ
       const needsPickingBuffer =
         Number.isInteger(props.highlightedObjectIndex) ||
         props.pickable ||
-        props.extensions.some(e => e.getNeedsPickingBuffer.call(this, e));
+        props.extensions.some(extension => extension.getNeedsPickingBuffer.call(this, extension));
 
       // Only generate picking buffer if needed
       if (hasPickingBuffer !== needsPickingBuffer) {

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -24,6 +24,7 @@ export type LayersPassRenderOptions = {
   clearCanvas?: boolean;
   layerFilter?: (context: FilterContext) => boolean;
   moduleParameters?: any;
+  preRenderStats?: Record<string, any>;
 };
 
 type DrawLayerParameters = {

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -24,6 +24,7 @@ export type LayersPassRenderOptions = {
   clearCanvas?: boolean;
   layerFilter?: (context: FilterContext) => boolean;
   moduleParameters?: any;
+  /** Stores returned results from Effect.preRender, for use downstream in the render pipeline */
   preRenderStats?: Record<string, any>;
 };
 

--- a/test/modules/core/lib/layer-extension.spec.js
+++ b/test/modules/core/lib/layer-extension.spec.js
@@ -7,6 +7,7 @@ class MockExtension extends LayerExtension {
   getShaders() {
     return {modules: [{name: 'empty-module', vs: ''}]};
   }
+
   initializeState(context, extension) {
     extension.opts.assert(this instanceof Layer, 'initializeState: Self is layer instance');
     extension.opts.assert(context.gl, 'initializeState: context received');
@@ -23,17 +24,20 @@ class MockExtension extends LayerExtension {
 
     MockExtension.initializeCalled++;
   }
+
   updateState(updateParams, extension) {
     extension.opts.assert(this instanceof Layer, 'updateState: Self is layer instance');
     extension.opts.assert(updateParams.changeFlags, 'updateState: changeFlags received');
 
     MockExtension.updateCalled++;
   }
+
   finalizeState(extension) {
     extension.opts.assert(this instanceof Layer, 'finalizeState: Self is layer instance');
 
     MockExtension.finalizeCalled++;
   }
+
   getNeedsPickingBuffer() {
     return this.props.ext_pickable;
   }

--- a/test/modules/core/lib/layer-extension.spec.js
+++ b/test/modules/core/lib/layer-extension.spec.js
@@ -34,11 +34,15 @@ class MockExtension extends LayerExtension {
 
     MockExtension.finalizeCalled++;
   }
+  getNeedsPickingBuffer() {
+    return this.props.ext_pickable;
+  }
 }
 
 MockExtension.defaultProps = {
   ext_getValue: {type: 'accessor', value: 0},
-  ext_enabled: false
+  ext_enabled: false,
+  ext_pickable: false
 };
 
 MockExtension.resetStats = () => {
@@ -60,24 +64,40 @@ test('LayerExtension', t => {
       {
         props: {
           id: 'test-layer',
-          data: [],
+          data: [0, 1, 2],
           ext_getValue: 0,
           extensions: [extension0]
         },
-        onAfterUpdate: () => {
+        onAfterUpdate: ({layer}) => {
           t.is(MockExtension.initializeCalled, 1, 'initializeState called');
           t.is(MockExtension.updateCalled, 1, 'updateState called');
           t.is(MockExtension.finalizeCalled, 0, 'finalizeState called');
+
+          const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+          t.ok(instancePickingColors.state.constant, 'picking buffer is disabled');
         }
       },
       {
         updateProps: {
           extensions: [extension1]
         },
-        onAfterUpdate: () => {
+        onAfterUpdate: ({layer}) => {
           t.is(MockExtension.initializeCalled, 1, 'initializeState not called');
           t.is(MockExtension.updateCalled, 1, 'updateState not called');
           t.is(MockExtension.finalizeCalled, 0, 'finalizeState not called');
+        }
+      },
+      {
+        updateProps: {
+          ext_pickable: true
+        },
+        onAfterUpdate: ({layer}) => {
+          t.is(MockExtension.initializeCalled, 1, 'initializeState not called');
+          t.is(MockExtension.updateCalled, 2, 'updateState not called');
+          t.is(MockExtension.finalizeCalled, 0, 'finalizeState not called');
+
+          const {instancePickingColors} = layer.getAttributeManager().getAttributes();
+          t.notOk(instancePickingColors.state.constant, 'picking buffer is enabled');
         }
       },
       {
@@ -86,7 +106,7 @@ test('LayerExtension', t => {
         },
         onAfterUpdate: () => {
           t.is(MockExtension.initializeCalled, 1, 'initializeState not called');
-          t.is(MockExtension.updateCalled, 2, 'updateState called');
+          t.is(MockExtension.updateCalled, 3, 'updateState called');
           t.is(MockExtension.finalizeCalled, 0, 'finalizeState not called');
         }
       }


### PR DESCRIPTION
For #7374

See relevant discussions in https://github.com/visgl/deck.gl/pull/7375

#### Change List
- `EffectManager.addDefaultEffect` supports sorting of effects
- Add `LayerExtension.getNeedsPickingBuffer` to enable picking buffer on a layer
- Add `preRenderStats` to `LayersPassRenderOptions` to pass information from `Effect.preRender` to downstream pipelines.