### PR TITLE
Fix ScenegraphLayer shader injection from extensions

### DIFF
--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -198,7 +198,7 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
       modules.push(pbr);
     }
 
-    return {vs, fs, modules};
+    return super.getShaders({vs, fs, modules});
   }
 
   initializeState() {


### PR DESCRIPTION
For #7952

#### Change List
- `ScenegraphLayer.getShaders` should call `Layer.getShaders` to handle injection properly
