### PR TITLE
Replace proj4 with lightweight alternative

### DIFF
--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -42,7 +42,6 @@
     "@luma.gl/experimental": "^8.5.16",
     "@math.gl/core": "^3.6.2",
     "@math.gl/culling": "^3.6.2",
-    "@math.gl/proj4": "^3.6.3",
     "@math.gl/web-mercator": "^3.6.2",
     "@types/geojson": "^7946.0.8",
     "h3-js": "^3.7.0",

--- a/modules/geo-layers/src/wms-layer/utils.ts
+++ b/modules/geo-layers/src/wms-layer/utils.ts
@@ -1,0 +1,15 @@
+import {lngLatToWorld} from '@math.gl/web-mercator';
+
+// https://epsg.io/3857
+// +proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs
+const HALF_EARTH_CIRCUMFERENCE = 6378137 * Math.PI;
+
+/** Projects EPSG:4326 to EPSG:3857
+ * This is a lightweight replacement of proj4. Use tests to ensure conformance.
+ */
+export function WGS84ToPseudoMercator(coord: [number, number]): [number, number] {
+  const mercator = lngLatToWorld(coord);
+  mercator[0] = (mercator[0] / 256 - 1) * HALF_EARTH_CIRCUMFERENCE;
+  mercator[1] = (mercator[1] / 256 - 1) * HALF_EARTH_CIRCUMFERENCE;
+  return mercator;
+}

--- a/modules/geo-layers/src/wms-layer/wms-layer.ts
+++ b/modules/geo-layers/src/wms-layer/wms-layer.ts
@@ -18,7 +18,7 @@ import {
 import {BitmapLayer} from '@deck.gl/layers';
 import type {ImageSourceMetadata, ImageType, ImageServiceType} from '@loaders.gl/wms';
 import {ImageSource, createImageSource} from '@loaders.gl/wms';
-import {Proj4Projection} from '@math.gl/proj4';
+import {WGS84ToPseudoMercator} from './utils';
 
 /** All props supported by the TileLayer */
 export type WMSLayerProps = CompositeLayerProps & _WMSLayerProps;
@@ -54,8 +54,6 @@ const defaultProps: DefaultProps<WMSLayerProps> = {
     value: (requestId: unknown, error: Error) => console.error(error, requestId)
   }
 };
-
-const projConverter = new Proj4Projection({from: 'EPSG:4326', to: 'EPSG:3857'});
 
 /**
  * The layer is used in Hex Tile layer in order to properly discard invisible elements during animation
@@ -205,8 +203,8 @@ export class WMSLayer<ExtraPropsT extends {} = {}> extends CompositeLayer<
       srs
     };
     if (srs === 'EPSG:3857') {
-      const [minX, minY] = projConverter.project([bounds[0], bounds[1]]);
-      const [maxX, maxY] = projConverter.project([bounds[2], bounds[3]]);
+      const [minX, minY] = WGS84ToPseudoMercator([bounds[0], bounds[1]]);
+      const [maxX, maxY] = WGS84ToPseudoMercator([bounds[2], bounds[3]]);
       requestParams.bbox = [minX, minY, maxX, maxY];
     }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@loaders.gl/csv": "^3.3.1",
     "@loaders.gl/polyfills": "^3.3.1",
     "@luma.gl/test-utils": "^8.5.16",
+    "@math.gl/proj4": "^3.6.3",
     "@probe.gl/bench": "^3.5.4",
     "@probe.gl/test-utils": "^3.5.4",
     "@types/react": "^18.0.0",

--- a/test/modules/geo-layers/wms-layer.spec.js
+++ b/test/modules/geo-layers/wms-layer.spec.js
@@ -3,6 +3,9 @@
 import test from 'tape-promise/tape';
 import {generateLayerTests, testLayerAsync} from '@deck.gl/test-utils';
 import {_WMSLayer as WMSLayer} from '@deck.gl/geo-layers';
+import {Proj4Projection} from '@math.gl/proj4';
+import {WGS84ToPseudoMercator} from '@deck.gl/geo-layers/wms-layer/utils';
+import {equals} from '@math.gl/core';
 
 test.skip('WMSLayer', async t => {
   const testCases = generateLayerTests({
@@ -16,5 +19,28 @@ test.skip('WMSLayer', async t => {
     onBeforeUpdate: ({testCase}) => t.comment(testCase.title)
   });
   await testLayerAsync({Layer: WMSLayer, testCases, onError: t.notOk});
+  t.end();
+});
+
+test('EPSG:4326 -> EPSG:3857', t => {
+  const projConverter = new Proj4Projection({from: 'EPSG:4326', to: 'EPSG:3857'});
+
+  const testCases = [
+    [-180, -85.06], // bound min
+    [180, 85.06], // bound max
+    [-122.45, 37.78], // SF
+    [-0.122, 51.51], // London
+    [-58.59, -34.62], // Buenos Aires
+    [174.57, -36.86] // Aukland
+  ];
+
+  for (const coord of testCases) {
+    const actual = WGS84ToPseudoMercator(coord);
+    const expected = projConverter.project(coord);
+    // t.comment(actual);
+    // t.comment(expected);
+    t.ok(equals(actual, expected), 'matches proj4 output');
+  }
+
   t.end();
 });


### PR DESCRIPTION
Saves ~78k in bundle size

#### Change List
- Move proj4 to dev dependencies (for testing)
- Alternative projection util
- Tests
