### PR TITLE
CollisionFilterExtension: Discard outside clip space

### DIFF
--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -72,7 +72,8 @@ const inject = {
     vec2 collision_texCoords = collision_getCoords(collision_common_position);
     collision_fade = collision_isVisible(collision_texCoords, geometry.pickingColor / 255.0);
     if (collision_fade < 0.0001) {
-      position = vec4(0.);
+      // Position outside clip space bounds to discard
+      position = vec4(0.0, 0.0, 2.0, 1.0);
     }
   }
   `,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/7776
<!-- For other PRs without open issue -->
#### Background

Using `vec4(0.)` to discard a vertex seems to have precision issues, safer to have a point that is clearly outside (e.g. where `w !== 0`.

<!-- For all the PRs -->
#### Change List
- Discard vertex by placing outside clip space
