### PR TITLE
Fix tile culling in repeating WebMercatorViewport

### DIFF
--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -93,7 +93,6 @@ export default class LayersPass extends Pass {
       const drawLayerParams = this._getDrawLayerParams(viewport, options);
 
       // render this viewport
-      // @ts-expect-error
       const subViewports = viewport.subViewports || [viewport];
       for (const subViewport of subViewports) {
         const stats = this._drawLayersInViewport(

--- a/modules/core/src/viewports/viewport.ts
+++ b/modules/core/src/viewports/viewport.ts
@@ -211,6 +211,10 @@ export default class Viewport {
     this.unprojectFlat = this.unprojectFlat.bind(this);
   }
 
+  get subViewports(): Viewport[] | null {
+    return null;
+  }
+
   get metersPerPixel(): number {
     return this.distanceScales.metersPerUnit[2] / this.scale;
   }

--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -286,19 +286,27 @@ export class Tileset2D {
     }
 
     if (cullRect && this._viewport) {
-      const [minX, minY, maxX, maxY] = getCullBounds({
+      const boundsArr = this._getCullBounds({
         viewport: this._viewport,
         z: this._zRange,
         cullRect
       });
       const {bbox} = tile;
-      if ('west' in bbox) {
-        return bbox.west < maxX && bbox.east > minX && bbox.south < maxY && bbox.north > minY;
+      for (const [minX, minY, maxX, maxY] of boundsArr) {
+        let overlaps;
+        if ('west' in bbox) {
+          overlaps = bbox.west < maxX && bbox.east > minX && bbox.south < maxY && bbox.north > minY;
+        } else {
+          // top/bottom could be swapped depending on the indexing system
+          const y0 = Math.min(bbox.top, bbox.bottom);
+          const y1 = Math.max(bbox.top, bbox.bottom);
+          overlaps = bbox.left < maxX && bbox.right > minX && y0 < maxY && y1 > minY;
+        }
+        if (overlaps) {
+          return true;
+        }
       }
-      // top/bottom could be swapped depending on the indexing system
-      const y0 = Math.min(bbox.top, bbox.bottom);
-      const y1 = Math.max(bbox.top, bbox.bottom);
-      return bbox.left < maxX && bbox.right > minX && y0 < maxY && y1 > minY;
+      return false;
     }
     return true;
   }

--- a/test/modules/geo-layers/tileset-2d/tileset-2d.spec.js
+++ b/test/modules/geo-layers/tileset-2d/tileset-2d.spec.js
@@ -409,6 +409,109 @@ test('Tileset2D#traversal', async t => {
   t.end();
 });
 
+test('Tileset2D#isTileVisible', async t => {
+  const cullRect = {x: 50, y: 48, width: 100, height: 1};
+
+  const testCases = [
+    {
+      title: 'tile visibility for render',
+      viewport: new WebMercatorViewport({
+        width: 200,
+        height: 100,
+        longitude: 0,
+        latitude: 0,
+        zoom: 3
+      }),
+      checks: [{id: '3-3-3', result: true}]
+    },
+    {
+      title: 'culling',
+      viewport: new WebMercatorViewport({
+        width: 200,
+        height: 100,
+        longitude: -170,
+        latitude: 0,
+        zoom: 3
+      }),
+      checks: [
+        {id: '3-3-3', result: false},
+        {id: '0-3-3', result: true},
+        {id: '0-3-3', cullRect, result: true},
+        {id: '0-4-3', result: true},
+        {id: '0-4-3', cullRect, result: false}
+      ]
+    },
+    {
+      title: 'visibility across the 180 meridian',
+      viewport: new WebMercatorViewport({
+        width: 200,
+        height: 100,
+        longitude: -179.9,
+        latitude: 0,
+        zoom: 3,
+        repeat: true
+      }),
+      checks: [
+        {id: '0-3-3', result: true},
+        {id: '0-3-3', cullRect, result: true},
+        {id: '0-4-3', result: true},
+        {id: '0-4-3', cullRect, result: false},
+        {id: '7-3-3', result: true},
+        {id: '7-3-3', cullRect, result: true},
+        {id: '7-4-3', result: true},
+        {id: '7-4-3', cullRect, result: false}
+      ]
+    },
+    {
+      title: 'culling with zRange',
+      viewport: new WebMercatorViewport({
+        width: 200,
+        height: 100,
+        longitude: -179.9,
+        latitude: 0,
+        pitch: 60,
+        zoom: 3,
+        repeat: true
+      }),
+      zRange: [0, 100000],
+      checks: [
+        {id: '0-3-3', cullRect, result: true},
+        {id: '0-4-3', cullRect, result: true},
+        {id: '7-3-3', cullRect, result: true},
+        {id: '7-4-3', cullRect, result: true}
+      ]
+    }
+  ];
+
+  let viewport, options;
+  const updateTileset = () => tileset.update(viewport, options);
+  const tileset = new Tileset2D({
+    getTileData,
+    onTileLoad: updateTileset,
+    onTileError: updateTileset
+  });
+
+  for (const testCase of testCases) {
+    t.comment(testCase.title);
+    viewport = testCase.viewport;
+    options = {zRange: testCase.zRange};
+
+    updateTileset();
+    await sleep(10);
+
+    for (const {id, cullRect, result} of testCase.checks) {
+      const tile = tileset._cache.get(id);
+      t.is(
+        tileset.isTileVisible(tile, cullRect),
+        result,
+        `isTileVisible ${cullRect ? 'with cullRect ' : ''}returns correct value for ${id}`
+      );
+    }
+  }
+
+  t.end();
+});
+
 function validateVisibility(strategy, selectedTiles, tiles) {
   /* eslint-disable default-case */
   switch (strategy) {


### PR DESCRIPTION
For #7614

When using `MapView` with `repeat: true`, and the scissor rect crosses the 180 meridian, the world space culling bounds may not be described by a single rectangle.

#### Change List
- `getCullBounds` handles sub viewports
- Unit tests
