### PR TITLE
fix(mapbox): crash when interleaved overlay is removed then added back

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -385,7 +385,7 @@ export default class Deck {
 
   /** Stop rendering and dispose all resources */
   finalize() {
-    this.animationLoop.stop();
+    this.animationLoop?.stop();
     this.animationLoop = null;
     this._lastPointerDownInfo = null;
 

--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -79,8 +79,7 @@ export function getDeckInstance({
   } else {
     deckInstance = new Deck(deckProps);
     map.on('remove', () => {
-      deckInstance.finalize();
-      map.__deck = null;
+      removeDeckInstance(map);
     });
   }
 
@@ -105,6 +104,11 @@ function watchMapMove(deck: Deck, map: Map & {__deck?: Deck | null}) {
     }
   };
   map.on('move', _handleMapMove);
+}
+
+export function removeDeckInstance(map: Map & {__deck?: Deck | null}) {
+  map.__deck?.finalize();
+  map.__deck = null;
 }
 
 export function getInterleavedProps(currProps: DeckProps) {

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -1,5 +1,5 @@
 import {Deck, assert} from '@deck.gl/core';
-import {getViewState, getDeckInstance, getInterleavedProps} from './deck-utils';
+import {getViewState, getDeckInstance, removeDeckInstance, getInterleavedProps} from './deck-utils';
 
 import type {Map, IControl, MapMouseEvent} from 'mapbox-gl';
 import type {MjolnirGestureEvent, MjolnirPointerEvent} from 'mjolnir.js';
@@ -121,7 +121,6 @@ export default class MapboxOverlay implements IControl {
       }
     }
 
-    this._deck?.finalize();
     this._deck = undefined;
     this._map = undefined;
     this._container = undefined;
@@ -138,11 +137,13 @@ export default class MapboxOverlay implements IControl {
     map.off('mouseout', this._handleMouseEvent);
     map.off('click', this._handleMouseEvent);
     map.off('dblclick', this._handleMouseEvent);
+    this._deck?.finalize();
   }
 
   private _onRemoveInterleaved(map: Map): void {
     map.off('styledata', this._handleStyleChange);
     resolveLayers(map, this._deck, this._props.layers, []);
+    removeDeckInstance(map);
   }
 
   getDefaultPosition() {

--- a/test/modules/mapbox/mapbox-overlay.spec.js
+++ b/test/modules/mapbox/mapbox-overlay.spec.js
@@ -201,6 +201,36 @@ test('MapboxOverlay#interleaved', t => {
   });
 });
 
+test('MapboxOverlay#interleaved#remove and add', t => {
+  const map = new MockMapboxMap({
+    center: {lng: -122.45, lat: 37.78},
+    zoom: 14
+  });
+  const overlay = new MapboxOverlay({
+    interleaved: true,
+    layers: [new ScatterplotLayer({id: 'poi'})],
+    parameters: {
+      depthMask: false,
+      cull: true
+    },
+    useDevicePixels: 1
+  });
+
+  map.addControl(overlay);
+  let deck = overlay._deck;
+  t.ok(deck && deck.animationLoop, 'Deck instance is created');
+  map.removeControl(overlay);
+  t.notOk(deck.animationLoop, 'Deck instance is finalized');
+
+  map.addControl(overlay);
+  deck = overlay._deck;
+  t.ok(deck && deck.animationLoop, 'Deck instance is created');
+  map.removeControl(overlay);
+  t.notOk(deck.animationLoop, 'Deck instance is finalized');
+
+  t.end();
+});
+
 test('MapboxOverlay#interleavedNoInitialLayers', t => {
   const map = new MockMapboxMap({
     center: {lng: -122.45, lat: 37.78},


### PR DESCRIPTION
For #7818

#### Change List
- `Deck` fix error if double-finalized
- Delete cached Deck instance on map when interleaved control is removed
- Unit test
