### PR TITLE
[website] Update FirstPersonView example for v9

### DIFF
--- a/examples/website/360-video/app.jsx
+++ b/examples/website/360-video/app.jsx
@@ -7,8 +7,9 @@ import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {SphereGeometry} from '@luma.gl/engine';
 
 // Video created by the NASA Jet Propulsion Laboratory, Public domain, via Wikimedia Commons
+// Source: https://commons.wikimedia.org/wiki/File:NASA_VR-360_Astronaut_Training-_Space_Walk.webm
 const VIDEO_URL =
-  'https://upload.wikimedia.org/wikipedia/commons/transcoded/0/0a/NASA_VR-360_Astronaut_Training-_Space_Walk.webm/NASA_VR-360_Astronaut_Training-_Space_Walk.webm.1080p.webm';
+  'https://upload.wikimedia.org/wikipedia/commons/0/0a/NASA_VR-360_Astronaut_Training-_Space_Walk.webm';
 
 const sphere = new SphereGeometry({
   nlat: 50,

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -224,7 +224,7 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
     hasNormals?: boolean;
     positionBounds?: [number[], number[]] | null;
     uniformStore: UniformStore<{
-      picking: Record<string, UniformValue>
+      picking: Record<string, UniformValue>;
     }>;
   };
 
@@ -361,9 +361,9 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
   }
 
   protected getModel(mesh: Mesh): Model {
-    const { device } = this.context;
-    const { texture } = this.props;
-    const { uniformStore, emptyTexture } = this.state;
+    const {device} = this.context;
+    const {texture} = this.props;
+    const {uniformStore, emptyTexture} = this.state;
 
     const model = new Model(device, {
       ...this.getShaders(),
@@ -372,7 +372,7 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
       geometry: getGeometry(mesh),
       isInstanced: true,
       bindings: {
-        picking: uniformStore.getManagedUniformBuffer(device, 'picking'),
+        picking: uniformStore.getManagedUniformBuffer(device, 'picking')
       }
     });
 

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -32,7 +32,7 @@ import {
   LayerContext,
   Material
 } from '@deck.gl/core';
-import {Texture, UniformStore, UniformValue} from '@luma.gl/core';
+import {Texture} from '@luma.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
 // import {PBRMaterialParser} from '@luma.gl/gltf';
 import {GL} from '@luma.gl/constants';
@@ -223,9 +223,6 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
     emptyTexture: Texture;
     hasNormals?: boolean;
     positionBounds?: [number[], number[]] | null;
-    uniformStore: UniformStore<{
-      picking: Record<string, UniformValue>;
-    }>;
   };
 
   getShaders() {
@@ -303,8 +300,7 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
         data: new Uint8Array(4),
         width: 1,
         height: 1
-      }),
-      uniformStore: new UniformStore({picking})
+      })
     });
   }
 
@@ -361,21 +357,16 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
   }
 
   protected getModel(mesh: Mesh): Model {
-    const {device} = this.context;
-    const {texture} = this.props;
-    const {uniformStore, emptyTexture} = this.state;
-
-    const model = new Model(device, {
+    const model = new Model(this.context.device, {
       ...this.getShaders(),
       id: this.props.id,
       bufferLayout: this.getAttributeManager()!.getBufferLayouts(),
       geometry: getGeometry(mesh),
-      isInstanced: true,
-      bindings: {
-        picking: uniformStore.getManagedUniformBuffer(device, 'picking')
-      }
+      isInstanced: true
     });
 
+    const {texture} = this.props;
+    const {emptyTexture} = this.state;
     model.setBindings({
       sampler: (texture as Texture) || emptyTexture
     });

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -32,7 +32,7 @@ import {
   LayerContext,
   Material
 } from '@deck.gl/core';
-import {Texture} from '@luma.gl/core';
+import {Texture, UniformStore, UniformValue} from '@luma.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
 // import {PBRMaterialParser} from '@luma.gl/gltf';
 import {GL} from '@luma.gl/constants';
@@ -223,6 +223,9 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
     emptyTexture: Texture;
     hasNormals?: boolean;
     positionBounds?: [number[], number[]] | null;
+    uniformStore: UniformStore<{
+      picking: Record<string, UniformValue>
+    }>;
   };
 
   getShaders() {
@@ -300,7 +303,8 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
         data: new Uint8Array(4),
         width: 1,
         height: 1
-      })
+      }),
+      uniformStore: new UniformStore({picking})
     });
   }
 
@@ -357,16 +361,21 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
   }
 
   protected getModel(mesh: Mesh): Model {
-    const model = new Model(this.context.device, {
+    const { device } = this.context;
+    const { texture } = this.props;
+    const { uniformStore, emptyTexture } = this.state;
+
+    const model = new Model(device, {
       ...this.getShaders(),
       id: this.props.id,
       bufferLayout: this.getAttributeManager()!.getBufferLayouts(),
       geometry: getGeometry(mesh),
-      isInstanced: true
+      isInstanced: true,
+      bindings: {
+        picking: uniformStore.getManagedUniformBuffer(device, 'picking'),
+      }
     });
 
-    const {texture} = this.props;
-    const {emptyTexture} = this.state;
     model.setBindings({
       sampler: (texture as Texture) || emptyTexture
     });


### PR DESCRIPTION
- fixes https://github.com/visgl/deck.gl/issues/8315
- requires https://github.com/visgl/luma.gl/pull/1853
- related to https://github.com/visgl/luma.gl/pull/1810
- related to https://github.com/visgl/luma.gl/issues/1850

~~My guess is that my changes to manually bind picking uniforms in `simple-mesh-layer.ts` do not really belong in this file, but I've left that part in place for now since it did resolve the errors. Currently the mesh renders entirely in the picking color `#00ffff`, but if I comment that line of the shader out we do see the 360º video as expected, so I think all that's left is the fixes to picking discussed in #1850.~~

~~Since there are a few related PRs and discussions in flight, I'm just opening this PR for visibility.~~

Fixes broken link to 360º video. Earlier commits in this PR included a partial workaround for broken picking, but I've removed the workarounds here and left that to Felix in https://github.com/visgl/deck.gl/pull/8334.