### PR TITLE
[website] Remove luma.gl/core GL import from website

### DIFF
--- a/examples/website/election/app.js
+++ b/examples/website/election/app.js
@@ -2,7 +2,6 @@
 import {GoogleMapsOverlay as DeckOverlay} from '@deck.gl/google-maps';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {scaleLog} from 'd3-scale';
-import GL from '@luma.gl/constants';
 
 import mapStyle from './map-style';
 
@@ -58,7 +57,10 @@ export async function renderToDOM(container, options = {}) {
   const overlay = new DeckOverlay({
     parameters: {
       // Additive blending
-      blendFunc: [GL.SRC_ALPHA, GL.ONE, GL.ONE, GL.ONE_MINUS_SRC_ALPHA]
+      blendColorSrcFactor: 'src-alpha',
+      blendColorDstFactor: 'one',
+      blendAlphaSrcFactor: 'one',
+      blendAlphaDstFactor: 'one-minus-dst-alpha'
     },
     layers: renderLayers(options),
     getTooltip

--- a/examples/website/line/app.jsx
+++ b/examples/website/line/app.jsx
@@ -4,7 +4,6 @@ import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import DeckGL from '@deck.gl/react';
 import {LineLayer, ScatterplotLayer} from '@deck.gl/layers';
-import GL from '@luma.gl/constants';
 
 // Source data CSV
 const DATA_URL = {
@@ -86,8 +85,12 @@ export default function App({
       controller={true}
       pickingRadius={5}
       parameters={{
-        blendFunc: [GL.SRC_ALPHA, GL.ONE, GL.ONE_MINUS_DST_ALPHA, GL.ONE],
-        blendEquation: GL.FUNC_ADD
+        blendColorOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
+        blendAlphaOperation: 'add',
+        blendAlphaSrcFactor: 'one-minus-dst-alpha',
+        blendAlphaDstFactor: 'one'
       }}
       getTooltip={getTooltip}
     >

--- a/examples/website/plot/plot-layer/surface-layer.ts
+++ b/examples/website/plot/plot-layer/surface-layer.ts
@@ -8,7 +8,6 @@ import type {
   LayerDataSource,
   LayerProps
 } from '@deck.gl/core';
-import {GL} from '@luma.gl/constants';
 import {Model} from '@luma.gl/engine';
 import {ScaleLinear} from 'd3-scale';
 
@@ -83,11 +82,11 @@ export default class SurfaceLayer<
       colors: {
         size: 4,
         accessor: ['getPosition', 'getColor'],
-        type: GL.UNSIGNED_BYTE,
+        type: WebGL2RenderingContext.UNSIGNED_BYTE,
         update: this.calculateColors,
         noAlloc
       },
-      pickingColors: {size: 3, type: GL.UNSIGNED_BYTE, update: this.calculatePickingColors, noAlloc}
+      pickingColors: {size: 3, type: WebGL2RenderingContext.UNSIGNED_BYTE, update: this.calculatePickingColors, noAlloc}
     });
     /* eslint-enable max-len */
 

--- a/examples/website/plot/plot-layer/utils.js
+++ b/examples/website/plot/plot-layer/utils.js
@@ -1,5 +1,4 @@
 /* global document */
-import {GL} from '@luma.gl/constants';
 
 // helper for textMatrixToTexture
 function setTextStyle(ctx, fontSize) {
@@ -67,7 +66,7 @@ export function textMatrixToTexture(glContext, data, fontSize = 48) {
     columnWidths,
     texture: glContext.device.createTexture({
       pixels: canvas,
-      [GL.TEXTURE_MAG_FILTER]: GL.LINEAR
+      magFilter: 'linear'
     })
   };
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Folllowup to https://github.com/visgl/deck.gl/pull/8509, allows website to build now that we no longer use `inline-webgl-constants`

<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Remove `GL from '@luma.gl/constants'` imports
- Replace constants
