### PR TITLE
Use getCanvas() in GoogleMapsOverlay

### DIFF
--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -76,9 +76,9 @@ export default class GoogleMapsOverlay {
   setProps(props: Partial<GoogleMapsOverlayProps>): void {
     Object.assign(this.props, props);
     if (this._deck) {
-      if (props.style) {
-        // @ts-ignore accessing protected member
-        const parentStyle = this._deck.canvas.parentElement.style;
+      const canvas = this._deck.getCanvas();
+      if (props.style && canvas?.parentElement) {
+        const parentStyle = canvas.parentElement.style;
         Object.assign(parentStyle, props.style);
         props.style = null;
       }
@@ -202,10 +202,12 @@ export default class GoogleMapsOverlay {
       this._overlay as google.maps.OverlayView
     );
 
-    // @ts-ignore accessing protected member
-    const parentStyle = deck.canvas.parentElement.style;
-    parentStyle.left = `${left}px`;
-    parentStyle.top = `${top}px`;
+    const canvas = deck.getCanvas();
+    if (canvas?.parentElement) {
+      const parentStyle = canvas.parentElement.style;
+      parentStyle.left = `${left}px`;
+      parentStyle.top = `${top}px`;
+    }
 
     const altitude = 10000;
     deck.setProps({


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Followup to https://github.com/visgl/deck.gl/pull/7919

<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Also use `getCanvas()` in `GoogleMapsOverlay`
- Defensive checks for when canvas isn't available
