### PR TITLE
v8 audit tile layer types

### DIFF
--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -5,11 +5,7 @@ import CartoSpatialTileLoader from './schema/carto-spatial-tile-loader';
 registerLoaders([CartoRasterTileLoader, CartoSpatialTileLoader]);
 
 import {PickingInfo} from '@deck.gl/core';
-import {
-  TileLayer,
-  _Tile2DHeader as Tile2DHeader,
-  _Tileset2D as Tileset2D
-} from '@deck.gl/geo-layers';
+import {TileLayer, _Tile2DHeader as Tile2DHeader, TileLayerProps} from '@deck.gl/geo-layers';
 
 function isFeatureIdDefined(value: unknown): boolean {
   return value !== undefined && value !== null && value !== '';
@@ -21,7 +17,7 @@ const defaultProps: DefaultProps<SpatialIndexTileLayerProps> = {
 
 /** All properties supported by SpatialIndexTileLayer. */
 export type SpatialIndexTileLayerProps<DataT = any> = _SpatialIndexTileLayerProps<DataT> &
-  TileLayer<DataT>;
+  TileLayerProps<DataT>;
 
 /** Properties added by SpatialIndexTileLayer. */
 type _SpatialIndexTileLayerProps<DataT = any> = {
@@ -35,12 +31,8 @@ export default class SpatialIndexTileLayer<
   static layerName = 'SpatialIndexTileLayer';
   static defaultProps = defaultProps;
 
-  state!: {
-    // TODO: tileset should be generic for either H3Tileset2D or QuadbinTileset2D
-    tileset: Tileset2D | null;
-    isLoaded: boolean;
-    frameNumber?: number;
-
+  state!: TileLayer<DataT>['state'] & {
+    // TODO: tileset: Tileset2D should be generic for either H3Tileset2D or QuadbinTileset2D
     hoveredFeatureId: BigInt | number | null;
     highlightColor?: number[];
   };
@@ -103,18 +95,16 @@ export default class SpatialIndexTileLayer<
 
   _featureInTile(tile: Tile2DHeader, featureId: BigInt | number) {
     // TODO: Tile2DHeader index should be generic for H3TileIndex or QuadbinTileIndex
-    const {getTileZoom, getParentIndex} = this.state.tileset!;
-    const tileZoom = getTileZoom(tile.index);
+    const tileset = this.state.tileset!;
+    const tileZoom = tileset.getTileZoom(tile.index);
     // @ts-ignore
     const KEY = tile.index.q ? 'q' : 'i';
-    let featureIndex = {[KEY]: featureId};
-    // @ts-ignore
-    let featureZoom = getTileZoom(featureIndex);
+    // TODO - Tileset2D methods expect tile index in the shape of {x, y, z}
+    let featureIndex: any = {[KEY]: featureId};
+    let featureZoom = tileset.getTileZoom(featureIndex);
     while (!(featureZoom <= tileZoom)) {
-      // @ts-ignore
-      featureIndex = getParentIndex(featureIndex);
-      // @ts-ignore
-      featureZoom = getTileZoom(featureIndex);
+      featureIndex = tileset.getParentIndex(featureIndex);
+      featureZoom = tileset.getTileZoom(featureIndex);
     }
 
     return featureIndex[KEY] === tile.index[KEY];

--- a/modules/geo-layers/src/mvt-layer/find-index-binary.ts
+++ b/modules/geo-layers/src/mvt-layer/find-index-binary.ts
@@ -15,13 +15,13 @@ const GEOM_TYPES = ['points', 'lines', 'polygons'];
  * @param {Object} data - The data in binary format
  * @param {String} uniqueIdProperty - Name of the unique id property
  * @param {Number|String} featureId - feature id to find
- * @param {String} layerName - the layer to search in
+ * @param {String|null} layerName - the layer to search in
  */
 export default function findIndexBinary(
   data: BinaryFeatures,
   uniqueIdProperty: string,
   featureId: string | number,
-  layerName: string
+  layerName: string | null
 ): number {
   for (const gt of GEOM_TYPES) {
     const index = data[gt] && findIndexByType(data[gt], uniqueIdProperty, featureId, layerName);
@@ -37,7 +37,7 @@ function findIndexByType(
   geomData: FeatureTypes,
   uniqueIdProperty: string,
   featureId: string | number,
-  layerName: string
+  layerName: string | null
 ): number {
   const featureIds = geomData.featureIds.value;
 

--- a/modules/geo-layers/src/mvt-layer/find-index-binary.ts
+++ b/modules/geo-layers/src/mvt-layer/find-index-binary.ts
@@ -8,20 +8,17 @@ import type {
 type FeatureTypes = BinaryPointFeatures | BinaryLineFeatures | BinaryPolygonFeatures;
 
 const GEOM_TYPES = ['points', 'lines', 'polygons'];
+
 /**
  * Return the index of feature (numericProps or featureIds) for given feature id
  * Example: findIndexBinary(data, 'id', 33) will return the index in the array of numericProps
  * of the feature 33.
- * @param {Object} data - The data in binary format
- * @param {String} uniqueIdProperty - Name of the unique id property
- * @param {Number|String} featureId - feature id to find
- * @param {String|null} layerName - the layer to search in
  */
 export default function findIndexBinary(
-  data: BinaryFeatures,
-  uniqueIdProperty: string,
-  featureId: string | number,
-  layerName: string | null
+  data: BinaryFeatures, // The data in binary format
+  uniqueIdProperty: string, // Name of the unique id property
+  featureId: string | number, // feature id to find
+  layerName: string | null // the layer to search in
 ): number {
   for (const gt of GEOM_TYPES) {
     const index = data[gt] && findIndexByType(data[gt], uniqueIdProperty, featureId, layerName);

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -402,7 +402,7 @@ export default class MVTLayer<ExtraProps extends {} = {}> extends TileLayer<
     const tileset: Tileset2D | null = this.state.tileset;
 
     // @ts-expect-error selectedTiles are always initialized when tile is being processed
-    tileset?.selectedTiles.forEach((tile: Tile2DHeader & ContentWGS84Cache) => {
+    tileset!.selectedTiles.forEach((tile: Tile2DHeader & ContentWGS84Cache) => {
       if (!tile.hasOwnProperty(propName)) {
         // eslint-disable-next-line accessor-pairs
         Object.defineProperty(tile, propName, {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -104,17 +104,13 @@ export default class MVTLayer<ExtraProps extends {} = {}> extends TileLayer<
   static layerName = 'MVTLayer';
   static defaultProps = defaultProps;
 
-  state!: {
-    tileset: Tileset2D | null;
-    isLoaded: boolean;
-    frameNumber?: number;
-
-    data?: any;
-    tileJSON: TileJson | null;
+  state!: TileLayer<ParsedMvtTile>['state'] & {
     binary: boolean;
-    hoveredFeatureId: string | number | null;
-    hoveredFeatureLayerName: string | null;
+    data: URLTemplate;
+    tileJSON: TileJson | null;
     highlightColor?: number[];
+    hoveredFeatureId: number | string | null;
+    hoveredFeatureLayerName: string | null;
   };
 
   initializeState(): void {
@@ -131,7 +127,7 @@ export default class MVTLayer<ExtraProps extends {} = {}> extends TileLayer<
   }
 
   get isLoaded(): boolean {
-    return this.state?.data && super.isLoaded;
+    return Boolean(this.state?.data && super.isLoaded);
   }
 
   updateState({props, oldProps, context, changeFlags}: UpdateParameters<this>) {
@@ -399,10 +395,10 @@ export default class MVTLayer<ExtraProps extends {} = {}> extends TileLayer<
 
   private _setWGS84PropertyForTiles(): void {
     const propName = 'dataInWGS84';
-    const tileset: Tileset2D | null = this.state.tileset;
+    const tileset: Tileset2D = this.state.tileset!;
 
     // @ts-expect-error selectedTiles are always initialized when tile is being processed
-    tileset!.selectedTiles.forEach((tile: Tile2DHeader & ContentWGS84Cache) => {
+    tileset.selectedTiles.forEach((tile: Tile2DHeader & ContentWGS84Cache) => {
       if (!tile.hasOwnProperty(propName)) {
         // eslint-disable-next-line accessor-pairs
         Object.defineProperty(tile, propName, {

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -131,7 +131,7 @@ export default class MVTLayer<ExtraProps extends {} = {}> extends TileLayer<
   }
 
   get isLoaded(): boolean {
-    return this.state && this.state.data && this.state.tileset && super.isLoaded;
+    return this.state?.data && super.isLoaded;
   }
 
   updateState({props, oldProps, context, changeFlags}: UpdateParameters<this>) {

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -243,10 +243,10 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   private _updateTileset(): void {
-    const {tileset} = this.state;
+    const tileset = this.state.tileset!;
     const {zRange, modelMatrix} = this.props;
-    const frameNumber = tileset!.update(this.context.viewport, {zRange, modelMatrix});
-    const {isLoaded} = tileset!;
+    const frameNumber = tileset.update(this.context.viewport, {zRange, modelMatrix});
+    const {isLoaded} = tileset;
 
     const loadingStateChanged = this.state.isLoaded !== isLoaded;
     const tilesetChanged = this.state.frameNumber !== frameNumber;
@@ -342,41 +342,39 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   renderLayers(): Layer | null | LayersList {
-    return (
-      this.state.tileset?.tiles.map((tile: Tile2DHeader) => {
-        const subLayerProps = this.getSubLayerPropsByTile(tile);
-        // cache the rendered layer in the tile
-        if (!tile.isLoaded && !tile.content) {
-          // nothing to show
-        } else if (!tile.layers) {
-          const layers = this.renderSubLayers({
-            ...this.props,
-            ...this.getSubLayerProps({
-              id: tile.id,
-              updateTriggers: this.props.updateTriggers
-            }),
-            data: tile.content,
-            _offset: 0,
-            tile
-          });
-          tile.layers = (flatten(layers, Boolean) as Layer<{tile?: Tile2DHeader}>[]).map(layer =>
-            layer.clone({
-              tile,
-              ...subLayerProps
-            })
-          );
-        } else if (
-          subLayerProps &&
-          tile.layers[0] &&
-          Object.keys(subLayerProps).some(
-            propName => tile.layers![0].props[propName] !== subLayerProps[propName]
-          )
-        ) {
-          tile.layers = tile.layers.map(layer => layer.clone(subLayerProps));
-        }
-        return tile.layers;
-      }) || null
-    );
+    return this.state.tileset!.tiles.map((tile: Tile2DHeader) => {
+      const subLayerProps = this.getSubLayerPropsByTile(tile);
+      // cache the rendered layer in the tile
+      if (!tile.isLoaded && !tile.content) {
+        // nothing to show
+      } else if (!tile.layers) {
+        const layers = this.renderSubLayers({
+          ...this.props,
+          ...this.getSubLayerProps({
+            id: tile.id,
+            updateTriggers: this.props.updateTriggers
+          }),
+          data: tile.content,
+          _offset: 0,
+          tile
+        });
+        tile.layers = (flatten(layers, Boolean) as Layer<{tile?: Tile2DHeader}>[]).map(layer =>
+          layer.clone({
+            tile,
+            ...subLayerProps
+          })
+        );
+      } else if (
+        subLayerProps &&
+        tile.layers[0] &&
+        Object.keys(subLayerProps).some(
+          propName => tile.layers![0].props[propName] !== subLayerProps[propName]
+        )
+      ) {
+        tile.layers = tile.layers.map(layer => layer.clone(subLayerProps));
+      }
+      return tile.layers;
+    });
   }
 
   filterSubLayer({layer, cullRect}: FilterContext) {

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -202,7 +202,7 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         tileset.reloadAll();
       } else {
         // some render options changed, regenerate sub layers now
-        this.state.tileset?.tiles.forEach(tile => {
+        tileset.tiles.forEach(tile => {
           tile.layers = null;
         });
       }
@@ -379,6 +379,6 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
 
   filterSubLayer({layer, cullRect}: FilterContext) {
     const {tile} = (layer as Layer<{tile: Tile2DHeader}>).props;
-    return Boolean(this.state.tileset?.isTileVisible(tile, cullRect));
+    return this.state.tileset!.isTileVisible(tile, cullRect);
   }
 }

--- a/modules/geo-layers/src/tileset-2d/tile-2d-header.ts
+++ b/modules/geo-layers/src/tileset-2d/tile-2d-header.ts
@@ -1,6 +1,7 @@
 /* eslint-env browser */
 import {RequestScheduler} from '@loaders.gl/loader-utils';
 import {TileBoundingBox, TileIndex, TileLoadProps} from './types';
+import type {Layer} from '@deck.gl/core';
 
 export type TileLoadDataProps<DataT = any> = {
   requestScheduler: RequestScheduler;
@@ -17,7 +18,7 @@ export class Tile2DHeader<DataT = any> {
   children: Tile2DHeader[] | null;
   content: DataT | null;
   state?: number;
-  layers?: any[] | null; // Layer[] | null
+  layers?: Layer[] | null;
 
   id!: string; // assigned _always_ with result of `getTileId`
   zoom!: number; // assigned _always_ with result of `getTileZoom`

--- a/modules/geo-layers/src/tileset-2d/tile-2d-traversal.ts
+++ b/modules/geo-layers/src/tileset-2d/tile-2d-traversal.ts
@@ -183,7 +183,7 @@ class OSMNode {
 export function getOSMTileIndices(
   viewport: Viewport,
   maxZ: number,
-  zRange: ZRange | undefined,
+  zRange: ZRange | null,
   bounds?: Bounds
 ): TileIndex[] {
   const project: ((xyz: number[]) => number[]) | null =

--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -356,7 +356,7 @@ export class Tileset2D {
   }
 
   /** Returns a zoom level for a tile index */
-  getTileZoom(this: void, index: TileIndex) {
+  getTileZoom(index: TileIndex) {
     return index.z;
   }
 
@@ -368,7 +368,7 @@ export class Tileset2D {
   }
 
   /** Returns index of the parent tile */
-  getParentIndex(this: void, index: TileIndex) {
+  getParentIndex(index: TileIndex) {
     const x = Math.floor(index.x / 2);
     const y = Math.floor(index.y / 2);
     const z = index.z - 1;

--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -1,7 +1,7 @@
 import {Viewport} from '@deck.gl/core';
 
 import {RequestScheduler} from '@loaders.gl/loader-utils';
-import {Matrix4, equals} from '@math.gl/core';
+import {Matrix4, NumericArray, equals} from '@math.gl/core';
 
 import {Tile2DHeader} from './tile-2d-header';
 
@@ -123,7 +123,7 @@ export class Tileset2D {
 
   private _cacheByteSize: number;
   private _viewport: Viewport | null;
-  private _zRange?: ZRange;
+  private _zRange: ZRange | null;
   private _selectedTiles: Tile2DHeader[] | null;
   private _frameNumber: number;
   private _modelMatrix: Matrix4;
@@ -162,6 +162,7 @@ export class Tileset2D {
 
     // Cache the last processed viewport
     this._viewport = null;
+    this._zRange = null;
     this._selectedTiles = null;
     this._frameNumber = 0;
 
@@ -226,8 +227,12 @@ export class Tileset2D {
    */
   update(
     viewport: Viewport,
-    {zRange, modelMatrix}: {zRange?: ZRange; modelMatrix?: Matrix4} = {}
+    {zRange, modelMatrix}: {zRange: ZRange | null; modelMatrix: NumericArray | null} = {
+      zRange: null,
+      modelMatrix: null
+    }
   ): number {
+    // @ts-expect-error Matrix4 can accept null
     const modelMatrixAsMatrix4 = new Matrix4(modelMatrix);
     const isModelMatrixNew = !modelMatrixAsMatrix4.equals(this._modelMatrix);
     if (
@@ -326,7 +331,7 @@ export class Tileset2D {
     viewport: Viewport;
     maxZoom?: number;
     minZoom?: number;
-    zRange: ZRange | undefined;
+    zRange: ZRange | null;
     tileSize?: number;
     modelMatrix?: Matrix4;
     modelMatrixInverse?: Matrix4;
@@ -352,7 +357,7 @@ export class Tileset2D {
   }
 
   /** Returns a zoom level for a tile index */
-  getTileZoom(index: TileIndex) {
+  getTileZoom(this: void, index: TileIndex) {
     return index.z;
   }
 
@@ -364,7 +369,7 @@ export class Tileset2D {
   }
 
   /** Returns index of the parent tile */
-  getParentIndex(index: TileIndex) {
+  getParentIndex(this: void, index: TileIndex) {
     const x = Math.floor(index.x / 2);
     const y = Math.floor(index.y / 2);
     const z = index.z - 1;

--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -232,8 +232,7 @@ export class Tileset2D {
       modelMatrix: null
     }
   ): number {
-    // @ts-expect-error Matrix4 can accept null
-    const modelMatrixAsMatrix4 = new Matrix4(modelMatrix);
+    const modelMatrixAsMatrix4 = modelMatrix ? new Matrix4(modelMatrix) : new Matrix4();
     const isModelMatrixNew = !modelMatrixAsMatrix4.equals(this._modelMatrix);
     if (
       !this._viewport ||

--- a/modules/geo-layers/src/tileset-2d/utils.ts
+++ b/modules/geo-layers/src/tileset-2d/utils.ts
@@ -143,7 +143,7 @@ export function getCullBounds({
   cullRect: {x: number; y: number; width: number; height: number};
 }): [number, number, number, number][] {
   const subViewports = viewport.subViewports || [viewport];
-  return subViewports.map(v => getCullBoundsInViewport(v, z!, cullRect));
+  return subViewports.map(v => getCullBoundsInViewport(v, z || 0, cullRect));
 }
 
 function getCullBoundsInViewport(

--- a/modules/geo-layers/src/tileset-2d/utils.ts
+++ b/modules/geo-layers/src/tileset-2d/utils.ts
@@ -138,12 +138,12 @@ export function getCullBounds({
   /** Current viewport */
   viewport: Viewport;
   /** Current z range */
-  z: ZRange | number | undefined;
+  z: ZRange | number | null;
   /** Culling rectangle in screen space */
   cullRect: {x: number; y: number; width: number; height: number};
 }): [number, number, number, number][] {
   const subViewports = viewport.subViewports || [viewport];
-  return subViewports.map(v => getCullBoundsInViewport(v, z, cullRect));
+  return subViewports.map(v => getCullBoundsInViewport(v, z!, cullRect));
 }
 
 function getCullBoundsInViewport(
@@ -273,7 +273,7 @@ export function getTileIndices({
   viewport: Viewport;
   maxZoom?: number;
   minZoom?: number;
-  zRange: ZRange | undefined;
+  zRange: ZRange | null;
   extent?: Bounds;
   tileSize?: number;
   modelMatrix?: Matrix4;


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
As I was working on #8290 I noticed internal state (such as `state.tileset`) wasn't typed, which led to some difficultly when working on the layer. This PR adds types to for internal state to `TileLayer` and layers that extend it, namely `MVTLayer`, `SpatialIndexTileLayer`. Along the way I visited `Tileset2D` to ensure it was consistent with the layer's types.

I'll port changes to v9 as well, some of these layers are disabled so v8 is better for testing.

<!-- For all the PRs -->
#### Change List
- Types internal state for `TileLayer`, `MVTLayer`, and `SpatialIndexTileLayer`
- Initializes optional state to `null` if the layer resets it to `null`
- Changes tile types from `undefined` to `null` where necessary
