### PR TITLE
Fix issue where deck.gl blocks wheel scroll over non-interactive area

### DIFF
--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -532,12 +532,12 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     if (!this.scrollZoom) {
       return false;
     }
-    event.srcEvent.preventDefault();
 
     const pos = this.getCenter(event);
     if (!this.isPointInBounds(pos, event)) {
       return false;
     }
+    event.srcEvent.preventDefault();
 
     const {speed = 0.01, smooth = false} = this.scrollZoom === true ? {} : this.scrollZoom;
     const {delta} = event;


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/discussions/8101

#### Change List
- Only block wheel scroll if event is inside of an interactive view
