### PR TITLE
Handle hidden canvas

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -734,9 +734,9 @@ export default class Deck {
     if (!canvas) {
       return;
     }
-    // Fallback to width/height when clientWidth/clientHeight are 0 or undefined.
-    const newWidth = canvas.clientWidth || canvas.width;
-    const newHeight = canvas.clientHeight || canvas.height;
+    // Fallback to width/height when clientWidth/clientHeight are undefined (OffscreenCanvas).
+    const newWidth = canvas.clientWidth ?? canvas.width;
+    const newHeight = canvas.clientHeight ?? canvas.height;
     if (newWidth !== this.width || newHeight !== this.height) {
       // @ts-expect-error private assign to read-only property
       this.width = newWidth;

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -311,11 +311,11 @@ export default class ViewManager {
   private _updateController(
     view: View,
     viewState: any,
-    viewport: Viewport,
+    viewport: Viewport | null,
     controller?: Controller<any> | null
   ): Controller<any> | null {
     const controllerProps = view.controller;
-    if (controllerProps) {
+    if (controllerProps && viewport) {
       const resolvedProps = {
         ...viewState,
         ...controllerProps,
@@ -369,7 +369,9 @@ export default class ViewManager {
       // Update the controller
       this.controllers[view.id] = this._updateController(view, viewState, viewport, oldController);
 
-      this._viewports.unshift(viewport);
+      if (viewport) {
+        this._viewports.unshift(viewport);
+      }
     }
 
     // Remove unused controllers

--- a/modules/core/src/views/view.ts
+++ b/modules/core/src/views/view.ts
@@ -131,6 +131,9 @@ export default abstract class View<
 
     // Resolve relative viewport dimensions
     const viewportDimensions = this.getDimensions({width, height});
+    if (!viewportDimensions.height || !viewportDimensions.width) {
+      return null;
+    }
     return new this.ViewportType({...viewState, ...this.props, ...viewportDimensions});
   }
 

--- a/test/modules/core/lib/view-manager.spec.js
+++ b/test/modules/core/lib/view-manager.spec.js
@@ -231,6 +231,32 @@ test('ViewManager#update view props', t => {
   t.end();
 });
 
+/* eslint-disable max-statements */
+test('ViewManager#zero-size', t => {
+  const mainView = new MapView({id: 'main', controller: true});
+
+  const viewManager = new ViewManager({
+    views: [mainView],
+    viewState: {
+      longitude: -122,
+      latitude: 38,
+      zoom: 12
+    },
+    width: 100,
+    height: 100
+  });
+
+  t.ok(viewManager.controllers.main, 'main controller is created');
+  t.is(viewManager.getViewports().length, 1, 'viewport is created');
+
+  viewManager.setProps({width: 0, height: 0});
+
+  t.notOk(viewManager.controllers.main, 'no valid controllers');
+  t.is(viewManager.getViewports().length, 0, 'no valid viewports');
+
+  t.end();
+});
+
 function mockControllerEvent(type, x, y, details) {
   return {
     type,

--- a/test/modules/core/shaderlib/project/project-functions.spec.js
+++ b/test/modules/core/shaderlib/project/project-functions.spec.js
@@ -63,6 +63,8 @@ const TEST_CASES = [
     position: [-10, 10, 10],
     params: {
       viewport: new OrthographicView().makeViewport({
+        width: 1,
+        height: 1,
         viewState: {
           target: [3.1416, 2.7183, 0],
           zoom: 4

--- a/test/modules/react/deckgl.spec.js
+++ b/test/modules/react/deckgl.spec.js
@@ -43,6 +43,7 @@ const getMockContext = () => (globalThis.__JSDOM__ ? gl : null);
 test('DeckGL#mount/unmount', t => {
   const ref = createRef();
   const container = document.createElement('div');
+  document.body.append(container);
   const root = createRoot(container);
 
   act(() => {
@@ -56,7 +57,8 @@ test('DeckGL#mount/unmount', t => {
         onLoad: () => {
           const {deck} = ref.current;
           t.ok(deck, 'DeckGL is initialized');
-          t.is(deck.getViewports()[0].longitude, TEST_VIEW_STATE.longitude, 'View state is set');
+          const viewport = deck.getViewports()[0];
+          t.is(viewport && viewport.longitude, TEST_VIEW_STATE.longitude, 'View state is set');
 
           act(() => {
             root.render(null);
@@ -64,6 +66,7 @@ test('DeckGL#mount/unmount', t => {
 
           t.notOk(deck.animationLoop, 'Deck is finalized');
 
+          container.remove();
           t.end();
         }
       })
@@ -74,6 +77,7 @@ test('DeckGL#mount/unmount', t => {
 
 test('DeckGL#render', t => {
   const container = document.createElement('div');
+  document.body.append(container);
   const root = createRoot(container);
   root.render(
     createElement(
@@ -88,6 +92,7 @@ test('DeckGL#render', t => {
           t.ok(child, 'Child is rendered');
 
           root.render(null);
+          container.remove();
           t.end();
         }
       },

--- a/test/node.ts
+++ b/test/node.ts
@@ -23,6 +23,13 @@ import {gl} from '@deck.gl/test-utils';
 const canvas = globalThis.document.createElement('canvas');
 canvas.width = gl.drawingBufferWidth;
 canvas.height = gl.drawingBufferHeight;
+// Deck class uses client width/height to calculate viewport sizes
+Object.defineProperty(canvas, 'clientWidth', {
+  value: canvas.width
+});
+Object.defineProperty(canvas, 'clientHeight', {
+  value: canvas.height
+});
 gl.canvas = canvas;
 
 import './modules';


### PR DESCRIPTION
For #7852

#### Change List
- Allow Deck class set `width` and `height` to 0
- Ignore viewport of size 0 (will skip `updateState` & `draw` of corresponding layers)
- Tests