### PR TITLE
[react] detect map component without defaultProps

### DIFF
--- a/modules/react/src/utils/evaluate-children.ts
+++ b/modules/react/src/utils/evaluate-children.ts
@@ -34,10 +34,7 @@ export function isComponent(child: React.ReactNode): child is React.ReactElement
 }
 
 function isReactMap(child: React.ReactElement): boolean {
-  const componentClass = child.type;
-  // @ts-expect-error defaultProps is not defined on JSXElementConstructor
-  const componentProps = componentClass && componentClass.defaultProps;
-  return componentProps && componentProps.mapStyle;
+  return child.props?.mapStyle;
 }
 
 function needsDeckGLViewProps(child: React.ReactElement): boolean {


### PR DESCRIPTION
#### Background

React deprecated `defaultProps` on functional components: https://github.com/facebook/react/pull/16210
react-map-gl change scheduled for v7.1: https://github.com/visgl/react-map-gl/pull/2173

This PR will detect a map component correctly when `defaultProps` is missing.
When used with `react-map-gl@>=7.0`, `props.mapStyle` is always specified by the user as the default `mapStyle` renders a blank map.
When used with `react-map-gl@<7.0`, `props.mapStyle` falls back to `defaultProps.mapStyle`.

#### Change List
- Do not rely on `defaultProps` when detecting React map component 
