### PR TITLE
Fix pickObjects when using binary data

### DIFF
--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -418,8 +418,13 @@ export default class DeckPicker {
       };
 
       info = getLayerPickingInfo({layer: pickInfo.pickedLayer as Layer, info, mode});
-      if (!uniqueInfos.has(info.object)) {
-        uniqueInfos.set(info.object, info);
+
+      // info.object may be null if the layer is using non-iterable data.
+      // Fall back to using <layer_id>[<index>] as identifier.
+      // info.layer is always populated because it's a picked pixel
+      const pickedObjectKey = info.object ?? `${info.layer!.id}[${info.index}]`;
+      if (!uniqueInfos.has(pickedObjectKey)) {
+        uniqueInfos.set(pickedObjectKey, info);
       }
     }
 

--- a/test/modules/core/lib/pick-layers.spec.js
+++ b/test/modules/core/lib/pick-layers.spec.js
@@ -206,6 +206,95 @@ const TEST_CASES = [
     }
   },
   {
+    id: 'scatterplotLayer-binary',
+    props: {
+      layers: [
+        new ScatterplotLayer({
+          data: {
+            length: DATA.points.length,
+            attributes: {
+              getPosition: {
+                value: new Float64Array(DATA.points.flatMap(d => d.COORDINATES)),
+                size: 2
+              },
+              getRadius: {value: new Float32Array(DATA.points.map(d => d.SPACES)), size: 1}
+            }
+          },
+          pickable: true,
+          radiusScale: 30,
+          radiusMinPixels: 1,
+          radiusMaxPixels: 30
+        })
+      ]
+    },
+    pickingMethods: {
+      pickObject: [
+        {
+          parameters: {
+            x: 60,
+            y: 160
+          },
+          results: {
+            count: 1
+          }
+        },
+        {
+          parameters: {
+            x: 90,
+            y: 350
+          },
+          results: {
+            count: 0
+          }
+        }
+      ],
+      pickObjects: [
+        {
+          parameters: {
+            x: 300,
+            y: 300,
+            width: 100,
+            height: 100
+          },
+          results: {
+            count: 34
+          }
+        },
+        {
+          parameters: {
+            x: 50,
+            y: 50,
+            width: 10,
+            height: 10
+          },
+          results: {
+            count: 0
+          }
+        }
+      ],
+      pickMultipleObjects: [
+        {
+          parameters: {
+            x: 250,
+            y: 273
+          },
+          results: {
+            count: 2
+          }
+        },
+        {
+          parameters: {
+            x: 300,
+            y: 300
+          },
+          results: {
+            count: 0
+          }
+        }
+      ]
+    }
+  },
+  {
     id: 'scatterplotLayer-masked',
     props: {
       layers: [
@@ -686,7 +775,7 @@ test(`pickingTest`, t => {
 
         if (pickInfos.length > 1) {
           t.equal(
-            new Set(pickInfos.map(x => x.object)).size,
+            new Set(pickInfos.map(x => x.object ?? x.index)).size,
             pickInfos.length,
             'Returned distinct picked objects'
           );


### PR DESCRIPTION
For #8197

`pickObjects` currently uses `pickInfo.object` to dedup results. When using binary data, `pickInfo.object` is always `null`. This PR falls back to use `pickInfo.index` in this case.

This is the same as #8216 without the breaking change. Targeting v8.x.

#### Change List
- Return correct results when calling `pickObjects` with binary data
- Unit test
