### PR TITLE
[chore] Bump peerDependencies to 9.0.0

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -39,8 +39,8 @@
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
-    "@deck.gl/layers": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
+    "@deck.gl/layers": "^9.0.0-alpha",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42"
   },

--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -39,8 +39,8 @@
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
-    "@deck.gl/layers": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42"
   },

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@arcgis/core": "^4.0.0",
-    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42"
   },

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@arcgis/core": "^4.0.0",
-    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42"
   },

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -60,11 +60,11 @@
     "@types/d3-scale": "^3.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/aggregation-layers": "^8.0.0",
-    "@deck.gl/core": "^8.0.0",
-    "@deck.gl/extensions": "^8.0.0",
-    "@deck.gl/geo-layers": "^8.0.0",
-    "@deck.gl/layers": "^8.0.0",
+    "@deck.gl/aggregation-layers": "^9.0.0",
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/extensions": "^9.0.0",
+    "@deck.gl/geo-layers": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0",
     "@loaders.gl/core": "4.0.3"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -60,11 +60,11 @@
     "@types/d3-scale": "^3.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0",
-    "@deck.gl/core": "^9.0.0",
-    "@deck.gl/extensions": "^9.0.0",
-    "@deck.gl/geo-layers": "^9.0.0",
-    "@deck.gl/layers": "^9.0.0",
+    "@deck.gl/aggregation-layers": "^9.0.0-alpha",
+    "@deck.gl/core": "^9.0.0-alpha",
+    "@deck.gl/extensions": "^9.0.0-alpha",
+    "@deck.gl/geo-layers": "^9.0.0-alpha",
+    "@deck.gl/layers": "^9.0.0-alpha",
     "@loaders.gl/core": "4.0.3"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -35,7 +35,7 @@
     "@luma.gl/shadertools": "9.0.0-alpha.42"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
     "@luma.gl/constants": "9.0.0-alpha.42",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42",

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -35,7 +35,7 @@
     "@luma.gl/shadertools": "9.0.0-alpha.42"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
     "@luma.gl/constants": "9.0.0-alpha.42",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42",

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -49,10 +49,10 @@
     "long": "^3.2.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
-    "@deck.gl/extensions": "^8.0.0",
-    "@deck.gl/layers": "^8.0.0",
-    "@deck.gl/mesh-layers": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/extensions": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0",
+    "@deck.gl/mesh-layers": "^9.0.0",
     "@loaders.gl/core": "4.0.3",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/shadertools": "9.0.0-alpha.42"

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -49,10 +49,10 @@
     "long": "^3.2.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
-    "@deck.gl/extensions": "^9.0.0",
-    "@deck.gl/layers": "^9.0.0",
-    "@deck.gl/mesh-layers": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
+    "@deck.gl/extensions": "^9.0.0-alpha",
+    "@deck.gl/layers": "^9.0.0-alpha",
+    "@deck.gl/mesh-layers": "^9.0.0-alpha",
     "@loaders.gl/core": "4.0.3",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/shadertools": "9.0.0-alpha.42"

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -37,7 +37,7 @@
     "@types/google.maps": "^3.48.6"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
     "@luma.gl/constants": "9.0.0-alpha.42",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42",

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -37,7 +37,7 @@
     "@types/google.maps": "^3.48.6"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
     "@luma.gl/constants": "9.0.0-alpha.42",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42",

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -36,7 +36,7 @@
     "expression-eval": "^5.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0"
+    "@deck.gl/core": "^9.0.0-alpha"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -36,7 +36,7 @@
     "expression-eval": "^5.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0"
+    "@deck.gl/core": "^9.0.0"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -44,7 +44,7 @@
     "earcut": "^2.2.4"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
     "@loaders.gl/core": "4.0.3",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42",

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -44,7 +44,7 @@
     "earcut": "^2.2.4"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
     "@loaders.gl/core": "4.0.3",
     "@luma.gl/core": "9.0.0-alpha.42",
     "@luma.gl/engine": "9.0.0-alpha.42",

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -35,7 +35,7 @@
     "@math.gl/web-mercator": "^4.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0"
+    "@deck.gl/core": "^9.0.0-alpha"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -35,7 +35,7 @@
     "@math.gl/web-mercator": "^4.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0"
+    "@deck.gl/core": "^9.0.0"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env=dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0"
+    "@deck.gl/core": "^9.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env=dev"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0"
+    "@deck.gl/core": "^9.0.0-alpha"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
     "@types/react": ">= 16.3",
     "react": ">=16.3",
     "react-dom": ">=16.3"

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
     "@types/react": ">= 16.3",
     "react": ">=16.3",
     "react-dom": ">=16.3"

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -27,7 +27,7 @@
     "@babel/runtime": "^7.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/core": "^9.0.0-alpha",
     "@luma.gl/test-utils": "9.0.0-alpha.42",
     "@luma.gl/webgl": "9.0.0-alpha.42",
     "@probe.gl/test-utils": "^4.0.0"

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -27,7 +27,7 @@
     "@babel/runtime": "^7.0.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0",
+    "@deck.gl/core": "^9.0.0",
     "@luma.gl/test-utils": "9.0.0-alpha.42",
     "@luma.gl/webgl": "9.0.0-alpha.42",
     "@probe.gl/test-utils": "^4.0.0"

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -35,7 +35,7 @@
     "preact": "^10.17.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^8.0.0"
+    "@deck.gl/core": "^9.0.0"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -35,7 +35,7 @@
     "preact": "^10.17.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "^9.0.0"
+    "@deck.gl/core": "^9.0.0-alpha"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Installing the v9 alpha package currently gives warnings of the form:

```
warning " > @deck.gl/aggregation-layers@9.0.0-alpha.3" has incorrect peer dependency "@deck.gl/core@^8.0.0".
```

<!-- For all the PRs -->
#### Change List
- Bump all v8 peerDependencies to v9