### PR TITLE
CARTO: Remove onDataLoad method

### DIFF
--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -28,7 +28,8 @@ const defaultProps: DefaultProps<VectorTileLayerProps> = {
 };
 
 /** All properties supported by VectorTileLayer. */
-export type VectorTileLayerProps = _VectorTileLayerProps & Omit<MVTLayerProps, 'data' | 'onDataLoad'>;
+export type VectorTileLayerProps = _VectorTileLayerProps &
+  Omit<MVTLayerProps, 'data' | 'onDataLoad'>;
 
 /** Properties added by VectorTileLayer. */
 type _VectorTileLayerProps = {

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -28,7 +28,7 @@ const defaultProps: DefaultProps<VectorTileLayerProps> = {
 };
 
 /** All properties supported by VectorTileLayer. */
-export type VectorTileLayerProps = _VectorTileLayerProps & Omit<MVTLayerProps, 'data'>;
+export type VectorTileLayerProps = _VectorTileLayerProps & Omit<MVTLayerProps, 'data' | 'onDataLoad'>;
 
 /** Properties added by VectorTileLayer. */
 type _VectorTileLayerProps = {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/8464
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Remove `onDataLoad` from props
