### PR TITLE
QueryParameters should be optional for boundaries

### DIFF
--- a/modules/carto/src/sources/boundary-query-source.ts
+++ b/modules/carto/src/sources/boundary-query-source.ts
@@ -6,7 +6,7 @@ export type BoundaryQuerySourceOptions = SourceOptions & {
   boundaryId: string;
   matchingColumn?: string;
   sqlQuery: string;
-  queryParameters: QueryParameters;
+  queryParameters?: QueryParameters;
 };
 type UrlParameters = {
   boundaryId: string;


### PR DESCRIPTION
QueryParameters should be optional for boundaries as in any querysource