### PR TITLE
(fix) MapboxOverlay: safeguard for redraw

### DIFF
--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -196,7 +196,9 @@ export default class MapboxOverlay implements IControl {
       // @ts-ignore (2345) map is always defined if deck is
       deck.setProps({viewState: getViewState(this._map)});
       // Redraw immediately if view state has changed
-      deck.redraw();
+      if (deck.isInitialized) {
+        deck.redraw();
+      }
     }
   };
 


### PR DESCRIPTION
For #7801

#### Change List
- Do not redraw before initialization
