### PR TITLE
IconManager preserve aspect ratio when auto packing

### DIFF
--- a/docs/api-reference/layers/icon-layer.md
+++ b/docs/api-reference/layers/icon-layer.md
@@ -250,12 +250,15 @@ If you choose to use auto packing, then `getIcon` should return an object which 
 the following properties.
 
 - `url` (String, required): url to fetch the icon
-- `height` (Number, required): height of icon
-- `width` (Number, required): width of icon
+- `height` (Number, required): max height of icon
+- `width` (Number, required): max width of icon
 - `id`: (String, optional): unique identifier of the icon, fall back to `url` if not specified
 - `anchorX`, `anchorY`, `mask` are the same as mentioned in `iconMapping`
 
-`IconLayer` use `id` (fallback to `url`) to dedupe icons. If for the same icon identifier, `getIcon` returns different `width` or `height`, `IconLayer` will only apply the first occurrence and ignore the rest of them.
+`IconLayer` uses `id` (fallback to `url`) to dedupe icons. For icons with the same id, even if their sizes differ, `IconLayer` will only define one icon according to the first occurrence and ignore the rest of them. Vice versa, for icons with different ids, even if `url`s are the same, the image will be fetched again to create a new definition with different size, anchor, etc.
+
+The image loaded from `url` is always resized to fit the box defined by `[width, height]` while preserving its aspect ratio.
+
 
 ##### `getPosition` ([Function](/docs/developer-guide/using-layers.md#accessors), optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 


### PR DESCRIPTION
#### Background

This issue has been raised in the Slack channel:

When using the `IconLayer` with auto packing, the application may not know the dimensions of an icon before loading it. Providing the wrong width/height will cause the rendered icon to be stretched.

After this PR, the `IconManager` preserves the aspect ratio of the incoming icon image while resizing.

This is technically a breaking change with no way of reverting to the old behavior. I would argue that it is the expected behavior, though.

Other caveats:
- The packing algorithm is still run before any icon is loaded using the user-provided width/height, so there may end up being some empty pixels in the texture when all is loaded. However, this way we only have to resize the texture once.
- If an icon image's aspect ratio is different from the pre-defined dimension, the pixels are centered in the provided bounding box. The default `anchorX`/`anchorY` (center of bounding box) will not be affected, but other values may appear off.

#### Change List
- IconManager preserve aspect ratio when auto packing
- Unit test
