### PR TITLE
Update example dependencies

### DIFF
--- a/examples/experimental/bezier/package.json
+++ b/examples/experimental/bezier/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/experimental/bezier/src/app.jsx
+++ b/examples/experimental/bezier/src/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {OrthographicView} from '@deck.gl/core';
 import BezierGraphLayer from './bezier-graph-layer';
@@ -25,4 +25,5 @@ export default function App({data = SAMPLE_GRAPH}) {
 }
 
 /* global document */
-render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.getElementById('app');
+createRoot(container).render(<App />);

--- a/examples/experimental/h3-grid/index.html
+++ b/examples/experimental/h3-grid/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/experimental/h3-grid/package.json
+++ b/examples/experimental/h3-grid/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.1.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/experimental/h3-grid/src/app.jsx
+++ b/examples/experimental/h3-grid/src/app.jsx
@@ -4,7 +4,7 @@ import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
 
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 
 import H3GridLayer from './h3-grid-layer';
 import {getMinZoom} from './h3-utils';
@@ -75,7 +75,7 @@ export default function App() {
         onViewStateChange={onViewStateChange}
         getTooltip={info => info.object}
       >
-        <Map mapLib={maplibre} mapStyle={MAP_STYLE} />
+        <Map mapLib={maplibregl} mapStyle={MAP_STYLE} />
       </DeckGL>
       <div style={CONTROL_PANEL_STYLE}>
         <div>Resolution: {resolution}</div>

--- a/examples/experimental/h3-grid/src/app.jsx
+++ b/examples/experimental/h3-grid/src/app.jsx
@@ -1,9 +1,10 @@
 import React, {useState} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
 
-import {StaticMap} from 'react-map-gl';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 
 import H3GridLayer from './h3-grid-layer';
 import {getMinZoom} from './h3-utils';
@@ -74,7 +75,7 @@ export default function App() {
         onViewStateChange={onViewStateChange}
         getTooltip={info => info.object}
       >
-        <StaticMap mapStyle={MAP_STYLE} />
+        <Map mapLib={maplibre} mapStyle={MAP_STYLE} />
       </DeckGL>
       <div style={CONTROL_PANEL_STYLE}>
         <div>Resolution: {resolution}</div>
@@ -93,4 +94,5 @@ export default function App() {
 
 /* global document */
 document.body.style.overflow = 'hidden';
-render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<App />);

--- a/examples/experimental/interleaved-buffer/package.json
+++ b/examples/experimental/interleaved-buffer/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@deck.gl/core": "^8.8.0",

--- a/examples/get-started/pure-js/arcgis/package.json
+++ b/examples/get-started/pure-js/arcgis/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@arcgis/core": "^4.21.0",

--- a/examples/get-started/pure-js/carto/app.js
+++ b/examples/get-started/pure-js/carto/app.js
@@ -1,4 +1,4 @@
-import mapboxgl from 'mapbox-gl';
+import maplibre from 'maplibre-gl';
 import {Deck} from '@deck.gl/core';
 import {fetchMap} from '@deck.gl/carto';
 
@@ -10,7 +10,7 @@ fetchMap({cartoMapId}).then(({initialViewState, mapStyle, layers}) => {
 
   // Add Mapbox GL for the basemap. It's not a requirement if you don't need a basemap.
   const MAP_STYLE = `https://basemaps.cartocdn.com/gl/${mapStyle.styleType}-gl-style/style.json`;
-  const map = new mapboxgl.Map({container: 'map', style: MAP_STYLE, interactive: false});
+  const map = new maplibre.Map({container: 'map', style: MAP_STYLE, interactive: false});
   deck.setProps({
     onViewStateChange: ({viewState}) => {
       const {longitude, latitude, ...rest} = viewState;

--- a/examples/get-started/pure-js/carto/app.js
+++ b/examples/get-started/pure-js/carto/app.js
@@ -1,4 +1,4 @@
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import {Deck} from '@deck.gl/core';
 import {fetchMap} from '@deck.gl/carto';
 
@@ -10,7 +10,7 @@ fetchMap({cartoMapId}).then(({initialViewState, mapStyle, layers}) => {
 
   // Add Mapbox GL for the basemap. It's not a requirement if you don't need a basemap.
   const MAP_STYLE = `https://basemaps.cartocdn.com/gl/${mapStyle.styleType}-gl-style/style.json`;
-  const map = new maplibre.Map({container: 'map', style: MAP_STYLE, interactive: false});
+  const map = new maplibregl.Map({container: 'map', style: MAP_STYLE, interactive: false});
   deck.setProps({
     onViewStateChange: ({viewState}) => {
       const {longitude, latitude, ...rest} = viewState;

--- a/examples/get-started/pure-js/carto/index.html
+++ b/examples/get-started/pure-js/carto/index.html
@@ -24,10 +24,7 @@
                 height: 100%;
             }
         </style>
-        <link
-            href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.css"
-            rel="stylesheet"
-        />
+        <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     </head>
     <body>
         <div id="container">

--- a/examples/get-started/pure-js/carto/package.json
+++ b/examples/get-started/pure-js/carto/package.json
@@ -9,12 +9,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@deck.gl/core": "^8.8.0",
-    "@deck.gl/layers": "^8.8.0",
-    "@deck.gl/geo-layers": "^8.8.0",
-    "@deck.gl/mesh-layers": "^8.8.0",
-    "@deck.gl/carto": "^8.8.0",
-    "mapbox-gl": "^1.13.0"
+    "deck.gl": "^8.8.0",
+    "maplibre-gl": "^2.4.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/examples/get-started/react/arcgis/app.jsx
+++ b/examples/get-started/react/arcgis/app.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 import {Map} from '@esri/react-arcgis';
 import {loadArcGISModules} from '@deck.gl/arcgis';
@@ -81,4 +81,4 @@ function App() {
 }
 
 /* global document */
-ReactDOM.render(<App />, document.getElementById('root'));
+createRoot(document.getElementById('root')).render(<App />);

--- a/examples/get-started/react/arcgis/package.json
+++ b/examples/get-started/react/arcgis/package.json
@@ -13,8 +13,8 @@
     "@esri/react-arcgis": "^5.1.0",
     "esri-loader": "^3.3.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/examples/get-started/react/basic/app.jsx
+++ b/examples/get-started/react/basic/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL, {GeoJsonLayer, ArcLayer} from 'deck.gl';
 
 // source: Natural Earth http://www.naturalearthdata.com/ via geojson.xyz
@@ -63,4 +63,5 @@ function Root() {
 }
 
 /* global document */
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/examples/get-started/react/basic/package.json
+++ b/examples/get-started/react/basic/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/examples/get-started/react/google-maps/app.jsx
+++ b/examples/get-started/react/google-maps/app.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState, useMemo} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {GeoJsonLayer, ArcLayer} from 'deck.gl';
 import {Wrapper, Status} from '@googlemaps/react-wrapper';
 import {GoogleMapsOverlay as DeckOverlay} from '@deck.gl/google-maps';
@@ -93,4 +93,5 @@ function Root() {
 }
 
 /* global document */
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/examples/get-started/react/google-maps/package.json
+++ b/examples/get-started/react/google-maps/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@googlemaps/react-wrapper": "^1.1.32",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/examples/get-started/react/mapbox/app.jsx
+++ b/examples/get-started/react/mapbox/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {StaticMap, MapContext, NavigationControl} from 'react-map-gl';
 import DeckGL, {GeoJsonLayer, ArcLayer} from 'deck.gl';
 
@@ -72,4 +72,5 @@ function Root() {
 }
 
 /* global document */
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/examples/get-started/react/mapbox/package.json
+++ b/examples/get-started/react/mapbox/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-map-gl": "^5.3.0"
   },
   "devDependencies": {

--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -18,7 +18,7 @@
     "react": "^16.3.0",
     "react-autobind": "^1.0.6",
     "react-dom": "^16.3.0",
-    "react-map-gl": "^5.1.0",
+    "react-map-gl": "^5.3.0",
     "react-stats-zavatta": "^0.0.6"
   },
   "devDependencies": {

--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Playground</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; overflow: hidden;}
     #app {width: 100vw; height: 100vh; display: flex; flex-direction: row; align-items: stretch;}

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/3d-tiles": "^3.3.0-alpha.10",
@@ -17,10 +17,11 @@
     "@luma.gl/constants": "^8.5.12",
     "brace": "^0.11.1",
     "deck.gl": "^8.8.0",
-    "react": "~16.9.0",
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
     "react-ace": "^6.1.4",
-    "react-dom": "~16.9.0",
-    "react-map-gl": "^5.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0",
     "react-virtualized-auto-sizer": "^1.0.2"
   },
   "devDependencies": {

--- a/examples/playground/src/app.jsx
+++ b/examples/playground/src/app.jsx
@@ -1,7 +1,7 @@
 import React, {Component, Fragment} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import {StaticMap} from 'react-map-gl';
+import {Map} from 'react-map-gl';
 import DeckWithMapboxMaps from './deck-with-mapbox-maps';
 import DeckWithGoogleMaps from './deck-with-google-maps';
 
@@ -169,7 +169,7 @@ export class App extends Component {
           id="json-deck"
           {...jsonProps}
           initialViewState={initialViewState}
-          Map={StaticMap}
+          Map={Map}
         />
       );
     }
@@ -209,5 +209,5 @@ export class App extends Component {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/playground/src/deck-with-mapbox-maps.jsx
+++ b/examples/playground/src/deck-with-mapbox-maps.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import DeckGL from '@deck.gl/react';
 import {View} from '@deck.gl/core';
+import maplibre from 'maplibre-gl';
 
 export default class DeckWithMapboxMaps extends Component {
   render() {
@@ -13,6 +14,7 @@ export default class DeckWithMapboxMaps extends Component {
           <View id={view.props.id} key={view.props.id}>
             <this.props.Map
               reuseMap
+              mapLib={maplibre}
               mapStyle={view.props.mapStyle}
               mapboxApiAccessToken={view.props.mapToken || this.props.mapboxApiAccessToken}
             />

--- a/examples/playground/src/deck-with-mapbox-maps.jsx
+++ b/examples/playground/src/deck-with-mapbox-maps.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import DeckGL from '@deck.gl/react';
 import {View} from '@deck.gl/core';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 
 export default class DeckWithMapboxMaps extends Component {
   render() {
@@ -14,7 +14,7 @@ export default class DeckWithMapboxMaps extends Component {
           <View id={view.props.id} key={view.props.id}>
             <this.props.Map
               reuseMap
-              mapLib={maplibre}
+              mapLib={maplibregl}
               mapStyle={view.props.mapStyle}
               mapboxApiAccessToken={view.props.mapToken || this.props.mapboxApiAccessToken}
             />

--- a/examples/website/360-video/app.jsx
+++ b/examples/website/360-video/app.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 import DeckGL from '@deck.gl/react';
 import {FirstPersonView, COORDINATE_SYSTEM} from '@deck.gl/core';
@@ -95,5 +95,5 @@ export default function App() {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/360-video/package.json
+++ b/examples/website/360-video/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/3d-heatmap/app.jsx
+++ b/examples/website/3d-heatmap/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import {HexagonLayer} from '@deck.gl/aggregation-layers';
 import DeckGL from '@deck.gl/react';
@@ -110,7 +110,7 @@ export default function App({
       controller={true}
       getTooltip={getTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/3d-heatmap/app.jsx
+++ b/examples/website/3d-heatmap/app.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import {HexagonLayer} from '@deck.gl/aggregation-layers';
 import DeckGL from '@deck.gl/react';
@@ -109,18 +110,19 @@ export default function App({
       controller={true}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   csv(DATA_URL, (error, response) => {
     if (!error) {
       const data = response.map(d => [Number(d.lng), Number(d.lat)]);
-      render(<App data={data} />, container);
+      root.render(<App data={data} />);
     }
   });
 }

--- a/examples/website/3d-heatmap/index.html
+++ b/examples/website/3d-heatmap/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/3d-heatmap/package.json
+++ b/examples/website/3d-heatmap/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-request": "^1.0.5",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/3d-tiles/app.jsx
+++ b/examples/website/3d-tiles/app.jsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
 
@@ -54,11 +55,11 @@ export default function App({
 
   return (
     <DeckGL layers={[tile3DLayer]} initialViewState={initialViewState} controller={true}>
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/3d-tiles/app.jsx
+++ b/examples/website/3d-tiles/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
 
@@ -55,7 +55,7 @@ export default function App({
 
   return (
     <DeckGL layers={[tile3DLayer]} initialViewState={initialViewState} controller={true}>
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing />
     </DeckGL>
   );
 }

--- a/examples/website/3d-tiles/index.html
+++ b/examples/website/3d-tiles/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset='UTF-8' />
     <title>3D Tiles Example</title>
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style>
       body {
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
     "@loaders.gl/3d-tiles": "^3.3.0-alpha.10",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/arc/app.jsx
+++ b/examples/website/arc/app.jsx
@@ -2,7 +2,7 @@
 import React, {useState, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {scaleQuantile} from 'd3-scale';
@@ -110,7 +110,7 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
       controller={true}
       getTooltip={getTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/arc/app.jsx
+++ b/examples/website/arc/app.jsx
@@ -1,7 +1,8 @@
 /* global fetch */
 import React, {useState, useMemo} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {scaleQuantile} from 'd3-scale';
@@ -109,17 +110,18 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
       controller={true}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   fetch(DATA_URL)
     .then(response => response.json())
     .then(({features}) => {
-      render(<App data={features} />, container);
+      root.render(<App data={features} />);
     });
 }

--- a/examples/website/arc/index.html
+++ b/examples/website/arc/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/arc/package.json
+++ b/examples/website/arc/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/brushing/app.jsx
+++ b/examples/website/brushing/app.jsx
@@ -1,7 +1,8 @@
 /* global fetch */
 import React, {useMemo} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScatterplotLayer, ArcLayer} from '@deck.gl/layers';
 import {BrushingExtension} from '@deck.gl/extensions';
@@ -179,17 +180,18 @@ export default function App({
       controller={true}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   fetch(DATA_URL)
     .then(response => response.json())
     .then(({features}) => {
-      render(<App data={features} />, container);
+      root.render(<App data={features} />);
     });
 }

--- a/examples/website/brushing/app.jsx
+++ b/examples/website/brushing/app.jsx
@@ -2,7 +2,7 @@
 import React, {useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScatterplotLayer, ArcLayer} from '@deck.gl/layers';
 import {BrushingExtension} from '@deck.gl/extensions';
@@ -180,7 +180,7 @@ export default function App({
       controller={true}
       getTooltip={getTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/brushing/index.html
+++ b/examples/website/brushing/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/brushing/package.json
+++ b/examples/website/brushing/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/carto-sql/app.jsx
+++ b/examples/website/carto-sql/app.jsx
@@ -1,6 +1,7 @@
 import React, {useState, useCallback} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {LinearInterpolator} from '@deck.gl/core';
 import {CartoLayer, setDefaultCredentials, API_VERSIONS, MAP_TYPES} from '@deck.gl/carto';
@@ -109,11 +110,11 @@ export default function App({
       onLoad={rotateCamera}
       onViewStateChange={v => updateViewState(v.viewState)}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/carto-sql/app.jsx
+++ b/examples/website/carto-sql/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {LinearInterpolator} from '@deck.gl/core';
 import {CartoLayer, setDefaultCredentials, API_VERSIONS, MAP_TYPES} from '@deck.gl/carto';
@@ -110,7 +110,7 @@ export default function App({
       onLoad={rotateCamera}
       onViewStateChange={v => updateViewState(v.viewState)}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/carto-sql/index.html
+++ b/examples/website/carto-sql/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/carto-sql/package.json
+++ b/examples/website/carto-sql/package.json
@@ -5,13 +5,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/contour/app.jsx
+++ b/examples/website/contour/app.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ContourLayer} from '@deck.gl/aggregation-layers';
 
@@ -85,11 +86,11 @@ export default function App({
       getTooltip={getTooltip}
       style={{mixBlendMode: 'lighten'}}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/contour/app.jsx
+++ b/examples/website/contour/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ContourLayer} from '@deck.gl/aggregation-layers';
 
@@ -86,7 +86,7 @@ export default function App({
       getTooltip={getTooltip}
       style={{mixBlendMode: 'lighten'}}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/contour/index.html
+++ b/examples/website/contour/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/contour/package.json
+++ b/examples/website/contour/package.json
@@ -5,13 +5,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/data-filter/app.jsx
+++ b/examples/website/data-filter/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
-import {render} from 'react-dom';
-
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {DataFilterExtension} from '@deck.gl/extensions';
@@ -118,7 +118,7 @@ export default function App({data, mapStyle = MAP_STYLE}) {
         controller={true}
         getTooltip={getTooltip}
       >
-        <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+        <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
       </DeckGL>
 
       {timeRange && (
@@ -136,7 +136,8 @@ export default function App({data, mapStyle = MAP_STYLE}) {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
   csv(DATA_URL, (error, response) => {
     if (!error) {
       const data = response.map(row => ({
@@ -146,7 +147,7 @@ export function renderToDOM(container) {
         depth: Number(row.Depth),
         magnitude: Number(row.Magnitude)
       }));
-      render(<App data={data} />, container);
+      root.render(<App data={data} />);
     }
   });
 }

--- a/examples/website/data-filter/app.jsx
+++ b/examples/website/data-filter/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {DataFilterExtension} from '@deck.gl/extensions';
@@ -118,7 +118,7 @@ export default function App({data, mapStyle = MAP_STYLE}) {
         controller={true}
         getTooltip={getTooltip}
       >
-        <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+        <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
       </DeckGL>
 
       {timeRange && (

--- a/examples/website/data-filter/index.html
+++ b/examples/website/data-filter/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/data-filter/package.json
+++ b/examples/website/data-filter/package.json
@@ -6,16 +6,17 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "d3-request": "^1.0.5",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/election/package.json
+++ b/examples/website/election/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",

--- a/examples/website/geojson/app.jsx
+++ b/examples/website/geojson/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer, PolygonLayer} from '@deck.gl/layers';
 import {LightingEffect, AmbientLight, _SunLight as SunLight} from '@deck.gl/core';
@@ -115,7 +115,7 @@ export default function App({data = DATA_URL, mapStyle = MAP_STYLE}) {
       controller={true}
       getTooltip={getTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/geojson/app.jsx
+++ b/examples/website/geojson/app.jsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer, PolygonLayer} from '@deck.gl/layers';
 import {LightingEffect, AmbientLight, _SunLight as SunLight} from '@deck.gl/core';
@@ -114,11 +115,11 @@ export default function App({data = DATA_URL, mapStyle = MAP_STYLE}) {
       controller={true}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/geojson/index.html
+++ b/examples/website/geojson/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/geojson/package.json
+++ b/examples/website/geojson/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/ghcn/app.jsx
+++ b/examples/website/ghcn/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useMemo} from 'react';
 
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {OrthographicView} from '@deck.gl/core';
 import {TextLayer, PathLayer} from '@deck.gl/layers';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
@@ -170,12 +170,13 @@ export default function App({data, groupBy = 'Country'}) {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   /* global fetch */
   fetch(DATA_URL)
     .then(resp => resp.json())
     .then(data => {
-      render(<App data={data} />, container);
+      root.render(<App data={data} />);
     });
 }

--- a/examples/website/ghcn/package.json
+++ b/examples/website/ghcn/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/globe/app.jsx
+++ b/examples/website/globe/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useState, useMemo, useCallback} from 'react';
 
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 import DeckGL from '@deck.gl/react';
 import {
@@ -129,7 +129,8 @@ export default function App({data}) {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   async function loadData(dates) {
     const data = [];
@@ -137,7 +138,7 @@ export function renderToDOM(container) {
       const url = `${DATA_URL}/${date}.csv`;
       const flights = await load(url, CSVLoader, {csv: {skipEmptyLines: true}});
       data.push({flights, date});
-      render(<App data={data} />, container);
+      root.render(<App data={data} />);
     }
   }
 

--- a/examples/website/globe/package.json
+++ b/examples/website/globe/package.json
@@ -6,15 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/csv": "^3.3.0-alpha.10",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/google-3d/package.json
+++ b/examples/website/google-3d/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@turf/rhumb-bearing": "^6.5.0",

--- a/examples/website/heatmap/app.jsx
+++ b/examples/website/heatmap/app.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';
 
@@ -40,11 +41,11 @@ export default function App({
 
   return (
     <DeckGL initialViewState={INITIAL_VIEW_STATE} controller={true} layers={layers}>
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/heatmap/app.jsx
+++ b/examples/website/heatmap/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';
 
@@ -41,7 +41,7 @@ export default function App({
 
   return (
     <DeckGL initialViewState={INITIAL_VIEW_STATE} controller={true} layers={layers}>
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/heatmap/index.html
+++ b/examples/website/heatmap/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/heatmap/package.json
+++ b/examples/website/heatmap/package.json
@@ -5,13 +5,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/highway/app.jsx
+++ b/examples/website/highway/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {scaleLinear, scaleThreshold} from 'd3-scale';
@@ -153,7 +153,7 @@ export default function App({roads = DATA_URL.ROADS, year, accidents, mapStyle =
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
 
       {renderTooltip({incidents, fatalities, year, hoverInfo})}
     </DeckGL>

--- a/examples/website/highway/app.jsx
+++ b/examples/website/highway/app.jsx
@@ -1,6 +1,7 @@
 import React, {useState, useMemo} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {scaleLinear, scaleThreshold} from 'd3-scale';
@@ -152,7 +153,7 @@ export default function App({roads = DATA_URL.ROADS, year, accidents, mapStyle =
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
 
       {renderTooltip({incidents, fatalities, year, hoverInfo})}
     </DeckGL>
@@ -160,7 +161,8 @@ export default function App({roads = DATA_URL.ROADS, year, accidents, mapStyle =
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   const formatRow = d => ({
     ...d,
@@ -170,7 +172,7 @@ export function renderToDOM(container) {
 
   csv(DATA_URL.ACCIDENTS, formatRow, (error, response) => {
     if (!error) {
-      render(<App accidents={response} year={response[0].year} />, container);
+      root.render(<App accidents={response} year={response[0].year} />);
     }
   });
 }

--- a/examples/website/highway/index.html
+++ b/examples/website/highway/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
     .tooltip {pointer-events: none; position: absolute; z-index: 9; font-size: 12px; padding: 8px; background: #000; color: #fff; min-width: 160px; max-height: 240px; overflow-y: hidden;}

--- a/examples/website/highway/package.json
+++ b/examples/website/highway/package.json
@@ -6,15 +6,16 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-request": "^1.0.5",
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/i3s/package.json
+++ b/examples/website/i3s/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/i3s": "^3.3.0-alpha.10",

--- a/examples/website/icon/app.jsx
+++ b/examples/website/icon/app.jsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
 import {IconLayer} from '@deck.gl/layers';
@@ -108,7 +109,7 @@ export default function App({
       onViewStateChange={hideTooltip}
       onClick={expandTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
 
       {renderTooltip(hoverInfo)}
     </DeckGL>
@@ -116,5 +117,5 @@ export default function App({
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/icon/app.jsx
+++ b/examples/website/icon/app.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
 import {IconLayer} from '@deck.gl/layers';
@@ -109,7 +109,7 @@ export default function App({
       onViewStateChange={hideTooltip}
       onClick={expandTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
 
       {renderTooltip(hoverInfo)}
     </DeckGL>

--- a/examples/website/icon/index.html
+++ b/examples/website/icon/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
     .tooltip {pointer-events: none; position: absolute; z-index: 9; font-size: 12px; padding: 8px; background: #000; color: #fff; min-width: 160px; max-height: 240px; overflow-y: hidden;}

--- a/examples/website/icon/package.json
+++ b/examples/website/icon/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0",
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0",
     "supercluster": "^6.0.1"
   },
   "devDependencies": {

--- a/examples/website/image-tile/app.jsx
+++ b/examples/website/image-tile/app.jsx
@@ -1,6 +1,6 @@
 /* global fetch, DOMParser */
 import React, {useState, useEffect} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 import DeckGL, {OrthographicView, COORDINATE_SYSTEM} from 'deck.gl';
 import {TileLayer} from '@deck.gl/geo-layers';
@@ -96,5 +96,5 @@ export default function App({autoHighlight = true, onTilesLoad}) {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/image-tile/package.json
+++ b/examples/website/image-tile/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/line/app.jsx
+++ b/examples/website/line/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {render} from 'react-dom';
-
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {LineLayer, ScatterplotLayer} from '@deck.gl/layers';
 import GL from '@luma.gl/constants';
@@ -91,11 +91,11 @@ export default function App({
       }}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/line/app.jsx
+++ b/examples/website/line/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {LineLayer, ScatterplotLayer} from '@deck.gl/layers';
 import GL from '@luma.gl/constants';
@@ -91,7 +91,7 @@ export default function App({
       }}
       getTooltip={getTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/line/index.html
+++ b/examples/website/line/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/line/package.json
+++ b/examples/website/line/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/map-tile/app.jsx
+++ b/examples/website/map-tile/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
@@ -114,5 +114,5 @@ export default function App({showBorder = false, onTilesLoad = null}) {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/map-tile/package.json
+++ b/examples/website/map-tile/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/mesh/app.jsx
+++ b/examples/website/mesh/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {
   COORDINATE_SYSTEM,
@@ -105,5 +105,5 @@ export default function App() {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/mesh/package.json
+++ b/examples/website/mesh/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/obj": "^3.3.0-alpha.10",
     "@math.gl/core": "^3.6.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/plot/app.jsx
+++ b/examples/website/plot/app.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {OrbitView} from '@deck.gl/core';
 import PlotLayer from './plot-layer';
@@ -61,5 +61,5 @@ export default function App({resolution = 200, showAxis = true, equation = EQUAT
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/plot/package.json
+++ b/examples/website/plot/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/point-cloud/app.jsx
+++ b/examples/website/point-cloud/app.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, {useState, useEffect} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {COORDINATE_SYSTEM, OrbitView, LinearInterpolator} from '@deck.gl/core';
 import {PointCloudLayer} from '@deck.gl/layers';
@@ -90,5 +90,5 @@ export default function App({onLoad}) {
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/point-cloud/package.json
+++ b/examples/website/point-cloud/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/las": "^3.3.0-alpha.10",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/radio/app.jsx
+++ b/examples/website/radio/app.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useState, useMemo, useCallback} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import {MapView, WebMercatorViewport, FlyToInterpolator} from '@deck.gl/core';
 import {ScatterplotLayer, PathLayer} from '@deck.gl/layers';
 import {MVTLayer, H3HexagonLayer} from '@deck.gl/geo-layers';
@@ -228,7 +228,7 @@ export default function App({
       getTooltip={getTooltip}
     >
       <MapView id="main">
-        <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} />
+        <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} />
         <SearchBar data={data} onChange={onSelectStation} />
       </MapView>
       {showMinimap && (

--- a/examples/website/radio/app.jsx
+++ b/examples/website/radio/app.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {useState, useMemo, useCallback} from 'react';
-
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import {MapView, WebMercatorViewport, FlyToInterpolator} from '@deck.gl/core';
 import {ScatterplotLayer, PathLayer} from '@deck.gl/layers';
 import {MVTLayer, H3HexagonLayer} from '@deck.gl/geo-layers';
@@ -228,7 +228,7 @@ export default function App({
       getTooltip={getTooltip}
     >
       <MapView id="main">
-        <StaticMap reuseMaps mapStyle={mapStyle} />
+        <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} />
         <SearchBar data={data} onChange={onSelectStation} />
       </MapView>
       {showMinimap && (
@@ -241,9 +241,10 @@ export default function App({
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  const root = createRoot(container);
+  root.render(<App />);
 
   load(DATA_URL.STATIONS, CSVLoader, {csv: {delimiter: '\t', skipEmptyLines: true}}).then(data => {
-    render(<App data={data} />, container);
+    root.render(<App data={data} />);
   });
 }

--- a/examples/website/radio/index.html
+++ b/examples/website/radio/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/radio/package.json
+++ b/examples/website/radio/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/csv": "^3.3.0-alpha.10",
@@ -14,9 +14,10 @@
     "@material-ui/lab": "^4.0.0-alpha.57",
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/safegraph/package.json
+++ b/examples/website/safegraph/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "@loaders.gl/csv": "^3.3.0-alpha.10",

--- a/examples/website/scatterplot/app.jsx
+++ b/examples/website/scatterplot/app.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScatterplotLayer} from '@deck.gl/layers';
 
@@ -44,11 +45,11 @@ export default function App({
 
   return (
     <DeckGL layers={layers} initialViewState={INITIAL_VIEW_STATE} controller={true}>
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/scatterplot/app.jsx
+++ b/examples/website/scatterplot/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScatterplotLayer} from '@deck.gl/layers';
 
@@ -45,7 +45,7 @@ export default function App({
 
   return (
     <DeckGL layers={layers} initialViewState={INITIAL_VIEW_STATE} controller={true}>
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/scatterplot/index.html
+++ b/examples/website/scatterplot/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/scatterplot/package.json
+++ b/examples/website/scatterplot/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/scenegraph/app.jsx
+++ b/examples/website/scenegraph/app.jsx
@@ -2,7 +2,7 @@
 import React, {useEffect, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
 
@@ -125,7 +125,7 @@ export default function App({sizeScale = 25, onDataLoad, mapStyle = MAP_STYLE}) 
       controller={true}
       getTooltip={getTooltip}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/scenegraph/app.jsx
+++ b/examples/website/scenegraph/app.jsx
@@ -1,8 +1,8 @@
 /* global fetch, setTimeout, clearTimeout */
 import React, {useEffect, useState} from 'react';
-import {render} from 'react-dom';
-
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
 
@@ -125,11 +125,11 @@ export default function App({sizeScale = 25, onDataLoad, mapStyle = MAP_STYLE}) 
       controller={true}
       getTooltip={getTooltip}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/scenegraph/index.html
+++ b/examples/website/scenegraph/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/scenegraph/package.json
+++ b/examples/website/scenegraph/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/screen-grid/app.jsx
+++ b/examples/website/screen-grid/app.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScreenGridLayer} from '@deck.gl/aggregation-layers';
 import {isWebGL2} from '@luma.gl/core';
@@ -67,11 +68,11 @@ export default function App({
       onWebGLInitialized={onInitialized}
       controller={true}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/screen-grid/app.jsx
+++ b/examples/website/screen-grid/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {ScreenGridLayer} from '@deck.gl/aggregation-layers';
 import {isWebGL2} from '@luma.gl/core';
@@ -68,7 +68,7 @@ export default function App({
       onWebGLInitialized={onInitialized}
       controller={true}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/screen-grid/index.html
+++ b/examples/website/screen-grid/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/screen-grid/package.json
+++ b/examples/website/screen-grid/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/tagmap/app.jsx
+++ b/examples/website/tagmap/app.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {TextLayer} from '@deck.gl/layers';
 import TagmapLayer from './tagmap-layer';
@@ -56,7 +56,7 @@ export default function App({
       initialViewState={INITIAL_VIEW_STATE}
       controller={{dragRotate: false}}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/tagmap/app.jsx
+++ b/examples/website/tagmap/app.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable max-len */
 import React from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {TextLayer} from '@deck.gl/layers';
 import TagmapLayer from './tagmap-layer';
@@ -55,11 +56,11 @@ export default function App({
       initialViewState={INITIAL_VIEW_STATE}
       controller={{dragRotate: false}}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/tagmap/index.html
+++ b/examples/website/tagmap/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/tagmap/package.json
+++ b/examples/website/tagmap/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0",
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0",
     "tagmap.js": "^1.1.1"
   },
   "devDependencies": {

--- a/examples/website/terrain/app.jsx
+++ b/examples/website/terrain/app.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-statements */
 import React from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 
 import {TerrainLayer} from '@deck.gl/geo-layers';
@@ -50,5 +50,5 @@ export default function App({
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/terrain/package.json
+++ b/examples/website/terrain/package.json
@@ -6,13 +6,12 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/examples/website/trips/app.jsx
+++ b/examples/website/trips/app.jsx
@@ -1,7 +1,8 @@
 /* global window */
 import React, {useState, useEffect} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibre from 'maplibre-gl';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import DeckGL from '@deck.gl/react';
 import {PolygonLayer} from '@deck.gl/layers';
@@ -127,11 +128,11 @@ export default function App({
       initialViewState={initialViewState}
       controller={true}
     >
-      <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }
 
 export function renderToDOM(container) {
-  render(<App />, container);
+  createRoot(container).render(<App />);
 }

--- a/examples/website/trips/app.jsx
+++ b/examples/website/trips/app.jsx
@@ -2,7 +2,7 @@
 import React, {useState, useEffect} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl';
-import maplibre from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import DeckGL from '@deck.gl/react';
 import {PolygonLayer} from '@deck.gl/layers';
@@ -128,7 +128,7 @@ export default function App({
       initialViewState={initialViewState}
       controller={true}
     >
-      <Map reuseMaps mapLib={maplibre} mapStyle={mapStyle} preventStyleDiffing={true} />
+      <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
     </DeckGL>
   );
 }

--- a/examples/website/trips/index.html
+++ b/examples/website/trips/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>deck.gl Example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     body {margin: 0; font-family: sans-serif; width: 100vw; height: 100vh; overflow: hidden;}
   </style>

--- a/examples/website/trips/package.json
+++ b/examples/website/trips/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "start": "vite --open",
     "start-local": "vite --config ../../vite.config.local.mjs",
-    "build": "tsc && vite build"
+    "build": "vite build"
   },
   "dependencies": {
     "deck.gl": "^8.8.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.6.0",

--- a/test/apps/attribute-transition/app.jsx
+++ b/test/apps/attribute-transition/app.jsx
@@ -1,7 +1,7 @@
 /* global document console */
 /* eslint-disable no-console */
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL, {COORDINATE_SYSTEM, OrthographicView, ScatterplotLayer, PolygonLayer} from 'deck.gl';
 
 import DataGenerator from './data-generator';
@@ -146,4 +146,5 @@ class Root extends Component {
   }
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/attribute-transition/package.json
+++ b/test/apps/attribute-transition/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/carto-dynamic-tile/app.jsx
+++ b/test/apps/carto-dynamic-tile/app.jsx
@@ -1,7 +1,7 @@
 /* global document */
 /* eslint-disable no-console */
 import React, {useState} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {CartoLayer, FORMATS, MAP_TYPES} from '@deck.gl/carto';
 import {GeoJsonLayer} from '@deck.gl/layers';
@@ -186,4 +186,5 @@ function ObjectSelect({title, obj, value, onSelect}) {
   );
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/carto-dynamic-tile/package.json
+++ b/test/apps/carto-dynamic-tile/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.0.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/custom-tileset/app.jsx
+++ b/test/apps/custom-tileset/app.jsx
@@ -1,7 +1,7 @@
 /* global document */
 /* eslint-disable no-console */
 import React, {useState} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {StaticMap} from 'react-map-gl';
 import {BASEMAP} from '@deck.gl/carto';
 import DeckGL from '@deck.gl/react';
@@ -81,4 +81,5 @@ function Root() {
   );
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/custom-tileset/package.json
+++ b/test/apps/custom-tileset/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.0.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/data-filter/package.json
+++ b/test/apps/data-filter/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/data-filter/src/app.jsx
+++ b/test/apps/data-filter/src/app.jsx
@@ -1,7 +1,7 @@
 /* global window, document */
 /* eslint-disable no-console */
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL, {GeoJsonLayer, COORDINATE_SYSTEM} from 'deck.gl';
 import {DataFilterExtension} from '@deck.gl/extensions';
 
@@ -85,4 +85,5 @@ class Root extends Component {
   }
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/frustum-cull/app.jsx
+++ b/test/apps/frustum-cull/app.jsx
@@ -1,8 +1,10 @@
 /* global window */
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL, {MapView, SimpleMeshLayer, LineLayer, WebMercatorViewport} from 'deck.gl';
-import {StaticMap} from 'react-map-gl';
+
 import {SphereGeometry} from '@luma.gl/core';
 
 import {getCulling, getFrustumBounds} from './frustum-utils';
@@ -100,7 +102,7 @@ class Root extends Component {
         onViewStateChange={this._onViewStateChange}
       >
         <MapView id="main">
-          <StaticMap key="map" mapStyle="mapbox://styles/mapbox/light-v9" />
+          <Map key="map" mapLib={maplibregl} mapStyle="mapbox://styles/mapbox/light-v9" />
         </MapView>
         <MapView id="minimap">
           <div style={MINIMAP_STYLE} />
@@ -112,4 +114,5 @@ class Root extends Component {
 }
 
 /* global document */
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/frustum-cull/package.json
+++ b/test/apps/frustum-cull/package.json
@@ -4,9 +4,10 @@
     "start-local": "vite --config ../vite.config.local.mjs"
   },
   "dependencies": {
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^4.1.2"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/json-layer/app.jsx
+++ b/test/apps/json-layer/app.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
 import * as layers from '@deck.gl/layers';
@@ -39,4 +39,5 @@ export default class App extends Component {
 }
 
 /* global document */
-render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<App />);

--- a/test/apps/json-layer/package.json
+++ b/test/apps/json-layer/package.json
@@ -7,8 +7,8 @@
     "@deck.gl/core": "^8.4.0",
     "@deck.gl/react": "^8.4.0",
     "@deck.gl/json": "^8.4.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/mapbox-layers/package.json
+++ b/test/apps/mapbox-layers/package.json
@@ -5,9 +5,10 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "mapbox-gl": "^2.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/mapbox-layers/react-app.jsx
+++ b/test/apps/mapbox-layers/react-app.jsx
@@ -1,8 +1,8 @@
 /* global document */
 import React, {useState, useRef, useCallback} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL, {ScatterplotLayer, ArcLayer, TextLayer} from 'deck.gl';
-import {StaticMap} from 'react-map-gl';
+import {Map} from 'react-map-gl';
 
 import {MapboxLayer} from '@deck.gl/mapbox';
 
@@ -93,7 +93,7 @@ function App() {
       layerFilter={layerFilter}
     >
       {glContext && (
-        <StaticMap
+        <Map
           ref={mapRef}
           gl={glContext}
           mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
@@ -105,4 +105,5 @@ function App() {
   );
 }
 
-render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<App />);

--- a/test/apps/mapbox-tile/app.jsx
+++ b/test/apps/mapbox-tile/app.jsx
@@ -1,7 +1,7 @@
 /* global document */
 /* eslint-disable no-console */
 import React, {PureComponent} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {MVTLayer} from '@deck.gl/geo-layers';
 
@@ -90,4 +90,5 @@ class Root extends PureComponent {
   }
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/mapbox-tile/package.json
+++ b/test/apps/mapbox-tile/package.json
@@ -7,8 +7,8 @@
     "@mapbox/vector-tile": "^1.3.1",
     "deck.gl": "^8.0.0",
     "pbf": "^3.1.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/mask-first-person/package.json
+++ b/test/apps/mask-first-person/package.json
@@ -6,10 +6,7 @@
   "dependencies": {
     "deck.gl": "^8.4.0",
     "@math.gl/core": "3.6.0",
-    "@turf/circle": "6.5.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^4.1.2"
+    "@turf/circle": "6.5.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/mask-orthographic/app.jsx
+++ b/test/apps/mask-orthographic/app.jsx
@@ -1,6 +1,6 @@
 /* global fetch */
 import React, {useState, useMemo} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {COORDINATE_SYSTEM, OrthographicView} from '@deck.gl/core';
 import {SolidPolygonLayer} from '@deck.gl/layers';
@@ -76,4 +76,5 @@ export default function App() {
   );
 }
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+createRoot(container).render(<App />);

--- a/test/apps/mask-orthographic/package.json
+++ b/test/apps/mask-orthographic/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.6.0-alpha.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/mask/app.jsx
+++ b/test/apps/mask/app.jsx
@@ -1,7 +1,8 @@
 /* global fetch */
 import React, {useState, useMemo, useCallback} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer, SolidPolygonLayer} from '@deck.gl/layers';
 import {ScatterplotLayer, ArcLayer} from '@deck.gl/layers';
@@ -251,7 +252,7 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}
       >
-        <StaticMap reuseMaps mapStyle={mapStyle} preventStyleDiffing={true} />
+        <Map reuseMaps mapLib={maplibregl} mapStyle={mapStyle} preventStyleDiffing={true} />
       </DeckGL>
       <div style={{position: 'absolute', background: 'white', padding: 10, userSelect: 'none'}}>
         <label>
@@ -282,5 +283,5 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
 fetch(DATA_URL)
   .then(response => response.json())
   .then(({features}) => {
-    render(<App data={features} />, document.getElementById('app'));
+    createRoot(document.getElementById('app')).render(<App data={features} />);
   });

--- a/test/apps/mask/package.json
+++ b/test/apps/mask/package.json
@@ -6,9 +6,10 @@
   "dependencies": {
     "d3-scale": "^2.0.0",
     "deck.gl": "^8.6.0-alpha.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/minimap/app.jsx
+++ b/test/apps/minimap/app.jsx
@@ -1,7 +1,8 @@
 /* global window */
 import React, {Component} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {View, MapView} from '@deck.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
@@ -152,14 +153,16 @@ export class App extends Component {
         views={VIEWS}
         onViewStateChange={this._onViewStateChange}
       >
-        <StaticMap
+        <Map
           reuseMaps
+          mapLib={maplibregl}
           mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json"
           preventStyleDiffing={true}
         />
         <View id="minimap">
-          <StaticMap
+          <Map
             reuseMaps
+            mapLib={maplibregl}
             mapStyle="https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json"
             preventStyleDiffing={true}
           />
@@ -170,4 +173,5 @@ export class App extends Component {
 }
 
 /* global document */
-render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<App />);

--- a/test/apps/minimap/package.json
+++ b/test/apps/minimap/package.json
@@ -5,9 +5,10 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.0"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/multi-viewport/app.jsx
+++ b/test/apps/multi-viewport/app.jsx
@@ -1,7 +1,8 @@
 /* global document */
 import React, {Component} from 'react';
-import {render} from 'react-dom';
-import {StaticMap} from 'react-map-gl';
+import {createRoot} from 'react-dom/client';
+import {Map} from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
 
 import DeckGL, {
   COORDINATE_SYSTEM,
@@ -121,10 +122,11 @@ class Root extends Component {
 
   _renderMap({width, height, viewState}) {
     return (
-      <StaticMap
+      <Map
         {...viewState}
         width={width}
         height={height}
+        mapLib={maplibregl}
         mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json"
       />
     );
@@ -150,4 +152,5 @@ class Root extends Component {
   }
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/multi-viewport/package.json
+++ b/test/apps/multi-viewport/package.json
@@ -6,9 +6,10 @@
   "dependencies": {
     "deck.gl": "^8.4.0",
     "@math.gl/core": "3.6.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^4.1.2"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/partial-update/app.jsx
+++ b/test/apps/partial-update/app.jsx
@@ -1,7 +1,7 @@
 /* global document */
 /* eslint-disable no-console */
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL, {COORDINATE_SYSTEM, ScatterplotLayer, PolygonLayer} from 'deck.gl';
 
 import DataGenerator from './data-generator';
@@ -134,4 +134,5 @@ class Root extends Component {
   }
 }
 
-render(<Root />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/partial-update/package.json
+++ b/test/apps/partial-update/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "deck.gl": "^8.4.0",
     "html-webpack-plugin": "^3.2.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/svg-interoperability/app.jsx
+++ b/test/apps/svg-interoperability/app.jsx
@@ -1,7 +1,7 @@
 /* global document, window,*/
 /* eslint-disable no-console */
 import React, {PureComponent} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL, {COORDINATE_SYSTEM, ScatterplotLayer, OrthographicView} from 'deck.gl';
 import ContourLayer from '@deck.gl/layers/contour-layer/contour-layer';
 
@@ -228,7 +228,5 @@ class Root extends PureComponent {
   }
 }
 
-const root = document.createElement('div');
-document.body.appendChild(root);
-
-render(<Root />, root);
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<Root />);

--- a/test/apps/svg-interoperability/package.json
+++ b/test/apps/svg-interoperability/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/video/app.jsx
+++ b/test/apps/video/app.jsx
@@ -1,5 +1,5 @@
 import React, {createRef, Component} from 'react';
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import DeckGL from '@deck.gl/react';
 import {OrthographicView, COORDINATE_SYSTEM} from '@deck.gl/core';
 import {BitmapLayer} from '@deck.gl/layers';
@@ -76,4 +76,5 @@ export class App extends Component {
 }
 
 /* global document */
-render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<App />);

--- a/test/apps/video/package.json
+++ b/test/apps/video/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/viewport-transitions-flyTo/package.json
+++ b/test/apps/viewport-transitions-flyTo/package.json
@@ -5,9 +5,10 @@
   },
   "dependencies": {
     "deck.gl": "^8.4.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
-    "react-map-gl": "^5.0.11"
+    "maplibre-gl": "^2.4.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-map-gl": "^7.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"

--- a/test/apps/viewport-transitions-flyTo/src/app.jsx
+++ b/test/apps/viewport-transitions-flyTo/src/app.jsx
@@ -1,6 +1,7 @@
 /* global window */
 import React, {Component} from 'react';
-import {StaticMap} from 'react-map-gl';
+import {Map} from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
 import DeckGL, {MapController, FlyToInterpolator, TRANSITION_EVENTS} from 'deck.gl';
 
 import ControlPanel from './control-panel';
@@ -92,7 +93,8 @@ export default class App extends Component {
           controller={MapController}
           onViewStateChange={this._onViewStateChange}
         >
-          <StaticMap
+          <Map
+            mapLib={maplibregl}
             mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json"
             dragToRotate={false}
           />

--- a/test/apps/viewport-transitions-flyTo/src/root.jsx
+++ b/test/apps/viewport-transitions-flyTo/src/root.jsx
@@ -1,6 +1,7 @@
 /* global document */
 import React from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import App from './app';
 
-ReactDOM.render(<App />, document.body.appendChild(document.createElement('div')));
+const container = document.body.appendChild(document.createElement('div'));
+createRoot(container).render(<App />);

--- a/test/apps/wboit/index.jsx
+++ b/test/apps/wboit/index.jsx
@@ -1,6 +1,6 @@
 /* global document */
 import React, {Component} from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 class Root extends Component {
   constructor(props) {
@@ -25,12 +25,12 @@ class Root extends Component {
 
 // ---- Main ---- //
 
-const container = document.createElement('div');
-document.body.appendChild(container);
+const container = document.body.appendChild(document.createElement('div'));
+const root = createRoot(container);
 
 const render = () => {
   const App = require('./app').default;
-  ReactDOM.render(<Root AppComponent={App} />, container);
+  root.render(<Root AppComponent={App} />);
 };
 
 render();


### PR DESCRIPTION
For #7635 

For all examples and test apps where it applies:

#### Change List
- Removed `tsc` from `build` script. The examples do not currently contain their own tsconfig.json and `tsc` just fails.
- Updated `react-map-gl` to v7 and use `maplibre-gl` as map provider in all except the following examples:
  + `get-started/react/mapbox` - depends on `NavigationControl` which is no longer supported in v7
  + `layer-browser` - depends on `NavigationControl` which is no longer supported in v7
  + `safegraph` (the mapbox integration example on the [website](https://deck.gl/examples/mapbox/)) - for testing against the latest version of mapbox-gl
- Updated `react` and `react-dom` to v18
