### PR TITLE
Use canvas rather than htmlCanvas in deck.spec

### DIFF
--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -61,7 +61,7 @@ test('Deck#no views', t => {
     device,
     width: 1,
     height: 1,
-    autoResizeDrawingBuffer: device.canvasContext.htmlCanvas.clientWidth > 0,
+    autoResizeDrawingBuffer: device.canvasContext.canvas.clientWidth > 0,
 
     viewState: {longitude: 0, latitude: 0, zoom: 0},
     views: [],


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

`yarn test` fails when run locally due to `htmlCanvas` not being defined

<!-- For all the PRs -->
#### Change List
- [Use canvas rather than htmlCanvas in deck.spec](https://github.com/visgl/deck.gl/commit/973de77c1873546c08135ca2f76a0cc22846cad6)
