### PR TITLE
CARTO: merge loadOptions passed in prop

### DIFF
--- a/modules/carto/src/layers/carto-layer.ts
+++ b/modules/carto/src/layers/carto-layer.ts
@@ -311,11 +311,17 @@ export default class CartoLayer<ExtraProps extends {} = {}> extends CompositeLay
     if (!data) return null;
 
     const {credentials, updateTriggers} = this.props;
-    const loadOptions: any = {};
+    const loadOptions: any = this.getLoadOptions() || {};
     if (apiVersion === API_VERSIONS.V3) {
       const localConfig = {...getDefaultCredentials(), ...credentials} as CloudNativeCredentials;
       const {accessToken} = localConfig;
-      loadOptions.fetch = {headers: {Authorization: `Bearer ${accessToken}`}};
+      loadOptions.fetch = {
+        ...loadOptions.fetch,
+        headers: {
+          ...loadOptions.fetch?.headers,
+          Authorization: `Bearer ${accessToken}`
+        }
+      };
     }
 
     const [layer, props] = this._getSubLayerAndProps();


### PR DESCRIPTION
#### Background

`loadOptions` passed to `CartoLayer` were getting [overwritten](https://github.com/visgl/deck.gl/blob/master/modules/carto/src/layers/carto-layer.ts#L329)

<!-- For all the PRs -->
#### Change List
- Merge `loadOptions` with access token
- Test
