### PR TITLE
Update json-configuration.js to read React from configuration root

### DIFF
--- a/docs/api-reference/json/conversion-reference.md
+++ b/docs/api-reference/json/conversion-reference.md
@@ -56,6 +56,52 @@ Whenever the `JSONConverter` component finds the `@@type` field, it looks into t
 like that in the configuration object above. These classes can be layers, views, or other objects,
  provided the classes have been registered.
 
+## React components and using `@@type` (experimental)
+
+Conversion happens by default for react components. For example, when this configuration of classes is passed to a
+ `JSONConverter`–
+
+```js
+import React from 'react';
+
+import TestComponent from '@/components/test';
+
+const configuration = {
+  classes: Object.assign({}, { React },
+  reactComponents: {
+    TestComponent
+  }
+};
+```
+
+and used to resolve this JSON object–
+
+```json
+{
+  "@@type": "TestComponent",
+  // props for the component
+  "color": [0, 128, 255],
+  "anotherProp": 1
+}
+```
+
+it will replace it with a React component.
+
+```js
+{
+  $$typeof: Symbol(react.element),
+  key: null,
+  props: {
+    color: [0, 128, 255],
+    anotherProp: 1
+  },
+  // ...
+}
+```
+
+You can use it directly to render a react component.
+
+A warning will be raised if the named react component is not registered.
 
 ## Functions and using `@@function`
 
@@ -148,7 +194,7 @@ will replace the constants' value with the value provided in configuration decla
 
 ```js
 {
-  controller: MapController, // MapController class from '@deck.gl/core' 
+  controller: MapController, // MapController class from '@deck.gl/core'
   layers: [
     new ScatterplotLayer({
       data: ...,

--- a/docs/api-reference/json/conversion-reference.md
+++ b/docs/api-reference/json/conversion-reference.md
@@ -67,7 +67,7 @@ import React from 'react';
 import TestComponent from '@/components/test';
 
 const configuration = {
-  classes: Object.assign({}, { React },
+  React,
   reactComponents: {
     TestComponent
   }

--- a/docs/api-reference/json/json-configuration.md
+++ b/docs/api-reference/json/json-configuration.md
@@ -9,6 +9,6 @@ Object with the following fields.
 * `constants` - A map of constants that should be made available to the JSON string resolver.
 
 > * `reactComponents` - a map of general react components that should be made available to the JSON class resolver.
-> React support is experimental. The React dependency has to be injected via the configuration classes
+> * `React` - React support is experimental. The React dependency has to be injected via the configuration
 
 See more details in the `Configuration Reference` section.

--- a/docs/api-reference/json/json-configuration.md
+++ b/docs/api-reference/json/json-configuration.md
@@ -9,6 +9,6 @@ Object with the following fields.
 * `constants` - A map of constants that should be made available to the JSON string resolver.
 
 > * `reactComponents` - a map of general react components that should be made available to the JSON class resolver.
-> React support is experimental. The React dependency has to be injected via the configuration
+> React support is experimental. The React dependency has to be injected via the configuration classes
 
 See more details in the `Configuration Reference` section.

--- a/modules/json/src/helpers/instantiate-class.js
+++ b/modules/json/src/helpers/instantiate-class.js
@@ -32,7 +32,7 @@ function instantiateJavaScriptClass(Class, props, configuration) {
 }
 
 function instantiateReactComponent(Component, props, configuration) {
-  const {React} = configuration.classes;
+  const {React} = configuration;
   const {children = []} = props;
   delete props.children;
   if (configuration.preProcessClassProps) {

--- a/modules/json/src/helpers/instantiate-class.js
+++ b/modules/json/src/helpers/instantiate-class.js
@@ -32,7 +32,7 @@ function instantiateJavaScriptClass(Class, props, configuration) {
 }
 
 function instantiateReactComponent(Component, props, configuration) {
-  const {React} = configuration;
+  const {React} = configuration.classes;
   const {children = []} = props;
   delete props.children;
   if (configuration.preProcessClassProps) {

--- a/modules/json/src/json-configuration.js
+++ b/modules/json/src/json-configuration.js
@@ -17,6 +17,7 @@ export default class JSONConfiguration {
     this.enumerations = {};
     this.constants = {};
     this.functions = {};
+    this.React = null;
     // TODO - this needs to be simpler, function conversion should be built in
     this.convertFunction = parseExpressionString;
     this.preProcessClassProps = (Class, props) => props;


### PR DESCRIPTION
Read `React` from configuration as the `JsonConfiguration` merge function only allows to [add known attributes to the class](https://github.com/visgl/deck.gl/blob/master/modules/json/src/json-configuration.js#L40). 

Right now, React is always undefined when you try to render `reactComponents` and you will get this error `Cannot read properties of undefined (reading 'createElement')`

```
function instantiateReactComponent(Component, props, configuration) {
  const {React} = configuration;
  const {children = []} = props;
  delete props.children;
  if (configuration.preProcessClassProps) {
    props = configuration.preProcessClassProps(Component, props, configuration);
  }

  props = convertFunctions(props, configuration);

  return React.createElement(Component, props, children);
}
```