### PR TITLE
fix(core): Ensure picking buffer is cleared before each pass

### DIFF
--- a/modules/core/src/passes/pick-layers-pass.ts
+++ b/modules/core/src/passes/pick-layers-pass.ts
@@ -79,7 +79,6 @@ export default class PickLayersPass extends LayersPass {
       {
         scissorTest: true,
         scissor: [x, y, width, height],
-        clearColor: [0, 0, 0, 0],
         // When used as Mapbox custom layer, the context state may be dirty
         // TODO - Remove when mapbox fixes this issue
         // https://github.com/mapbox/mapbox-gl-js/issues/7801
@@ -103,7 +102,8 @@ export default class PickLayersPass extends LayersPass {
           effects: effects?.filter(e => e.useInPicking),
           pass,
           isPicking: true,
-          moduleParameters
+          moduleParameters,
+          clearColor: [0, 0, 0, 0]
         })
     );
 


### PR DESCRIPTION
Currently the picking buffer is not cleared correctly before each picking pass. In this block...

https://github.com/visgl/deck.gl/blob/eb44d5e53bc45cf97871c9f37aaed65a650a5e97/modules/core/src/passes/pick-layers-pass.ts#L80-L111

... we pass the clearColor into `withGLParameters`, but `layers-pass.ts` overrides it below:

https://github.com/visgl/deck.gl/blob/eb44d5e53bc45cf97871c9f37aaed65a650a5e97/modules/core/src/passes/layers-pass.ts#L63-L71

This PR provides one possible solution to the bug. But I am wondering if either the type definitions, or the current usage pattern of `withGLParameters`, should be changed in v9 to avoid similar issues. Perhaps `clearColor` should not be accepted as a parameter to `withGLParameters`? Or we start to remove uses of `withGLParameters` as we are working toward WebGPU support? 

- fixes #8443
- related #8471
