### PR TITLE
Use maplibre in Codepen examples

### DIFF
--- a/website/src/doc-demos/codepen-automation.js
+++ b/website/src/doc-demos/codepen-automation.js
@@ -242,7 +242,7 @@ new DeckGL({
   `;
 
   gotoSource({
-    dependencies: dependencies.concat(['https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.js']),
+    dependencies: dependencies.concat(['https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js']),
     title: `deck.gl ${Layer.layerName}`,
     source
   });


### PR DESCRIPTION
#### Change List
- Change Codepen dependency to maplibre-gl
