### PR TITLE
TerrainExtension: Support picking on draped layers

### DIFF
--- a/examples/website/google-3d-tiles/app.jsx
+++ b/examples/website/google-3d-tiles/app.jsx
@@ -32,6 +32,17 @@ const INITIAL_VIEW_STATE = {
 const BUILDING_DATA =
   'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/google-3d-tiles/buildings.geojson';
 
+function getTooltip({object}) {
+  return (
+    object && {
+      html: `\
+    <div><b>Distance to nearest tree</b></div>
+    <div>${object.properties.distance_to_nearest_tree}</div>
+    `
+    }
+  );
+}
+
 export default function App({data = TILESET_URL, distance = 0, opacity = 0.2}) {
   const [credits, setCredits] = useState('');
 
@@ -64,7 +75,8 @@ export default function App({data = TILESET_URL, distance = 0, opacity = 0.2}) {
       getFillColor: ({properties}) => colorScale(properties.distance_to_nearest_tree),
       opacity,
       getFilterValue: f => f.properties.distance_to_nearest_tree,
-      filterRange: [distance, 500]
+      filterRange: [distance, 500],
+      pickable: true
     })
   ];
 
@@ -75,6 +87,7 @@ export default function App({data = TILESET_URL, distance = 0, opacity = 0.2}) {
         initialViewState={INITIAL_VIEW_STATE}
         controller={{touchRotate: true, inertia: 250}}
         layers={layers}
+        getTooltip={getTooltip}
       />
       <div
         style={{position: 'absolute', left: '8px', bottom: '4px', color: 'white', fontSize: '10px'}}

--- a/modules/extensions/src/terrain/terrain-effect.ts
+++ b/modules/extensions/src/terrain/terrain-effect.ts
@@ -202,7 +202,12 @@ export class TerrainEffect implements Effect {
             devicePixelRatio: 1
           }
         });
-        terrainCover.isDirty = false;
+
+        if (!this.isPicking) {
+          // IsDirty refers to the normal fbo, not the picking fbo.
+          // Only mark it as not dirty if the normal fbo was updated.
+          terrainCover.isDirty = false;
+        }
       }
     } catch (err) {
       terrainLayer.raiseError(err as Error, `Error rendering terrain cover ${terrainCover.id}`);

--- a/modules/extensions/src/terrain/terrain-effect.ts
+++ b/modules/extensions/src/terrain/terrain-effect.ts
@@ -65,7 +65,8 @@ export class TerrainEffect implements Effect {
       return;
     }
 
-    const {viewports, isPicking = false} = opts;
+    const {viewports} = opts;
+    const isPicking = opts.pass.startsWith('picking');
     this.isPicking = isPicking;
     this.isDrapingEnabled = true;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #7892
<!-- For other PRs without open issue -->
<!-- #### Background -->
<!-- For all the PRs -->
#### Change List
- Update terrain extension example with tooltip
- Detect picking render passes in terrain extension
- Fix terrain cover invalidation

To test, start `google-3d-tiles` example locally:
Just the updated example: Tooltips don't work.
Updated example and fixes: Tooltips work.
