### PR TITLE
Fix initial viewport when view is not MapView

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -743,6 +743,8 @@ export default class Deck {
       // @ts-expect-error private assign to read-only property
       this.height = newHeight;
       this.viewManager?.setProps({width: newWidth, height: newHeight});
+      // Make sure that any new layer gets initialized with the current viewport
+      this.layerManager?.activateViewport(this.getViewports()[0]);
       this.props.onResize({width: newWidth, height: newHeight});
     }
   }


### PR DESCRIPTION
For #

An unintended consequence from #7856 - when the ViewManager is initialized, it might not create any valid viewport instances due to width/height being 0. As a fallback, layers will be initialized with a default viewport which is a `WebMercatorViewport`. This causes problems with certain layers (`SolidPolygonLayer`, `TileLayer` etc.) whose states depend on the viewport type.

This PR copies this treatment https://github.com/visgl/deck.gl/blob/d6166cb792f65cedf03a3147df926abe32b210a3/modules/core/src/lib/deck.ts#L464-L466
To `_updateCanvasSize` as well, i.e. always update `LayerManager` if `ViewManager` is updated.

Technically speaking the existing line is a hack too. There is no guarantee that a new layer should use the FIRST viewport to initialize. The right way is to only initialize a layer when it's first drawn to a viewport, but that would be a change much larger than what's suitable for a patch.

#### Change List
- Always update `LayerManager` after calling `ViewManager.setProps`
