### PR TITLE
fix(geo-layers): Avoid instanceof check in WMSLayer

### DIFF
--- a/modules/geo-layers/src/wms-layer/wms-layer.ts
+++ b/modules/geo-layers/src/wms-layer/wms-layer.ts
@@ -156,10 +156,6 @@ export class WMSLayer<ExtraPropsT extends {} = {}> extends CompositeLayer<
   }
 
   _createImageSource(props: WMSLayerProps): ImageSource {
-    if (props.data instanceof ImageSource) {
-      return props.data;
-    }
-
     if (typeof props.data === 'string') {
       return createImageSource({
         url: props.data,
@@ -168,7 +164,7 @@ export class WMSLayer<ExtraPropsT extends {} = {}> extends CompositeLayer<
       });
     }
 
-    throw new Error('invalid image source in props.data');
+    return props.data;
   }
 
   /** Run a getMetadata on the image service */


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- When experimenting with passing `WMSService` instance from local code in loaders.gl, this check blocks layer from working.
#### Change List
- Remove the instanceof check. The property is already typed.
