### PR TITLE
MVTLayerProps: allow `higlightedFeatureId` to be number

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -75,7 +75,7 @@ export type _MVTLayerProps = {
   uniqueIdProperty?: string;
 
   /** A feature with ID corresponding to the supplied value will be highlighted. */
-  highlightedFeatureId?: string | null;
+  highlightedFeatureId?: string | number | null;
 
   /**
    * Use tile data in binary format.


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #8005

<!-- For all the PRs -->
#### Change List
- update type `MVTLayer`: optional `highlightedFeatureId` prop allows `number`, as well as `string` and `null`
