### PR TITLE
[mapbox] Fix interleaving when base map has terrain

### DIFF
--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -78,6 +78,10 @@ export type WebMercatorViewportOptions = {
   nearZMultiplier?: number;
   /** Scaler for the far plane, 1 unit equals to the distance from the camera to the edge of the screen. Default `1.01` */
   farZMultiplier?: number;
+  /** Optionally override the near plane position. `nearZMultiplier` is ignored if `nearZ` is supplied. */
+  nearZ?: number;
+  /** Optionally override the far plane position. `farZMultiplier` is ignored if `farZ` is supplied. */
+  farZ?: number;
   /** Render multiple copies of the world */
   repeat?: boolean;
   /** Internal use */
@@ -115,6 +119,8 @@ export default class WebMercatorViewport extends Viewport {
       bearing = 0,
       nearZMultiplier = 0.1,
       farZMultiplier = 1.01,
+      nearZ,
+      farZ,
       orthographic = false,
       projectionMatrix,
 
@@ -165,6 +171,13 @@ export default class WebMercatorViewport extends Viewport {
         nearZMultiplier,
         farZMultiplier
       });
+
+      if (Number.isFinite(nearZ)) {
+        projectionParameters.near = nearZ;
+      }
+      if (Number.isFinite(farZ)) {
+        projectionParameters.far = farZ;
+      }
     }
 
     // The uncentered matrix allows us two move the center addition to the

--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -275,7 +275,11 @@ function getViewport(deck: Deck, map: Map, useMapboxProjection = true): WebMerca
       ? // match mapbox-gl@>=1.3.0's projection matrix
         0.02
       : // use deck.gl's own default
-        0.1
+        0.1,
+    // @ts-expect-error Mapbox specific - extract near plane position
+    nearZ: map.transform._nearZ / map.transform.height,
+    // @ts-expect-error Mapbox specific - extract far plane position
+    farZ: map.transform._farZ / map.transform.height
   });
 }
 


### PR DESCRIPTION
For #8060

#### Background

The current projection matrix parameters in WebMercatorViewport are designed to match an early release of Mapbox. Between mapbox-gl, maplibre-gl, and their different major versions, the calculation has diverged significantly. This hack extracts near and far plane positions from a private property on the mapbox-gl map.

For the long term, I will open feature requests for the base maps to expose their projection matrix.

#### Change List
- WebMercatorViewport accepts external nearZ/farZ positions
- MapboxLayer uses base map nearZ/farZ if available
