### PR TITLE
Honor changing view controller type.

### DIFF
--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -326,8 +326,9 @@ export default class ViewManager {
         height: viewport.height
       };
 
-      // TODO - check if view / controller type has changed, and replace the controller
-      if (!controller) {
+      // Create controller if not already existing or if the type of the
+      // controller has changed.
+      if (!controller || (controller.constructor !== view.ControllerType)) {
         controller = this._createController(view, resolvedProps);
       }
       if (controller) {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
When replacing existing Views with changed Controller types, if the new Views happen to have the same ids, then the new Controller types are not honored, and instead the old, possibly incompatible Controllers are used instead.
<!-- For all the PRs -->
#### Change List
- Create new Controller if type has changed
