### PR TITLE
[Test]: GeoJsonLayer applies polygon tessellation on binary geometry format

### DIFF
--- a/modules/carto/src/index.ts
+++ b/modules/carto/src/index.ts
@@ -5,6 +5,7 @@ export {default as H3TileLayer} from './layers/h3-tile-layer';
 export {default as _PointLabelLayer} from './layers/point-label-layer';
 export {default as QuadbinTileLayer} from './layers/quadbin-tile-layer';
 export {default as RasterTileLayer} from './layers/raster-tile-layer';
+export {triangulate} from './layers/schema/carto-vector-tile-loader';
 export {default as BASEMAP} from './basemap';
 export {default as colorBins} from './style/color-bins-style';
 export {default as colorCategories} from './style/color-categories-style';

--- a/modules/carto/src/layers/schema/carto-vector-tile-loader.ts
+++ b/modules/carto/src/layers/schema/carto-vector-tile-loader.ts
@@ -65,7 +65,7 @@ function triangulatePolygon(
   }
 }
 
-function triangulate(polygons: BinaryPolygonFeatures) {
+export function triangulate(polygons: BinaryPolygonFeatures) {
   const {polygonIndices, positions, primitivePolygonIndices} = polygons;
   const triangles = [];
 

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -43,6 +43,7 @@
     "earcut": "^2.2.4"
   },
   "peerDependencies": {
+    "@deck.gl/carto": "^8.0.0",
     "@deck.gl/core": "^8.0.0",
     "@loaders.gl/core": "^3.4.13",
     "@luma.gl/core": "9.0.0-alpha.37",

--- a/modules/layers/src/geojson-layer/geojson-layer-props.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer-props.ts
@@ -1,4 +1,5 @@
 import {BinaryAttribute, LayerData, LayerProps} from '@deck.gl/core';
+import {triangulate} from '@deck.gl/carto';
 import {PolygonLayerProps, ScatterplotLayerProps} from '..';
 import {calculatePickingColors} from './geojson-binary';
 import {BinaryFeatures} from '@loaders.gl/schema';
@@ -120,6 +121,10 @@ export function createLayerPropsFromBinary(
     featureIds: polygons.featureIds
   } as LayerData<any>;
   layerProps.polygons._normalize = false;
+  if (polygons.polygonIndices.value.length > 0 && !polygons.triangles) {
+    // apply polygon tessellation if not already done
+    triangulate(polygons);
+  }
   if (polygons.triangles) {
     (layerProps.polygons.data as any).attributes.indices = polygons.triangles.value;
   }


### PR DESCRIPTION
Test: if GeoJsonLayer can apply polygon tessellation on binary geometry format using `polygonIndices` and `primitivePolygonIndices`, and the function`triangulate()` in module/carto