### PR TITLE
Avoid picking in overlays before deck is initialized

### DIFF
--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -7,7 +7,7 @@ import {
   getViewPropsFromOverlay,
   getViewPropsFromCoordinateTransformer
 } from './utils';
-import {Deck} from '@deck.gl/core';
+import {assert, Deck} from '@deck.gl/core';
 
 import type {DeckProps} from '@deck.gl/core';
 
@@ -87,19 +87,24 @@ export default class GoogleMapsOverlay {
     }
   }
 
-  /** Equivalent of `deck.pickObject`. */
-  pickObject(params) {
-    return this._deck && this._deck.pickObject(params);
+  /** Equivalent of `pickObject`. */
+  pickObject(params: Parameters<Deck['pickObject']>[0]): ReturnType<Deck['pickObject']> {
+    assert(this._deck);
+    return this._deck.pickObject(params);
   }
 
-  /** Equivalent of `deck.pickObjects`.  */
-  pickMultipleObjects(params) {
-    return this._deck && this._deck.pickMultipleObjects(params);
+  /** Equivalent of `pickMultipleObjects`. */
+  pickMultipleObjects(
+    params: Parameters<Deck['pickMultipleObjects']>[0]
+  ): ReturnType<Deck['pickMultipleObjects']> {
+    assert(this._deck);
+    return this._deck.pickMultipleObjects(params);
   }
 
-  /** Equivalent of `deck.pickMultipleObjects`. */
-  pickObjects(params) {
-    return this._deck && this._deck.pickObjects(params);
+  /** Equivalent of `pickObjects`. */
+  pickObjects(params: Parameters<Deck['pickObjects']>[0]): ReturnType<Deck['pickObjects']> {
+    assert(this._deck);
+    return this._deck.pickObjects(params);
   }
 
   /** Remove the overlay and release all underlying resources. */

--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -43,6 +43,11 @@ export default class GoogleMapsOverlay {
 
   /* Public API */
 
+  /** Equivalent of `deck.isInitialized`. */
+  get isInitialized(): boolean {
+    return Boolean(this._deck?.isInitialized);
+  }
+
   /** Add/remove the overlay from a map. */
   setMap(map: google.maps.Map | null): void {
     if (map === this._map) {

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -145,13 +145,13 @@ export default class MapboxOverlay implements IControl {
     return 'top-left';
   }
 
-  /** Forwards the Deck.pickObject method */
+  /** Equivalent of `pickObject`. */
   pickObject(params: Parameters<Deck['pickObject']>[0]): ReturnType<Deck['pickObject']> {
     assert(this._deck);
     return this._deck.pickObject(params);
   }
 
-  /** Forwards the Deck.pickMultipleObjects method */
+  /** Equivalent of `pickMultipleObjects`. */
   pickMultipleObjects(
     params: Parameters<Deck['pickMultipleObjects']>[0]
   ): ReturnType<Deck['pickMultipleObjects']> {
@@ -159,7 +159,7 @@ export default class MapboxOverlay implements IControl {
     return this._deck.pickMultipleObjects(params);
   }
 
-  /** Forwards the Deck.pickObjects method */
+  /** Equivalent of `pickObjects`. */
   pickObjects(params: Parameters<Deck['pickObjects']>[0]): ReturnType<Deck['pickObjects']> {
     assert(this._deck);
     return this._deck.pickObjects(params);

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -39,6 +39,11 @@ export default class MapboxOverlay implements IControl {
     this._props = otherProps;
   }
 
+  /** Equivalent of `deck.isInitialized`. */
+  get isInitialized(): boolean {
+    return Boolean(this._deck?.isInitialized);
+  }
+
   /** Update (partial) props of the underlying Deck instance. */
   setProps(props: MapboxOverlayProps): void {
     if (this._interleaved && props.layers) {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

I've originally reported a bug on Slack: https://deckgl.slack.com/archives/C34AC5MSQ/p1676629109034669
The picking functions were used by the mapbox event handlers before deck was fully initialized (which will be fixed by #7723).

Also, while looking into it, I noticed that the explicit picking support provided by the overlays also isn't guarded against incorrect use before deck is initialized.
Because the user of the overlay doesn't have direct deck access either, I proposed to forward `isInitialized`.

I've also added an assert in case `this._deck` doesn't exist yet to the picking functions and made comments more consistent.

#### Change List
- Add `isInitialized` to Mapbox- and GoogleMapsOverlay
- Add types to GoogleMapsOverlay picker
- Consistent picker comments in Mapbox- and GoogleMapsOverlay

---

**None of this was tested**
I'm not sure how to run automated tests for the deck.gl codebase. `yarn bootstrap` fails with gyp not able to find `python` (which should be `python3` on this macOS machine). `yarn test` failed during linter step in untouched code.
All my deck.gl projects use another private library which has hardcoded dependency on a specific deck.gl version, so manual testing would be cumbersome.