### PR TITLE
CARTO: data loading performance improvements

### DIFF
--- a/modules/carto/src/layers/schema/carto-spatial-tile-loader.ts
+++ b/modules/carto/src/layers/schema/carto-spatial-tile-loader.ts
@@ -1,7 +1,7 @@
 import {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 
 import {Tile, TileReader} from './carto-spatial-tile';
-import {parsePbf, unpackProperties} from './tile-loader-utils';
+import {parsePbf} from './tile-loader-utils';
 import {IndexScheme, binaryToSpatialjson, SpatialJson} from './spatialjson-utils';
 
 const CartoSpatialTileLoader: LoaderWithParser = {
@@ -31,10 +31,7 @@ function parseCartoSpatialTile(
 
   const {cells} = tile;
   const scheme = options?.cartoSpatialTile?.scheme;
-  const data = {
-    cells: {...cells, properties: unpackProperties(cells.properties)},
-    scheme
-  };
+  const data = {cells, scheme};
 
   return binaryToSpatialjson(data);
 }

--- a/modules/carto/src/layers/schema/carto-spatial-tile.ts
+++ b/modules/carto/src/layers/schema/carto-spatial-tile.ts
@@ -1,11 +1,6 @@
 import {readPackedFixed64} from './fast-pbf';
 import {Indices, IndexScheme} from './spatialjson-utils';
-import {
-  KeyValueProperties,
-  NumericProp,
-  NumericPropKeyValueReader,
-  PropertiesReader
-} from './carto-tile';
+import {NumericProp, NumericPropKeyValueReader, PropertiesReader} from './carto-tile';
 
 // Indices =====================================
 
@@ -22,7 +17,7 @@ export class IndicesReader {
 
 interface Cells {
   indices: Indices;
-  properties: KeyValueProperties[];
+  properties: Record<string, string>[];
   numericProps: Record<string, NumericProp>;
 }
 

--- a/modules/carto/src/layers/schema/carto-spatial-tile.ts
+++ b/modules/carto/src/layers/schema/carto-spatial-tile.ts
@@ -1,3 +1,4 @@
+import {readPackedFixed64} from './fast-pbf';
 import {Indices, IndexScheme} from './spatialjson-utils';
 import {
   KeyValueProperties,
@@ -10,11 +11,10 @@ import {
 
 export class IndicesReader {
   static read(pbf, end?: number): Indices {
-    const {value} = pbf.readFields(IndicesReader._readField, {value: []}, end);
-    return {value: new BigUint64Array(value)};
+    return pbf.readFields(IndicesReader._readField, {value: []}, end);
   }
   static _readField(this: void, tag: number, obj, pbf) {
-    if (tag === 1) readPackedFixed64(pbf, obj.value);
+    if (tag === 1) readPackedFixed64(pbf, obj);
   }
 }
 
@@ -60,24 +60,4 @@ export class TileReader {
     if (tag === 1) obj.scheme = pbf.readVarint();
     else if (tag === 2) obj.cells = CellsReader.read(pbf, pbf.readVarint() + pbf.pos);
   }
-}
-
-// pbf doesn't support BigInt natively, implement support for packed fixed64 type
-const SHIFT_LEFT_32 = BigInt((1 << 16) * (1 << 16));
-
-function readPackedEnd(pbf) {
-  return pbf.type === 2 ? pbf.readVarint() + pbf.pos : pbf.pos + 1;
-}
-function readFixed64(pbf) {
-  const a = BigInt(pbf.readFixed32());
-  const b = BigInt(pbf.readFixed32());
-  return a + b * SHIFT_LEFT_32;
-}
-
-function readPackedFixed64(pbf, arr) {
-  if (pbf.type !== 2) return arr.push(readFixed64(pbf));
-  const end = readPackedEnd(pbf);
-  arr = arr || [];
-  while (pbf.pos < end) arr.push(readFixed64(pbf));
-  return arr;
 }

--- a/modules/carto/src/layers/schema/carto-vector-tile-loader.ts
+++ b/modules/carto/src/layers/schema/carto-vector-tile-loader.ts
@@ -2,7 +2,7 @@ import {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {BinaryFeatures} from '@loaders.gl/schema';
 
 import {TileReader} from './carto-tile';
-import {parsePbf, unpackProperties} from './tile-loader-utils';
+import {parsePbf} from './tile-loader-utils';
 
 const CartoVectorTileLoader: LoaderWithParser = {
   name: 'CARTO Vector Tile',
@@ -25,15 +25,8 @@ function parseCartoVectorTile(
   if (!arrayBuffer) return null;
   const tile = parsePbf(arrayBuffer, TileReader);
 
-  const {points, lines, polygons} = tile;
-  const data = {
-    points: {...points, properties: unpackProperties(points.properties)},
-    lines: {...lines, properties: unpackProperties(lines.properties)},
-    polygons: {...polygons, properties: unpackProperties(polygons.properties)}
-  };
-
   // Note: there is slight, difference in `numericProps` type, however geojson/mvtlayer can cope with this
-  return data as unknown as BinaryFeatures;
+  return tile as unknown as BinaryFeatures;
 }
 
 export default CartoVectorTileLoader;

--- a/modules/carto/src/layers/schema/fast-pbf.ts
+++ b/modules/carto/src/layers/schema/fast-pbf.ts
@@ -1,0 +1,13 @@
+// Optimized (100X speed improvement) reading functions for binary data
+export function readPackedDouble(pbf, obj) {
+  const end = pbf.type === 2 ? pbf.readVarint() + pbf.pos : pbf.pos + 1;
+  obj.value = new Float64Array(pbf.buf.buffer.slice(pbf.pos, end));
+  pbf.pos = end;
+  return obj.value;
+}
+export function readPackedFixed64(pbf, obj) {
+  const end = pbf.type === 2 ? pbf.readVarint() + pbf.pos : pbf.pos + 1;
+  obj.value = new BigUint64Array(pbf.buf.buffer.slice(pbf.pos, end));
+  pbf.pos = end;
+  return obj.value;
+}

--- a/modules/carto/src/layers/schema/tile-loader-utils.ts
+++ b/modules/carto/src/layers/schema/tile-loader-utils.ts
@@ -1,6 +1,4 @@
 import Protobuf from 'pbf';
-import {KeyValueProperties} from './carto-tile';
-import {Properties} from './spatialjson-utils';
 
 export function parsePbf(buffer: ArrayBuffer, TileReader) {
   const pbf = new Protobuf(buffer);

--- a/modules/carto/src/layers/schema/tile-loader-utils.ts
+++ b/modules/carto/src/layers/schema/tile-loader-utils.ts
@@ -7,16 +7,3 @@ export function parsePbf(buffer: ArrayBuffer, TileReader) {
   const tile = TileReader.read(pbf);
   return tile;
 }
-
-export function unpackProperties(properties: KeyValueProperties[]): Properties[] {
-  if (!properties || !properties.length) {
-    return [];
-  }
-  return properties.map(item => {
-    const currentRecord: Properties = {};
-    item.data.forEach(({key, value}) => {
-      currentRecord[key] = value;
-    });
-    return currentRecord;
-  });
-}


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

The parsing of protobuffers is slower than it needs to be, due to the implementation iterating over large arrays of fixed size data, when it can just map the whole array into memory in some cases.

<!-- For all the PRs -->
#### Change List
- Implement direct memory copy versions of `readPackedDouble` and `readPackedFixed64`
- Return the correct data structure from `TileReader` to avoid second pass to `unpackProperties`
- Speed up picking with spatial index layers by exploiting the tile/data heirarchy
