### PR TITLE
Avoid rewriting error.message

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -259,7 +259,7 @@ const defaultProps = {
   onBeforeRender: noop,
   onAfterRender: noop,
   onLoad: noop,
-  onError: (error: Error) => log.error(error.message)(),
+  onError: (error: Error) => log.error(error.message, error.cause)(),
   onHover: null,
   onClick: null,
   onDragStart: null,

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -547,7 +547,7 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   /** (Internal) Propagate an error event through the system */
   raiseError(error: Error, message: string): void {
     if (message) {
-      error.message = `${message}: ${error.message}`;
+      error = new Error(`${message}: ${error.message}`, {cause: error});
     }
     if (!this.props.onError?.(error)) {
       this.context?.onError?.(error, this);

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -547,6 +547,8 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   /** (Internal) Propagate an error event through the system */
   raiseError(error: Error, message: string): void {
     if (message) {
+      // Duplicating error message for backward compatibility, see #7986
+      // TODO - revisit in v9
       error = new Error(`${message}: ${error.message}`, {cause: error});
     }
     if (!this.props.onError?.(error)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "jsx": "react",
     "strict": true,
     "noImplicitAny": false,

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "build": true,
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -10,6 +10,7 @@
     "declarationMap": true,
     "noEmit": false,
     "emitDeclarationOnly": true,
+    "useDefineForClassFields": false,
     // Uncomment to debug
     // "listEmittedFiles": true
   }


### PR DESCRIPTION
For #7945

#### Change List
- `layer.raiseError` wraps the incoming error instead of trying to amend it. `Error.cause` is universally supported as of 2022, see [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#browser_compatibility)
- Log `error.cause` in Deck's default `onError` callback
