### PR TITLE
CARTO: Boundaries handle empty 204 responses

### DIFF
--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -1,3 +1,4 @@
+import {log} from '@deck.gl/core';
 import {Tile as PropertiesTile} from './schema/carto-properties-tile';
 import {Tile as VectorTile} from './schema/carto-tile';
 import {_deepEqual as deepEqual} from '@deck.gl/core';
@@ -19,9 +20,10 @@ export function mergeBoundaryData(geometry: VectorTile, properties: PropertiesTi
   const mapping = {};
   for (const {geoid, ...rest} of properties.properties) {
     if (geoid in mapping) {
-      throw new Error(`Duplicate geoid key in mapping: ${geoid}`);
+      log.warn(`Duplicate geoid key in boundary mapping, using first occurance`)();
+    } else {
+      mapping[geoid] = rest;
     }
-    mapping[geoid] = rest;
   }
 
   for (const type of ['points', 'lines', 'polygons']) {

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -104,7 +104,7 @@ export default class VectorTileLayer<ExtraProps extends {} = {}> extends MVTLaye
     const [geometry, attributes] = await Promise.all([geometryFetch, attributesFetch]);
     if (!geometry) return null;
 
-    return mergeBoundaryData(geometry, attributes);
+    return attributes ? mergeBoundaryData(geometry, attributes) : geometry;
   }
 
   renderSubLayers(


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Followup to https://github.com/visgl/deck.gl/pull/8269
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Handle empty 204 responses
- Log instead of throw on duplicate geoid
