### PR TITLE
Add willReadFrequently flag to 2d context creation

### DIFF
--- a/modules/layers/src/icon-layer/icon-manager.ts
+++ b/modules/layers/src/icon-layer/icon-manager.ts
@@ -417,7 +417,9 @@ export default class IconManager {
     })[]
   ): void {
     // This method is only called in the auto packing case, where _canvas is defined
-    const ctx = this._canvas!.getContext('2d') as CanvasRenderingContext2D;
+    const ctx = this._canvas!.getContext('2d', {
+      willReadFrequently: true
+    }) as CanvasRenderingContext2D;
 
     for (const icon of icons) {
       this._pendingCount++;

--- a/modules/layers/src/text-layer/font-atlas-manager.ts
+++ b/modules/layers/src/text-layer/font-atlas-manager.ts
@@ -203,7 +203,7 @@ export default class FontAtlasManager {
       canvas = document.createElement('canvas');
       canvas.width = MAX_CANVAS_WIDTH;
     }
-    const ctx = canvas.getContext('2d')!;
+    const ctx = canvas.getContext('2d', {willReadFrequently: true})!;
 
     setTextStyle(ctx, fontFamily, fontSize, fontWeight);
 


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/discussions/7623

According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#browser_compatibility this flag is not implemented in Safari but it doesn't seem to break when I tested locally.

#### Change List
- IconManager
- FontAtlasManager
