### PR TITLE
CARTO: Don't hardcode mime-types

### DIFF
--- a/modules/carto/src/layers/carto-tile-layer.ts
+++ b/modules/carto/src/layers/carto-tile-layer.ts
@@ -58,18 +58,8 @@ export default class CartoTileLayer<ExtraProps extends {} = {}> extends MVTLayer
     }
 
     let loadOptions = this.getLoadOptions();
-    const {fetch, formatTiles} = this.props;
+    const {fetch} = this.props;
     const {signal} = tile;
-
-    // The backend doesn't yet support our custom mime-type, so force it here
-    // TODO remove once backend sends the correct mime-type
-    if (formatTiles === TILE_FORMATS.BINARY) {
-      loadOptions = {
-        ...loadOptions,
-        mimeType: 'application/vnd.carto-vector-tile'
-      };
-    }
-
     return fetch(url, {propName: 'data', layer: this, loadOptions, signal});
   }
 

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -98,8 +98,7 @@ export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> exten
         maxZoom: maxresolution,
         loadOptions: {
           ...this.getLoadOptions(),
-          cartoSpatialTile: {scheme: 'h3'},
-          mimeType: 'application/vnd.carto-spatial-tile'
+          cartoSpatialTile: {scheme: 'h3'}
         }
       })
     ];

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -71,8 +71,7 @@ export default class QuadbinTileLayer<
         maxZoom,
         loadOptions: {
           ...this.getLoadOptions(),
-          cartoSpatialTile: {scheme: 'quadbin'},
-          mimeType: 'application/vnd.carto-spatial-tile'
+          cartoSpatialTile: {scheme: 'quadbin'}
         }
       })
     ];

--- a/test/modules/carto/mock-fetch.ts
+++ b/test/modules/carto/mock-fetch.ts
@@ -78,6 +78,9 @@ function mockFetchMapsV2() {
 export function mockFetchMapsV3() {
   const fetch = globalThis.fetch;
   globalThis.fetch = (url, {headers}) => {
+    if (url.indexOf('formatTiles=binary') !== -1) {
+      headers = {...headers, 'Content-Type': 'application/vnd.carto-vector-tile'};
+    }
     return Promise.resolve({
       json: () => {
         if (url.indexOf('format=tilejson') !== -1) {


### PR DESCRIPTION
Followup to https://github.com/visgl/deck.gl/pull/8056

<!-- For other PRs without open issue -->
#### Background

The old versions of the CARTO API did not set explicit mime-types for responses. Both the vector and spatial index binary format simply returned `Content-Type: application/x-protobuf` which meant loaders.gl has no way to select a loader automatically. As of v=3.2 the API returns explicit mimeTypes so loaders.gl can automatically select the correct loader without having to be informed explictly via `loadOptions`

<!-- For all the PRs -->
#### Change List
- Remove hardcoded mime-types in Layer classes
- Update test mock API to return mime-type for binary vector tile responses
