### PR TITLE
Fix TileLayer passing async props to sub layers

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -342,7 +342,9 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       } else if (!tile.layers) {
         const layers = this.renderSubLayers({
           ...this.props,
-          id: `${this.id}-${tile.id}`,
+          ...this.getSubLayerProps({
+            id: tile.id
+          }),
           data: tile.content,
           _offset: 0,
           tile


### PR DESCRIPTION
For #7968

After #7513, we merge the props definition of extension classes into the props prototype, and use the async prop handling from `ComponentState`. `TileLayer` uses `{...props}` to pass props to `renderSubLayers`, which does not enumerate async props. In this case, the sublayers never receive the resolved values of `fillPatternAtlas` and `fillPatternMapping`, both added by the `FillStyleExtension`.

#### Change List
- Call `getSubLayerProps` in `TileLayer.renderLayers`
