### PR TITLE
Fix bug when using default value in attributes with size greater than 1

### DIFF
--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -509,7 +509,10 @@ export default class DataColumn<Options, State> implements IShaderAttribute {
       return out;
     }
     if (!value) {
-      out[start] = defaultValue[0];
+      let i = size;
+      while (--i >= 0) {
+        out[start + i] = defaultValue[i];
+      }
       return out;
     }
 

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -307,7 +307,7 @@ test('Attribute#updateBuffer', t => {
       {id: 'B', value: 20, color: [128, 128, 128, 128]},
       {id: 'C', value: 7, color: [255, 255, 255]},
       {id: 'D', value: 0, color: [0, 0, 0, 128]},
-      {id: 'E', value: 0, color: undefined},
+      {id: 'E', value: 0, color: undefined}
     ],
     getColor: d => d.color,
     getValue: d => d.value

--- a/test/modules/core/lib/attribute/attribute.spec.js
+++ b/test/modules/core/lib/attribute/attribute.spec.js
@@ -306,7 +306,8 @@ test('Attribute#updateBuffer', t => {
       {id: 'A', value: 10, color: [255, 0, 0]},
       {id: 'B', value: 20, color: [128, 128, 128, 128]},
       {id: 'C', value: 7, color: [255, 255, 255]},
-      {id: 'D', value: 0, color: [0, 0, 0, 128]}
+      {id: 'D', value: 0, color: [0, 0, 0, 128]},
+      {id: 'E', value: 0, color: undefined},
     ],
     getColor: d => d.color,
     getValue: d => d.value
@@ -315,7 +316,7 @@ test('Attribute#updateBuffer', t => {
   const TEST_PARAMS = [
     {
       title: 'standard',
-      numInstances: 4
+      numInstances: 5
     },
     {
       title: 'variable size',
@@ -350,7 +351,8 @@ test('Attribute#updateBuffer', t => {
         255, 0, 0, 255,
         128, 128, 128, 128,
         255, 255, 255, 255,
-        0, 0, 0, 128
+        0, 0, 0, 128, 
+        0, 0, 0, 255
       ],
       // prettier-ignore
       'variable size': [


### PR DESCRIPTION
I was experiencing a bug that traced back to the attribute auto updater using data left over in reallocated buffers. This happens when an attribute's size is larger than 1 and the accessor returns `undefined`:

In the auto updater, the relevant block is https://github.com/visgl/deck.gl/blob/8.9-release/modules/core/src/lib/attribute/attribute.ts#L404-L410. When `objectValue` is undefined, calling `attribute._normalizeValue` ends up in https://github.com/visgl/deck.gl/blob/8.9-release/modules/core/src/lib/attribute/data-column.ts#L511-L514 -- which only puts `defaultValue[0]` into `out`. Thus when the auto updater calls [`fillArrray`](https://github.com/visgl/deck.gl/blob/master/modules/core/src/lib/attribute/attribute.ts#L405), it will only copy over a single value per vertex (`out` is plumbed through to where `fillArray` determines how many values to populate in `target`: https://github.com/visgl/deck.gl/blob/8.8-release/modules/core/src/utils/flatten.ts#L61 ). Since only one value per vertex is being populated, there are many values in the array left with whatever was in them last time they were handed back to the allocator!
