### PR TITLE
fix(mapbox): overlay position affected by text alignment

### DIFF
--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -66,6 +66,7 @@ export default class MapboxOverlay implements IControl {
       position: 'absolute',
       left: 0,
       top: 0,
+      textAlign: 'initial',
       pointerEvents: 'none'
     });
     this._container = container;


### PR DESCRIPTION
For #8528

#### Change List
- Reset container text alignment
