### PR TITLE
TextLayer scaling consistency

### DIFF
--- a/docs/api-reference/layers/text-layer.md
+++ b/docs/api-reference/layers/text-layer.md
@@ -173,7 +173,9 @@ Available options are `break-all` and `break-word`. A valid `maxWidth` has to be
 
 * Default: `-1`
 
-`maxWidth` is used together with `break-word` for wrapping text. The value of `maxWidth` is multiplied with the text size to specify the width limit to break the text into multiple lines. For example, `maxWidth: 10.0` used with `getSize: 12` is roughly the equivalent of `max-width: 120px` in CSS.
+A unitless number that will be multiplied with the current text size to set the width limit of a string. If specified, when the text is longer than the width limit, it will be wrapped into multiple lines using the strategy of `wordBreak`.
+
+For example, `maxWidth: 10.0` used with `getSize: 12` is roughly the equivalent of `max-width: 120px` in CSS.
 
 ##### `outlineWidth` (Number, optional) {#outlinewidth}
 

--- a/docs/api-reference/layers/text-layer.md
+++ b/docs/api-reference/layers/text-layer.md
@@ -173,7 +173,7 @@ Available options are `break-all` and `break-word`. A valid `maxWidth` has to be
 
 * Default: `-1`
 
-`maxWidth` is used together with `break-word` for wrapping text. The value of `maxWidth` specifies the width limit to break the text into multiple lines.
+`maxWidth` is used together with `break-word` for wrapping text. The value of `maxWidth` is multiplied with the text size to specify the width limit to break the text into multiple lines. For example, `maxWidth: 10.0` used with `getSize: 12` is roughly the equivalent of `max-width: 120px` in CSS.
 
 ##### `outlineWidth` (Number, optional) {#outlinewidth}
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,7 +4,7 @@
 
 #### Breaking changes
 
-- `TextLayer`'s `maxWidth` is now relative to the font size. This change aims to make this prop more intuitive to use. If you have been using this prop in previous versions, divide its value by `64` (or `fontSettings.fontSize`).
+- `TextLayer`'s `maxWidth` is now relative to the text size. This change aims to make this prop more intuitive to use. If you have been using this prop in previous versions, divide its value by `64` (or `fontSettings.fontSize` if it's set manually).
 
 
 ## Upgrading from deck.gl v8.7 to v8.8

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,12 @@
 # Upgrade Guide
 
+## Upgrading from deck.gl v8.8 to v8.9
+
+#### Breaking changes
+
+- `TextLayer`'s `maxWidth` is now relative to the font size. This change aims to make this prop more intuitive to use. If you have been using this prop in previous versions, divide its value by `64` (or `fontSettings.fontSize`).
+
+
 ## Upgrading from deck.gl v8.7 to v8.8
 
 #### Breaking changes

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -378,7 +378,7 @@ const TextLayerExample = {
     maxWidth: {
       name: 'maxWidth',
       type: 'number',
-      max: 5000
+      max: 100
     },
     backgroundPadding: {type: 'compound', elements: ['padding']},
     padding: {
@@ -403,7 +403,7 @@ const TextLayerExample = {
     },
     autoHighlight: true,
     pickable: true,
-    maxWidth: 500,
+    maxWidth: 50,
     wordBreak: 'break-word',
     highlightColor: [0, 0, 128, 128],
     getText: x => `${x.LOCATION_NAME}\n${x.ADDRESS}`,


### PR DESCRIPTION
#### Background

This PR addresses 2 semi-related issues:

- It's unclear what the value of the `maxWidth` prop refers to. It is not CSS pixels, and it is not a multiplier.
- When using `TextLayer` with background and the `CollisionFilterExtension`, overriding `sizeScale` in `collisionTestProps` results in unexpected behavior in the `TextBackgroundLayer`.

Explanation:

In the context of the `TextLayer`, there are two size systems:
- User-specified text size, via `getSize` and `sizeScale`. The layer roughly matches the output of the layer to CSS pixels, e.g. `getSize: 12, sizeScale: 2` in layer props is roughly equivalent to `font-size: 24px` in CSS. Let's call this **pixel size**.
- Internally, character positions in a text blob are calculated using the sizes of `iconMapping`, which depends on how large each character is drawn into the font atlas. This is controlled by `fontSettings.fontSize` (default `64`) and most users do not set it manually. These numbers are intended to be used in the vertex shader and never to be exposed to the end user. Let's call this **texture size**.
 
In reality, the absolute scale of **texture size** is leaked to user-facing values in a few places:

- When calculating line breaks, `maxWidth` is tested against the **texture size**. This means that the effect of `maxWidth` is proportional to `fontSettings.fontSize`, a setting supposed to control the sharpness of the rendering, which is very confusing to the end user.
- When rendering the background sub layer, the `sizeScale` prop is overwritten with an internal **texture size** multiplier. This breaks if the user attempts to set the `sizeScale` of the background sub layer manually, as seen in the collision test case. 

#### Change List
- Breaking change: make `maxWidth` a multiplier to the text size. Clarify in Upgrade Guide and layer docs.
- Pass through `sizeScale` from `TextLayer` to `TextBackgroundLayer`.
