### PR TITLE
fix(core): premature release of texture prop

### DIFF
--- a/modules/core/src/lifecycle/prop-types.ts
+++ b/modules/core/src/lifecycle/prop-types.ts
@@ -202,13 +202,13 @@ const TYPE_DEFINITIONS = {
       if (!context || !context.gl) {
         return null;
       }
-      return createTexture(context.gl, value, {
+      return createTexture(component.id, context.gl, value, {
         ...propType.parameters,
         ...component.props.textureParameters
       });
     },
-    release: value => {
-      destroyTexture(value);
+    release: (value, propType: ImagePropType, component) => {
+      destroyTexture(component.id, value);
     }
   }
 } as const;

--- a/modules/core/src/utils/texture.ts
+++ b/modules/core/src/utils/texture.ts
@@ -9,9 +9,10 @@ const DEFAULT_TEXTURE_PARAMETERS: Record<number, number> = {
 };
 
 // Track the textures that are created by us. They need to be released when they are no longer used.
-const internalTextures: Record<string, boolean> = {};
+const internalTextures: Record<string, string> = {};
 
 export function createTexture(
+  owner: string,
   gl: WebGLRenderingContext,
   image: any,
   parameters: Record<number, number>
@@ -43,15 +44,16 @@ export function createTexture(
     }
   });
   // Track this texture
-  internalTextures[texture.id] = true;
+  internalTextures[texture.id] = owner;
   return texture;
 }
 
-export function destroyTexture(texture: Texture2D) {
+export function destroyTexture(owner: string, texture: Texture2D) {
   if (!texture || !(texture instanceof Texture2D)) {
     return;
   }
-  if (internalTextures[texture.id]) {
+  // Only delete the texture if requested by the same layer that created it
+  if (internalTextures[texture.id] === owner) {
     texture.delete();
     delete internalTextures[texture.id];
   }

--- a/modules/extensions/src/fill-style/fill-style-extension.ts
+++ b/modules/extensions/src/fill-style/fill-style-extension.ts
@@ -185,8 +185,7 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
   }
 
   finalizeState(this: Layer<FillStyleExtensionProps>) {
-    const {patternTexture, emptyTexture} = this.state;
-    patternTexture?.delete();
+    const {emptyTexture} = this.state;
     emptyTexture?.delete();
   }
 

--- a/test/modules/extensions/fill-style.spec.js
+++ b/test/modules/extensions/fill-style.spec.js
@@ -50,6 +50,15 @@ test('FillStyleExtension#PolygonLayer', t => {
         t.notOk(strokeLayer.state.emptyTexture, 'should not be enabled in PathLayer');
         t.notOk('fill_patternMask' in uniforms, 'should not be enabled in PathLayer');
       }
+    },
+    {
+      title: `Finalizing a sublayer should not affect the parent layer's loaded props`,
+      updateProps: {
+        data: []
+      },
+      onAfterUpdate: ({layer}) => {
+        t.ok(layer.props.fillPatternAtlas.handle, 'fillPatternAtlas texture is not deleted');
+      }
     }
   ];
 


### PR DESCRIPTION
For #7854

When `FillStyleExtension` is used with a composite layer, the `fillPatternAtlas` prop is loaded by the top-level layer (`GeoJsonLayer` in this case) and passed down to sublayers (`SolidPolygonLayer`). However, when a sublayer is finalized due to data change, it is able to delete the external texture, despite that the texture is still in use. This PR ensures that textures can only be released by the layer that created them.

#### Change List
- Use layer id to track texture ownership
- Test
