### PR TITLE
Use getStride() in bufferLayoutEqual() comparison

### DIFF
--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -4,7 +4,7 @@ import {Buffer, BufferLayout, BufferAttributeLayout} from '@luma.gl/core';
 import {BufferWithAccessor} from '@luma.gl/webgl';
 import {GL} from '@luma.gl/constants';
 
-import {glArrayFromType, getBufferAttributeLayout} from './gl-utils';
+import {glArrayFromType, getBufferAttributeLayout, getStride} from './gl-utils';
 import typedArrayManager from '../../utils/typed-array-manager';
 import {toDoublePrecisionArray} from '../../utils/math-utils';
 import log from '../../utils/log';
@@ -33,10 +33,6 @@ export type ShaderAttributeOptions = Partial<BufferAccessor> & {
   vertexOffset?: number;
   elementOffset?: number;
 };
-
-function getStride(accessor: DataColumnSettings<any>): number {
-  return accessor.stride || accessor.size * accessor.bytesPerElement;
-}
 
 function resolveShaderAttribute(
   baseAccessor: DataColumnSettings<any>,

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -62,11 +62,15 @@ export function getBufferAttributeLayout(
   };
 }
 
+export function getStride(accessor: DataColumnSettings<any>): number {
+  return accessor.stride || accessor.size * accessor.bytesPerElement;
+}
+
 export function bufferLayoutEqual(accessor1: BufferAccessor, accessor2: BufferAccessor) {
   return (
     (accessor1.type ?? GL.FLOAT) === (accessor2.type ?? GL.FLOAT) &&
     accessor1.size === accessor2.size &&
-    accessor1.stride === accessor2.stride &&
+    getStride(accessor1) === getStride(accessor2) &&
     (accessor1.offset || 0) === (accessor2.offset || 0)
   );
 }

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -1,7 +1,7 @@
 import {GL} from '@luma.gl/constants';
 import type {BufferAttributeLayout, VertexFormat} from '@luma.gl/core';
 import type {TypedArrayConstructor} from '../../types/types';
-import type {BufferAccessor} from './data-column';
+import type {BufferAccessor, DataColumnSettings} from './data-column';
 
 /* eslint-disable complexity */
 export function glArrayFromType(glType: number): TypedArrayConstructor {

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -62,11 +62,14 @@ export function getBufferAttributeLayout(
   };
 }
 
-export function getStride(accessor: DataColumnSettings<any>): number {
+export function getStride(accessor: DataColumnSettings<unknown>): number {
   return accessor.stride || accessor.size * accessor.bytesPerElement;
 }
 
-export function bufferLayoutEqual(accessor1: BufferAccessor, accessor2: BufferAccessor) {
+export function bufferLayoutEqual(
+  accessor1: DataColumnSettings<unknown>,
+  accessor2: DataColumnSettings<unknown>
+) {
   return (
     (accessor1.type ?? GL.FLOAT) === (accessor2.type ?? GL.FLOAT) &&
     accessor1.size === accessor2.size &&


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/8219

<!-- For other PRs without open issue -->
#### Background

`ColumnLayer` was not rendering correctly, a regression first introduced in https://github.com/visgl/deck.gl/pull/8153 by adding a [layoutChanged()](https://github.com/visgl/deck.gl/pull/8153/files#diff-6865938bd9e33227cb4501cefc20abe93abb4098905de00a0653cd1a80750544R641)
 check to the core `Layer` class. In the case of the `ColumnLayer` this was evaluating to `true` becuase the underlying comparison in [bufferLayoutEqual()](https://github.com/visgl/deck.gl/pull/8153/files#diff-11742470930e1b6ff2ef1c13c6102c1a9d18f0cbd76ef0bdb1655b68573b8b55R69) was detecting a change in the `instancePickingColors`, specifically the `stride` prop missing in the old accessor and set to `4` in the new accessor.

`Data-Column` uses the `getStride()` function to calculate the stride when it is missing and this evaulates to 4 for the old accessor also, thus the update triggered by `bufferLayoutEqual()` returning true is unnecessary. 

This fix passes the `getStride()` function into `bufferLayoutEqual()` to avoid such false positives. While this fixes the `ColumnLayer`, it is somewhat a happy accident, and I'm still not clear on why the layer doesn't render without this change

<!-- For all the PRs -->
#### Change List
- Use `getStride()` in `bufferLayoutEqual()`
