### PR TITLE
Carto: fix support for quantile color scale in static tilesets in fetchMap

### DIFF
--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -243,7 +243,9 @@ function domainFromAttribute(attribute, scaleType: SCALE_TYPE, scaleLength: numb
   }
 
   if (scaleType === 'quantile' && attribute.quantiles) {
-    return attribute.quantiles[scaleLength];
+    return attribute.quantiles.global
+      ? attribute.quantiles.global[scaleLength]
+      : attribute.quantiles[scaleLength];
   }
 
   let {min} = attribute;

--- a/test/apps/carto-map/app.ts
+++ b/test/apps/carto-map/app.ts
@@ -72,7 +72,8 @@ const examples = [
   '3c892452-3806-4ebf-821b-a76f4562dd0c', // points and lines
   '21cc8261-e626-4778-a78b-76fe8b808214', // markers tilesets
   '4e8f215f-97b4-4f4e-8b53-465c3908c317', // markers points
-  '27de26b4-b94f-4e94-b291-41d1a21d3d02' // HexColumn color
+  '27de26b4-b94f-4e94-b291-41d1a21d3d02', // HexColumn color,
+  'c9e6c75f-3d7f-46f7-a5b4-705b7f1a44c9' // static quadbin tileset
 ];
 const params = new URLSearchParams(location.search.slice(1));
 const id = params.has('id') ? params.get('id')! : examples[0];

--- a/test/modules/carto/api/layer-map.spec.ts
+++ b/test/modules/carto/api/layer-map.spec.ts
@@ -91,6 +91,44 @@ const COLOR_TESTS = [
     data: [{v: 0}, {v: 1}, {v: 5}],
     d: {v: 0},
     expected: [134, 141, 145, 255]
+  },
+  {
+    colorField: {name: 'v'},
+    colorScale: 'quantile',
+    colorRange: {
+      colors
+    },
+    opacity: 1,
+    data: {
+      tilestats: {
+        layers: [
+          {
+            attributes: [{attribute: 'v', quantiles: {6: [1, 2, 3, 4, 5, 6]}}]
+          }
+        ]
+      }
+    },
+    d: {properties: {v: 1}},
+    expected: [90, 24, 70, 255]
+  },
+  {
+    colorField: {name: 'v'},
+    colorScale: 'quantile',
+    colorRange: {
+      colors
+    },
+    opacity: 1,
+    data: {
+      tilestats: {
+        layers: [
+          {
+            attributes: [{attribute: 'v', quantiles: {global: {6: [1, 2, 3, 4, 5, 6]}}}]
+          }
+        ]
+      }
+    },
+    d: {properties: {v: 3.5}},
+    expected: [227, 97, 28, 255]
   }
 ];
 


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background

Quantile stats for numeric attributes in static spatial index tilesets  are enclosed in extra `global` object
<!-- For all the PRs -->
#### Change List
- support extra `global` container for quantile stats in carto fetchMap API
