### PR TITLE
Update mask when layer instance changes

### DIFF
--- a/modules/extensions/src/mask/mask-effect.ts
+++ b/modules/extensions/src/mask/mask-effect.ts
@@ -124,7 +124,17 @@ export default class MaskEffect implements Effect {
       // If a channel is new
       channelInfo === oldChannelInfo ||
       // If sublayers have changed
-      oldChannelInfo.layers.length !== channelInfo.layers.length ||
+      channelInfo.layers.length !== oldChannelInfo.layers.length ||
+      channelInfo.layers.some(
+        (layer, i) =>
+          // Layer instance is updated
+          // Layer props might have changed
+          // Undetermined props could have an effect on the output geometry of a mask layer,
+          // for example getRadius+updateTriggers, radiusScale, modelMatrix
+          layer !== oldChannelInfo.layers[i] ||
+          // Some prop is in transition
+          layer.props.transitions
+      ) ||
       // If a sublayer's positions have been updated, the cached bounds will change shallowly
       channelInfo.layerBounds.some((b, i) => b !== oldChannelInfo.layerBounds[i]);
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/7635, specifically required for animating mask in https://github.com/visgl/deck.gl/pull/7681

Logic is similar to that used in `TerrainEffect`: https://github.com/visgl/deck.gl/blob/master/modules/extensions/src/terrain/height-map-builder.ts#L59-L65

<!-- For all the PRs -->
#### Change List
- Check for new Layer instance and transitions when checking for `maskChanged`
