### PR TITLE
chore(ci): Update CI dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Publish release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
 
     steps:
-      - uses: actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b # v2.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Get git tags (https://github.com/actions/checkout/issues/206)
         run: git fetch --tags -f
 
       - name: Use Node.js
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18.x'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   test-node:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        node-version: ['18.x']
     permissions:
       checks: write
       contents: read
@@ -23,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '18.x'
 
       - name: Install dependencies
         run: |
@@ -47,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x']
         python-version: [3.8]
 
     steps:
@@ -58,10 +54,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '18.x'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b # v2.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -51,15 +51,15 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   test-node:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: ['18.x']
     permissions:
       checks: write
       contents: read
@@ -20,11 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b # v2.1.1
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
-          # headless GL 6.0.1 needs recent version of Node 16.
-          node-version: '16.19'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: |
@@ -45,20 +47,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        node-version: ['18.x']
         python-version: [3.8]
 
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Use Python ${{ matrix.python-version }}
         uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        with:
+          node-version: ${{ matrix.node-version }}
+
       - name: Install dependencies
         run: |
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.1/install.sh | bash
-          nvm install 16.9 && nvm use 16.9
           cd bindings/pydeck
           make setup-env
           make init

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,12 +23,12 @@ jobs:
       GoogleMapsMapId: ${{ secrets.GOOGLE_MAPS_MAP_ID }}
 
     steps:
-      - uses: actions/checkout@86f86b36ef15e6570752e7175f451a512eac206b # v2.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Use Node.js
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18.x'
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Get version
         id: get-version


### PR DESCRIPTION
Updating CI to Node.js v18 LTS and current versions of GitHub Actions. Fixes a few errors in the CI logs. Security support for Node.js v16 ended in September. Some older GitHub Actions were still relying on Node.js v12.

https://endoflife.date/nodejs

We could also configure Dependabot or Renovate Bot to do this automatically, if that's of interest.