### PR TITLE
CARTO: Use null as default value for KeyValueObject

### DIFF
--- a/modules/carto/src/layers/schema/carto-tile.ts
+++ b/modules/carto/src/layers/schema/carto-tile.ts
@@ -8,7 +8,7 @@ interface KeyValueObject {
 
 class KeyValueObjectReader {
   static read(pbf, end?: number): KeyValueObject {
-    return pbf.readFields(KeyValueObjectReader._readField, {key: '', value: ''}, end);
+    return pbf.readFields(KeyValueObjectReader._readField, {key: '', value: null}, end);
   }
   static _readField(this: void, tag: number, obj: KeyValueObject, pbf) {
     if (tag === 1) obj.key = pbf.readString();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

The current API doesn't support passing NULL values in properties. It is possible to make the change in backend such that in the case of a NULL value the `value` property in the `KeyValueObject` is omitted, thus indicating a NULL. To support this the client must stop providing the empty string as a default value

<!-- For all the PRs -->
#### Change List
- Use `null` as default for `KeyValueObject.value`