### PR TITLE
CARTO: Handle DEFAULT-INITIAL-VIEWPORT in H3Tileset2D

### DIFF
--- a/modules/carto/src/layers/h3-tileset-2d.ts
+++ b/modules/carto/src/layers/h3-tileset-2d.ts
@@ -75,6 +75,7 @@ export default class H3Tileset2D extends Tileset2D {
    */
   // @ts-expect-error Tileset2D should be generic over TileIndex
   getTileIndices({viewport, minZoom, maxZoom}): H3TileIndex[] {
+    if (viewport.latitude === undefined) return [];
     const [east, south, west, north] = viewport.getBounds();
 
     let z = getHexagonResolution(viewport);

--- a/test/modules/carto/layers/h3-tileset-2d.spec.js
+++ b/test/modules/carto/layers/h3-tileset-2d.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-promise/tape';
 import H3Tileset2D from '@deck.gl/carto/layers/h3-tileset-2d';
-import {WebMercatorViewport} from '@deck.gl/core';
+import {Viewport, WebMercatorViewport} from '@deck.gl/core';
 import {equals} from '@math.gl/core';
 
 test('H3Tileset2D', async t => {
@@ -110,5 +110,14 @@ test('H3Tileset2D max zoom', async t => {
   t.equal(indices.length, 16, 'without max zoom');
   indices = tileset.getTileIndices({viewport, maxZoom: 1});
   t.equal(indices.length, 7, 'max zoom added');
+  t.end();
+});
+
+test.only('H3Tileset2D default viewport', async t => {
+  const tileset = new H3Tileset2D({});
+  // See layer-manager.ts
+  const viewport = new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'});
+  let indices = tileset.getTileIndices({viewport});
+  t.equal(indices.length, 0, 'Empty initial viewport');
   t.end();
 });

--- a/test/modules/carto/layers/h3-tileset-2d.spec.js
+++ b/test/modules/carto/layers/h3-tileset-2d.spec.js
@@ -113,7 +113,7 @@ test('H3Tileset2D max zoom', async t => {
   t.end();
 });
 
-test.only('H3Tileset2D default viewport', async t => {
+test('H3Tileset2D default viewport', async t => {
   const tileset = new H3Tileset2D({});
   // See layer-manager.ts
   const viewport = new Viewport({id: 'DEFAULT-INITIAL-VIEWPORT'});


### PR DESCRIPTION
#### Background

It is possible that the `H3TileLayer` is initialized (in particular when used with React) before the `WebMeractorViewport` is passed in. The missing latitude in the default viewport provided by `LayerManager`then causes a crash

<!-- For all the PRs -->
#### Change List
- Handle non-geospatial viewport in `H3Tileset2D`
- Test
