### PR TITLE
TextLayer.fontSettings propType compare depth 1

### DIFF
--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -218,7 +218,7 @@ const defaultProps: DefaultProps<TextLayerProps> = {
   lineHeight: DEFAULT_LINE_HEIGHT,
   outlineWidth: {type: 'number', value: 0, min: 0},
   outlineColor: {type: 'color', value: DEFAULT_COLOR},
-  fontSettings: {type: 'object', value: {}, optional: true, compare: 1},
+  fontSettings: {type: 'object', value: {}, compare: 1},
 
   // auto wrapping options
   wordBreak: 'break-word',

--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -218,7 +218,7 @@ const defaultProps: DefaultProps<TextLayerProps> = {
   lineHeight: DEFAULT_LINE_HEIGHT,
   outlineWidth: {type: 'number', value: 0, min: 0},
   outlineColor: {type: 'color', value: DEFAULT_COLOR},
-  fontSettings: {},
+  fontSettings: {type: 'object', value: {}, optional: true, compare: 1},
 
   // auto wrapping options
   wordBreak: 'break-word',


### PR DESCRIPTION
#### Background

`TextLayer.fontSettings` propType doesn't include a compare depth leading to unnecessary state updates