### PR TITLE
[chore] Fix widget module publishing

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -16,7 +16,7 @@ module.exports = getBabelConfig({
     ],
     overrides: [
       {
-        include: './modules/widgets/**/*.{ts,tsx}',
+        include: './modules/widgets/**/*.tsx',
         // Parse preact-style JSX in @deck.gl/widgets.
         presets: [['@babel/typescript', {jsxPragma: 'h'}]],
         plugins: [['@babel/plugin-transform-react-jsx', {pragma: 'h'}]]

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "gl": "6.0.2",
     "glsl-transpiler": "^1.8.6",
     "jsdom": "^20.0.0",
-    "ocular-dev-tools": "2.0.0-alpha.13",
+    "ocular-dev-tools": "2.0.0-alpha.18",
     "pre-commit": "^1.2.2",
     "pre-push": "^0.1.1",
     "react": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9634,10 +9634,10 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-ocular-dev-tools@2.0.0-alpha.13:
-  version "2.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-2.0.0-alpha.13.tgz#4fc64baf9111e97fc7712ed081523253674d413e"
-  integrity sha512-1uw/WjBU7o+2sX7sL8warF5Mzy3TG2VkIdn+q6vE4ixUNAS15QzWqanABWkTbyUi9TtdOYmQMTbGgyZl0YiNVw==
+ocular-dev-tools@2.0.0-alpha.18:
+  version "2.0.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-2.0.0-alpha.18.tgz#6483afe6a54cb0293eba5487db798daed942e810"
+  integrity sha512-szLVQ/ViYU7RF0TvJ1NNCI3IxAvKavxZw/iltULUJsPLcJPxhcIEbx0e/SQTc97JbgGkxWcWmdWmpzthxuPSHg==
   dependencies:
     "@babel/cli" "^7.14.5"
     "@babel/core" "^7.14.5"


### PR DESCRIPTION
For #7946 #8182

#### Change List
- Fix babel config syntax
- Bump ocular-dev-tools to include https://github.com/uber-web/ocular/pull/435 for publishing the widgets module
