### PR TITLE
Extend tooltip style.transform instead of overwriting it

### DIFF
--- a/modules/core/src/lib/tooltip.ts
+++ b/modules/core/src/lib/tooltip.ts
@@ -62,6 +62,9 @@ export default class Tooltip {
       return;
     }
 
+    el.style.display = 'block';
+    el.style.transform = `translate(${x}px, ${y}px)`;
+
     if (typeof displayInfo === 'string') {
       el.innerText = displayInfo;
     } else if (!displayInfo) {
@@ -81,8 +84,6 @@ export default class Tooltip {
       Object.assign(el.style, displayInfo.style);
     }
     this.isVisible = true;
-    el.style.display = el.style.display || 'block';
-    el.style.transform = el.style.transform || `translate(${x}px, ${y}px)`;
   }
 
   remove(): void {

--- a/modules/core/src/lib/tooltip.ts
+++ b/modules/core/src/lib/tooltip.ts
@@ -62,9 +62,6 @@ export default class Tooltip {
       return;
     }
 
-    el.style.display = 'block';
-    el.style.transform = `translate(${x}px, ${y}px)`;
-
     if (typeof displayInfo === 'string') {
       el.innerText = displayInfo;
     } else if (!displayInfo) {
@@ -81,9 +78,14 @@ export default class Tooltip {
       if (displayInfo.className) {
         el.className = displayInfo.className;
       }
-      Object.assign(el.style, displayInfo.style);
     }
     this.isVisible = true;
+    el.style.display = 'block';
+    el.style.transform = `translate(${x}px, ${y}px)`;
+
+    if (displayInfo && typeof displayInfo === 'object' && 'style' in displayInfo) {
+      Object.assign(el.style, displayInfo.style);
+    }
   }
 
   remove(): void {

--- a/modules/core/src/lib/tooltip.ts
+++ b/modules/core/src/lib/tooltip.ts
@@ -81,8 +81,8 @@ export default class Tooltip {
       Object.assign(el.style, displayInfo.style);
     }
     this.isVisible = true;
-    el.style.display = 'block';
-    el.style.transform = `translate(${x}px, ${y}px)`;
+    el.style.display = el.style.display || 'block';
+    el.style.transform = el.style.transform || `translate(${x}px, ${y}px)`;
   }
 
   remove(): void {

--- a/test/modules/core/lib/tooltip.spec.js
+++ b/test/modules/core/lib/tooltip.spec.js
@@ -26,7 +26,8 @@ function getTooltipFunc(pickedValue) {
     className: 'coolTooltip',
     html: `<strong>Number of points:</strong> ${pickedValue.object.elevationValue}`,
     style: {
-      backgroundColor: 'lemonchiffon'
+      backgroundColor: 'lemonchiffon',
+      transform: 'translate(10px, 20px)'
     }
   };
 }
@@ -42,6 +43,7 @@ test('Tooltip#setTooltip', t => {
   const tooltip = new Tooltip(canvas);
   tooltip.setTooltip(getTooltipFunc(pickedInfo), pickedInfo.x, pickedInfo.y);
   t.equals(tooltip.el.style.backgroundColor, 'lemonchiffon');
+  t.equals(tooltip.el.style.transform, 'translate(10px, 20px)');
   t.equals(tooltip.el.innerHTML, '<strong>Number of points:</strong> 10');
   t.equals(tooltip.el.className, 'coolTooltip');
   t.equals(canvasContainer.querySelector('.coolTooltip').style.top, '0px');
@@ -57,6 +59,7 @@ test('Tooltip#setTooltipWithString', t => {
   tooltip.setTooltip(pickedInfoFunc(pickedInfo), pickedInfo.x, pickedInfo.y);
   t.equals(tooltip.el.innerText, 'Number of points: 10');
   t.equals(tooltip.el.className, 'deck-tooltip');
+  t.equals(tooltip.el.style.transform, `translate(${pickedInfo.x}px, ${pickedInfo.y}px)`);
   remove();
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
The tooltip element is shown below the picked object and this is not optimal when your object is in the bottom right of the map. This is not the best in terms of UX and the tooltip can overflow. Since deck doesn't handle tooltip position based on the dimensions of the tooltip element we need a way to pass in our own `style.transform` to setTooltip.

This PR has a minor improvement that uses user-provided `style.transform` without overwriting it at the end of setTooltip function. A similar change has been made to the overwrite of `style.display` because it's also hardcoded. See discussion in #7024 for more context.

#### Change List
- ENH: Extend el.style.transform in setTooltip
- TST: Add test to show getTooltip using user provided 'style.transform'