### PR TITLE
CARTO: Remove aggregationResLevel prop

### DIFF
--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -18,7 +18,6 @@ const renderSubLayers = (props: H3HexagonLayerProps) => {
 };
 
 const defaultProps: DefaultProps<H3HexagonLayerProps> = {
-  aggregationResLevel: 4,
   data: TilejsonPropType
 };
 
@@ -32,7 +31,6 @@ type H3HexagonLayerProps<DataT = unknown> = Record<string, any>;
 /** Properties added by H3TileLayer. */
 type _H3TileLayerProps<DataT> = Omit<H3HexagonLayerProps<DataT>, 'data'> & {
   data: null | TilejsonResult | Promise<TilejsonResult>;
-  aggregationResLevel?: number;
 };
 
 export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -1,11 +1,11 @@
 import {CompositeLayer, CompositeLayerProps, Layer, LayersList, DefaultProps} from '@deck.gl/core';
-import {H3HexagonLayer} from '@deck.gl/geo-layers';
+import {H3HexagonLayer, H3HexagonLayerProps} from '@deck.gl/geo-layers';
 import H3Tileset2D, {getHexagonResolution} from './h3-tileset-2d';
-import SpatialIndexTileLayer from './spatial-index-tile-layer';
+import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import type {TilejsonResult} from '../sources/types';
 import {injectAccessToken, TilejsonPropType} from './utils';
 
-const renderSubLayers = (props: H3HexagonLayerProps) => {
+export const renderSubLayers = props => {
   const {data} = props;
   const {index} = props.tile;
   if (!data || !data.length) return null;
@@ -17,21 +17,18 @@ const renderSubLayers = (props: H3HexagonLayerProps) => {
   });
 };
 
-const defaultProps: DefaultProps<H3HexagonLayerProps> = {
+const defaultProps: DefaultProps<H3TileLayerProps> = {
   data: TilejsonPropType
 };
 
 /** All properties supported by H3TileLayer. */
 export type H3TileLayerProps<DataT = unknown> = _H3TileLayerProps<DataT> & CompositeLayerProps;
 
-// TODO: use type from h3-hexagon-layer when available
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type H3HexagonLayerProps<DataT = unknown> = Record<string, any>;
-
 /** Properties added by H3TileLayer. */
-type _H3TileLayerProps<DataT> = Omit<H3HexagonLayerProps<DataT>, 'data'> & {
-  data: null | TilejsonResult | Promise<TilejsonResult>;
-};
+type _H3TileLayerProps<DataT> = Omit<H3HexagonLayerProps<DataT>, 'data'> &
+  Omit<SpatialIndexTileLayerProps<DataT>, 'data'> & {
+    data: null | TilejsonResult | Promise<TilejsonResult>;
+  };
 
 export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends CompositeLayer<
   ExtraPropsT & Required<_H3TileLayerProps<DataT>>

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -16,7 +16,6 @@ export const renderSubLayers = props => {
 };
 
 const defaultProps: DefaultProps<QuadbinTileLayerProps> = {
-  aggregationResLevel: 6,
   data: TilejsonPropType
 };
 
@@ -27,7 +26,6 @@ export type QuadbinTileLayerProps<DataT = unknown> = _QuadbinTileLayerProps<Data
 /** Properties added by QuadbinTileLayer. */
 type _QuadbinTileLayerProps<DataT> = Omit<QuadbinLayerProps<DataT>, 'data'> & {
   data: null | TilejsonResult | Promise<TilejsonResult>;
-  aggregationResLevel?: number;
 };
 
 export default class QuadbinTileLayer<

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -1,7 +1,7 @@
 import {CompositeLayer, CompositeLayerProps, Layer, LayersList, DefaultProps} from '@deck.gl/core';
 import QuadbinLayer, {QuadbinLayerProps} from './quadbin-layer';
 import QuadbinTileset2D from './quadbin-tileset-2d';
-import SpatialIndexTileLayer from './spatial-index-tile-layer';
+import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import {hexToBigInt} from 'quadbin';
 import type {TilejsonResult} from '../sources/types';
 import {injectAccessToken, TilejsonPropType} from './utils';
@@ -24,9 +24,10 @@ export type QuadbinTileLayerProps<DataT = unknown> = _QuadbinTileLayerProps<Data
   CompositeLayerProps;
 
 /** Properties added by QuadbinTileLayer. */
-type _QuadbinTileLayerProps<DataT> = Omit<QuadbinLayerProps<DataT>, 'data'> & {
-  data: null | TilejsonResult | Promise<TilejsonResult>;
-};
+type _QuadbinTileLayerProps<DataT> = Omit<QuadbinLayerProps<DataT>, 'data'> &
+  Omit<SpatialIndexTileLayerProps<DataT>, 'data'> & {
+    data: null | TilejsonResult | Promise<TilejsonResult>;
+  };
 
 export default class QuadbinTileLayer<
   DataT = any,

--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -1,7 +1,7 @@
 import {CompositeLayer, CompositeLayerProps, DefaultProps, Layer, LayersList} from '@deck.gl/core';
 import RasterLayer, {RasterLayerProps} from './raster-layer';
 import QuadbinTileset2D from './quadbin-tileset-2d';
-import SpatialIndexTileLayer from './spatial-index-tile-layer';
+import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import type {TilejsonResult} from '../sources/types';
 import {injectAccessToken, TilejsonPropType} from './utils';
 
@@ -20,9 +20,10 @@ export type RasterTileLayerProps<DataT = unknown> = _RasterTileLayerProps<DataT>
   CompositeLayerProps;
 
 /** Properties added by RasterTileLayer. */
-type _RasterTileLayerProps<DataT> = Omit<RasterLayerProps<DataT>, 'data'> & {
-  data: null | TilejsonResult | Promise<TilejsonResult>;
-};
+type _RasterTileLayerProps<DataT> = Omit<RasterLayerProps<DataT>, 'data'> &
+  Omit<SpatialIndexTileLayerProps<DataT>, 'data'> & {
+    data: null | TilejsonResult | Promise<TilejsonResult>;
+  };
 
 export default class RasterTileLayer<
   DataT = any,

--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -11,18 +11,14 @@ function isFeatureIdDefined(value: unknown): boolean {
   return value !== undefined && value !== null && value !== '';
 }
 
-const defaultProps: DefaultProps<SpatialIndexTileLayerProps> = {
-  aggregationResLevel: 4
-};
+const defaultProps: DefaultProps<SpatialIndexTileLayerProps> = {};
 
 /** All properties supported by SpatialIndexTileLayer. */
 export type SpatialIndexTileLayerProps<DataT = unknown> = _SpatialIndexTileLayerProps &
   TileLayer<DataT>;
 
 /** Properties added by SpatialIndexTileLayer. */
-type _SpatialIndexTileLayerProps = {
-  aggregationResLevel?: number;
-};
+type _SpatialIndexTileLayerProps = {};
 
 export default class SpatialIndexTileLayer<
   DataT = any,
@@ -35,16 +31,6 @@ export default class SpatialIndexTileLayer<
     hoveredFeatureId: number | null;
     highlightColor: number[];
   };
