### PR TITLE
doc: using-with-mapbox: fix broken link

### DIFF
--- a/docs/developer-guide/base-maps/using-with-mapbox.md
+++ b/docs/developer-guide/base-maps/using-with-mapbox.md
@@ -38,7 +38,7 @@ If you are using react-map-gl, there are several ways to provide a token to your
 
 ## Compatibility with Mapbox GL JS forks
 
-As of v2.0, Mapbox GL JS [went proprietary](https://github.com/mapbox/mapbox-gl-js/blob/main/CHANGELOG.md#200) and requires a Mapbox account to use even if you don't load tiles from the Mapbox data service. Community forks of the v1 code base such as [MapLibre GL JS](https://maplibre.org) can generally be used as a drop-in replacement of mapbox-gl. If you are using react-map-gl, follow [these instructions](http://visgl.github.io/react-map-gl/docs/get-started/get-started#using-with-a-mapbox-gl-fork).
+As of v2.0, Mapbox GL JS [went proprietary](https://github.com/mapbox/mapbox-gl-js/blob/main/CHANGELOG.md#200) and requires a Mapbox account to use even if you don't load tiles from the Mapbox data service. Community forks of the v1 code base such as [MapLibre GL JS](https://maplibre.org) can generally be used as a drop-in replacement of mapbox-gl. If you are using react-map-gl, see [their Get Started guide](http://visgl.github.io/react-map-gl/docs/get-started) for more details.
 
 If the forked libraries and Mapbox API diverge in the future, compatibility issues may arise. deck.gl intends to support open source efforts wherever reasonable. Please report any issue on GitHub.
 


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/8538
#### Change List
- Fix broken link to react-map-gl's docs regarding usage with a mapbox-gl fork
