### PR TITLE
Fix PostProcessEffect prop update

### DIFF
--- a/modules/core/src/effects/post-process-effect.ts
+++ b/modules/core/src/effects/post-process-effect.ts
@@ -26,7 +26,7 @@ export default class PostProcessEffect implements Effect {
   preRender(): void {}
 
   postRender(gl: WebGLRenderingContext, params: PostRenderOptions): Framebuffer {
-    const passes = this.passes || createPasses(gl, this.module, this.id, this.props);
+    const passes = this.passes || createPasses(gl, this.module, this.id);
     this.passes = passes;
 
     const {target} = params;
@@ -37,7 +37,7 @@ export default class PostProcessEffect implements Effect {
       if (target && index === this.passes.length - 1) {
         outputBuffer = target;
       }
-      this.passes[index].render({inputBuffer, outputBuffer});
+      this.passes[index].render({inputBuffer, outputBuffer, moduleSettings: this.props});
       const switchBuffer = outputBuffer;
       outputBuffer = inputBuffer;
       inputBuffer = switchBuffer;
@@ -55,19 +55,13 @@ export default class PostProcessEffect implements Effect {
   }
 }
 
-function createPasses(
-  gl: WebGLRenderingContext,
-  module: ShaderModule,
-  id: string,
-  moduleSettings: any
-): ScreenPass[] {
+function createPasses(gl: WebGLRenderingContext, module: ShaderModule, id: string): ScreenPass[] {
   if (!module.passes) {
     const fs = getFragmentShaderForRenderPass(module);
     const pass = new ScreenPass(gl, {
       id,
       module,
-      fs,
-      moduleSettings
+      fs
     });
     return [pass];
   }
@@ -79,8 +73,7 @@ function createPasses(
     return new ScreenPass(gl, {
       id: idn,
       module,
-      fs,
-      moduleSettings
+      fs
     });
   });
 }

--- a/modules/core/src/passes/screen-pass.ts
+++ b/modules/core/src/passes/screen-pass.ts
@@ -14,12 +14,12 @@ type ScreenPassProps = {
   module: ShaderModule;
   fs: string | null;
   id: string;
-  moduleSettings: any;
 };
 
 type ScreenPassRenderOptions = {
   inputBuffer: Framebuffer;
   outputBuffer: Framebuffer;
+  moduleSettings: any;
 };
 
 export default class ScreenPass extends Pass {
@@ -58,7 +58,7 @@ export default class ScreenPass extends Pass {
     const {inputBuffer} = options;
     clear(gl, {color: true});
     this.model.draw({
-      moduleSettings: this.props.moduleSettings,
+      moduleSettings: options.moduleSettings,
       uniforms: {
         texture: inputBuffer,
         texSize: [inputBuffer.width, inputBuffer.height]


### PR DESCRIPTION
For #7748

The bug was introduced in #7515 - as part of the effort to avoid destroying/recreating models, `PostProcessEffect.setProps` was added to update existing module settings, but the settings are not propagated to the model.

#### Change List
- `ScreenPass` moves `moduleSettings` from constructor to `render` parameter
- `PostProcessEffect` calls new `ScreenPass` API