-
-  updateState(params: UpdateParameters<this>) {
-    const {props, oldProps} = params;
-    if (props.aggregationResLevel !== oldProps.aggregationResLevel) {
-      // Tileset cache is invalid when resLevel changes
-      this.setState({tileset: null});
-    }
-
-    super.updateState(params);
-  }
 
   protected _updateAutoHighlight(info: PickingInfo): void {
     const {hoveredFeatureId} = this.state;

--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -1,11 +1,11 @@
 import {registerLoaders} from '@loaders.gl/core';
-import {DefaultProps, UpdateParameters} from '@deck.gl/core';
+import {DefaultProps} from '@deck.gl/core';
 import CartoRasterTileLoader from './schema/carto-raster-tile-loader';
 import CartoSpatialTileLoader from './schema/carto-spatial-tile-loader';
 registerLoaders([CartoRasterTileLoader, CartoSpatialTileLoader]);
 
 import {PickingInfo} from '@deck.gl/core';
-import {TileLayer, _Tile2DHeader as Tile2DHeader} from '@deck.gl/geo-layers';
+import {TileLayer, _Tile2DHeader as Tile2DHeader, TileLayerProps} from '@deck.gl/geo-layers';
 
 function isFeatureIdDefined(value: unknown): boolean {
   return value !== undefined && value !== null && value !== '';
@@ -15,7 +15,7 @@ const defaultProps: DefaultProps<SpatialIndexTileLayerProps> = {};
 
 /** All properties supported by SpatialIndexTileLayer. */
 export type SpatialIndexTileLayerProps<DataT = unknown> = _SpatialIndexTileLayerProps &
-  TileLayer<DataT>;
+  TileLayerProps<DataT>;
 
 /** Properties added by SpatialIndexTileLayer. */
 type _SpatialIndexTileLayerProps = {};


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/8148

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Remove `aggregationResLevel` prop
- Tidy types in Spatial Index layers
