### PR TITLE
[Feat] Add onTileLoading callback on TileLayers

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -13,15 +13,15 @@ import {
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {LayersList} from '@deck.gl/core';
 
-import type {TileLoadProps, ZRange} from '../tileset-2d';
+import type {TileLoadProps, ZRange} from '../tileset-2d/index';
 import {
   Tileset2D,
   Tile2DHeader,
   RefinementStrategy,
   STRATEGY_DEFAULT,
   Tileset2DProps
-} from '../tileset-2d';
-import {urlType, URLTemplate, getURLFromTemplate} from '../tileset-2d';
+} from '../tileset-2d/index';
+import {urlType, URLTemplate, getURLFromTemplate} from '../tileset-2d/index';
 
 const defaultProps: DefaultProps<TileLayerProps> = {
   TilesetClass: Tileset2D,
@@ -175,12 +175,11 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   get isLoaded(): boolean {
-    const selectedTiles = this.state?.tileset?.selectedTiles;
-    return selectedTiles
-      ? selectedTiles.every(
+    return Boolean(
+      this.state?.tileset?.selectedTiles?.every(
         tile => tile.isLoaded && tile.layers && tile.layers.every(layer => layer.isLoaded)
       )
-      : false;
+    );
   }
 
   shouldUpdateState({changeFlags}): boolean {

--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -13,15 +13,15 @@ import {
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {LayersList} from '@deck.gl/core';
 
-import type {TileLoadProps, ZRange} from '../tileset-2d/index';
+import type {TileLoadProps, ZRange} from '../tileset-2d';
 import {
   Tileset2D,
   Tile2DHeader,
   RefinementStrategy,
   STRATEGY_DEFAULT,
   Tileset2DProps
-} from '../tileset-2d/index';
-import {urlType, URLTemplate, getURLFromTemplate} from '../tileset-2d/index';
+} from '../tileset-2d';
+import {urlType, URLTemplate, getURLFromTemplate} from '../tileset-2d';
 
 const defaultProps: DefaultProps<TileLayerProps> = {
   TilesetClass: Tileset2D,
@@ -31,6 +31,7 @@ const defaultProps: DefaultProps<TileLayerProps> = {
   getTileData: {type: 'function', optional: true, value: null},
   // TODO - change to onViewportLoad to align with Tile3DLayer
   onViewportLoad: {type: 'function', optional: true, value: null},
+  onTilesLoading: {type: 'function', optional: true, value: null},
   onTileLoad: {type: 'function', value: tile => {}},
   onTileUnload: {type: 'function', value: tile => {}},
   // eslint-disable-next-line
@@ -75,6 +76,9 @@ type _TileLayerProps<DataT> = {
 
   /** Called when all tiles in the current viewport are loaded. */
   onViewportLoad?: ((tiles: Tile2DHeader<DataT>[]) => void) | null;
+
+  /** Called when tiles first start to load and when state changes. */
+  onTilesLoading?: (() => void) | null;
 
   /** Called when a tile successfully loads. */
   onTileLoad?: (tile: Tile2DHeader<DataT>) => void;
@@ -171,11 +175,12 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   get isLoaded(): boolean {
-    return Boolean(
-      this.state?.tileset?.selectedTiles?.every(
+    const selectedTiles = this.state?.tileset?.selectedTiles;
+    return selectedTiles
+      ? selectedTiles.every(
         tile => tile.isLoaded && tile.layers && tile.layers.every(layer => layer.isLoaded)
       )
-    );
+      : false;
   }
 
   shouldUpdateState({changeFlags}): boolean {
@@ -273,6 +278,13 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
     }
   }
 
+  _onTilesLoading(): void {
+    const {onTilesLoading} = this.props;
+    if (onTilesLoading) {
+      onTilesLoading();
+    }
+  }
+
   _onTileLoad(tile: Tile2DHeader<DataT>): void {
     this.props.onTileLoad(tile);
     tile.layers = null;
@@ -296,7 +308,7 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   getTileData(tile: TileLoadProps): Promise<DataT> | DataT | null {
     const {data, getTileData, fetch} = this.props;
     const {signal} = tile;
-
+    this._onTilesLoading?.();
     tile.url =
       typeof data === 'string' || Array.isArray(data) ? getURLFromTemplate(data, tile) : null;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/8359. This PR adds a callback that allows the developer to know if tiles have begun to load for a specific layer. Currently tests for geo-layers are disabled so this was tested manually. The included video was made from the examples/get-started/react/basic example. This worked until the most recent changes to master from #https://github.com/visgl/deck.gl/pull/8473 where some changes were made surrounding `this.device.setParametersWebGL`.

<!-- For other PRs without open issue -->
<!-- For all the PRs -->
#### Change List
- `modules/geo-layers/src/tile-layer/tile-layer.ts`

```javascript
// For the example a react hook was used to trigger the loading state
let [loading, setLoading] = React.useState(false);

const tileLayer = new TileLayer({
  data: [<data sources for tiles>],
  onTilesLoading: () => setLoading(true),
  onViewportLoad: () => setLoading(false),
});
```
https://github-production-user-asset-6210df.s3.amazonaws.com/14153643/304517179-b80e9f32-7846-4864-977a-e75b174e12b2.mp4

Video Explanation:

When the application first loads the "loading" overlay is shown which is triggered by the `onTilesLoading` callback that sets the state to true. Once the `onViewportLoad` callback resolves it sets the state to false. When the map is zoomed out and more tiles begin to load the process repeats. 

Use Case:

The new `onTilesLoading` callback allows developers to know when tile loading begins on a tile layer. This callback along with  `onViewportLoad` may be used together to display a loading indicator for any tile layer (see the code example above). The overlay in the example video would be replaced by a spinner or some other traditional loading indicator.

