### PR TITLE
chore(website): Switch contour-layer demo to CPU aggregation

### DIFF
--- a/examples/website/contour/app.jsx
+++ b/examples/website/contour/app.jsx
@@ -53,6 +53,7 @@ export default function App({
       },
       pickable: true,
       aggregation: 'MAX',
+      gpuAggregation: false, // TODO(v9): Re-enable GPU aggregation.
       contours,
       cellSize
     })

--- a/modules/aggregation-layers/src/contour-layer/contour-layer.ts
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.ts
@@ -25,7 +25,6 @@ import {
   Accessor,
   AccessorFunction,
   Color,
-  Layer,
   log,
   Position,
   UpdateParameters,


### PR DESCRIPTION
Related:

- #8314

Switches counter-layer to CPU aggregation. This works without further changes. Once GPU grid aggregation is working again (see #8321) we can switch this back.

![Screenshot 2024-01-12 at 11 35 36 AM](https://github.com/visgl/deck.gl/assets/1848368/f5f07ff5-54c8-4d24-b86d-fe769d9a872d)
