### PR TITLE
Fix autoHighlight crash when TileLayer is used as a sub layer

### DIFF
--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
@@ -148,14 +148,11 @@ export default class Tile3DLayer<DataT = any, ExtraPropsT = {}> extends Composit
   }
 
   getPickingInfo({info, sourceLayer}: GetPickingInfoParams) {
-    const {layerMap} = this.state;
-    const layerId = sourceLayer && sourceLayer.id;
-    if (layerId) {
-      // layerId: this.id-[scenegraph|pointcloud]-tileId
-      const substr = layerId.substring(this.id.length + 1);
-      const tileId = substr.substring(substr.indexOf('-') + 1);
-      info.object = layerMap[tileId] && layerMap[tileId].tile;
+    const sourceTile = sourceLayer && (sourceLayer.props as any).tile;
+    if (info.picked) {
+      info.object = sourceTile;
     }
+    (info as any).sourceTile = sourceTile;
 
     return info;
   }
@@ -168,8 +165,10 @@ export default class Tile3DLayer<DataT = any, ExtraPropsT = {}> extends Composit
   }
 
   protected _updateAutoHighlight(info: PickingInfo): void {
-    if (info.sourceLayer) {
-      info.sourceLayer.updateAutoHighlight(info);
+    const sourceTile = (info as any).sourceTile;
+    const layerCache = this.state.layerMap[sourceTile?.id];
+    if (layerCache && layerCache.layer) {
+      layerCache.layer.updateAutoHighlight(info);
     }
   }
 

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -315,15 +315,20 @@ export default class TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeL
   }
 
   getPickingInfo({info, sourceLayer}: GetPickingInfoParams): TiledPickingInfo<DataT> {
+    const sourceTile = (sourceLayer as any).props.tile;
     if (info.picked) {
-      (info as any).tile = (sourceLayer as any).props.tile;
+      (info as any).tile = sourceTile;
     }
+    (info as any).sourceTile = sourceTile;
     return info;
   }
 
   protected _updateAutoHighlight(info: PickingInfo): void {
-    if (info.sourceLayer) {
-      info.sourceLayer.updateAutoHighlight(info);
+    const sourceTile = (info as any).sourceTile as Tile2DHeader;
+    if (sourceTile && sourceTile.layers) {
+      for (const layer of sourceTile.layers) {
+        layer.updateAutoHighlight(info);
+      }
     }
   }
 


### PR DESCRIPTION
If the TileLayer is rendered as a sub layer of another layer (e.g. TerrainLayer), `pickingInfo.sourceLayer` points to the TileLayer itself, creating an infinite loop in `updateAutoHighlight`. The same goes for `Tile3DLayer`.

`updateAutoHighlight` should not depend on a pick info field that it doesn't manage.

#### Change List
- Create a separate field `sourceTile` in `pickingInfo` for tile highlighting.
