### PR TITLE
chore(types): Remove remaining references to /typed entrypoints

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ dist/
 dist-es6/
 test/
 website/build/
-modules/*/typed
 node_modules/
 workers/
 dist.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build/
 dist/
-modules/*/typed
 **/*.min.js
 node_modules/
 coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
 website/build
 **/dist*/**/*
 dist.js
-modules/*/typed
 *.min.js
 **/mapbox-gl-dev.js
 **/mapbox-gl.js

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -71,8 +71,8 @@ map.addControl(overlay);
 The following code demonstrates how to create a React component from `MapboxOverlay` with `react-map-gl@7.x` and Typescript:
 
 ```tsx
-import {ScatterplotLayer} from '@deck.gl/layers/typed';
-import {MapboxOverlay, MapboxOverlayProps} from '@deck.gl/mapbox/typed';
+import {ScatterplotLayer} from '@deck.gl/layers';
+import {MapboxOverlay, MapboxOverlayProps} from '@deck.gl/mapbox';
 import {useControl} from 'react-map-gl';
 
 import Map, {NavigationControl} from 'react-map-gl';

--- a/docs/get-started/using-with-typescript.md
+++ b/docs/get-started/using-with-typescript.md
@@ -1,5 +1,7 @@
 # Using deck.gl with TypeScript
 
+## deck.gl v9+
+
 Starting from v9.0, deck.gl publishes official TypeScript types for all modules. If TypeScript is enabled in your project, imports from deck.gl packages will include types. Examples:
 
 ```js
@@ -14,7 +16,7 @@ import type {GeoJsonLayerProps} from '@deck.gl/layers';
 
 Help us improve the types by reporting issues or sending suggestions on GitHub!
 
-## Alternative Solution for deck.gl v8.x
+## deck.gl v8
 
 Starting from v8.8, deck.gl publishes "public preview" TypeScript types via an opt-in only entry point. To use the official types in your application, find the following statements:
 
@@ -42,7 +44,7 @@ Note that the typed exports are a work in progress. They are not exposed by defa
 The typed exports will remain at the `typed` entry points throughout the rest of the 8.x releases. They will be exposed directly at the package roots starting in v9.0.
 
 
-## Alternative Solution for Legacy Versions
+## Legacy Versions
 
 If you are using a version before v8.8, a third-party typings library is available.
 

--- a/docs/get-started/using-with-typescript.md
+++ b/docs/get-started/using-with-typescript.md
@@ -1,32 +1,22 @@
 # Using deck.gl with TypeScript
 
-Starting from v8.8, deck.gl publishes "public preview" TypeScript types via an opt-in only entry point. To use the official types in your application, find the following statements:
+Starting from v9.0, deck.gl publishes official TypeScript types for all modules. If TypeScript is enabled in your project, imports from deck.gl packages will include types. Examples:
 
 ```js
+// Values and types.
 import DeckGL from '@deck.gl/react';
 import {GeoJsonLayer} from '@deck.gl/layers';
+
+// Types only.
+import type {DeckGLRef} from '@deck.gl/react';
+import type {GeoJsonLayerProps} from '@deck.gl/layers';
 ```
 
-and replace the package name with `@deck.gl/<module_name>/typed`:
-
-```typescript
-import DeckGL from '@deck.gl/react/typed';
-import {GeoJsonLayer} from '@deck.gl/layers/typed';
-```
-
-You can also import additional type definitions:
-
-```typescript
-import type {DeckGLRef} from '@deck.gl/react/typed';
-import type {GeoJsonLayerProps} from '@deck.gl/layers/typed';
-```
-
-Note that the typed exports are a work in progress. They are not exposed by default to prevent any typing errors from breaking existing TypeScript applications. Help us improve them by reporting any issues or suggestions on GitHub!
-
-The typed exports will remain at the `typed` entry points throughout the rest of the 8.x releases. They will be exposed directly at the package roots starting in v9.0.
-
+Help us improve the types by reporting issues or sending suggestions on GitHub!
 
 ## Alternative Solution for Legacy Versions
+
+In v8.x releases beginning with v8.8, deck.gl published "public preview" TypeScript types, with an opt-in entry point. To use TypeScript with these versions of deck.gl, import `@deck.gl/<module_name>/typed` instead of `@deck.gl/<module_name>`.
 
 If you are using a version before v8.8, a third-party typings library is available.
 

--- a/docs/get-started/using-with-typescript.md
+++ b/docs/get-started/using-with-typescript.md
@@ -14,9 +14,35 @@ import type {GeoJsonLayerProps} from '@deck.gl/layers';
 
 Help us improve the types by reporting issues or sending suggestions on GitHub!
 
-## Alternative Solution for Legacy Versions
+## Alternative Solution for deck.gl v8.x
 
