### PR TITLE
Refactor: Rename selectedCounty setter function to adhere to common c…

### DIFF
--- a/examples/website/arc/app.jsx
+++ b/examples/website/arc/app.jsx
@@ -78,7 +78,7 @@ function getTooltip({object}) {
 
 /* eslint-disable react/no-deprecated */
 export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
-  const [selectedCounty, selectCounty] = useState(null);
+  const [selectedCounty, setSelectedCounty] = useState(null);
 
   const arcs = useMemo(() => calculateArcs(data, selectedCounty), [data, selectedCounty]);
 
@@ -89,7 +89,7 @@ export default function App({data, strokeWidth = 1, mapStyle = MAP_STYLE}) {
       stroked: false,
       filled: true,
       getFillColor: [0, 0, 0, 0],
-      onClick: ({object}) => selectCounty(object),
+      onClick: ({object}) => setSelectedCounty(object),
       pickable: true
     }),
     new ArcLayer({


### PR DESCRIPTION
…onvention

It is a [common convention](https://legacy.reactjs.org/docs/hooks-state.html#declaring-a-state-variable) to initialize the setter function variable name returned from  useState with 'set'

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
