### PR TITLE
TypeScript: fix some TS erros

### DIFF
--- a/modules/aggregation-layers/src/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/aggregation-layer.ts
@@ -31,7 +31,7 @@ import {filterProps} from './utils/prop-utils';
 export type AggregationLayerProps<DataT = any> = CompositeLayerProps<DataT>;
 
 export default abstract class AggregationLayer<
-  ExtraPropsT = {}
+  ExtraPropsT = unknown
 > extends CompositeLayer<ExtraPropsT> {
   static layerName = 'AggregationLayer';
 

--- a/modules/aggregation-layers/src/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/aggregation-layer.ts
@@ -31,7 +31,7 @@ import {filterProps} from './utils/prop-utils';
 export type AggregationLayerProps<DataT = any> = CompositeLayerProps<DataT>;
 
 export default abstract class AggregationLayer<
-  ExtraPropsT = unknown
+  ExtraPropsT extends {} = {}
 > extends CompositeLayer<ExtraPropsT> {
   static layerName = 'AggregationLayer';
 

--- a/modules/aggregation-layers/src/contour-layer/contour-layer.ts
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.ts
@@ -145,7 +145,7 @@ export type _ContourLayerProps<DataT> = {
 };
 
 /** Aggregate data into iso-lines or iso-bands for a given threshold and cell size. */
-export default class ContourLayer<DataT = any, ExtraPropsT = {}> extends GridAggregationLayer<
+export default class ContourLayer<DataT = any, ExtraPropsT = unknown> extends GridAggregationLayer<
   ExtraPropsT & Required<_ContourLayerProps<DataT>>
 > {
   static layerName = 'ContourLayer';

--- a/modules/aggregation-layers/src/contour-layer/contour-layer.ts
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.ts
@@ -145,9 +145,10 @@ export type _ContourLayerProps<DataT> = {
 };
 
 /** Aggregate data into iso-lines or iso-bands for a given threshold and cell size. */
-export default class ContourLayer<DataT = any, ExtraPropsT = unknown> extends GridAggregationLayer<
-  ExtraPropsT & Required<_ContourLayerProps<DataT>>
-> {
+export default class ContourLayer<
+  DataT = any,
+  ExtraPropsT extends {} = {}
+> extends GridAggregationLayer<ExtraPropsT & Required<_ContourLayerProps<DataT>>> {
   static layerName = 'ContourLayer';
   static defaultProps = defaultProps;
 

--- a/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
@@ -237,9 +237,10 @@ export type _CPUGridLayerProps<DataT> = {
 };
 
 /** Aggregate data into a grid-based heatmap. Aggregation is performed on CPU. */
-export default class CPUGridLayer<DataT = any, ExtraPropsT = unknown> extends AggregationLayer<
-  ExtraPropsT & Required<_CPUGridLayerProps<DataT>>
-> {
+export default class CPUGridLayer<
+  DataT = any,
+  ExtraPropsT extends {} = {}
+> extends AggregationLayer<ExtraPropsT & Required<_CPUGridLayerProps<DataT>>> {
   static layerName = 'CPUGridLayer';
   static defaultProps = defaultProps;
 

--- a/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
@@ -237,7 +237,7 @@ export type _CPUGridLayerProps<DataT> = {
 };
 
 /** Aggregate data into a grid-based heatmap. Aggregation is performed on CPU. */
-export default class CPUGridLayer<DataT = any, ExtraPropsT = {}> extends AggregationLayer<
+export default class CPUGridLayer<DataT = any, ExtraPropsT = unknown> extends AggregationLayer<
   ExtraPropsT & Required<_CPUGridLayerProps<DataT>>
 > {
   static layerName = 'CPUGridLayer';

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.ts
@@ -169,9 +169,10 @@ export type _GPUGridLayerProps<DataT> = {
 };
 
 /** Aggregate data into a grid-based heatmap. Aggregation is performed on GPU (WebGL2 only). */
-export default class GPUGridLayer<DataT = any, ExtraPropsT = unknown> extends GridAggregationLayer<
-  ExtraPropsT & Required<_GPUGridLayerProps<DataT>>
-> {
+export default class GPUGridLayer<
+  DataT = any,
+  ExtraPropsT extends {} = {}
+> extends GridAggregationLayer<ExtraPropsT & Required<_GPUGridLayerProps<DataT>>> {
   static layerName = 'GPUGridLayer';
   static defaultProps = defaultProps;
 

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.ts
@@ -169,7 +169,7 @@ export type _GPUGridLayerProps<DataT> = {
 };
 
 /** Aggregate data into a grid-based heatmap. Aggregation is performed on GPU (WebGL2 only). */
-export default class GPUGridLayer<DataT = any, ExtraPropsT = {}> extends GridAggregationLayer<
+export default class GPUGridLayer<DataT = any, ExtraPropsT = unknown> extends GridAggregationLayer<
   ExtraPropsT & Required<_GPUGridLayerProps<DataT>>
 > {
   static layerName = 'GPUGridLayer';

--- a/modules/aggregation-layers/src/grid-aggregation-layer.ts
+++ b/modules/aggregation-layers/src/grid-aggregation-layer.ts
@@ -29,7 +29,7 @@ import {pointToDensityGridDataCPU} from './cpu-grid-layer/grid-aggregator';
 export type GridAggregationLayerProps<DataT = any> = AggregationLayerProps<DataT>;
 
 export default abstract class GridAggregationLayer<
-  ExtraPropsT = unknown
+  ExtraPropsT extends {} = {}
 > extends AggregationLayer<ExtraPropsT> {
   static layerName = 'GridAggregationLayer';
 

--- a/modules/aggregation-layers/src/grid-aggregation-layer.ts
+++ b/modules/aggregation-layers/src/grid-aggregation-layer.ts
@@ -29,7 +29,7 @@ import {pointToDensityGridDataCPU} from './cpu-grid-layer/grid-aggregator';
 export type GridAggregationLayerProps<DataT = any> = AggregationLayerProps<DataT>;
 
 export default abstract class GridAggregationLayer<
-  ExtraPropsT = {}
+  ExtraPropsT = unknown
 > extends AggregationLayer<ExtraPropsT> {
   static layerName = 'GridAggregationLayer';
 

--- a/modules/aggregation-layers/src/grid-layer/grid-layer.ts
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer.ts
@@ -35,7 +35,7 @@ type _GridLayerProps<DataT> = _CPUGridLayerProps<DataT> &
   };
 
 /** Aggregate data into a grid-based heatmap. The color and height of a cell are determined based on the objects it contains. */
-export default class GridLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
+export default class GridLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_GridLayerProps<DataT>>
 > {
   static layerName = 'GridLayer';

--- a/modules/aggregation-layers/src/grid-layer/grid-layer.ts
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer.ts
@@ -35,7 +35,7 @@ type _GridLayerProps<DataT> = _CPUGridLayerProps<DataT> &
   };
 
 /** Aggregate data into a grid-based heatmap. The color and height of a cell are determined based on the objects it contains. */
-export default class GridLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+export default class GridLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_GridLayerProps<DataT>>
 > {
   static layerName = 'GridLayer';

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -187,9 +187,10 @@ type _HeatmapLayerProps<DataT> = {
 };
 
 /** Visualizes the spatial distribution of data. */
-export default class HeatmapLayer<DataT = any, ExtraPropsT = unknown> extends AggregationLayer<
-  ExtraPropsT & Required<_HeatmapLayerProps<DataT>>
-> {
+export default class HeatmapLayer<
+  DataT = any,
+  ExtraPropsT extends {} = {}
+> extends AggregationLayer<ExtraPropsT & Required<_HeatmapLayerProps<DataT>>> {
   static layerName = 'HeatmapLayer';
   static defaultProps = defaultProps;
 

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -187,7 +187,7 @@ type _HeatmapLayerProps<DataT> = {
 };
 
 /** Visualizes the spatial distribution of data. */
-export default class HeatmapLayer<DataT = any, ExtraPropsT = {}> extends AggregationLayer<
+export default class HeatmapLayer<DataT = any, ExtraPropsT = unknown> extends AggregationLayer<
   ExtraPropsT & Required<_HeatmapLayerProps<DataT>>
 > {
   static layerName = 'HeatmapLayer';

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
@@ -247,7 +247,7 @@ type _HexagonLayerProps<DataT = any> = {
 };
 
 /** Aggregates data into a hexagon-based heatmap. The color and height of a hexagon are determined based on the objects it contains. */
-export default class HexagonLayer<ExtraPropsT = {}> extends AggregationLayer<
+export default class HexagonLayer<ExtraPropsT = unknown> extends AggregationLayer<
   ExtraPropsT & Required<_HexagonLayerProps>
 > {
   static layerName = 'HexagonLayer';

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
@@ -247,7 +247,7 @@ type _HexagonLayerProps<DataT = any> = {
 };
 
 /** Aggregates data into a hexagon-based heatmap. The color and height of a hexagon are determined based on the objects it contains. */
-export default class HexagonLayer<ExtraPropsT = unknown> extends AggregationLayer<
+export default class HexagonLayer<ExtraPropsT extends {} = {}> extends AggregationLayer<
   ExtraPropsT & Required<_HexagonLayerProps>
 > {
   static layerName = 'HexagonLayer';

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
@@ -47,7 +47,7 @@ export type _ScreenGridCellLayerProps<DataT> = _ScreenGridLayerProps<DataT> & {
   maxTexture: Texture2D;
 };
 
-export default class ScreenGridCellLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class ScreenGridCellLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_ScreenGridCellLayerProps<DataT>>
 > {
   static layerName = 'ScreenGridCellLayer';

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
@@ -47,7 +47,7 @@ export type _ScreenGridCellLayerProps<DataT> = _ScreenGridLayerProps<DataT> & {
   maxTexture: Texture2D;
 };
 
-export default class ScreenGridCellLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class ScreenGridCellLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_ScreenGridCellLayerProps<DataT>>
 > {
   static layerName = 'ScreenGridCellLayer';

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.ts
@@ -139,9 +139,10 @@ export type _ScreenGridLayerProps<DataT> = {
 };
 
 /** Aggregates data into histogram bins and renders them as a grid. */
-export default class ScreenGridLayer<DataT = any, ExtraProps = {}> extends GridAggregationLayer<
-  ExtraProps & Required<_ScreenGridLayerProps<DataT>>
-> {
+export default class ScreenGridLayer<
+  DataT = any,
+  ExtraProps extends {} = {}
+> extends GridAggregationLayer<ExtraProps & Required<_ScreenGridLayerProps<DataT>>> {
   static layerName = 'ScreenGridLayer';
   static defaultProps = defaultProps;
 

--- a/modules/carto/src/layers/carto-layer.ts
+++ b/modules/carto/src/layers/carto-layer.ts
@@ -165,11 +165,11 @@ type _CartoLayerProps = {
   queryParameters?: QueryParameters;
 };
 
-export default class CartoLayer<ExtraProps = {}> extends CompositeLayer<
+export default class CartoLayer<ExtraProps extends {} = {}> extends CompositeLayer<
   Required<_CartoLayerProps> & ExtraProps
 > {
   static layerName = 'CartoLayer';
-  static defaultProps = defaultProps as any;
+  static defaultProps = defaultProps;
 
   initializeState(): void {
     this.state = {

--- a/modules/carto/src/layers/carto-tile-layer.ts
+++ b/modules/carto/src/layers/carto-tile-layer.ts
@@ -42,7 +42,7 @@ type _CartoTileLayerProps = {
 
 export default class CartoTileLayer<
   DataT extends Feature = Feature,
-  ExtraProps = {}
+  ExtraProps extends {} = {}
 > extends MVTLayer<DataT, Required<_CartoTileLayerProps> & ExtraProps> {
   static layerName = 'CartoTileLayer';
   static defaultProps = defaultProps;

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -38,7 +38,7 @@ type _H3TileLayerProps<DataT> = H3HexagonLayerProps<DataT> & {
   aggregationResLevel?: number;
 };
 
-export default class H3TileLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
+export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_H3TileLayerProps<DataT>>
 > {
   static layerName = 'H3TileLayer';

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -38,7 +38,7 @@ type _H3TileLayerProps<DataT> = H3HexagonLayerProps<DataT> & {
   aggregationResLevel?: number;
 };
 
-export default class H3TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+export default class H3TileLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_H3TileLayerProps<DataT>>
 > {
   static layerName = 'H3TileLayer';

--- a/modules/carto/src/layers/quadbin-layer.ts
+++ b/modules/carto/src/layers/quadbin-layer.ts
@@ -22,7 +22,7 @@ type _QuadbinLayerProps<DataT> = {
   getQuadbin?: AccessorFunction<DataT, bigint>;
 };
 
-export default class QuadbinLayer<DataT = any, ExtraProps = {}> extends GeoCellLayer<
+export default class QuadbinLayer<DataT = any, ExtraProps extends {} = {}> extends GeoCellLayer<
   DataT,
   Required<_QuadbinLayerProps<DataT>> & ExtraProps
 > {

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -33,9 +33,10 @@ type _QuadbinTileLayerProps<DataT> = QuadbinLayerProps<DataT> & {
   aggregationResLevel?: number;
 };
 
-export default class QuadbinTileLayer<DataT = any, ExtraProps = {}> extends CompositeLayer<
-  ExtraProps & Required<_QuadbinTileLayerProps<DataT>>
-> {
+export default class QuadbinTileLayer<
+  DataT = any,
+  ExtraProps extends {} = {}
+> extends CompositeLayer<ExtraProps & Required<_QuadbinTileLayerProps<DataT>>> {
   static layerName = 'QuadbinTileLayer';
   static defaultProps = defaultProps;
 

--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -29,10 +29,10 @@ type _SpatialIndexTileLayerProps<DataT = any> = {
   aggregationResLevel?: number;
 };
 
-export default class SpatialIndexTileLayer<DataT = any, ExtraProps = {}> extends TileLayer<
-  DataT,
-  ExtraProps & Required<_SpatialIndexTileLayerProps<DataT>>
-> {
+export default class SpatialIndexTileLayer<
+  DataT = any,
+  ExtraProps extends {} = {}
+> extends TileLayer<DataT, ExtraProps & Required<_SpatialIndexTileLayerProps<DataT>>> {
   static layerName = 'SpatialIndexTileLayer';
   static defaultProps = defaultProps;
 

--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -31,7 +31,7 @@ import {PROP_TYPES_SYMBOL} from '../lifecycle/constants';
 
 const TRACE_RENDER_LAYERS = 'compositeLayer.renderLayers';
 
-export default abstract class CompositeLayer<PropsT = {}> extends Layer<
+export default abstract class CompositeLayer<PropsT = unknown> extends Layer<
   PropsT & Required<CompositeLayerProps>
 > {
   static layerName: string = 'CompositeLayer';

--- a/modules/core/src/lib/composite-layer.ts
+++ b/modules/core/src/lib/composite-layer.ts
@@ -31,7 +31,7 @@ import {PROP_TYPES_SYMBOL} from '../lifecycle/constants';
 
 const TRACE_RENDER_LAYERS = 'compositeLayer.renderLayers';
 
-export default abstract class CompositeLayer<PropsT = unknown> extends Layer<
+export default abstract class CompositeLayer<PropsT extends {} = {}> extends Layer<
   PropsT & Required<CompositeLayerProps>
 > {
   static layerName: string = 'CompositeLayer';

--- a/modules/core/src/lib/layer-extension.ts
+++ b/modules/core/src/lib/layer-extension.ts
@@ -24,14 +24,7 @@ import type {UpdateParameters} from './layer';
 import type {LayerContext} from './layer-manager';
 
 export default abstract class LayerExtension<OptionsT = undefined> {
-  /**
-   * Note that defaultProps of a LayerExtension does not behave like defaultProps of a Layer:
-      - The default values are not automatically merged with user-supplied props when the layer is constructed
-      - The types are not used during props diff
-   * Currently they are only used in getSubLayerProps
-   * TODO: find a more consistent solution
-   */
-  static defaultProps: any = {};
+  static defaultProps = {};
   opts!: OptionsT;
 
   constructor(opts?: OptionsT) {

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -185,7 +185,7 @@ export type UpdateParameters<LayerT extends Layer> = {
   changeFlags: ChangeFlags;
 };
 
-export default abstract class Layer<PropsT = unknown> extends Component<
+export default abstract class Layer<PropsT extends {} = {}> extends Component<
   PropsT & Required<LayerProps>
 > {
   static defaultProps = defaultProps;

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -188,7 +188,7 @@ export type UpdateParameters<LayerT extends Layer> = {
 export default abstract class Layer<PropsT extends {} = {}> extends Component<
   PropsT & Required<LayerProps>
 > {
-  static defaultProps = defaultProps;
+  static defaultProps: DefaultProps = defaultProps;
   static layerName: string = 'Layer';
 
   internalState: LayerState<this> | null = null;

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -185,7 +185,9 @@ export type UpdateParameters<LayerT extends Layer> = {
   changeFlags: ChangeFlags;
 };
 
-export default abstract class Layer<PropsT = {}> extends Component<PropsT & Required<LayerProps>> {
+export default abstract class Layer<PropsT = unknown> extends Component<
+  PropsT & Required<LayerProps>
+> {
   static defaultProps = defaultProps;
   static layerName: string = 'Layer';
 

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -19,7 +19,7 @@ export type StatefulComponentProps<PropsT> = PropsT & {
   [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;
 };
 
-export default class Component<PropsT = {}> {
+export default class Component<PropsT = unknown> {
   static componentName: string = 'Component';
   static defaultProps: Readonly<{}> = {};
 

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -19,7 +19,7 @@ export type StatefulComponentProps<PropsT> = PropsT & {
   [ASYNC_RESOLVED_SYMBOL]: Partial<PropsT>;
 };
 
-export default class Component<PropsT = unknown> {
+export default class Component<PropsT extends {} = {}> {
   static componentName: string = 'Component';
   static defaultProps: Readonly<{}> = {};
 

--- a/modules/core/src/lifecycle/create-props.ts
+++ b/modules/core/src/lifecycle/create-props.ts
@@ -13,10 +13,10 @@ import {StatefulComponentProps} from './component';
 import type Component from './component';
 
 // Create a property object
-export function createProps<T>(
-  component: Component<T>,
-  propObjects: Partial<T>[]
-): StatefulComponentProps<T> {
+export function createProps<PropsT extends {}>(
+  component: Component<PropsT>,
+  propObjects: Partial<PropsT>[]
+): StatefulComponentProps<PropsT> {
   // Resolve extension value
   let extensions: any[] | undefined;
   for (let i = propObjects.length - 1; i >= 0; i--) {

--- a/modules/core/src/lifecycle/prop-types.ts
+++ b/modules/core/src/lifecycle/prop-types.ts
@@ -35,8 +35,8 @@ type DefaultProp<T> =
   | AccessorPropType<T>
   | FunctionPropType<T>;
 
-export type DefaultProps<T extends Record<string, any>> = {
-  [propName in keyof T]?: DefaultProp<Required<T>[propName]>;
+export type DefaultProps<PropsT extends {} = {}> = {
+  [propName in keyof PropsT]?: DefaultProp<Required<PropsT>[propName]>;
 };
 
 type BooleanPropType = BasePropType<boolean> & {

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -111,11 +111,11 @@ export type LayerProps<DataType = any> = {
   /**
    * Custom implementation to fetch and parse content from URLs.
    */
-  fetch?: <PropsT>(
+  fetch?: <LayerT extends Layer>(
     url: string,
     context: {
       propName: string;
-      layer: Layer<PropsT>;
+      layer: LayerT;
       loaders?: Loader[];
       loadOptions?: any;
       signal?: AbortSignal;
@@ -207,9 +207,9 @@ export type LayerProps<DataType = any> = {
    * Called when remote data is fetched and parsed.
    */
   onDataLoad?:
-    | (<PropsT>(
+    | (<LayerT extends Layer>(
         data: LayerData<DataType>,
-        context: {propName: string; layer: Layer<PropsT>}
+        context: {propName: string; layer: LayerT}
       ) => void)
     | null;
   /**

--- a/modules/core/src/utils/texture.ts
+++ b/modules/core/src/utils/texture.ts
@@ -9,7 +9,7 @@ const DEFAULT_TEXTURE_PARAMETERS: Record<number, number> = {
 };
 
 // Track the textures that are created by us. They need to be released when they are no longer used.
-const internalTextures: Record<string, Texture2D> = {};
+const internalTextures: Record<string, boolean> = {};
 
 export function createTexture(
   gl: WebGLRenderingContext,

--- a/modules/extensions/src/clip/clip.ts
+++ b/modules/extensions/src/clip/clip.ts
@@ -97,7 +97,7 @@ varying vec2 clip_commonPosition;
 
 /** Adds support for clipping rendered layers by rectangular bounds. */
 export default class ClipExtension extends LayerExtension {
-  static defaultProps: any = defaultProps;
+  static defaultProps = defaultProps;
   static extensionName = 'ClipExtension';
 
   getShaders(this: Layer<ClipExtensionProps>) {

--- a/modules/extensions/src/data-filter/shader-module.ts
+++ b/modules/extensions/src/data-filter/shader-module.ts
@@ -1,4 +1,4 @@
-import {_ShaderModule as ShaderModule} from '@deck.gl/core/typed';
+import {_ShaderModule as ShaderModule} from '@deck.gl/core';
 
 import type {DataFilterExtensionProps} from './data-filter';
 

--- a/modules/geo-layers/src/geo-cell-layer/GeoCellLayer.ts
+++ b/modules/geo-layers/src/geo-cell-layer/GeoCellLayer.ts
@@ -8,11 +8,11 @@ const defaultProps: DefaultProps<GeoCellLayerProps> = {
 /** All properties supported by GeoCellLayer. */
 export type GeoCellLayerProps<DataT = any> = PolygonLayerProps<DataT> & CompositeLayerProps<DataT>;
 
-export default class GeoCellLayer<DataT = any, ExtraProps = {}> extends CompositeLayer<
+export default class GeoCellLayer<DataT = any, ExtraProps extends {} = {}> extends CompositeLayer<
   Required<GeoCellLayerProps<DataT>> & ExtraProps
 > {
   static layerName = 'GeoCellLayer';
-  static defaultProps = defaultProps;
+  static defaultProps: DefaultProps = defaultProps;
 
   /** Implement to generate props to create geometry. */
   indexToBounds(): Partial<GeoCellLayer['props']> | null {

--- a/modules/geo-layers/src/geohash-layer/geohash-layer.ts
+++ b/modules/geo-layers/src/geohash-layer/geohash-layer.ts
@@ -1,8 +1,8 @@
-import {AccessorFunction} from '@deck.gl/core';
+import {AccessorFunction, DefaultProps} from '@deck.gl/core';
 import GeoCellLayer from '../geo-cell-layer/GeoCellLayer';
 import {getGeohashPolygon} from './geohash-utils';
 
-const defaultProps = {
+const defaultProps: DefaultProps<GeohashLayerProps> = {
   getGeohash: {type: 'accessor', value: d => d.geohash}
 };
 
@@ -19,12 +19,12 @@ type GeohashLayerProps<DataT = any> = {
 };
 
 /** Render filled and/or stroked polygons based on the [Geohash](https://en.wikipedia.org/wiki/Geohash) geospatial indexing system. */
-export default class GeohashLayer<DataT = any, ExtraProps = {}> extends GeoCellLayer<
+export default class GeohashLayer<DataT = any, ExtraProps extends {} = {}> extends GeoCellLayer<
   DataT,
   Required<GeohashLayerProps> & ExtraProps
 > {
   static layerName = 'GeohashLayer';
-  static defaultProps: any = defaultProps;
+  static defaultProps = defaultProps;
 
   indexToBounds(): Partial<GeoCellLayer['props']> | null {
     const {data, getGeohash} = this.props;

--- a/modules/geo-layers/src/great-circle-layer/great-circle-layer.ts
+++ b/modules/geo-layers/src/great-circle-layer/great-circle-layer.ts
@@ -31,10 +31,10 @@ export type GreatCircleLayerProps<DataT = any> = ArcLayerProps<DataT>;
 // This layer has been merged into the core ArcLayer
 // Keeping for backward-compatibility
 /** @deprecated Use ArcLayer with `greatCircle: true` instead */
-export default class GreatCircleLayer<DataT = any, ExtraProps = {}> extends ArcLayer<
+export default class GreatCircleLayer<DataT = any, ExtraProps extends {} = {}> extends ArcLayer<
   DataT,
   ExtraProps
 > {
   static layerName = 'GreatCircleLayer';
-  static defaultProps: any = defaultProps;
+  static defaultProps = defaultProps;
 }

--- a/modules/geo-layers/src/h3-layers/h3-cluster-layer.ts
+++ b/modules/geo-layers/src/h3-layers/h3-cluster-layer.ts
@@ -22,7 +22,7 @@ type _H3ClusterLayerProps<DataT> = {
   getHexagons?: AccessorFunction<DataT, H3IndexInput[]>;
 };
 
-export default class H3ClusterLayer<DataT = any, ExtraProps = {}> extends GeoCellLayer<
+export default class H3ClusterLayer<DataT = any, ExtraProps extends {} = {}> extends GeoCellLayer<
   DataT,
   Required<_H3ClusterLayerProps<DataT>> & ExtraProps
 > {

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.ts
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.ts
@@ -145,7 +145,7 @@ type _H3HexagonLayerProps<DataT> = {
 /**
  * Render hexagons from the [H3](https://h3geo.org/) geospatial indexing system.
  */
-export default class H3HexagonLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+export default class H3HexagonLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_H3HexagonLayerProps<DataT> & Required<PolygonLayerProps<DataT>>>
 > {
   static defaultProps = defaultProps;

--- a/modules/geo-layers/src/h3-layers/h3-hexagon-layer.ts
+++ b/modules/geo-layers/src/h3-layers/h3-hexagon-layer.ts
@@ -145,7 +145,10 @@ type _H3HexagonLayerProps<DataT> = {
 /**
  * Render hexagons from the [H3](https://h3geo.org/) geospatial indexing system.
  */
-export default class H3HexagonLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
+export default class H3HexagonLayer<
+  DataT = any,
+  ExtraPropsT extends {} = {}
+> extends CompositeLayer<
   ExtraPropsT & Required<_H3HexagonLayerProps<DataT> & Required<PolygonLayerProps<DataT>>>
 > {
   static defaultProps = defaultProps;

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.ts
@@ -42,7 +42,7 @@ type _MeshLayerProps<DataT> = {
   featureIds?: NumericArray | null;
 };
 
-export default class MeshLayer<DataT = any, ExtraProps = {}> extends SimpleMeshLayer<
+export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends SimpleMeshLayer<
   DataT,
   Required<_MeshLayerProps<DataT>> & ExtraProps
 > {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -93,10 +93,10 @@ export type _MVTLayerProps = {
 type ContentWGS84Cache = {_contentWGS84?: Feature[]};
 
 /** Render data formatted as [Mapbox Vector Tiles](https://docs.mapbox.com/vector-tiles/specification/). */
-export default class MVTLayer<DataT extends Feature = Feature, ExtraProps = {}> extends TileLayer<
-  ParsedMvtTile,
-  Required<_MVTLayerProps> & ExtraProps
-> {
+export default class MVTLayer<
+  DataT extends Feature = Feature,
+  ExtraProps extends {} = {}
+> extends TileLayer<ParsedMvtTile, Required<_MVTLayerProps> & ExtraProps> {
   static layerName = 'MVTLayer';
   static defaultProps = defaultProps;
 

--- a/modules/geo-layers/src/quadkey-layer/quadkey-layer.ts
+++ b/modules/geo-layers/src/quadkey-layer/quadkey-layer.ts
@@ -20,7 +20,7 @@ type _QuadkeyLayerProps<DataT> = {
 };
 
 /** Render filled and/or stroked polygons based on the [Quadkey](https://towardsdatascience.com/geospatial-indexing-with-quadkeys-d933dff01496) geospatial indexing system. */
-export default class QuadkeyLayer<DataT = any, ExtraProps = {}> extends GeoCellLayer<
+export default class QuadkeyLayer<DataT = any, ExtraProps extends {} = {}> extends GeoCellLayer<
   DataT,
   Required<_QuadkeyLayerProps<DataT>> & ExtraProps
 > {

--- a/modules/geo-layers/src/s2-layer/s2-layer.ts
+++ b/modules/geo-layers/src/s2-layer/s2-layer.ts
@@ -40,7 +40,7 @@ type _S2LayerProps<DataT> = {
 };
 
 /** Render filled and/or stroked polygons based on the [S2](http://s2geometry.io/) geospatial indexing system. */
-export default class S2Layer<DataT = any, ExtraProps = {}> extends GeoCellLayer<
+export default class S2Layer<DataT = any, ExtraProps extends {} = {}> extends GeoCellLayer<
   DataT,
   Required<_S2LayerProps<DataT>> & ExtraProps
 > {

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.ts
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.ts
@@ -125,7 +125,7 @@ type _TerrainLayerProps = {
 };
 
 /** Render mesh surfaces from height map images. */
-export default class TerrainLayer<ExtraPropsT = unknown> extends CompositeLayer<
+export default class TerrainLayer<ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_TerrainLayerProps & Required<TileLayerProps<MeshAndTexture>>>
 > {
   static defaultProps = defaultProps;

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.ts
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.ts
@@ -125,7 +125,7 @@ type _TerrainLayerProps = {
 };
 
 /** Render mesh surfaces from height map images. */
-export default class TerrainLayer<ExtraPropsT = {}> extends CompositeLayer<
+export default class TerrainLayer<ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_TerrainLayerProps & Required<TileLayerProps<MeshAndTexture>>>
 > {
   static defaultProps = defaultProps;

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.ts
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.ts
@@ -36,7 +36,7 @@ import type {MeshAttributes} from '@loaders.gl/schema';
 import {TerrainWorkerLoader} from '@loaders.gl/terrain';
 import TileLayer, {TileLayerProps} from '../tile-layer/tile-layer';
 import type {Bounds, GeoBoundingBox, TileBoundingBox, TileLoadProps, ZRange} from '../tileset-2d';
-import {Tile2DHeader, urlType, getURLFromTemplate} from '../tileset-2d';
+import {Tile2DHeader, urlType, getURLFromTemplate, URLTemplate} from '../tileset-2d';
 
 const DUMMY_DATA = [1];
 
@@ -63,7 +63,7 @@ const defaultProps: DefaultProps<TerrainLayerProps> = {
     }
   },
   // Supply url to local terrain worker bundle. Only required if running offline and cannot access CDN.
-  workerUrl: {type: 'string', value: null},
+  workerUrl: '',
   // Same as SimpleMeshLayer wireframe
   wireframe: false,
   material: true,
@@ -71,10 +71,8 @@ const defaultProps: DefaultProps<TerrainLayerProps> = {
   loaders: [TerrainWorkerLoader]
 };
 
-type URLTemplate = string | string[];
-
 // Turns array of templates into a single string to work around shallow change
-function urlTemplateToUpdateTrigger(template: URLTemplate | null): string {
+function urlTemplateToUpdateTrigger(template: URLTemplate): string {
   if (Array.isArray(template)) {
     return template.join(';');
   }
@@ -103,7 +101,7 @@ type _TerrainLayerProps = {
   elevationData: URLTemplate;
 
   /** Image url to use as texture. **/
-  texture?: URLTemplate | null;
+  texture?: URLTemplate;
 
   /** Martini error tolerance in meters, smaller number -> more detailed mesh. **/
   meshMaxError?: number;
@@ -122,6 +120,11 @@ type _TerrainLayerProps = {
 
   /** Material props for lighting effect. **/
   material?: Material;
+
+  /**
+   * @deprecated Use `loadOptions.terrain.workerUrl` instead
+   */
+  workerUrl?: string;
 };
 
 /** Render mesh surfaces from height map images. */

--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
@@ -79,7 +79,7 @@ type _Tile3DLayerProps<DataT> = {
 export default class Tile3DLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_Tile3DLayerProps<DataT>>
 > {
-  static defaultProps = defaultProps as any;
+  static defaultProps = defaultProps;
   static layerName = 'Tile3DLayer';
 
   state!: {

--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
@@ -76,7 +76,7 @@ type _Tile3DLayerProps<DataT> = {
 };
 
 /** Render 3d tiles data formatted according to the [3D Tiles Specification](https://www.opengeospatial.org/standards/3DTiles) and [`ESRI I3S`](https://github.com/Esri/i3s-spec) */
-export default class Tile3DLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+export default class Tile3DLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_Tile3DLayerProps<DataT>>
 > {
   static defaultProps = defaultProps as any;

--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
@@ -76,7 +76,7 @@ type _Tile3DLayerProps<DataT> = {
 };
 
 /** Render 3d tiles data formatted according to the [3D Tiles Specification](https://www.opengeospatial.org/standards/3DTiles) and [`ESRI I3S`](https://github.com/Esri/i3s-spec) */
-export default class Tile3DLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
+export default class Tile3DLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_Tile3DLayerProps<DataT>>
 > {
   static defaultProps = defaultProps as any;

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -26,7 +26,7 @@ import {urlType, getURLFromTemplate} from '../tileset-2d';
 const defaultProps: DefaultProps<TileLayerProps> = {
   TilesetClass: Tileset2D,
   data: {type: 'data', value: []},
-  dataComparator: urlType.equals,
+  dataComparator: urlType.equal,
   renderSubLayers: {type: 'function', value: props => new GeoJsonLayer(props), compare: false},
   getTileData: {type: 'function', optional: true, value: null, compare: false},
   // TODO - change to onViewportLoad to align with Tile3DLayer
@@ -149,7 +149,7 @@ export type TiledPickingInfo<DataT = any> = PickingInfo & {
 export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_TileLayerProps<DataT>>
 > {
-  static defaultProps = defaultProps as any;
+  static defaultProps: DefaultProps = defaultProps;
   static layerName = 'TileLayer';
 
   initializeState() {

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -146,7 +146,7 @@ export type TiledPickingInfo<DataT = any> = PickingInfo & {
  *
  * Instead of fetching the entire dataset, it only loads and renders what's visible in the current viewport.
  */
-export default class TileLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+export default class TileLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_TileLayerProps<DataT>>
 > {
   static defaultProps = defaultProps as any;

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -146,7 +146,7 @@ export type TiledPickingInfo<DataT = any> = PickingInfo & {
  *
  * Instead of fetching the entire dataset, it only loads and renders what's visible in the current viewport.
  */
-export default class TileLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
+export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_TileLayerProps<DataT>>
 > {
   static defaultProps = defaultProps as any;

--- a/modules/geo-layers/src/tileset-2d/index.ts
+++ b/modules/geo-layers/src/tileset-2d/index.ts
@@ -14,6 +14,7 @@ export {Tileset2D, STRATEGY_DEFAULT} from './tileset-2d';
 
 export {Tile2DHeader} from './tile-2d-header';
 
+export type {URLTemplate} from './utils';
 export {
   isGeoBoundingBox,
   isURLTemplate,

--- a/modules/geo-layers/src/tileset-2d/utils.ts
+++ b/modules/geo-layers/src/tileset-2d/utils.ts
@@ -6,14 +6,16 @@ import {Bounds, GeoBoundingBox, TileBoundingBox, TileIndex, ZRange} from './type
 const TILE_SIZE = 512;
 const DEFAULT_EXTENT: Bounds = [-Infinity, -Infinity, Infinity, Infinity];
 
+export type URLTemplate = string | string[] | null;
+
 export const urlType = {
-  type: 'url',
-  value: null,
+  type: 'object' as const,
+  value: null as URLTemplate,
   validate: (value, propType) =>
     (propType.optional && value === null) ||
     typeof value === 'string' ||
     (Array.isArray(value) && value.every(url => typeof url === 'string')),
-  equals: (value1, value2) => {
+  equal: (value1, value2) => {
     if (value1 === value2) {
       return true;
     }
@@ -62,7 +64,7 @@ function stringHash(s: string): number {
 }
 
 export function getURLFromTemplate(
-  template: string | string[],
+  template: URLTemplate,
   tile: {
     index: TileIndex;
     id: string;

--- a/modules/geo-layers/src/trips-layer/trips-layer.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.ts
@@ -56,7 +56,7 @@ type _TripsLayerProps<DataT = any> = {
 };
 
 /** Render animated paths that represent vehicle trips. */
-export default class TripsLayer<DataT = any, ExtraProps = {}> extends PathLayer<
+export default class TripsLayer<DataT = any, ExtraProps extends {} = {}> extends PathLayer<
   DataT,
   Required<_TripsLayerProps> & ExtraProps
 > {

--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -137,7 +137,7 @@ type _ArcLayerProps<DataT> = {
 };
 
 /** Render raised arcs joining pairs of source and target coordinates. */
-export default class ArcLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class ArcLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_ArcLayerProps<DataT>>
 > {
   static layerName = 'ArcLayer';

--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -137,7 +137,7 @@ type _ArcLayerProps<DataT> = {
 };
 
 /** Render raised arcs joining pairs of source and target coordinates. */
-export default class ArcLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class ArcLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_ArcLayerProps<DataT>>
 > {
   static layerName = 'ArcLayer';

--- a/modules/layers/src/bitmap-layer/bitmap-layer.ts
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.ts
@@ -110,7 +110,7 @@ type _BitmapLayerProps = {
 };
 
 /** Render a bitmap at specified boundaries. */
-export default class BitmapLayer<ExtraPropsT = {}> extends Layer<
+export default class BitmapLayer<ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_BitmapLayerProps>
 > {
   static layerName = 'BitmapLayer';

--- a/modules/layers/src/bitmap-layer/bitmap-layer.ts
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.ts
@@ -110,7 +110,7 @@ type _BitmapLayerProps = {
 };
 
 /** Render a bitmap at specified boundaries. */
-export default class BitmapLayer<ExtraPropsT = unknown> extends Layer<
+export default class BitmapLayer<ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_BitmapLayerProps>
 > {
   static layerName = 'BitmapLayer';

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -226,7 +226,7 @@ type _ColumnLayerProps<DataT> = {
 };
 
 /** Render extruded cylinders (tessellated regular polygons) at given coordinates. */
-export default class ColumnLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class ColumnLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_ColumnLayerProps<DataT>>
 > {
   static layerName = 'ColumnLayer';

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -226,7 +226,7 @@ type _ColumnLayerProps<DataT> = {
 };
 
 /** Render extruded cylinders (tessellated regular polygons) at given coordinates. */
-export default class ColumnLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class ColumnLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_ColumnLayerProps<DataT>>
 > {
   static layerName = 'ColumnLayer';

--- a/modules/layers/src/column-layer/grid-cell-layer.ts
+++ b/modules/layers/src/column-layer/grid-cell-layer.ts
@@ -40,7 +40,7 @@ type _GridCellLayerProps = {
   cellSize?: number;
 };
 
-export default class GridCellLayer<DataT = any, ExtraPropsT = {}> extends ColumnLayer<
+export default class GridCellLayer<DataT = any, ExtraPropsT = unknown> extends ColumnLayer<
   DataT,
   ExtraPropsT & Required<_GridCellLayerProps>
 > {

--- a/modules/layers/src/column-layer/grid-cell-layer.ts
+++ b/modules/layers/src/column-layer/grid-cell-layer.ts
@@ -40,7 +40,7 @@ type _GridCellLayerProps = {
   cellSize?: number;
 };
 
-export default class GridCellLayer<DataT = any, ExtraPropsT = unknown> extends ColumnLayer<
+export default class GridCellLayer<DataT = any, ExtraPropsT extends {} = {}> extends ColumnLayer<
   DataT,
   ExtraPropsT & Required<_GridCellLayerProps>
 > {

--- a/modules/layers/src/geojson-layer/geojson-layer.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer.ts
@@ -328,7 +328,7 @@ type GeoJsonPickingInfo = PickingInfo & {
 /** Render GeoJSON formatted data as polygons, lines and points (circles, icons and/or texts). */
 export default class GeoJsonLayer<
   DataT extends Feature = Feature,
-  ExtraProps = {}
+  ExtraProps extends {} = {}
 > extends CompositeLayer<Required<GeoJsonLayerProps<DataT>> & ExtraProps> {
   static layerName = 'GeoJsonLayer';
   static defaultProps = defaultProps;

--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -132,7 +132,7 @@ const defaultProps: DefaultProps<IconLayerProps> = {
 };
 
 /** Render raster icons at given coordinates. */
-export default class IconLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class IconLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_IconLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -132,7 +132,7 @@ const defaultProps: DefaultProps<IconLayerProps> = {
 };
 
 /** Render raster icons at given coordinates. */
-export default class IconLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_IconLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/line-layer/line-layer.ts
+++ b/modules/layers/src/line-layer/line-layer.ts
@@ -108,7 +108,7 @@ type _LineLayerProps<DataT> = {
 /**
  * A layer that renders straight lines joining pairs of source and target coordinates.
  */
-export default class LineLayer<DataT = any, ExtraProps = {}> extends Layer<
+export default class LineLayer<DataT = any, ExtraProps extends {} = {}> extends Layer<
   ExtraProps & Required<_LineLayerProps<DataT>>
 > {
   static layerName = 'LineLayer';

--- a/modules/layers/src/path-layer/path-layer.ts
+++ b/modules/layers/src/path-layer/path-layer.ts
@@ -136,7 +136,7 @@ const ATTRIBUTE_TRANSITION = {
 };
 
 /** Render lists of coordinate points as extruded polylines with mitering. */
-export default class PathLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_PathLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/path-layer/path-layer.ts
+++ b/modules/layers/src/path-layer/path-layer.ts
@@ -136,7 +136,7 @@ const ATTRIBUTE_TRANSITION = {
 };
 
 /** Render lists of coordinate points as extruded polylines with mitering. */
-export default class PathLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class PathLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_PathLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -127,7 +127,7 @@ type _PointCloudLayerProps<DataT> = {
 };
 
 /** Render a point cloud with 3D positions, normals and colors. */
-export default class PointCloudLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class PointCloudLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_PointCloudLayerProps<DataT>>
 > {
   static layerName = 'PointCloudLayer';

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -127,7 +127,7 @@ type _PointCloudLayerProps<DataT> = {
 };
 
 /** Render a point cloud with 3D positions, normals and colors. */
-export default class PointCloudLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class PointCloudLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_PointCloudLayerProps<DataT>>
 > {
   static layerName = 'PointCloudLayer';

--- a/modules/layers/src/polygon-layer/polygon-layer.ts
+++ b/modules/layers/src/polygon-layer/polygon-layer.ts
@@ -246,7 +246,7 @@ const defaultProps: DefaultProps<PolygonLayerProps> = {
 };
 
 /** A composite layer that renders filled, stroked and/or extruded polygons. */
-export default class PolygonLayer<DataT = any, ExtraProps = {}> extends CompositeLayer<
+export default class PolygonLayer<DataT = any, ExtraProps extends {} = {}> extends CompositeLayer<
   Required<_PolygonLayerProps<DataT>> & ExtraProps
 > {
   static layerName = 'PolygonLayer';

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -172,7 +172,7 @@ const defaultProps: DefaultProps<ScatterplotLayerProps> = {
 };
 
 /** Render circles at given coordinates. */
-export default class ScatterplotLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class ScatterplotLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_ScatterplotLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -172,7 +172,7 @@ const defaultProps: DefaultProps<ScatterplotLayerProps> = {
 };
 
 /** Render circles at given coordinates. */
-export default class ScatterplotLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class ScatterplotLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_ScatterplotLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -132,7 +132,7 @@ const ATTRIBUTE_TRANSITION = {
   }
 };
 
-export default class SolidPolygonLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_SolidPolygonLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -132,7 +132,7 @@ const ATTRIBUTE_TRANSITION = {
   }
 };
 
-export default class SolidPolygonLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class SolidPolygonLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_SolidPolygonLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -49,7 +49,7 @@ const defaultProps: DefaultProps<MultiIconLayerProps> = {
   outlineColor: {type: 'color', value: [0, 0, 0, 255]}
 };
 
-export default class MultiIconLayer<DataT, ExtraPropsT = unknown> extends IconLayer<
+export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends IconLayer<
   DataT,
   ExtraPropsT & Required<_MultiIconLayerProps<DataT>>
 > {

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -49,7 +49,7 @@ const defaultProps: DefaultProps<MultiIconLayerProps> = {
   outlineColor: {type: 'color', value: [0, 0, 0, 255]}
 };
 
-export default class MultiIconLayer<DataT, ExtraPropsT = {}> extends IconLayer<
+export default class MultiIconLayer<DataT, ExtraPropsT = unknown> extends IconLayer<
   DataT,
   ExtraPropsT & Required<_MultiIconLayerProps<DataT>>
 > {

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
@@ -56,7 +56,7 @@ const defaultProps: DefaultProps<TextBackgroundLayerProps> = {
   getLineWidth: {type: 'accessor', value: 1}
 };
 
-export default class TextBackgroundLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class TextBackgroundLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_TextBackgroundLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
@@ -56,7 +56,7 @@ const defaultProps: DefaultProps<TextBackgroundLayerProps> = {
   getLineWidth: {type: 'accessor', value: 1}
 };
 
-export default class TextBackgroundLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class TextBackgroundLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_TextBackgroundLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -233,7 +233,7 @@ const defaultProps: DefaultProps<TextLayerProps> = {
 };
 
 /** Render text labels at given coordinates. */
-export default class TextLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
+export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_TextLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -233,7 +233,7 @@ const defaultProps: DefaultProps<TextLayerProps> = {
 };
 
 /** Render text labels at given coordinates. */
-export default class TextLayer<DataT = any, ExtraPropsT = {}> extends CompositeLayer<
+export default class TextLayer<DataT = any, ExtraPropsT = unknown> extends CompositeLayer<
   ExtraPropsT & Required<_TextLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -177,7 +177,7 @@ const defaultProps: DefaultProps<ScenegraphLayerProps> = {
 };
 
 /** Render a number of instances of a complete glTF scenegraph. */
-export default class ScenegraphLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_ScenegraphLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -177,7 +177,7 @@ const defaultProps: DefaultProps<ScenegraphLayerProps> = {
 };
 
 /** Render a number of instances of a complete glTF scenegraph. */
-export default class ScenegraphLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class ScenegraphLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_ScenegraphLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -194,7 +194,7 @@ const defaultProps: DefaultProps<SimpleMeshLayerProps> = {
 };
 
 /** Render a number of instances of an arbitrary 3D geometry. */
-export default class SimpleMeshLayer<DataT = any, ExtraPropsT = {}> extends Layer<
+export default class SimpleMeshLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
   ExtraPropsT & Required<_SimpleMeshLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -194,7 +194,7 @@ const defaultProps: DefaultProps<SimpleMeshLayerProps> = {
 };
 
 /** Render a number of instances of an arbitrary 3D geometry. */
-export default class SimpleMeshLayer<DataT = any, ExtraPropsT = unknown> extends Layer<
+export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> extends Layer<
   ExtraPropsT & Required<_SimpleMeshLayerProps<DataT>>
 > {
   static defaultProps = defaultProps;

--- a/test/modules/geo-layers/tileset-2d/utils.spec.js
+++ b/test/modules/geo-layers/tileset-2d/utils.spec.js
@@ -464,31 +464,31 @@ test('urlType', t => {
   );
   t.notOk(urlType.validate(['https://server.com/{z}/{x}/{y}.png', null], urlType), 'is not valid');
 
-  t.ok(urlType.equals('', ''), 'should be equal');
+  t.ok(urlType.equal('', ''), 'should be equal');
   t.ok(
-    urlType.equals('https://server.com/{z}/{x}/{y}.png', 'https://server.com/{z}/{x}/{y}.png'),
+    urlType.equal('https://server.com/{z}/{x}/{y}.png', 'https://server.com/{z}/{x}/{y}.png'),
     'should be equal'
   );
   t.ok(
-    urlType.equals(['https://server.com/{z}/{x}/{y}.png'], ['https://server.com/{z}/{x}/{y}.png']),
+    urlType.equal(['https://server.com/{z}/{x}/{y}.png'], ['https://server.com/{z}/{x}/{y}.png']),
     'should be equal'
   );
   t.notOk(
-    urlType.equals('https://server.com/{z}/{x}/{y}.png', [
+    urlType.equal('https://server.com/{z}/{x}/{y}.png', [
       'https://server.com/ep1/{z}/{x}/{y}.png',
       'https://server.com/ep2/{z}/{x}/{y}.png'
     ]),
     'should not be equal'
   );
   t.notOk(
-    urlType.equals(
+    urlType.equal(
       ['https://server.com/{z}/{x}/{y}.png'],
       ['https://server.com/ep1/{z}/{x}/{y}.png', 'https://server.com/ep2/{z}/{x}/{y}.png']
     ),
     'should not be equal'
   );
   t.notOk(
-    urlType.equals(
+    urlType.equal(
       [
         'https://anotherserver.com/ep1/{z}/{x}/{y}.png',
         'https://anotherserver.com/ep2/{z}/{x}/{y}.png'


### PR DESCRIPTION
We previously set `PropsT` default to `{}` because `any` defeats type checking on `layer.props`. However, this leads to the type error `Layer<PropsT> does not extend Layer<{}>` when we use `this` where `Layer` is expected.

See [playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAMghiCAnACkg9mAzlAvFAbwCgpSoATOYOALijgDsQBtAXQG4SzM4BjAS1B0GAVwC2AI2ScyUAG78s-CQBsIdCenRrGnAL5EiAeiNReKuFhzxESADwBRAB7AkcNJiwAVPPSYA+QmNTc0trBGRHFzcPbB98Aj1A4lCrWAj7Z1d3DDjfEQYAawZ0AHcGZK5SMFysOiyY2p8AMnTbWKxOKrN0BixXEV5gdCQAChrPeuiczxa25A6ASiDZWWAAC0UAOgnsX13O7oNu4Ah+0YtbOhtkReuMldXSEygAZXX0ERVyKGQMJCgowK5AgADN+AwID9doturJLsgdrUdvxeIU4KpoPhQXAVFgIF0ns9TO9Pt9fkh-oDShgGABzKC7KCgSCwolQBFIJGeLY8ASgXwAcghclx-B+opUIgggsJRJepK+PykUHQhUBN3sHS8gUU9HmSDZRKQEGAIiQDGZm0OsgMBiAA)

#### Change List
- `ExtraPropsT` defaults to `unknown` instead of `{}`
