### PR TITLE
Respect `DataT` on `TripsLayer` props

### DIFF
--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
@@ -249,7 +249,7 @@ type _HexagonLayerProps<DataT = unknown> = {
 /** Aggregates data into a hexagon-based heatmap. The color and height of a hexagon are determined based on the objects it contains. */
 export default class HexagonLayer<DataT, ExtraPropsT extends {} = {}> extends AggregationLayer<
   DataT,
-  ExtraPropsT & Required<_HexagonLayerProps>
+  ExtraPropsT & Required<_HexagonLayerProps<DataT>>
 > {
   static layerName = 'HexagonLayer';
   static defaultProps = defaultProps;

--- a/modules/geo-layers/src/trips-layer/trips-layer.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.ts
@@ -58,7 +58,7 @@ type _TripsLayerProps<DataT = unknown> = {
 /** Render animated paths that represent vehicle trips. */
 export default class TripsLayer<DataT = any, ExtraProps extends {} = {}> extends PathLayer<
   DataT,
-  Required<_TripsLayerProps> & ExtraProps
+  Required<_TripsLayerProps<DataT>> & ExtraProps
 > {
   static layerName = 'TripsLayer';
   static defaultProps = defaultProps;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Closes #8507

While working on this, I briefly searched for similar errors by looking for `ExtraPropsT & Required<` and noticed `HexagonLayer` had the same issue.

<!-- For all the PRs -->
#### Change List
- Forward `DataT` from `TripsLayer` instance to `_TripsLayerProps` instance
- Forward `DataT` from `HexagonLayer` instance to `_HexagonLayerProps` instance
