### PR TITLE
Add embedded demo to new extension docs

### DIFF
--- a/docs/api-reference/extensions/collision-filter-extension.md
+++ b/docs/api-reference/extensions/collision-filter-extension.md
@@ -5,8 +5,14 @@ The `CollisionFilterExtension` allows layers to hide features which overlap with
 
 To use this extension on a layer, add the `CollisionFilterExtension` to the layer's `extensions` prop.
 
-<!-- TODO: Codepen demo -->
 <div style={{position:'relative',height:450}}></div>
+<div style={{position:'absolute',transform:'translateY(-450px)',paddingLeft:'inherit',paddingRight:'inherit',left:0,right:0}}>
+  <iframe height="450" style={{width: '100%'}} scrolling="no" title="deck.gl CollideExtension" src="https://codepen.io/vis-gl/embed/oNPXXzm?height=450&theme-id=light&default-tab=result" frameborder="no" loading="lazy" allowtransparency="true" allowfullscreen="true">
+    See the Pen <a href='https://codepen.io/vis-gl/pen/oNPXXzm'>deck.gl CollideExtension</a> by vis.gl
+    (<a href='https://codepen.io/vis-gl'>@vis-gl</a>) on <a href='https://codepen.io'>CodePen</a>.
+  </iframe>
+</div>
+
 
 ```js
 import {ScatterplotLayer} from '@deck.gl/layers';

--- a/docs/api-reference/extensions/overview.md
+++ b/docs/api-reference/extensions/overview.md
@@ -10,11 +10,13 @@ This module contains the following extensions:
 
 - [BrushingExtension](./brushing-extension.md)
 - [ClipExtension](./clip-extension.md)
+- [CollideExtension](./collide-extension.md)
 - [DataFilterExtension](./data-filter-extension.md)
 - [FillStyleExtension](./fill-style-extension.md)
 - [Fp64Extension](./fp64-extension.md)
 - [MaskExtension](./mask-extension.md)
 - [PathStyleExtension](./path-style-extension.md)
+- [TerrainExtension](./terrain-extension.md)
 
 For instructions on authoring your own layer extensions, visit [developer guide](../../developer-guide/custom-layers/layer-extensions.md).
 

--- a/docs/api-reference/extensions/overview.md
+++ b/docs/api-reference/extensions/overview.md
@@ -10,7 +10,7 @@ This module contains the following extensions:
 
 - [BrushingExtension](./brushing-extension.md)
 - [ClipExtension](./clip-extension.md)
-- [CollideExtension](./collide-extension.md)
+- [CollisionFilterExtension](./collision-filter-extension.md)
 - [DataFilterExtension](./data-filter-extension.md)
 - [FillStyleExtension](./fill-style-extension.md)
 - [Fp64Extension](./fp64-extension.md)

--- a/docs/api-reference/extensions/terrain-extension.md
+++ b/docs/api-reference/extensions/terrain-extension.md
@@ -9,8 +9,14 @@ To use this extension, first define a terrain source with the prop `operation: '
 
 For each layer that should be fitted to the terrain surface, add the `TerrainExtension` to its `extensions` prop.
 
-<!-- TODO: Codepen demo -->
 <div style={{position:'relative',height:450}}></div>
+<div style={{position:'absolute',transform:'translateY(-450px)',paddingLeft:'inherit',paddingRight:'inherit',left:0,right:0}}>
+  <iframe height="450" style={{width: '100%'}} scrolling="no" title="deck.gl TerrainExtension" src="https://codepen.io/vis-gl/embed/VwGLLeR?height=450&theme-id=light&default-tab=result" frameborder="no" loading="lazy" allowtransparency="true" allowfullscreen="true">
+    See the Pen <a href='https://codepen.io/vis-gl/pen/VwGLLeR'>deck.gl TerrainExtension</a> by vis.gl
+    (<a href='https://codepen.io/vis-gl'>@vis-gl</a>) on <a href='https://codepen.io'>CodePen</a>.
+  </iframe>
+</div>
+
 
 ```js
 import {GeoJsonLayer} from '@deck.gl/layers';


### PR DESCRIPTION
For #7635 

https://codepen.io/vis-gl/pen/oNPXXzm

![image](https://user-images.githubusercontent.com/2059298/219783494-2a1f2d65-5001-412d-b98e-a5724179894d.png)

@felixpalmer There is a bug here - the collide map is not rerendered after the icon layer is loaded, you'll need to move around to get it to update.

https://codepen.io/vis-gl/pen/VwGLLeR

![image](https://user-images.githubusercontent.com/2059298/219783582-db34001c-dedd-482a-a11e-b7f4708eedf6.png)


#### Change List
- CollideExtension doc
- TerrainExtension doc
