### PR TITLE
Update PR template for linked-issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,13 @@
 <!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
 <!-- Anything doesn't work as expected is a bug, including code, doc and test -->
-For #
+
+<!-- Reference the issue that this closes -->
+<!-- If it only partially resolves it, change this to "For #" -->
+Closes #
+
 <!-- For other PRs without open issue -->
 #### Background
+
 <!-- For all the PRs -->
 #### Change List
 -


### PR DESCRIPTION
#### Background

The PR template tells users to use "For #" but that won't work with GitHub linked issues:

https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

#### Change List
- Change PR template from "For #" to "Closes #"
- Restructure PR template for readability