### PR TITLE
Support css variables in `style` prop

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -736,7 +736,10 @@ export default class Deck {
       parent.appendChild(canvas);
     }
 
-    Object.assign(canvas.style, props.style);
+    // Set css variables and properties
+    Object.entries(props.style).map(([key, value]) =>
+      (canvas as HTMLCanvasElement).style.setProperty(key, value as string)
+    );
 
     return canvas;
   }

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -466,6 +466,7 @@ export default class Deck {
     // Merge with existing props
     Object.assign(this.props, props);
 
+    this._setStyle(this.props);
     // Update CSS size of canvas
     this._setCanvasSize(this.props);
 
@@ -742,6 +743,21 @@ export default class Deck {
     );
 
     return canvas;
+  }
+
+  /** Updates canvas style, if provided as props */
+  private _setStyle(props: Required<DeckProps>): void {
+    if (!this.canvas) {
+      return;
+    }
+    const newStyle = props.style;
+    const oldStyle = this.props.style;
+    if (!deepEqual(oldStyle, newStyle, 1)) {
+      Object.entries(oldStyle).map(([key]) => this.canvas.style.removeProperty(key));
+      Object.entries(newStyle).map(([key, value]) =>
+        this.canvas.style.setProperty(key, value as string)
+      );
+    }
   }
 
   /** Updates canvas width and/or height, if provided as props */

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -297,5 +297,17 @@ test('Deck#style', t => {
     t.is(deck.getCanvas().style.getPropertyValue(key), value, 'style is applied');
   });
 
+  deck.setProps({
+    style: {
+      '--css-var': 'updated'
+    }
+  });
+  t.is(deck.getCanvas().style.getPropertyValue('--css-var'), 'updated', 'style is updated');
+  t.is(
+    deck.getCanvas().style.getPropertyValue('backgroundColor'),
+    'pink',
+    'old style is still set'
+  );
+
   t.end();
 });

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -264,3 +264,38 @@ test('Deck#resourceManager', async t => {
   deck.finalize();
   t.end();
 });
+
+test('Deck#style', t => {
+  const style = {
+    backgroundColor: 'pink',
+    '--css-var': 'test'
+  };
+
+  const deck = new Deck({
+    device,
+    width: 1,
+    height: 1,
+    // This is required because the jsdom canvas does not have client width/height
+    autoResizeDrawingBuffer: device.canvasContext.canvas.clientWidth > 0,
+
+    viewState: {
+      longitude: 0,
+      latitude: 0,
+      zoom: 0
+    },
+
+    layers: [],
+
+    style
+  });
+
+  console.log(style);
+  console.log(deck.getCanvas());
+  console.log(deck.getCanvas().style);
+
+  Object.entries(style).map(([key, value]) => {
+    t.is(deck.getCanvas().style.getPropertyValue(key), value, 'style is applied');
+  });
+
+  t.end();
+});


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #7946 
<!-- For other PRs without open issue -->
#### Background
We aim to offer a convenient method for theming UI widgets using CSS variables through the deck `style` property. However, our current styling approach supports only CSS properties and not variables.
<!-- For all the PRs -->
#### Change List
- Use `setProperty` instead of `assign` for setting css style values.
