### PR TITLE
docs: fix formatting of link

### DIFF
--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -4,7 +4,7 @@ import {HeatmapLayerDemo} from '@site/src/doc-demos/aggregation-layers';
 
 <HeatmapLayerDemo />
 
-`HeatmapLayer` can be used to visualize spatial distribution of data. It internally implements [Gaussian Kernel Density Estimation](https://en.wikipedia.org/wiki/Kernel_(statistics%29#Kernel_functions_in_common_use) to render heatmaps. Note that this layer does not support all platforms; see "limitations" section below.
+`HeatmapLayer` can be used to visualize spatial distribution of data. It internally implements [Gaussian Kernel Density Estimation](https://en.wikipedia.org/wiki/Kernel%20%28statistics%29#Kernel_functions_in_common_use) to render heatmaps. Note that this layer does not support all platforms; see "limitations" section below.
 
 ```js
 import DeckGL from '@deck.gl/react';


### PR DESCRIPTION
This fixes the formatting of a link.

The URL included parenthesis that were confusing the markdown parser, so I've encoded these characters.

This affected both the [rendering of the file on GitHub](https://github.com/jamesscottbrown/deck.gl/blob/master/docs/api-reference/aggregation-layers/heatmap-layer.md) and on the [generated docs site](https://deck.gl/docs/api-reference/aggregation-layers/heatmap-layer).