### PR TITLE
Fix scripting interface error when canvas is invisible

### DIFF
--- a/modules/core/src/scripting/deckgl.ts
+++ b/modules/core/src/scripting/deckgl.ts
@@ -114,11 +114,13 @@ export default class DeckGL extends Deck {
     // Update the base map
     if (this._map) {
       const viewport = this.getViewports()[0];
-      this._map.setProps({
-        width: viewport.width,
-        height: viewport.height,
-        viewState: viewport
-      });
+      if (viewport) {
+        this._map.setProps({
+          width: viewport.width,
+          height: viewport.height,
+          viewState: viewport
+        });
+      }
     }
     super._drawLayers(redrawReason, options);
   }


### PR DESCRIPTION
For #8226

Deck may not have any valid viewport if canvas size is 0.

#### Change List
- Sanity check before using viewport
