### PR TITLE
[pydeck] Create .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"


### PR DESCRIPTION
In October we'll need to have this .readthedocs.yml configuration in order to generate our RTD docs, which should be the sole source of our docs (pydeck.gl should lead to this page as well)

More about the file: https://docs.readthedocs.io/en/stable/config-file/v2.html

Our RTD docs: https://deckgl.readthedocs.io/en/latest/