### PR TITLE
docs: correct division sign to multiplication

### DIFF
--- a/docs/developer-guide/coordinate-systems.md
+++ b/docs/developer-guide/coordinate-systems.md
@@ -132,7 +132,7 @@ The most performant way to transform the dimensions for each object is to use an
 
 The conversion between meter sizes and common sizes depend on the projection mode:
 
-- [MapView](../api-reference/core/map-view.md) and [FirstPersonView](../api-reference/core/first-person-view.md): 512 common units equals `C / cos(phi)` where `C` is the circumference of earth, and `phi` is the latitude in radians.
+- [MapView](../api-reference/core/map-view.md) and [FirstPersonView](../api-reference/core/first-person-view.md): 512 common units equals `C * cos(phi)` where `C` is the circumference of earth, and `phi` is the latitude in radians.
 - [GlobeView](../api-reference/core/globe-view.md): 512 common units equals the diameter of the earth.
 - [OrbitView](../api-reference/core/orbit-view.md) and [OrthographicView](../api-reference/core/orthographic-view.md): 1 meter unit equals 1 common unit.
 


### PR DESCRIPTION
I *think* this is a typo in the docs.

I think a multiplication sign would mean that the map is scaled such that whatever circle of latitude is being viewed corresponds to 512 common units, which seems reasonable.

A multiplication sign would also be consistent with how OSM map tlles work - the OSM wiki states [1]:

> The horizontal distance represented by each square tile, measured along the parallel at a given latitude, is given by:
> $S_{tile} = C ∙ cos(latitude) / 2^{zoomlevel}$

I initially noticed this because points on a scatteplot layer were about bigger than expected, and the error seemed to be roughly a factor of $1/cos^2(\phi)$,

[1]: https://wiki.openstreetmap.org/wiki/Zoom_levels