-In v8.x releases beginning with v8.8, deck.gl published "public preview" TypeScript types, with an opt-in entry point. To use TypeScript with these versions of deck.gl, import `@deck.gl/<module_name>/typed` instead of `@deck.gl/<module_name>`.
+Starting from v8.8, deck.gl publishes "public preview" TypeScript types via an opt-in only entry point. To use the official types in your application, find the following statements:
+
+```js
+import DeckGL from '@deck.gl/react';
+import {GeoJsonLayer} from '@deck.gl/layers';
+```
+
+and replace the package name with `@deck.gl/<module_name>/typed`:
+
+```typescript
+import DeckGL from '@deck.gl/react/typed';
+import {GeoJsonLayer} from '@deck.gl/layers/typed';
+```
+
+You can also import additional type definitions:
+
+```typescript
+import type {DeckGLRef} from '@deck.gl/react/typed';
+import type {GeoJsonLayerProps} from '@deck.gl/layers/typed';
+```
+
+Note that the typed exports are a work in progress. They are not exposed by default to prevent any typing errors from breaking existing TypeScript applications. Help us improve them by reporting any issues or suggestions on GitHub!
+
+The typed exports will remain at the `typed` entry points throughout the rest of the 8.x releases. They will be exposed directly at the package roots starting in v9.0.
+
+
+## Alternative Solution for Legacy Versions
 
 If you are using a version before v8.8, a third-party typings library is available.
 

--- a/examples/experimental/tfjs/src/demo-histogram.ts
+++ b/examples/experimental/tfjs/src/demo-histogram.ts
@@ -1,4 +1,4 @@
-import {Deck, OrthographicView} from '@deck.gl/core/typed';
+import {Deck, OrthographicView} from '@deck.gl/core';
 import {HistogramLayer} from './layers/histogram-layer';
 
 const slider = document.createElement('input');

--- a/examples/experimental/tfjs/src/demo-spectrogram.ts
+++ b/examples/experimental/tfjs/src/demo-spectrogram.ts
@@ -1,4 +1,4 @@
-import {Deck, OrthographicView} from '@deck.gl/core/typed';
+import {Deck, OrthographicView} from '@deck.gl/core';
 import {SpectrogramLayer, SpectrogramSettings} from './layers/spectrogram-layer';
 
 const SETTINGS: SpectrogramSettings = {

--- a/examples/experimental/tfjs/src/layers/histogram-layer.ts
+++ b/examples/experimental/tfjs/src/layers/histogram-layer.ts
@@ -10,8 +10,8 @@ import {
   UpdateParameters,
   AttributeManager,
   _deepEqual
-} from '@deck.gl/core/typed';
-import {GridCellLayer} from '@deck.gl/layers/typed';
+} from '@deck.gl/core';
+import {GridCellLayer} from '@deck.gl/layers';
 import {Buffer} from '@luma.gl/core';
 import {Matrix4} from '@math.gl/core';
 

--- a/examples/experimental/tfjs/src/layers/spectrogram-layer.ts
+++ b/examples/experimental/tfjs/src/layers/spectrogram-layer.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs';
 
-import {UpdateParameters, Layer, CompositeLayer, LayersList} from '@deck.gl/core/typed';
+import {UpdateParameters, Layer, CompositeLayer, LayersList} from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 
 import {Tensor2DLayer} from './tensor-2d-layer';

--- a/examples/experimental/tfjs/src/layers/tensor-2d-layer.ts
+++ b/examples/experimental/tfjs/src/layers/tensor-2d-layer.ts
@@ -1,5 +1,5 @@
-import {BitmapLayer} from '@deck.gl/layers/typed';
-import type {GetPickingInfoParams, Texture} from '@deck.gl/core/typed';
+import {BitmapLayer} from '@deck.gl/layers';
+import type {GetPickingInfoParams, Texture} from '@deck.gl/core';
 import type {Texture2D} from '@luma.gl/webgl';
 
 export class Tensor2DLayer extends BitmapLayer<{

--- a/examples/website/carto-sql/app.tsx
+++ b/examples/website/carto-sql/app.tsx
@@ -1,11 +1,11 @@
-import React, {useMemo, useState, useCallback} from 'react';
+import React, {useState, useCallback} from 'react';
 import {createRoot} from 'react-dom/client';
-import {Map, ViewState} from 'react-map-gl';
+import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {LinearInterpolator, PickingInfo} from '@deck.gl/core';
 import {colorBins, H3TileLayer, h3QuerySource} from '@deck.gl/carto';
-import {TooltipContent} from '@deck.gl/core/typed/lib/tooltip';
+import { TooltipContent } from '@deck.gl/core/dist/lib/tooltip';
 
 const INITIAL_VIEW_STATE = {
   latitude: 35.7368521,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
     "postinstall": "./scripts/postinstall.sh",
-    "clean": "ocular-clean && rm -rf modules/*/typed",
+    "clean": "ocular-clean",
     "build": "npm run clean && ocular-build && lerna run build",
     "version": "ocular-build core,carto",
     "lint": "ocular-lint",


### PR DESCRIPTION
In v9.0 (and implemented in #8460), TypeScript type definitions are included in the default entrypoints for all deck.gl modules. This PR cleans up remaining references to the legacy /typed entrypoints, and updates the documentation.
