### PR TITLE
deepEqual consistency

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -429,7 +429,8 @@ export default class Deck {
     }
     if (
       props.initialViewState &&
-      !deepEqual(this.props.initialViewState, props.initialViewState, 2)
+      // depth = 3 when comparing viewStates: viewId.position.0
+      !deepEqual(this.props.initialViewState, props.initialViewState, 3)
     ) {
       // Overwrite internal view state
       this.viewState = props.initialViewState;

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -429,7 +429,7 @@ export default class Deck {
     }
     if (
       props.initialViewState &&
-      !deepEqual(this.props.initialViewState, props.initialViewState, 1)
+      !deepEqual(this.props.initialViewState, props.initialViewState, 2)
     ) {
       // Overwrite internal view state
       this.viewState = props.initialViewState;

--- a/modules/core/src/lib/effect-manager.ts
+++ b/modules/core/src/lib/effect-manager.ts
@@ -43,10 +43,7 @@ export default class EffectManager {
   setProps(props) {
     if ('effects' in props) {
       // Compare effects against each other shallowly
-      if (
-        props.effects.length !== this.effects.length ||
-        !deepEqual(props.effects, this.effects, 1)
-      ) {
+      if (!deepEqual(props.effects, this.effects, 1)) {
         this._setEffects(props.effects);
       }
     }

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -266,8 +266,8 @@ export default class ViewManager {
 
   private _setViewState(viewState: any): void {
     if (viewState) {
-      // Only need single level of depth when comparing viewStates
-      const viewStateChanged = !deepEqual(viewState, this.viewState, 2);
+      // depth = 3 when comparing viewStates: viewId.position.0
+      const viewStateChanged = !deepEqual(viewState, this.viewState, 3);
 
       if (viewStateChanged) {
         this.setNeedsUpdate('viewState changed');

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -267,7 +267,7 @@ export default class ViewManager {
   private _setViewState(viewState: any): void {
     if (viewState) {
       // Only need single level of depth when comparing viewStates
-      const viewStateChanged = !deepEqual(viewState, this.viewState, 1);
+      const viewStateChanged = !deepEqual(viewState, this.viewState, 2);
 
       if (viewStateChanged) {
         this.setNeedsUpdate('viewState changed');

--- a/modules/core/src/lifecycle/prop-types.ts
+++ b/modules/core/src/lifecycle/prop-types.ts
@@ -148,7 +148,7 @@ const TYPE_DEFINITIONS = {
   },
   object: {
     equal(value1, value2, propType: ObjectPropType) {
-      return propType.compare ? deepEqual(value1, value2, propType.depth || 0) : value1 === value2;
+      return propType.compare ? deepEqual(value1, value2, propType.depth || 1) : value1 === value2;
     }
   },
   function: {

--- a/modules/core/src/utils/deep-equal.ts
+++ b/modules/core/src/utils/deep-equal.ts
@@ -10,35 +10,38 @@ export function deepEqual(a: any, b: any, depth: number): boolean {
   if (a === b) {
     return true;
   }
-  if (
-    !a ||
-    !b ||
-    Array.isArray(a) !== Array.isArray(b) ||
-    typeof a !== 'object' ||
-    typeof b !== 'object'
-  ) {
+  if (!depth || !a || !b) {
     return false;
   }
-
-  // Handle case where key in b is missing from a
-  if (Array.isArray(b)) {
-    if (b.length !== a.length) return false;
-  } else {
-    for (const key in b) {
-      if (!(key in a)) return false;
-    }
-  }
-
-  for (const key in a) {
-    if (depth) {
-      // Often will have shallow equality, so skip function invocation
-      if (a[key] !== b[key] && !deepEqual(a[key], b[key], depth - 1)) {
-        return false;
-      }
-    } else if (a[key] !== b[key]) {
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) {
       return false;
     }
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i], depth - 1)) {
+        return false;
+      }
+    }
+    return true;
   }
-
-  return true;
+  if (Array.isArray(b)) {
+    return false;
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+    for (const key of aKeys) {
+      if (!b.hasOwnProperty(key)) {
+        return false;
+      }
+      if (!deepEqual(a[key], b[key], depth - 1)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
 }

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -129,7 +129,7 @@ export default class CollisionFilterEffect implements Effect {
       // If render info is new
       renderInfo === oldRenderInfo ||
       // If sublayers have changed
-      !deepEqual(oldRenderInfo.layers, renderInfo.layers, 0) ||
+      !deepEqual(oldRenderInfo.layers, renderInfo.layers, 1) ||
       // If a sublayer's bounds have been updated
       renderInfo.layerBounds.some((b, i) => !equals(b, oldRenderInfo.layerBounds[i])) ||
       // If a sublayer's isLoaded state has been updated

--- a/test/modules/core/utils/deep-equal.spec.js
+++ b/test/modules/core/utils/deep-equal.spec.js
@@ -11,29 +11,37 @@ const TEST_CASES = [
   {
     a: {x: obj},
     b: {x: obj},
+    depth: 0,
+    output: false
+  },
+  {
+    a: {x: obj},
+    b: {x: obj},
+    depth: 1,
     output: true
   },
   {
     a: {x: obj},
     b: {x: {...obj}},
+    depth: 1,
     output: false
   },
   {
     a: {x: obj},
     b: {x: {...obj}},
-    depth: 1,
+    depth: 2,
     output: true
   },
   {
     a: {map: {longitude: -122.45, latitude: 37.78, zoom: 8}},
     b: {map: {}},
-    depth: 1,
+    depth: 2,
     output: false
   },
   {
     a: {map: {longitude: -122.45, latitude: 37.78, zoom: 8}},
     b: {map: {longitude: -122.45, latitude: 37.78, zoom: 8}},
-    depth: 1,
+    depth: 2,
     output: true
   },
   {
@@ -51,13 +59,13 @@ const TEST_CASES = [
   {
     a: {x: {y: {z: 1}}},
     b: {x: {y: {z: 1}}},
-    depth: 1,
+    depth: 2,
     output: false
   },
   {
     a: {x: {y: {z: 1}}},
     b: {x: {y: {z: 1}}},
-    depth: 2,
+    depth: 3,
     output: true
   },
   {
@@ -69,21 +77,25 @@ const TEST_CASES = [
   {
     a: [1, 2, 3, 4],
     b: [1, 2, 3, 4],
+    depth: 1,
     output: true
   },
   {
     a: [1, 2, 3, 4],
     b: [1, 2, 3, 5],
+    depth: 1,
     output: false
   },
   {
     a: [1, 2, 3, 4],
     b: [1, 2, 3],
+    depth: 1,
     output: false
   },
   {
     a: [1, 2, 3],
     b: [1, 2, 3, 4],
+    depth: 1,
     output: false
   },
   {
@@ -95,7 +107,7 @@ const TEST_CASES = [
       {threshold: 1, color: [50, 50, 50]},
       {threshold: 2, color: [100, 100, 100]}
     ],
-    depth: 2,
+    depth: 3,
     output: true
   },
   {
@@ -107,7 +119,7 @@ const TEST_CASES = [
       {threshold: [1000, 2000], color: [50, 50, 50]},
       {threshold: 2, color: [100, 100, 100]}
     ],
-    depth: 2,
+    depth: 3,
     output: false
   }
 ];


### PR DESCRIPTION
Follow up of  #7506

The JSDoc states that `depth: ...Use 0 (default) for shallow comparison, -1 for infinite depth` while 0 is really used for comparing child fields one level down.

Across the code base, I can find usages of both semantics (sometimes 1 for child element comparison, sometimes 0).

#### Change List
- Match `deepEqual` behavior with JSDoc
