### PR TITLE
Fix typescript errors mapbox module

### DIFF
--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -203,6 +203,7 @@ export default class MapboxOverlay implements IControl {
     }
   };
 
+  // eslint-disable-next-line complexity
   private _handleMouseEvent = (event: MapMouseEvent) => {
     const deck = this._deck;
     if (!deck || !deck.isInitialized) {
@@ -235,7 +236,7 @@ export default class MapboxOverlay implements IControl {
 
     switch (mockEvent.type) {
       case 'mousedown':
-        deck._onPointerDown(mockEvent as MjolnirGestureEvent);
+        deck._onPointerDown(mockEvent as unknown as MjolnirPointerEvent);
         this._lastMouseDownPoint = {
           ...event.point,
           clientX: event.originalEvent.clientX,
@@ -245,38 +246,38 @@ export default class MapboxOverlay implements IControl {
 
       case 'dragstart':
         mockEvent.type = 'panstart';
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'drag':
         mockEvent.type = 'panmove';
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'dragend':
         mockEvent.type = 'panend';
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'click':
         mockEvent.tapCount = 1;
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'dblclick':
         mockEvent.type = 'click';
         mockEvent.tapCount = 2;
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'mousemove':
         mockEvent.type = 'pointermove';
-        deck._onPointerMove(mockEvent as MjolnirPointerEvent);
+        deck._onPointerMove(mockEvent as unknown as MjolnirPointerEvent);
         break;
 
       case 'mouseout':
         mockEvent.type = 'pointerleave';
-        deck._onPointerMove(mockEvent as MjolnirPointerEvent);
+        deck._onPointerMove(mockEvent as unknown as MjolnirPointerEvent);
         break;
 
       default:


### PR DESCRIPTION
With the following version of typescript:
```bash
$ npx tsc -v
Version 4.6.4
```
I'm getting these errors:
```
modules/mapbox/src/mapbox-overlay.ts:279:29 - error TS2352: Conversion of type '{ type: string; deltaX?: number | undefined; deltaY?: number | undefined; offsetCenter: { x: number; y: number; }; srcEvent: MapMouseEvent; tapCount?: number | undefined; }' to type 'MjolnirPointerEvent' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.

279         deck._onPointerMove(mockEvent as MjolnirPointerEvent);
```

I've applied a fix in this PR, but I keep it under draft because I don't understand why it happens to me and not in the CI