### PR TITLE
Update Windows WSL2 instructions for Windows 11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,12 @@ To run the Node tests, you need to set up OpenGL support via X11 forwarding:
     ```bash
     # WSL 1
     export DISPLAY=localhost:0
-    # WSL 2
+    # WSL 2 + Windows 10
     export DISPLAY=$(grep -m 1 nameserver /etc/resolv.conf | awk '{print $2}'):0.0
+    # WSL 2 + Windows 11
+    echo $DISPLAY
+    # if result of above command is NOT ":0"
+    export $DISPLAY=":0"
     ```
 
 You can test that it is set up successfully with:


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
I noticed that when I went through this setup last month the instruction for setting the DISPLAY variable did not work for my version of Windows and WSL2.

Through this source #https://github.com/microsoft/WSL/issues/6430#issuecomment-881766991 it seems that the DISPLAY variable will work out of the box for Windows 11 users with a fresh install or properly updated version as described here #https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps

Tested on Windows 11 Home Build 22631

```
WSL version: 2.0.14.0
Kernel version: 5.15.133.1-1
WSLg version: 1.0.59
MSRDC version: 1.2.4677
Direct3D version: 1.611.1-81528511
DXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
Windows version: 10.0.22631.3155
```
<!-- For all the PRs -->
#### Change List
- CONTRIBUTING.md
