### PR TITLE
CARTO: Add queryParameters to stats requests in fetchMap

### DIFF
--- a/modules/carto/src/api/fetch-map.ts
+++ b/modules/carto/src/api/fetch-map.ts
@@ -113,7 +113,7 @@ async function _fetchTilestats(
   accessToken: string,
   apiBaseUrl: string
 ) {
-  const {connectionName: connection, data, id, source, type} = dataset;
+  const {connectionName: connection, data, id, source, type, queryParameters} = dataset;
   const errorContext: APIErrorContext = {requestType: 'Tile stats', connection, type, source};
   if (!('tilestats' in data)) {
     throw new CartoAPIError(new Error(`Invalid dataset for tilestats: ${id}`), errorContext);
@@ -132,7 +132,10 @@ async function _fetchTilestats(
   const stats = await requestWithParameters({
     baseUrl,
     headers,
-    parameters: type === 'query' ? {q: source} : {},
+    parameters:
+      type === 'query'
+        ? {q: source, ...(queryParameters && {queryParameters: JSON.stringify(queryParameters)})}
+        : {},
     errorContext
   });
 

--- a/modules/carto/src/api/fetch-map.ts
+++ b/modules/carto/src/api/fetch-map.ts
@@ -129,13 +129,17 @@ async function _fetchTilestats(
   }
 
   const headers = {Authorization: `Bearer ${accessToken}`};
+  const parameters: Record<string, string> = {};
+  if (type === 'query') {
+    parameters.q = source;
+    if (queryParameters) {
+      parameters.queryParameters = JSON.stringify(queryParameters);
+    }
+  }
   const stats = await requestWithParameters({
     baseUrl,
     headers,
-    parameters:
-      type === 'query'
-        ? {q: source, ...(queryParameters && {queryParameters: JSON.stringify(queryParameters)})}
-        : {},
+    parameters,
     errorContext
   });
 


### PR DESCRIPTION
#### Background

The fetchMap function in the CARTO submodule retrieves the Builder map configuration, including source query parameters but we need to add them also to the requests for attribute statistics.

#### Change List
- Add query parameters to stats requests in fetchMap 
