### PR TITLE
Fix pickObjects when using binary data

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -16,6 +16,10 @@ new Model(this.context.gl, {opts});
 
 - drawModes `GL.TRIANGLE_FAN` and `GL.LINE_LOOP` are not supported on WebGPU. Select different topology when creating geometries.
 
+### Deck
+
+- `Deck.pickObjects` minor breaking change: if the same `data` is used by multiple top-level layers (e.g. a `ScatterplotLayer` and a `TextLayer`) that are visible in the picking bounds, `pickObjects` will yield one result for each picked object+layer combination, instead of one result for each picked object in previous versions.
+
 ## Upgrading from deck.gl v8.8 to v8.9
 
 #### Breaking changes

--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -399,13 +399,17 @@ export default class DeckPicker {
 
     const pickInfos = getUniqueObjects(pickedResult);
 
-    // Only return unique infos, identified by info.object
-    const uniqueInfos = new Map();
+    // `getUniqueObjects` dedup by picked color
+    // However different picked color may be linked to the same picked object, e.g. stroke and fill of the same polygon
+    // picked from different sub layers of a GeoJsonLayer
+    // Here after resolving the picked index with `layer.getPickingInfo`, we need to dedup again by unique picked objects
+    const uniquePickedObjects = new Map<string, Set<unknown>>();
+    const uniqueInfos: PickingInfo[] = [];
 
-    const isMaxObjects = Number.isFinite(maxObjects);
+    const limitMaxObjects = Number.isFinite(maxObjects);
 
     for (let i = 0; i < pickInfos.length; i++) {
-      if (isMaxObjects && maxObjects && uniqueInfos.size >= maxObjects) {
+      if (limitMaxObjects && uniqueInfos.length >= maxObjects!) {
         break;
       }
       const pickInfo = pickInfos[i];
@@ -420,12 +424,22 @@ export default class DeckPicker {
       };
 
       info = getLayerPickingInfo({layer: pickInfo.pickedLayer as Layer, info, mode});
-      if (!uniqueInfos.has(info.object)) {
-        uniqueInfos.set(info.object, info);
+      // info.layer is always populated because it's a picked pixel
+      const pickedLayerId = info.layer!.id;
+      if (!uniquePickedObjects.has(pickedLayerId)) {
+        uniquePickedObjects.set(pickedLayerId, new Set<unknown>());
+      }
+      const uniqueObjectsInLayer = uniquePickedObjects.get(pickedLayerId) as Set<unknown>;
+      // info.object may be null if the layer is using non-iterable data.
+      // Fall back to using index as identifier.
+      const pickedObjectKey = info.object ?? info.index;
+      if (!uniqueObjectsInLayer.has(pickedObjectKey)) {
+        uniqueObjectsInLayer.add(pickedObjectKey);
+        uniqueInfos.push(info);
       }
     }
 
-    return Array.from(uniqueInfos.values());
+    return uniqueInfos;
   }
 
   /** Renders layers into the picking buffer with picking colors and read the pixels. */

--- a/test/modules/core/lib/pick-layers.spec.ts
+++ b/test/modules/core/lib/pick-layers.spec.ts
@@ -208,6 +208,95 @@ const TEST_CASES = [
     }
   },
   {
+    id: 'scatterplotLayer-binary',
+    props: {
+      layers: [
+        new ScatterplotLayer({
+          data: {
+            length: DATA.points.length,
+            attributes: {
+              getPosition: {
+                value: new Float64Array(DATA.points.flatMap(d => d.COORDINATES)),
+                size: 2
+              },
+              getRadius: {value: new Float32Array(DATA.points.map(d => d.SPACES)), size: 1}
+            }
+          },
+          pickable: true,
+          radiusScale: 30,
+          radiusMinPixels: 1,
+          radiusMaxPixels: 30
+        })
+      ]
+    },
+    pickingMethods: {
+      pickObject: [
+        {
+          parameters: {
+            x: 60,
+            y: 160
+          },
+          results: {
+            count: 1
+          }
+        },
+        {
+          parameters: {
+            x: 90,
+            y: 350
+          },
+          results: {
+            count: 0
+          }
+        }
+      ],
+      pickObjects: [
+        {
+          parameters: {
+            x: 300,
+            y: 300,
+            width: 100,
+            height: 100
+          },
+          results: {
+            count: 34
+          }
+        },
+        {
+          parameters: {
+            x: 50,
+            y: 50,
+            width: 10,
+            height: 10
+          },
+          results: {
+            count: 0
+          }
+        }
+      ],
+      pickMultipleObjects: [
+        {
+          parameters: {
+            x: 250,
+            y: 273
+          },
+          results: {
+            count: 2
+          }
+        },
+        {
+          parameters: {
+            x: 300,
+            y: 300
+          },
+          results: {
+            count: 0
+          }
+        }
+      ]
+    }
+  },
+  {
     id: 'scatterplotLayer-masked',
     props: {
       layers: [
@@ -688,7 +777,7 @@ test(`pickingTest`, t => {
 
         if (pickInfos.length > 1) {
           t.equal(
-            new Set(pickInfos.map(x => x.object)).size,
+            new Set(pickInfos.map(x => x.object ?? x.index)).size,
             pickInfos.length,
             'Returned distinct picked objects'
           );


### PR DESCRIPTION
For #8197

`pickObjects` currently uses `pickInfo.object` to dedup results. When using binary data, `pickInfo.object` is always `null`. This PR falls back to use `pickInfo.index` in this case.

There is a slight breaking change here: if the same `data` is used by multiple top-level layers (e.g. a ScatterplotLayer and a TextLayer), they now yield multiple picked results instead of one. I think this is the correct behavior, as the user would want to know which exact layer is picked. Open for discussion, though.

#### Change List
- Return correct results when calling `pickObjects` with binary data
- Unit test
