### PR TITLE
CARTO: Update website SQL example to use v3 API

### DIFF
--- a/examples/website/plot/plot-layer/axes-layer.js
+++ b/examples/website/plot/plot-layer/axes-layer.js
@@ -227,7 +227,7 @@ export default class AxesLayer extends Layer {
       vs: gridVertex,
       fs: fragmentShader,
       geometry: new Geometry({
-        topology: 'line-list',,
+        topology: 'line-list',
         attributes: {
           positions: new Float32Array(gridPositions),
           normals: new Float32Array(gridNormals)

--- a/website/src/examples/carto.js
+++ b/website/src/examples/carto.js
@@ -18,17 +18,9 @@ const INDUSTRIES = {
   'Eating Places': 'eap',
   'Grocery and Food Stores': 'gro'
 };
-const WEEKS = {
-  'Week 1': ['2020-01-01', '2020-01-05'],
-  'Week 2': ['2020-01-06', '2020-01-12'],
-  'Week 3': ['2020-01-06', '2020-01-12'],
-  'Week 4': ['2020-01-13', '2020-01-19'],
-  'Week 5': ['2020-01-20', '2020-01-26'],
-  'Week 6': ['2020-01-27', '2020-01-31']
-};
 
 class CartoSQLDemo extends Component {
-  static title = 'Mastercard Index In NewYork';
+  static title = 'Mastercard Index In New York';
 
   static code = `${GITHUB_TREE}/examples/website/carto-sql`;
 
@@ -44,8 +36,7 @@ class CartoSQLDemo extends Component {
       type: 'select',
       options: Object.keys(INDUSTRIES),
       value: 'Total Retail'
-    },
-    week: {displayName: 'Week', type: 'select', options: Object.keys(WEEKS), value: 'Week 1'}
+    }
   };
 
   static mapStyle = MAPBOX_STYLES.DARK;
@@ -88,9 +79,8 @@ class CartoSQLDemo extends Component {
     const {params} = this.props;
     const index = INDEXES[params.index.value];
     const industry = INDUSTRIES[params.industry.value];
-    const week = WEEKS[params.week.value];
 
-    return <App {...this.props} mrliIndex={index} industry={industry} week={week} />;
+    return <App {...this.props} mrliIndex={index} industry={industry} />;
   }
 }
 

--- a/website/src/examples/carto.js
+++ b/website/src/examples/carto.js
@@ -44,7 +44,7 @@ class CartoSQLDemo extends Component {
   static renderInfo() {
     return (
       <div>
-        <p>Mastercard Index January 2020 using a z18 QuadGrid.</p>
+        <p>Mastercard Index January 2020.</p>
         <p>
           A locations’s index shows how it ranks against all the other locations in the area. The
           number represents the percentile, for example, a 900 spend index means a location has


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

The CARTO [example](https://deck.gl/examples/carto) is using the old (v2) API, this PR updates it to the new API.

<!-- For all the PRs -->
#### Change List
- Update to v3 source
- Use colorBins & tidy
- Remove Weeks UI
