### PR TITLE
Reset isDragging state if panning is disabled dynamically

### DIFF
--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -329,7 +329,8 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     // Register/unregister events
     const isInteractive = Boolean(this.onViewStateChange);
     this.toggleEvents(EVENT_TYPES.WHEEL, isInteractive && scrollZoom);
-    this.toggleEvents(EVENT_TYPES.PAN, isInteractive && (dragPan || dragRotate));
+    // We always need the pan events to set the correct isDragging state, even if dragPan & dragRotate are both false
+    this.toggleEvents(EVENT_TYPES.PAN, isInteractive);
     this.toggleEvents(EVENT_TYPES.PINCH, isInteractive && (touchZoom || touchRotate));
     this.toggleEvents(EVENT_TYPES.TRIPLE_PAN, isInteractive && touchRotate);
     this.toggleEvents(EVENT_TYPES.DOUBLE_TAP, isInteractive && doubleClickZoom);


### PR DESCRIPTION
For #7933

In this use case, when `dragRotate` and `dragPan` are both disabled programmatically, the `panend` event handler is deregistered, leaving the `isDragging` state to `true`.

This change does not introduce new performance overhead because `Deck`'s `onDrag*` events are still listening to `pan*` events, and the recognizer is never turned off.

#### Change List
- Correct `isDragging` controller state when `dragRotate` and `dragPan` are both off.
