### PR TITLE
Fix component name warning for layer extensions

### DIFF
--- a/modules/core/src/lib/layer-extension.ts
+++ b/modules/core/src/lib/layer-extension.ts
@@ -25,6 +25,7 @@ import type {LayerContext} from './layer-manager';
 
 export default abstract class LayerExtension<OptionsT = unknown> {
   static defaultProps = {};
+  static extensionName = 'LayerExtension';
   opts!: OptionsT;
 
   constructor(opts?: OptionsT) {

--- a/modules/core/src/lib/layer-extension.ts
+++ b/modules/core/src/lib/layer-extension.ts
@@ -26,6 +26,11 @@ import type {LayerContext} from './layer-manager';
 export default abstract class LayerExtension<OptionsT = unknown> {
   static defaultProps = {};
   static extensionName = 'LayerExtension';
+
+  static get componentName() {
+    return Object.prototype.hasOwnProperty.call(this, 'extensionName') ? this.extensionName : '';
+  }
+
   opts!: OptionsT;
 
   constructor(opts?: OptionsT) {

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -188,6 +188,10 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   static defaultProps: DefaultProps = defaultProps;
   static layerName: string = 'Layer';
 
+  static override get componentName() {
+    return Object.prototype.hasOwnProperty.call(this, 'layerName') ? this.layerName : '';
+  }
+
   internalState: LayerState<this> | null = null;
   lifecycle: Lifecycle = LIFECYCLE.NO_STATE; // Helps track and debug the life cycle of the layers
 

--- a/modules/core/src/lifecycle/component.ts
+++ b/modules/core/src/lifecycle/component.ts
@@ -10,7 +10,7 @@ import {createProps} from './create-props';
 
 let counter = 0;
 
-export type StatefulComponentProps<PropsT> = PropsT & {
+export type StatefulComponentProps<PropsT extends {}> = PropsT & {
   id: string;
   [COMPONENT_SYMBOL]: Component<PropsT>;
   [PROP_TYPES_SYMBOL]: Record<string, PropType>;

--- a/modules/core/src/lifecycle/create-props.ts
+++ b/modules/core/src/lifecycle/create-props.ts
@@ -266,7 +266,9 @@ function getOwnProperty(object, prop) {
 
 function getComponentName(componentClass) {
   const componentName =
-    getOwnProperty(componentClass, 'layerName') || getOwnProperty(componentClass, 'componentName');
+    getOwnProperty(componentClass, 'layerName') ||
+    getOwnProperty(componentClass, 'extensionName') ||
+    getOwnProperty(componentClass, 'componentName');
   if (!componentName) {
     log.once(0, `${componentClass.name}.componentName not specified`)();
   }

--- a/modules/core/src/lifecycle/create-props.ts
+++ b/modules/core/src/lifecycle/create-props.ts
@@ -265,12 +265,9 @@ function getOwnProperty(object, prop) {
 }
 
 function getComponentName(componentClass) {
-  const componentName =
-    getOwnProperty(componentClass, 'layerName') ||
-    getOwnProperty(componentClass, 'extensionName') ||
-    getOwnProperty(componentClass, 'componentName');
+  const componentName = componentClass.componentName;
   if (!componentName) {
-    log.once(0, `${componentClass.name}.componentName not specified`)();
+    log.warn(`${componentClass.name}.componentName not specified`)();
   }
   return componentName || componentClass.name;
 }

--- a/test/modules/carto/layers/carto-tile-layer.spec.js
+++ b/test/modules/carto/layers/carto-tile-layer.spec.js
@@ -28,7 +28,7 @@ test(`CartoTileLayer#picking`, async t => {
     }
   }
 
-  TestCartoTileLayer.componentName = 'TestCartoTileLayer';
+  TestCartoTileLayer.layerName = 'TestCartoTileLayer';
 
   await testPickingLayer({
     layer: new TestCartoTileLayer({

--- a/test/modules/core/lib/picking.spec.js
+++ b/test/modules/core/lib/picking.spec.js
@@ -69,7 +69,7 @@ class TestMVTLayer extends MVTLayer {
   }
 }
 
-TestMVTLayer.componentName = 'TestMVTLayer';
+TestMVTLayer.layerName = 'TestMVTLayer';
 
 const testMVTLayer = new TestMVTLayer({
   id: 'test-mvt-layer',

--- a/test/modules/geo-layers/mvt-layer.spec.js
+++ b/test/modules/geo-layers/mvt-layer.spec.js
@@ -246,7 +246,7 @@ test('MVTLayer#autoHighlight', async t => {
     }
   }
 
-  TestMVTLayer.componentName = 'TestMVTLayer';
+  TestMVTLayer.layerName = 'TestMVTLayer';
 
   const onAfterUpdate = ({subLayers}) => {
     for (const layer of subLayers) {
@@ -304,7 +304,7 @@ for (const binary of [true, false]) {
       }
     }
 
-    TestMVTLayer.componentName = 'TestMVTLayer';
+    TestMVTLayer.layerName = 'TestMVTLayer';
 
     await testPickingLayer({
       layer: new TestMVTLayer({
@@ -429,7 +429,7 @@ test('MVTLayer#dataInWGS84', async t => {
     }
   }
 
-  TestMVTLayer.componentName = 'TestMVTLayer';
+  TestMVTLayer.layerName = 'TestMVTLayer';
 
   const viewport = new WebMercatorViewport({
     longitude: 0,


### PR DESCRIPTION
For #7811

Introduced by #7513 after we start merging default props from extensions.

#### Change List
- Use `Class.extensionName` as component name if exists
