### PR TITLE
CARTO: Increase GET limit to 8192

### DIFF
--- a/modules/carto/src/api/maps-v3-client.ts
+++ b/modules/carto/src/api/maps-v3-client.ts
@@ -30,7 +30,7 @@ import {parseMap} from './parseMap';
 import {log} from '@deck.gl/core';
 import {assert} from '../utils';
 
-const MAX_GET_LENGTH = 2048;
+const MAX_GET_LENGTH = 8192;
 const DEFAULT_CLIENT = 'deck-gl-carto';
 const V3_MINOR_VERSION = '3.1';
 

--- a/test/modules/carto/api/maps-api-client.spec.js
+++ b/test/modules/carto/api/maps-api-client.spec.js
@@ -522,7 +522,7 @@ test('fetchLayerData#post', async t => {
   const accessToken = 'XXX';
   const headers = {'Custom-Header': 'Custom-Header-Value'};
 
-  const source = `SELECT *, '${Array(2048).join('x')}' as r FROM cartobq.testtables.points_10k`;
+  const source = `SELECT *, '${Array(8192).join('x')}' as r FROM cartobq.testtables.points_10k`;
   const aggregationExp = 'avg(value) as value';
   const aggregationResLevel = 4;
   const geoColumn = 'customGeom';


### PR DESCRIPTION
POST requests create issues with the API, increase the size limit for GET request to allow larger queries