### PR TITLE
Audit Layer#isLoaded implementations

### DIFF
--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -114,7 +114,7 @@ export default class MVTLayer<ExtraProps extends {} = {}> extends TileLayer<
   }
 
   get isLoaded(): boolean {
-    return this.state && this.state.data && this.state.tileset && super.isLoaded;
+    return this.state?.data && super.isLoaded;
   }
 
   updateState({props, oldProps, context, changeFlags}: UpdateParameters<this>) {

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -165,8 +165,12 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   get isLoaded(): boolean {
-    return this.state?.tileset?.selectedTiles?.every(
-      tile => tile.isLoaded && tile.layers && tile.layers.every(layer => layer.isLoaded)
+    return Boolean(
+      this.state?.tileset?.isLoaded &&
+        this.state?.tileset?.selectedTiles?.every(tile =>
+          tile.layers?.every(layer => layer.isLoaded)
+        ) &&
+        super.isLoaded
     );
   }
 

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -165,13 +165,7 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   get isLoaded(): boolean {
-    return Boolean(
-      this.state?.tileset?.isLoaded &&
-        this.state?.tileset?.selectedTiles?.every(tile =>
-          tile.layers?.every(layer => layer.isLoaded)
-        ) &&
-        super.isLoaded
-    );
+    return Boolean(this.state?.tileset?.isLoaded && super.isLoaded);
   }
 
   shouldUpdateState({changeFlags}): boolean {

--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -181,7 +181,12 @@ export class Tileset2D {
   }
 
   get isLoaded(): boolean {
-    return this._selectedTiles !== null && this._selectedTiles.every(tile => tile.isLoaded);
+    return (
+      this._selectedTiles !== null &&
+      this._selectedTiles.every(
+        tile => tile.isLoaded && tile.layers?.every(layer => layer.isLoaded)
+      )
+    );
   }
 
   get needsReload(): boolean {

--- a/modules/geo-layers/src/wms-layer/wms-layer.ts
+++ b/modules/geo-layers/src/wms-layer/wms-layer.ts
@@ -85,7 +85,7 @@ export class WMSLayer<ExtraPropsT extends {} = {}> extends CompositeLayer<
   /** Returns true if all async resources are loaded */
   get isLoaded(): boolean {
     // Track the explicit loading done by this layer
-    return Boolean(this.state) && this.state.loadCounter === 0 && super.isLoaded;
+    return this.state?.loadCounter === 0 && super.isLoaded;
   }
 
   /** Lets deck.gl know that we want viewport change events */

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -240,6 +240,10 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
     this._deleteScenegraph();
   }
 
+  get isLoaded(): boolean {
+    return this.state?.scenegraph && super.isLoaded;
+  }
+
   private _updateScenegraph(): void {
     const props = this.props;
     const {gl} = this.context;

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -348,6 +348,10 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
       .draw();
   }
 
+  get isLoaded(): boolean {
+    return this.state?.model && super.isLoaded;
+  }
+
   protected getModel(mesh: Mesh): Model {
     const model = new Model(this.context.gl, {
       ...this.getShaders(),


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Building on top of #8260, I've audited many of the `isLoaded` functions for consistency and quality. Open to feedback or recommendations.

In our docs we say a layer is considered loaded if all asynchronous assets are loaded. Assets aren't formally defined as far as I'm aware, but I interpret them as anything required to load before the layer can be drawn.

I've reviewed each layer to ensure the following types of assets are settled:
- async props (ensure `super.isLoaded`)
- tiles in a tileset
- 3d parsing in mesh layers (Particularly useful for `Tile3DLayer` where `scenegraphs` are constantly loading) 

I've also looked for redundant checks and style inconsistencies (using chained optionals and casting to `Boolean` as needed).

<!-- For all the PRs -->
#### Change List
- Wait for `scenegraph` to parse in `ScenegraphLayer`
- Wait for `model` to parse in `SimpleMeshLayer`
- Use `Tileset2D#isLoaded` and `super.isLoaded` on `TileLayer`
- Move cached `Layer#isLoaded` check into `Tileset2D#isLoaded`
- Removed redundant check in MVTLayer#isLoaded
- Optional chain in WMSLayer#isLoaded
