### PR TITLE
Fix AggregateAccessor type

### DIFF
--- a/modules/aggregation-layers/src/types.ts
+++ b/modules/aggregation-layers/src/types.ts
@@ -1,4 +1,4 @@
-export type AggregateAccessor<DataT = any> = {
+export type AggregateAccessor<DataT = any> = (args: {
   /** a list of objects whose positions fall inside this cell. */
   objects: DataT[];
   objectInfo: {
@@ -7,4 +7,4 @@ export type AggregateAccessor<DataT = any> = {
     /** the value of the `data` prop */
     data: any;
   };
-};
+}) => number;


### PR DESCRIPTION
For #7967

`AggregateAccessor` is the type assigned to `getColorValue`/`getElevationValue` props in aggregation layers (`CPUGridLayer`, `HexagonLayer`).

#### Change List
- Correct `AggregateAccessor` type
