### PR TITLE
Fix Scatterplot layer rendering on Xclipse 920 graphics

### DIFF
--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-fragment.glsl.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-fragment.glsl.ts
@@ -58,10 +58,10 @@ void main(void) {
       }
       gl_FragColor = vec4(vLineColor.rgb, vLineColor.a * isLine);
     }
-  } else if (filled) {
-    gl_FragColor = vFillColor;
-  } else {
+  } else if (!filled) {
     discard;
+  } else {
+    gl_FragColor = vFillColor;
   }
 
   gl_FragColor.a *= inCircle;


### PR DESCRIPTION
This is a variant of #8046 targeted 8.9-release.

Fix for:
- #7613
- #6783

#### Background
Scatterplot layer does not load on the Exynos based Samsung S22/S22+/S22 Ultra devices which include new Xclipse 920 graphics IP. The change in fragment shader helps to avoid the issue on these devices.

Tested on Exynos based Samsung Galaxy S22.

#### Change List
- Rendering workaround for Xclipse 920 in Scatterplot layer fragment shader