### PR TITLE
Move core bundle source into src directory

### DIFF
--- a/modules/core/bundle/index.ts
+++ b/modules/core/bundle/index.ts
@@ -1,14 +1,14 @@
 // We use `require` here because luma and deck core must be imported before `global`
-import * as LumaGL from './lumagl';
-import {registerLoaders, load, parse, fetchFile} from '@loaders.gl/core';
+import * as LumaGL from '../src/scripting/lumagl';
+import * as LoadersGL from '../src/scripting/loadersgl';
 
 globalThis.luma = globalThis.luma || {};
 globalThis.loaders = globalThis.loaders || {};
 
 Object.assign(globalThis.luma, LumaGL);
-Object.assign(globalThis.loaders, {registerLoaders, load, parse, fetchFile});
+Object.assign(globalThis.loaders, LoadersGL);
 
 export * from '../src';
 export {register as _registerLoggers} from '../src/debug';
 
-export {default as DeckGL} from './deckgl';
+export {default as DeckGL} from '../src/scripting/deckgl';

--- a/modules/core/src/scripting/loadersgl.ts
+++ b/modules/core/src/scripting/loadersgl.ts
@@ -1,0 +1,5 @@
+/**
+ * Re-exported loaders.gl API in the pre-built bundle
+ * Cherry-pick loaders core exports that are relevant to deck
+ */
+export {registerLoaders, load, parse, fetchFile} from '@loaders.gl/core';

--- a/modules/core/src/scripting/lumagl.ts
+++ b/modules/core/src/scripting/lumagl.ts
@@ -1,4 +1,7 @@
-// Cherry-pick luma core exports that are relevant to deck
+/**
+ * Re-exported luma.gl API in the pre-built bundle
+ * Cherry-pick luma core exports that are relevant to deck
+ */
 export {
   // Core classes
   Model,


### PR DESCRIPTION
#### Background

`yarn test dist` is failing on master as a fallout of the test harness upgrade.

The issue is that a significant chunk of code in `modules/core/bundle` is also a dependency of `jupyter-widget`. The test harness can only correctly resolve import paths for code in `modules/*/src`.

Before all these changes to the test harness, the jupyter-widget tests were wrapped in a try/catch and silently ignored if imports failed. I do not believe it was the right solution as it also ignored any non-import-related issues. And we can no longer do that anyways because `require` is not allowed in the current ESM-only setup.

#### Change List
- Move `DeckGL` scripting interface into `core/src`
- JS -> TS
