### PR TITLE
CARTO: support long queres for stats requests via POST

### DIFF
--- a/modules/carto/src/api/maps-v3-client.ts
+++ b/modules/carto/src/api/maps-v3-client.ts
@@ -476,15 +476,31 @@ async function _fetchTilestats(
   const {connectionName: connection, source, type} = dataset;
 
   const statsUrl = buildStatsUrlFromBase(credentials.apiBaseUrl);
-  let url = `${statsUrl}/${connection}/`;
+  let baseUrl = `${statsUrl}/${connection}/`;
   if (type === MAP_TYPES.QUERY) {
-    url += `${attribute}?${encodeParameter('q', source)}`;
+    baseUrl += attribute;
   } else {
     // MAP_TYPE.TABLE
-    url += `${source}/${attribute}`;
+    baseUrl += `${source}/${attribute}`;
   }
+
   const errorContext = {requestType: REQUEST_TYPES.TILE_STATS, connection, type, source};
-  const stats = await requestData({url, format: FORMATS.JSON, accessToken, errorContext});
+  let url = baseUrl;
+  if (type === MAP_TYPES.QUERY) {
+    url += `?${encodeParameter('q', source)}`;
+  }
+  let stats;
+  if (url.length > MAX_GET_LENGTH && type === MAP_TYPES.QUERY) {
+    stats = await requestJson({
+      method: 'POST',
+      url: baseUrl,
+      accessToken,
+      body: JSON.stringify({q: source}),
+      errorContext
+    });
+  } else {
+    stats = await requestJson({url, accessToken, errorContext});
+  }
 
   // Replace tilestats for attribute with value from API
   const {attributes} = dataset.data.tilestats.layers[0];

--- a/test/modules/carto/mock-fetch.js
+++ b/test/modules/carto/mock-fetch.js
@@ -8,7 +8,17 @@ const BINARY_TILE = new Uint8Array(binaryTileData).buffer;
 
 export const TILEJSON_RESPONSE = {
   tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary']
+  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
+  tilestats: {
+    layers: [
+      {
+        attributes: [
+          {attribute: 'population', type: 'integer'},
+          {attribute: 'category', type: 'string'}
+        ]
+      }
+    ]
+  }
 };
 
 export const GEOJSON_RESPONSE = {
@@ -23,6 +33,16 @@ export const GEOJSON_RESPONSE = {
       }
     }
   ]
+};
+
+export const TILESTATS_RESPONSE = {
+  attribute: 'population',
+  avg: 10,
+  min: 1,
+  max: 20,
+  quantiles: [],
+  sum: 100,
+  type: 'Number'
 };
 
 export const MAPS_API_V1_RESPONSE = {
@@ -57,7 +77,8 @@ function mockFetchMapsV2() {
 
 export function mockFetchMapsV3() {
   const fetch = globalThis.fetch;
-  globalThis.fetch = (url, {headers}) => {
+  globalThis.fetch = (url, {headers, method}) => {
+    console.log('method', method, url);
     return Promise.resolve({
       json: () => {
         if (url.indexOf('format=tilejson') !== -1) {
@@ -73,6 +94,9 @@ export function mockFetchMapsV3() {
               url: ['https://xyz.com?format=tilejson&cache=12345678']
             }
           };
+        }
+        if (url.indexOf('stats') !== -1) {
+          return TILESTATS_RESPONSE;
         }
         if (url.indexOf('query') !== -1 || url.indexOf('table')) {
           return {

--- a/test/modules/carto/mock-fetch.js
+++ b/test/modules/carto/mock-fetch.js
@@ -77,8 +77,7 @@ function mockFetchMapsV2() {
 
 export function mockFetchMapsV3() {
   const fetch = globalThis.fetch;
-  globalThis.fetch = (url, {headers, method}) => {
-    console.log('method', method, url);
+  globalThis.fetch = (url, {headers}) => {
     return Promise.resolve({
       json: () => {
         if (url.indexOf('format=tilejson') !== -1) {


### PR DESCRIPTION
#### Background

Followup to https://github.com/visgl/deck.gl/pull/7643

<!-- For all the PRs -->
#### Change List
- Support switching to POST with long queries against the stats API
- Test for stats request flow
