### PR TITLE
Better support for maplibre in scripting interface

### DIFF
--- a/docs/api-reference/core/deckgl.md
+++ b/docs/api-reference/core/deckgl.md
@@ -40,23 +40,28 @@ The container in which deck.gl should append its canvas. Can be either a HTMLDiv
 
 ##### `map` (Object, optional)
 
-Default: `window.mapboxgl`
+Default: `window.mapboxgl || window.maplibregl`
 
-The scripting API offers out-of-the-box integration with Mapbox. To add a base map to your visualization, you need to include the Mapbox library and stylesheet:
+The scripting API offers out-of-the-box integration with [Mapbox GL JS](https://mapbox.com) or [MapLibre GL JS](https://maplibre.org). To add a base map to your visualization, you need to include the base map library and stylesheet:
 
 ```html
-<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css' rel='stylesheet' />
+<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js'></script>
+<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.css' rel='stylesheet' />
+<!-- or -->
+<script src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css" rel="stylesheet" />
 ```
 
-The above script adds `mapboxgl` to the global scope, which will be picked up by default. 
+The above script adds `mapboxgl` or `maplibregl` to the global scope, which will be picked up by default. 
 
 To disable the base map, simply exclude the mapbox script or set `map` to false.
 
 In some environments such as Observable, libraries cannot be imported into the global scope, in which case you need to manually pass the mapboxgl object to `map`:
 
 ```js
-mapboxgl = require('mapbox-gl@~0.44.1/dist/mapbox-gl.js');
+mapboxgl = require('mapbox-gl@^1.13.0/dist/mapbox-gl.js');
+// or
+maplibregl = require('maplibre-gl@^2.4.0/dist/maplibre-gl.js');
 ```
 
 And
@@ -64,23 +69,7 @@ And
 ```js
 new deck.DeckGL({
   ...
-  map: mapboxgl
-});
-```
-
-To use a mapbox-gl fork such as [MapLibre GL JS](https://maplibre.org), pass the corresponding library entry point to `map`:
-
-```html
-<script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
-```
-
-And 
-
-```js
-new deck.DeckGL({
-  ...
-  map: maplibregl
+  map: mapboxgl  // or maplibregl
 });
 ```
 
@@ -99,7 +88,7 @@ All [Deck](/docs/api-reference/core/deck.md) class methods, with these additiona
 
 ##### `getMapboxMap`
 
-Returns the mapbox-gl [Map](https://www.mapbox.com/mapbox-gl-js/api/#map) instance if a base map is present.
+Returns the mapbox-gl or maplibre-gl [Map](https://www.mapbox.com/mapbox-gl-js/api/#map) instance if a base map is present.
 
 
 ## Source

--- a/examples/gallery/src/arc-layer.html
+++ b/examples/gallery/src/arc-layer.html
@@ -4,9 +4,9 @@
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' /> 
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/bitmap-layer.html
+++ b/examples/gallery/src/bitmap-layer.html
@@ -3,8 +3,9 @@
     <title>deck.gl BitmapLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/boiler-plate.html
+++ b/examples/gallery/src/boiler-plate.html
@@ -2,7 +2,8 @@
   <head>
     <title>Get Started with deck.gl and Mapbox</title>
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />    
   </head>
 
   <body style="margin:0; width: 100vw; height: 100vh;"></body>

--- a/examples/gallery/src/column-layer.html
+++ b/examples/gallery/src/column-layer.html
@@ -3,8 +3,9 @@
     <title>deck.gl ColumnLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/contour-layer.html
+++ b/examples/gallery/src/contour-layer.html
@@ -3,9 +3,9 @@
     <title>deck.gl ContourLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/geojson-layer.html
+++ b/examples/gallery/src/geojson-layer.html
@@ -3,8 +3,9 @@
     <title>deck.gl GeoJsonLayer (Polygon) Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/great-circle-layer.html
+++ b/examples/gallery/src/great-circle-layer.html
@@ -3,9 +3,9 @@
     <title>deck.gl GreatCircleLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/hexagon-layer.html
+++ b/examples/gallery/src/hexagon-layer.html
@@ -4,9 +4,9 @@
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         font-family: Helvetica, Arial, sans-serif;

--- a/examples/gallery/src/highway.html
+++ b/examples/gallery/src/highway.html
@@ -4,9 +4,9 @@
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/icon-layer.html
+++ b/examples/gallery/src/icon-layer.html
@@ -5,7 +5,9 @@
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/rest.js/15.2.6/octokit-rest.min.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/line-layer.html
+++ b/examples/gallery/src/line-layer.html
@@ -3,8 +3,9 @@
     <title>deck.gl LineLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/scatterplot-layer.html
+++ b/examples/gallery/src/scatterplot-layer.html
@@ -3,9 +3,9 @@
     <title>deck.gl ScatterplotLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/screengrid-layer.html
+++ b/examples/gallery/src/screengrid-layer.html
@@ -3,9 +3,9 @@
     <title>deck.gl ScreenGridLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/text-layer.html
+++ b/examples/gallery/src/text-layer.html
@@ -3,9 +3,9 @@
     <title>deck.gl TextLayer Example</title>
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/gallery/src/tile-3d-layer.html
+++ b/examples/gallery/src/tile-3d-layer.html
@@ -3,7 +3,9 @@
   <title>deck.gl Tile3DLayer</title>
   <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
   <script src="https://unpkg.com/@loaders.gl/i3s@^2.3.0/dist/dist.min.js"></script>
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
+  <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
 </head>
 
 <body style="margin:0; width: 100vw; height: 100vh;"></body>

--- a/examples/gallery/src/viewport-transition.html
+++ b/examples/gallery/src/viewport-transition.html
@@ -4,9 +4,9 @@
 
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
 
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
     <style type="text/css">
       body {
         width: 100vw;

--- a/examples/get-started/scripting/carto/index.html
+++ b/examples/get-started/scripting/carto/index.html
@@ -3,12 +3,9 @@
         <!-- deck.gl standalone bundle -->
         <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
         <script src="https://unpkg.com/@deck.gl/carto@^8.8.0/dist.min.js"></script>
-        <!-- Mapbox dependencies -->
-        <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-        <link
-            href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.css"
-            rel="stylesheet"
-        />
+        <!-- Maplibre dependencies -->
+        <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+        <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
 
         <title>CARTO deck.gl example</title>
         <style type="text/css">

--- a/examples/get-started/scripting/mapbox/index.html
+++ b/examples/get-started/scripting/mapbox/index.html
@@ -3,9 +3,9 @@
     <!-- deck.gl standalone bundle -->
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
 
-    <!-- Mapbox dependencies -->
-    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.js"></script>
-    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.13.0/mapbox-gl.css" rel="stylesheet" />
+    <!-- Maplibre dependencies -->
+    <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+    <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
 
     <style type="text/css">
       body {margin: 0; padding: 0;}

--- a/modules/core/bundle/deckgl.js
+++ b/modules/core/bundle/deckgl.js
@@ -56,7 +56,7 @@ export default class DeckGL extends Deck {
 
     const viewState = props.viewState || props.initialViewState;
     const isMap = Number.isFinite(viewState && viewState.latitude);
-    const {map = window.mapboxgl} = props;
+    const {map = window.mapboxgl || window.maplibregl} = props;
 
     super({canvas: deckCanvas, ...props});
 


### PR DESCRIPTION
For #7635 

It's possible to use maplibre with the current bundle, but the user is required to pass `map: maplibregl` to the `DeckGL` constructor. This PR make it possible to use maplibre without this manual step.

#### Change List
- Auto detect `maplibregl` global object
- Documentation
- Move scripting examples to use maplibre-gl
