### PR TITLE
Disable transition render tests

### DIFF
--- a/test/render/test-cases/index.js
+++ b/test/render/test-cases/index.js
@@ -56,7 +56,8 @@ export default [].concat(
   scenegraphLayerTests,
   viewsTests,
   effectsTests,
-  transitionTests,
+  // TODO - Broken in headless mode with Chrome 113
+  // transitionTests,
   terrainLayerTests,
   collisionFilterExtensionTests
 );


### PR DESCRIPTION
Fix CI failure on master

As far as I can tell, this test is broken in the Chrome v113 headless mode only. The browser test passes without any issues. The `instancePositions` data at each step read correctly, but the rendering outputs do not match the buffer.

Downgrading puppeteer also makes the issue go away.

#### Change List
- Temporarily disable the attribute transition render tests.
