### PR TITLE
DeckRenderer to TypeScript

### DIFF
--- a/modules/core/src/lib/deck-renderer.ts
+++ b/modules/core/src/lib/deck-renderer.ts
@@ -52,10 +52,10 @@ export default class DeckRenderer {
       layerFilter: this.layerFilter,
       layers: [],
       viewports: [],
-      target: Framebuffer.getDefaultFramebuffer(this.gl),
       pass: 'screen',
       isPicking: this.drawPickingColors,
-      ...opts
+      ...opts,
+      target: opts.target || Framebuffer.getDefaultFramebuffer(this.gl)
     };
 
     if (renderOpts.effects) {

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -990,7 +990,6 @@ export default class Deck {
       onViewportActive: this.layerManager!.activateViewport,
       views: this.viewManager!.getViews(),
       pass: 'screen',
-      redrawReason,
       effects: this.effectManager!.getEffects(),
       ...renderOptions
     });

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -12,6 +12,7 @@ export type Rect = {x: number; y: number; width: number; height: number};
 
 export type LayersPassRenderOptions = {
   target?: Framebuffer;
+  isPicking?: boolean;
   pass: string;
   layers: Layer[];
   viewports: Viewport[];
@@ -22,7 +23,7 @@ export type LayersPassRenderOptions = {
   /** If true, recalculates render index (z) from 0. Set to false if a stack of layers are rendered in multiple passes. */
   clearStack?: boolean;
   clearCanvas?: boolean;
-  layerFilter?: (context: FilterContext) => boolean;
+  layerFilter?: ((context: FilterContext) => boolean) | null;
   moduleParameters?: any;
   /** Stores returned results from Effect.preRender, for use downstream in the render pipeline */
   preRenderStats?: Record<string, any>;
@@ -118,7 +119,15 @@ export default class LayersPass extends Pass {
   /* Resolve the parameters needed to draw each layer */
   protected _getDrawLayerParams(
     viewport: Viewport,
-    {layers, pass, layerFilter, cullRect, effects, moduleParameters}: LayersPassRenderOptions,
+    {
+      layers,
+      pass,
+      isPicking = false,
+      layerFilter,
+      cullRect,
+      effects,
+      moduleParameters
+    }: LayersPassRenderOptions,
     /** Internal flag, true if only used to determine whether each layer should be drawn */
     evaluateShouldDrawOnly: boolean = false
   ): DrawLayerParameters[] {
@@ -127,7 +136,7 @@ export default class LayersPass extends Pass {
     const drawContext: FilterContext = {
       layer: layers[0],
       viewport,
-      isPicking: pass.startsWith('picking'),
+      isPicking,
       renderPass: pass,
       cullRect
     };
@@ -256,7 +265,7 @@ export default class LayersPass extends Pass {
   private _shouldDrawLayer(
     layer: Layer,
     drawContext: FilterContext,
-    layerFilter: ((params: FilterContext) => boolean) | undefined,
+    layerFilter: ((params: FilterContext) => boolean) | undefined | null,
     layerFilterCache: Record<string, boolean>
   ) {
     const shouldDrawLayer = layer.props.visible && this.shouldDrawLayer(layer);

--- a/modules/core/src/passes/pick-layers-pass.ts
+++ b/modules/core/src/passes/pick-layers-pass.ts
@@ -39,8 +39,8 @@ export default class PickLayersPass extends LayersPass {
     byAlpha: EncodedPickingColors[];
   } | null = null;
 
-  render(props: PickLayersPassRenderOptions) {
-    if (props.pickingFBO) {
+  render(props: LayersPassRenderOptions | PickLayersPassRenderOptions) {
+    if ('pickingFBO' in props) {
       // When drawing into an off-screen buffer, use the alpha channel to encode layer index
       return this._drawPickingBuffer(props);
     }
@@ -105,6 +105,7 @@ export default class PickLayersPass extends LayersPass {
           cullRect,
           effects: effects?.filter(e => e.useInPicking),
           pass,
+          isPicking: true,
           moduleParameters
         })
     );

--- a/modules/extensions/src/collide/collide-effect.ts
+++ b/modules/extensions/src/collide/collide-effect.ts
@@ -42,7 +42,7 @@ export default class CollideEffect implements Effect {
       viewports,
       onViewportActive,
       views,
-      pass,
+      isPicking,
       preRenderStats = {}
     }: PreRenderOptions
   ): void {
@@ -50,7 +50,7 @@ export default class CollideEffect implements Effect {
       this.dummyCollideMap = new Texture2D(gl, {width: 1, height: 1});
     }
 
-    if (pass.startsWith('picking')) {
+    if (isPicking) {
       // Do not update on picking pass
       return;
     }
@@ -142,6 +142,7 @@ export default class CollideEffect implements Effect {
       // Rerender collide FBO
       this.collidePass!.renderCollideMap(collideFBO, {
         pass: 'collide',
+        isPicking: true,
         layers: renderInfo.layers,
         effects,
         layerFilter,

--- a/modules/extensions/src/mask/mask-effect.ts
+++ b/modules/extensions/src/mask/mask-effect.ts
@@ -44,7 +44,7 @@ export default class MaskEffect implements Effect {
 
   preRender(
     gl: WebGLRenderingContext,
-    {layers, layerFilter, viewports, onViewportActive, views, pass}: PreRenderOptions
+    {layers, layerFilter, viewports, onViewportActive, views, isPicking}: PreRenderOptions
   ): MaskPreRenderStats {
     let didRender = false;
     if (!this.dummyMaskMap) {
@@ -54,7 +54,7 @@ export default class MaskEffect implements Effect {
       });
     }
 
-    if (pass.startsWith('picking')) {
+    if (isPicking) {
       // Do not update on picking pass
       return {didRender};
     }

--- a/modules/extensions/src/terrain/terrain-effect.ts
+++ b/modules/extensions/src/terrain/terrain-effect.ts
@@ -65,8 +65,7 @@ export class TerrainEffect implements Effect {
       return;
     }
 
-    const {viewports, pass} = opts;
-    const isPicking = pass.startsWith('picking');
+    const {viewports, isPicking = false} = opts;
     this.isPicking = isPicking;
     this.isDrapingEnabled = true;
 

--- a/test/modules/extensions/terrain/terrain-effect.spec.js
+++ b/test/modules/extensions/terrain/terrain-effect.spec.js
@@ -53,6 +53,7 @@ test('TerrainEffect', async t => {
   // preRender#picking
   lifecycle.render({
     pass: 'picking:hover',
+    isPicking: true,
     deviceRect: {x: 200, y: 150, width: 1, height: 1},
     cullRect: {x: 200, y: 150, width: 1, height: 1}
   });
@@ -146,6 +147,7 @@ test('TerrainEffect#without draw operation', async t => {
   // preRender#picking
   lifecycle.render({
     pass: 'picking:hover',
+    isPicking: true,
     deviceRect: {x: 200, y: 150, width: 1, height: 1},
     cullRect: {x: 200, y: 150, width: 1, height: 1}
   });


### PR DESCRIPTION
#### Change List
- DeckRenderer to TypeScript
- Remove `pass.startsWith('picking')` hack, include a `isPicking` flag in render context
