### PR TITLE
[v9] Fix GoogleMapsOverlay by not clearing canvas

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -1024,6 +1024,7 @@ export default class Deck {
 
     setGLParameters(device, this.props.parameters);
 
+    this.device?.canvasContext?.resize({useDevicePixels: this.props.useDevicePixels});
     this.props.onBeforeRender({device, gl});
 
     const opts = {

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -1024,7 +1024,6 @@ export default class Deck {
 
     setGLParameters(device, this.props.parameters);
 
-    this.device?.canvasContext?.resize({useDevicePixels: this.props.useDevicePixels});
     this.props.onBeforeRender({device, gl});
 
     const opts = {

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -66,7 +66,7 @@ export default class LayersPass extends Pass {
         viewport: [0, 0, width, height]
       },
       // clear depth and color buffers, restoring transparency
-      clearColor: options.clearColor || (options.clearCanvas ? [0, 0, 0, 0] : undefined),
+      clearColor: options.clearColor ?? (options.clearCanvas ? [0, 0, 0, 0] : false),
       clearDepth: options.clearCanvas ? 1 : undefined
     });
 
@@ -85,8 +85,7 @@ export default class LayersPass extends Pass {
       viewports,
       views,
       onViewportActive,
-      clearStack = true,
-      clearCanvas = true
+      clearStack = true
     } = options;
     options.pass = options.pass || 'unknown';
 

--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -242,10 +242,23 @@ export default class GoogleMapsOverlay {
       // @ts-expect-error
       deck.setProps({_framebuffer});
 
+      // With external gl context, animation loop doesn't resize webgl-canvas and thus fails to
+      // calculate corrext pixel ratio. Force this manually.
+      // @ts-expect-error
+      deck.device.canvasContext.resize();
+
       // Camera changed, will trigger a map repaint right after this
       // Clear any change flag triggered by setting viewState so that deck does not request
       // a second repaint
       deck.needsRedraw({clearRedrawFlags: true});
+
+      // Workaround for bug in Google maps where viewport state is wrong
+      // TODO remove once fixed
+      setGLParameters(gl, {
+        viewport: [0, 0, gl.canvas.width, gl.canvas.height],
+        scissor: [0, 0, gl.canvas.width, gl.canvas.height],
+        stencilFunc: [gl.ALWAYS, 0, 255, gl.ALWAYS, 0, 255]
+      });
 
       withGLParameters(gl, GL_STATE, () => {
         deck._drawLayers('google-vector', {

--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -247,14 +247,6 @@ export default class GoogleMapsOverlay {
       // a second repaint
       deck.needsRedraw({clearRedrawFlags: true});
 
-      // Workaround for bug in Google maps where viewport state is wrong
-      // TODO remove once fixed
-      setGLParameters(gl, {
-        viewport: [0, 0, gl.canvas.width, gl.canvas.height],
-        scissor: [0, 0, gl.canvas.width, gl.canvas.height],
-        stencilFunc: [gl.ALWAYS, 0, 255, gl.ALWAYS, 0, 255]
-      });
-
       withGLParameters(gl, GL_STATE, () => {
         deck._drawLayers('google-vector', {
           clearCanvas: false


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #8302
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- [x] Fix LayerPass to obey `clearCanvas: false` and not clear framebuffer
- [x] configure devicePixelRatio in device.canvasContext
