### PR TITLE
[website] Clean up TS types in 'plot' example

### DIFF
--- a/examples/website/plot/plot-layer/axes-layer.ts
+++ b/examples/website/plot/plot-layer/axes-layer.ts
@@ -96,7 +96,6 @@ export default class AxesLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   static layerName = 'AxesLayer';
   static defaultProps = defaultProps;
 
-  // @ts-ignore
   state!: Layer['state'] & {
     models: [Model, Model];
     modelsByName: {grids: Model; labels: Model};

--- a/examples/website/plot/plot-layer/plot-layer.ts
+++ b/examples/website/plot/plot-layer/plot-layer.ts
@@ -118,7 +118,6 @@ export default class PlotLayer<DataT extends Vec3 = Vec3, ExtraPropsT extends {}
   static layerName = 'PlotLayer';
   static defaultProps = defaultProps;
 
-  // @ts-ignore
   state!: CompositeLayer['state'] & {
     xScale: ScaleLinear<number, number>;
     yScale: ScaleLinear<number, number>;

--- a/examples/website/plot/plot-layer/surface-layer.ts
+++ b/examples/website/plot/plot-layer/surface-layer.ts
@@ -68,7 +68,6 @@ export default class SurfaceLayer<
   static defaultProps = defaultProps;
   static layerName: string = 'SurfaceLayer';
 
-  // @ts-ignore
   state!: Layer['state'] & {
     model?: Model;
     vertexCount: number;

--- a/examples/website/plot/tsconfig.json
+++ b/examples/website/plot/tsconfig.json
@@ -1,4 +1,0 @@
-{
-    "extends": "../../../tsconfig.json",
-    "include": ["./**/*.ts"]
-}


### PR DESCRIPTION
Cleanup from #8289. Originally builds were failing without a `tsconfig.json`, but that's no longer happening — possibly something else got fixed during the PR review process. With `tsconfig.json` removed, the `// @ts-ignore` lines are no longer necessary, so we can define `this.state` in the same way as other examples.