### PR TITLE
chore: Add volta section to package.json on 8.10-release branch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "devDependencies": {
     "@arcgis/core": "^4.21.0",
-    "@loaders.gl/csv": "^3.4.13",
-    "@loaders.gl/polyfills": "^3.4.13",
+    "@loaders.gl/csv": "4.0.0-beta.6",
+    "@loaders.gl/polyfills": "4.0.0-beta.6",
     "@luma.gl/test-utils": "^8.5.20",
     "@math.gl/proj4": "^3.6.3",
     "@probe.gl/bench": "^3.5.4",
@@ -80,5 +80,9 @@
   "engines": {
     "node": ">=14"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "volta": {
+    "node": "18.18.2",
+    "yarn": "1.22.19"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "devDependencies": {
     "@arcgis/core": "^4.21.0",
-    "@loaders.gl/csv": "4.0.0-beta.6",
-    "@loaders.gl/polyfills": "4.0.0-beta.6",
+    "@loaders.gl/csv": "^3.4.13",
+    "@loaders.gl/polyfills": "^3.4.13",
     "@luma.gl/test-utils": "^8.5.20",
     "@math.gl/proj4": "^3.6.3",
     "@probe.gl/bench": "^3.5.4",


### PR DESCRIPTION
#### Background
- if the developer has installed volta locally, it will ensure that the versions of yarn and node that are specified in the package.json volta section are used. Otherwise this section is ignored.
- this can save time when returning to a repo after some hiatus, as it is very clear what node and yarn versions are expected to work.
- volta sections have been added to most frameworks including deck.gl master.
#### Change List
- Add volta section to package.json
