### PR TITLE
Add carto module to `version` build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postinstall": "./scripts/postinstall.sh",
     "clean": "ocular-clean && rm -rf modules/*/typed",
     "build": "npm run clean && ocular-build && lerna run build && node scripts/typed-entry.js",
-    "version": "ocular-build core && ocular-build carto",
+    "version": "ocular-build core,carto",
     "lint": "ocular-lint",
     "cover": "ocular-test cover",
     "publish": "ocular-publish",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postinstall": "./scripts/postinstall.sh",
     "clean": "ocular-clean && rm -rf modules/*/typed",
     "build": "npm run clean && ocular-build && lerna run build && node scripts/typed-entry.js",
-    "version": "ocular-build core",
+    "version": "ocular-build core && ocular-build carto",
     "lint": "ocular-lint",
     "cover": "ocular-test cover",
     "publish": "ocular-publish",


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

The carto module uses the `__VERSION__` injected by the build process to construct the URL needed for worker loaders. This parameter is injected during the build, however the publish process only bumps the npm version after the build completes. The `core` module also uses `__VERSION__` and is rebuilt using the `version` script after the bump to pick up the correct version

<!-- For all the PRs -->
#### Change List
- Rebuild the carto module in the `version` script