### PR TITLE
Change Attribute.type to VertexType from WebGL constants

### DIFF
--- a/modules/aggregation-layers/src/contour-layer/contour-layer.ts
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.ts
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {GL} from '@luma.gl/constants';
 import {LineLayer, SolidPolygonLayer} from '@deck.gl/layers';
 import {generateContours} from './contour-utils';
 import {
@@ -185,7 +184,7 @@ export default class ContourLayer<
       [POSITION_ATTRIBUTE_NAME]: {
         size: 3,
         accessor: 'getPosition',
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions()
       },
       // this attribute is used in gpu aggregation path only

--- a/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/cpu-grid-layer/cpu-grid-layer.ts
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {GL} from '@luma.gl/constants';
 import {GridCellLayer} from '@deck.gl/layers';
 import {Accessor, AccessorFunction, Color, Position, Material, DefaultProps} from '@deck.gl/core';
 
@@ -261,7 +260,7 @@ export default class CPUGridLayer<
     };
     const attributeManager = this.getAttributeManager()!;
     attributeManager.add({
-      positions: {size: 3, type: GL.DOUBLE, accessor: 'getPosition'}
+      positions: {size: 3, type: 'float64', accessor: 'getPosition'}
     });
     // color and elevation attributes can't be added as attributes
     // they are calcualted using 'getValue' accessor that takes an array of pints.

--- a/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.ts
+++ b/modules/aggregation-layers/src/gpu-grid-layer/gpu-grid-layer.ts
@@ -221,7 +221,7 @@ export default class GPUGridLayer<
       [POSITION_ATTRIBUTE_NAME]: {
         size: 3,
         accessor: 'getPosition',
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions()
       },
       color: {size: 3, accessor: 'getColorWeight'},

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -27,7 +27,6 @@ import {
   getTextureCoordinates
 } from './heatmap-layer-utils';
 import {Buffer, DeviceFeature, Texture, TextureProps, TextureFormat} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
 import {TextureTransform, TextureTransformProps} from '@luma.gl/engine';
 import {
   Accessor,
@@ -370,7 +369,7 @@ export default class HeatmapLayer<
   _setupAttributes() {
     const attributeManager = this.getAttributeManager()!;
     attributeManager.add({
-      positions: {size: 3, type: GL.DOUBLE, accessor: 'getPosition'},
+      positions: {size: 3, type: 'float64', accessor: 'getPosition'},
       weights: {size: 1, accessor: 'getWeight'}
     });
     this.setState({positionAttributeName: 'positions'});

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
@@ -29,7 +29,6 @@ import {
   DefaultProps
 } from '@deck.gl/core';
 import {ColumnLayer} from '@deck.gl/layers';
-import {GL} from '@luma.gl/constants';
 
 import {defaultColorRange} from '../utils/color-utils';
 
@@ -272,7 +271,7 @@ export default class HexagonLayer<DataT, ExtraPropsT extends {} = {}> extends Ag
     };
     const attributeManager = this.getAttributeManager()!;
     attributeManager.add({
-      positions: {size: 3, type: GL.DOUBLE, accessor: 'getPosition'}
+      positions: {size: 3, type: 'float64', accessor: 'getPosition'}
     });
     // color and elevation attributes can't be added as attributes
     // they are calculated using 'getValue' accessor that takes an array of pints.

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.ts
@@ -32,7 +32,6 @@ import {
   DefaultProps
 } from '@deck.gl/core';
 import type {Buffer, Texture} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
 import GPUGridAggregator from '../utils/gpu-grid-aggregation/gpu-grid-aggregator';
 import {AGGREGATION_OPERATION, getValueFunc} from '../utils/aggregation-operation-utils';
 import ScreenGridCellLayer from './screen-grid-cell-layer';
@@ -182,7 +181,7 @@ export default class ScreenGridLayer<
       [POSITION_ATTRIBUTE_NAME]: {
         size: 3,
         accessor: 'getPosition',
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions()
       },
       // this attribute is used in gpu aggregation path only

--- a/modules/carto/src/layers/raster-layer.ts
+++ b/modules/carto/src/layers/raster-layer.ts
@@ -1,4 +1,3 @@
-import {GL} from '@luma.gl/constants';
 import {
   Accessor,
   CompositeLayer,
@@ -48,16 +47,14 @@ class RasterColumnLayer extends ColumnLayer {
       },
       instanceFillColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getFillColor',
         defaultValue: [0, 0, 0, 255]
       },
       instanceLineColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getLineColor',
         defaultValue: [255, 255, 255, 255]

--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -14,13 +14,16 @@ import log from '../../utils/log';
 
 import type {TypedArray, NumericArray, TypedArrayConstructor} from '../../types/types';
 
+export type DataType = Exclude<VertexType, 'float16'>;
+export type LogicalDataType = DataType | 'float64';
+
 export type BufferAccessor = {
   /** Vertex data type. */
-  type?: VertexType;
+  type?: DataType;
   /** The number of elements per vertex attribute. */
   size?: number;
   /** 1 if instanced. */
-  divisor?: 1 | 0;
+  divisor?: number;
   /** Offset of the first vertex attribute into the buffer, in bytes. */
   offset?: number;
   /** The offset between the beginning of consecutive vertex attributes, in bytes. */
@@ -93,17 +96,17 @@ export type DataColumnOptions<Options> = Options &
     /** Vertex data type.
      * @default 'float32'
      */
-    type?: VertexType | 'float64';
+    type?: LogicalDataType;
     /** Internal API, use `type` instead */
-    logicalType?: VertexType | 'float64';
+    logicalType?: LogicalDataType;
     isIndexed?: boolean;
     defaultValue?: number | number[];
   };
 
 export type DataColumnSettings<Options> = DataColumnOptions<Options> & {
-  type: VertexType;
+  type: DataType;
   size: number;
-  logicalType?: VertexType | 'float64';
+  logicalType?: LogicalDataType;
   normalized: boolean;
   bytesPerElement: number;
   defaultValue: number[];
@@ -144,7 +147,7 @@ export default class DataColumn<Options, State> {
       ? [defaultValue]
       : defaultValue || new Array(this.size).fill(0);
 
-    let bufferType: VertexType;
+    let bufferType: DataType;
     if (doublePrecision) {
       bufferType = 'float32';
     } else if (!logicalType && opts.isIndexed) {
@@ -371,7 +374,7 @@ export default class DataColumn<Options, State> {
           accessor.type = 'float32';
         } else {
           const type = dataTypeFromTypedArray(opts.value);
-          accessor.type = accessor.normalized ? (type.replace('int', 'norm') as VertexType) : type;
+          accessor.type = accessor.normalized ? (type.replace('int', 'norm') as DataType) : type;
         }
       }
       accessor.bytesPerElement = opts.value.BYTES_PER_ELEMENT;

--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -1,13 +1,12 @@
 /* eslint-disable complexity */
 import type {Device} from '@luma.gl/core';
-import {Buffer, BufferLayout, BufferAttributeLayout} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
+import {Buffer, BufferLayout, BufferAttributeLayout, VertexType} from '@luma.gl/core';
 
 import {
-  glArrayFromType,
+  typedArrayFromDataType,
   getBufferAttributeLayout,
   getStride,
-  getGLTypeFromTypedArray
+  dataTypeFromTypedArray
 } from './gl-utils';
 import typedArrayManager from '../../utils/typed-array-manager';
 import {toDoublePrecisionArray} from '../../utils/math-utils';
@@ -16,19 +15,16 @@ import log from '../../utils/log';
 import type {TypedArray, NumericArray, TypedArrayConstructor} from '../../types/types';
 
 export type BufferAccessor = {
-  /** A WebGL data type, see [vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer#parameters). */
-  type?: number;
+  /** Vertex data type. */
+  type?: VertexType;
   /** The number of elements per vertex attribute. */
   size?: number;
   /** 1 if instanced. */
-  divisor?: number;
+  divisor?: 1 | 0;
   /** Offset of the first vertex attribute into the buffer, in bytes. */
   offset?: number;
   /** The offset between the beginning of consecutive vertex attributes, in bytes. */
   stride?: number;
-  /** Whether data values should be normalized. Note that all color attributes in deck.gl layers are normalized by default. */
-  normalized?: boolean;
-  integer?: boolean;
 };
 
 export type ShaderAttributeOptions = Partial<BufferAccessor> & {
@@ -90,19 +86,25 @@ function resolveDoublePrecisionShaderAttributes(
 }
 
 export type DataColumnOptions<Options> = Options &
-  BufferAccessor & {
+  Omit<BufferAccessor, 'type'> & {
     id?: string;
     vertexOffset?: number;
     fp64?: boolean;
-    logicalType?: number;
+    /** Vertex data type.
+     * @default 'float32'
+     */
+    type?: VertexType | 'float64';
+    /** Internal API, use `type` instead */
+    logicalType?: VertexType | 'float64';
     isIndexed?: boolean;
     defaultValue?: number | number[];
   };
 
 export type DataColumnSettings<Options> = DataColumnOptions<Options> & {
-  type: number;
+  type: VertexType;
   size: number;
-  logicalType?: number;
+  logicalType?: VertexType | 'float64';
+  normalized: boolean;
   bytesPerElement: number;
   defaultValue: number[];
   defaultType: TypedArrayConstructor;
@@ -135,26 +137,26 @@ export default class DataColumn<Options, State> {
     this.size = opts.size || 1;
 
     const logicalType = opts.logicalType || opts.type;
-    const doublePrecision = logicalType === GL.DOUBLE;
+    const doublePrecision = logicalType === 'float64';
 
     let {defaultValue} = opts;
     defaultValue = Number.isFinite(defaultValue)
       ? [defaultValue]
       : defaultValue || new Array(this.size).fill(0);
 
-    let bufferType: number;
+    let bufferType: VertexType;
     if (doublePrecision) {
-      bufferType = GL.FLOAT;
+      bufferType = 'float32';
     } else if (!logicalType && opts.isIndexed) {
-      bufferType = GL.UNSIGNED_INT;
+      bufferType = 'uint32';
     } else {
-      bufferType = logicalType || GL.FLOAT;
+      bufferType = logicalType || 'float32';
     }
 
     // This is the attribute type defined by the layer
     // If an external buffer is provided, this.type may be overwritten
     // But we always want to use defaultType for allocation
-    let defaultType = glArrayFromType(logicalType || bufferType || GL.FLOAT);
+    let defaultType = typedArrayFromDataType(logicalType || bufferType);
     this.doublePrecision = doublePrecision;
 
     // `fp64: false` tells a double-precision attribute to allocate Float32Arrays
@@ -172,6 +174,7 @@ export default class DataColumn<Options, State> {
       defaultValue: defaultValue as number[],
       logicalType,
       type: bufferType,
+      normalized: bufferType.includes('norm'),
       size: this.size,
       bytesPerElement: defaultType.BYTES_PER_ELEMENT
     };
@@ -361,8 +364,16 @@ export default class DataColumn<Options, State> {
     const accessor: DataColumnSettings<Options> = {...this.settings, ...opts};
 
     if (ArrayBuffer.isView(opts.value)) {
-      const is64Bit = this.doublePrecision && opts.value instanceof Float64Array;
-      accessor.type = opts.type || (is64Bit ? GL.FLOAT : getGLTypeFromTypedArray(opts.value));
+      if (!opts.type) {
+        // Deduce data type
+        const is64Bit = this.doublePrecision && opts.value instanceof Float64Array;
+        if (is64Bit) {
+          accessor.type = 'float32';
+        } else {
+          const type = dataTypeFromTypedArray(opts.value);
+          accessor.type = accessor.normalized ? (type.replace('int', 'norm') as VertexType) : type;
+        }
+      }
       accessor.bytesPerElement = opts.value.BYTES_PER_ELEMENT;
       accessor.stride = getStride(accessor);
     }
@@ -509,20 +520,20 @@ export default class DataColumn<Options, State> {
   // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer
   normalizeConstant(value: NumericArray): NumericArray {
     /* eslint-disable complexity */
-    switch (this.settings.type as GL) {
-      case GL.BYTE:
+    switch (this.settings.type) {
+      case 'snorm8':
         // normalize [-128, 127] to [-1, 1]
         return new Float32Array(value).map(x => ((x + 128) / 255) * 2 - 1);
 
-      case GL.SHORT:
+      case 'snorm16':
         // normalize [-32768, 32767] to [-1, 1]
         return new Float32Array(value).map(x => ((x + 32768) / 65535) * 2 - 1);
 
-      case GL.UNSIGNED_BYTE:
+      case 'unorm8':
         // normalize [0, 255] to [0, 1]
         return new Float32Array(value).map(x => x / 255);
 
-      case GL.UNSIGNED_SHORT:
+      case 'unorm16':
         // normalize [0, 65535] to [0, 1]
         return new Float32Array(value).map(x => x / 65535);
 
@@ -596,7 +607,7 @@ export default class DataColumn<Options, State> {
       ...this._buffer?.props,
       id: this.id,
       usage: isIndexed ? Buffer.INDEX : Buffer.VERTEX,
-      indexType: isIndexed ? ((type as GL) === GL.UNSIGNED_SHORT ? 'uint16' : 'uint32') : undefined,
+      indexType: isIndexed ? (type as 'uint16' | 'uint32') : undefined,
       byteLength
     });
 

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -1,13 +1,11 @@
 import {getTypedArrayFromDataType, getDataTypeFromTypedArray} from '@luma.gl/core';
-import type {BufferAttributeLayout, VertexType, VertexFormat} from '@luma.gl/core';
+import type {BufferAttributeLayout, VertexFormat} from '@luma.gl/core';
 import type {TypedArrayConstructor} from '../../types/types';
-import type {BufferAccessor, DataColumnSettings} from './data-column';
+import type {BufferAccessor, DataColumnSettings, LogicalDataType} from './data-column';
 
-export function typedArrayFromDataType(type: VertexType | 'float64'): TypedArrayConstructor {
+export function typedArrayFromDataType(type: LogicalDataType): TypedArrayConstructor {
   // Sorted in some order of likelihood to reduce amount of comparisons
   switch (type) {
-    case 'float16':
-      return Float32Array;
     case 'float64':
       return Float64Array;
     default:

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -1,6 +1,5 @@
-import {GL} from '@luma.gl/constants';
 import {getTypedArrayFromDataType, getDataTypeFromTypedArray} from '@luma.gl/core';
-import type {BufferAttributeLayout, TypedArray, VertexType, VertexFormat} from '@luma.gl/core';
+import type {BufferAttributeLayout, VertexType, VertexFormat} from '@luma.gl/core';
 import type {TypedArrayConstructor} from '../../types/types';
 import type {BufferAccessor, DataColumnSettings} from './data-column';
 

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -1,62 +1,34 @@
-import {GL, GLDataType} from '@luma.gl/constants';
-import type {BufferAttributeLayout, TypedArray, VertexFormat} from '@luma.gl/core';
+import {GL} from '@luma.gl/constants';
+import {getTypedArrayFromDataType, getDataTypeFromTypedArray} from '@luma.gl/core';
+import type {BufferAttributeLayout, TypedArray, VertexType, VertexFormat} from '@luma.gl/core';
 import type {TypedArrayConstructor} from '../../types/types';
 import type {BufferAccessor, DataColumnSettings} from './data-column';
 
-/* eslint-disable complexity */
-export function glArrayFromType(glType: number): TypedArrayConstructor {
+export function typedArrayFromDataType(type: VertexType | 'float64'): TypedArrayConstructor {
   // Sorted in some order of likelihood to reduce amount of comparisons
-  switch (glType as GL) {
-    case GL.FLOAT:
+  switch (type) {
+    case 'float16':
       return Float32Array;
-    case GL.DOUBLE:
+    case 'float64':
       return Float64Array;
-    case GL.UNSIGNED_SHORT:
-    case GL.UNSIGNED_SHORT_5_6_5:
-    case GL.UNSIGNED_SHORT_4_4_4_4:
-    case GL.UNSIGNED_SHORT_5_5_5_1:
-      return Uint16Array;
-    case GL.UNSIGNED_INT:
-      return Uint32Array;
-    case GL.UNSIGNED_BYTE:
-      return Uint8ClampedArray;
-    case GL.BYTE:
-      return Int8Array;
-    case GL.SHORT:
-      return Int16Array;
-    case GL.INT:
-      return Int32Array;
     default:
-      throw new Error('Unknown GL type');
+      return getTypedArrayFromDataType(type);
   }
 }
-/* eslint-enable complexity */
 
-const glTypeToBufferFormat = {
-  [GL.FLOAT]: 'float32',
-  [GL.DOUBLE]: 'float32',
-  [GL.UNSIGNED_SHORT]: 'uint16',
-  [GL.UNSIGNED_SHORT_5_6_5]: 'uint16',
-  [GL.UNSIGNED_SHORT_4_4_4_4]: 'uint16',
-  [GL.UNSIGNED_SHORT_5_5_5_1]: 'uint16',
-  [GL.UNSIGNED_INT]: 'uint32',
-  [GL.UNSIGNED_BYTE]: 'uint8',
-  [GL.BYTE]: 'sint8',
-  [GL.SHORT]: 'sint16',
-  [GL.INT]: 'sint32'
-} as const;
+export const dataTypeFromTypedArray = getDataTypeFromTypedArray;
 
 export function getBufferAttributeLayout(
   name: string,
   accessor: BufferAccessor
 ): BufferAttributeLayout {
-  let type = glTypeToBufferFormat[accessor.type ?? GL.FLOAT];
-  if (accessor.normalized) {
-    type = type.replace('int', 'norm');
-  }
   return {
     attribute: name,
-    format: (accessor.size as number) > 1 ? (`${type}x${accessor.size}` as VertexFormat) : type,
+    // @ts-expect-error Not all combinations are valid vertex formats; it's up to DataColumn to ensure
+    format:
+      (accessor.size as number) > 1
+        ? (`${accessor.type}x${accessor.size}` as VertexFormat)
+        : accessor.type,
     byteOffset: accessor.offset || 0
     // Note stride is set on the top level
   };
@@ -71,41 +43,9 @@ export function bufferLayoutEqual(
   accessor2: DataColumnSettings<unknown>
 ) {
   return (
-    (accessor1.type ?? GL.FLOAT) === (accessor2.type ?? GL.FLOAT) &&
+    accessor1.type === accessor2.type &&
     accessor1.size === accessor2.size &&
     getStride(accessor1) === getStride(accessor2) &&
     (accessor1.offset || 0) === (accessor2.offset || 0)
   );
-}
-
-const ERR_TYPE_DEDUCTION = 'Failed to deduce GL constant from typed array';
-
-/**
- * Converts TYPED ARRAYS to corresponding GL constant
- * Used to auto deduce gl parameter types
- * @todo Duplicated from `@luma.gl/webgl`.
- */
-export function getGLTypeFromTypedArray(arrayOrType: TypedArray): GLDataType {
-  // If typed array, look up constructor
-  const type = ArrayBuffer.isView(arrayOrType) ? arrayOrType.constructor : arrayOrType;
-  switch (type) {
-    case Float32Array:
-      return GL.FLOAT;
-    case Uint16Array:
-      return GL.UNSIGNED_SHORT;
-    case Uint32Array:
-      return GL.UNSIGNED_INT;
-    case Uint8Array:
-      return GL.UNSIGNED_BYTE;
-    case Uint8ClampedArray:
-      return GL.UNSIGNED_BYTE;
-    case Int8Array:
-      return GL.BYTE;
-    case Int16Array:
-      return GL.SHORT;
-    case Int32Array:
-      return GL.INT;
-    default:
-      throw new Error(ERR_TYPE_DEDUCTION);
-  }
 }

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -20,7 +20,6 @@
 
 /* eslint-disable react/no-direct-mutation-state */
 import {Buffer, TypedArray} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
 import {COORDINATE_SYSTEM} from './constants';
 import AttributeManager from './attribute/attribute-manager';
 import UniformTransitionManager from './uniform-transition-manager';
@@ -884,7 +883,7 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
       // TODO - this slightly slows down non instanced layers
       attributeManager.addInstanced({
         instancePickingColors: {
-          type: GL.UNSIGNED_BYTE,
+          type: 'uint8',
           size: 4,
           noAlloc: true,
           // Updaters are always called with `this` pointing to the layer

--- a/modules/core/src/transitions/gpu-spring-transition.ts
+++ b/modules/core/src/transitions/gpu-spring-transition.ts
@@ -55,7 +55,7 @@ export default class GPUSpringTransition implements GPUTransition {
     // attribute, it will be converted and returned as a regular attribute
     // `attribute.userData` is the original options passed when constructing the attribute.
     // This ensures that we set the proper `doublePrecision` flag and shader attributes.
-    this.attributeInTransition = new Attribute(device, {...attribute.settings, normalized: false});
+    this.attributeInTransition = new Attribute(device, attribute.settings);
     this.currentStartIndices = attribute.startIndices;
     // storing currentLength because this.buffer may be larger than the actual length we want to use
     // this is because we only reallocate buffers when they grow, not when they shrink,

--- a/modules/extensions/src/data-filter/data-filter-extension.ts
+++ b/modules/extensions/src/data-filter/data-filter-extension.ts
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {GL} from '@luma.gl/constants';
 import type {Framebuffer} from '@luma.gl/core';
 import type {Model} from '@luma.gl/engine';
 import type {Layer, LayerContext, Accessor, UpdateParameters} from '@deck.gl/core';
@@ -165,7 +164,7 @@ export default class DataFilterExtension extends LayerExtension<
       attributeManager.add({
         filterValues: {
           size: filterSize,
-          type: fp64 ? GL.DOUBLE : GL.FLOAT,
+          type: fp64 ? 'float64' : 'float32',
           accessor: 'getFilterValue',
           shaderAttributes: {
             filterValues: {
@@ -178,7 +177,6 @@ export default class DataFilterExtension extends LayerExtension<
         },
         filterCategoryValues: {
           size: categorySize,
-          type: GL.FLOAT,
           accessor: 'getFilterCategory',
           transform:
             categorySize === 1
@@ -206,8 +204,7 @@ export default class DataFilterExtension extends LayerExtension<
         filterIndices: {
           size: useFloatTarget ? 1 : 2,
           vertexOffset: 1,
-          type: GL.UNSIGNED_BYTE,
-          normalized: true,
+          type: 'unorm8',
           accessor: (object, {index}) => {
             const i = object && object.__source ? object.__source.index : index;
             return useFloatTarget ? (i + 1) % 255 : [(i + 1) % 255, Math.floor(i / 255) % 255];

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.ts
@@ -2,7 +2,6 @@ import type {NumericArray} from '@math.gl/core';
 import {parsePBRMaterial, ParsedPBRMaterial} from '@luma.gl/gltf';
 import {pbr} from '@luma.gl/shadertools';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 import type {MeshAttribute, MeshAttributes} from '@loaders.gl/schema';
 import type {UpdateParameters, DefaultProps, LayerContext} from '@deck.gl/core';
 import {SimpleMeshLayer, SimpleMeshLayerProps} from '@deck.gl/mesh-layers';
@@ -72,7 +71,7 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
       // attributeManager is always defined in a primitive layer
       attributeManager!.add({
         featureIdsPickingColors: {
-          type: GL.UNSIGNED_BYTE,
+          type: 'uint8',
           size: 3,
           noAlloc: true,
           // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -36,7 +36,6 @@ import {
 
 import {Geometry} from '@luma.gl/engine';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 import vs from './arc-layer-vertex.glsl';
 import fs from './arc-layer-fragment.glsl';
@@ -180,30 +179,28 @@ export default class ArcLayer<DataT = any, ExtraPropsT extends {} = {}> extends 
     attributeManager.addInstanced({
       instanceSourcePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getSourcePosition'
       },
       instanceTargetPositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getTargetPosition'
       },
       instanceSourceColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getSourceColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceTargetColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getTargetColor',
         defaultValue: DEFAULT_COLOR

--- a/modules/layers/src/bitmap-layer/bitmap-layer.ts
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.ts
@@ -35,7 +35,6 @@ import {
 } from '@deck.gl/core';
 import {Model} from '@luma.gl/engine';
 import type {SamplerProps, Texture} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
 import {lngLatToWorld} from '@math.gl/web-mercator';
 
 import createMesh from './create-mesh';
@@ -147,7 +146,7 @@ export default class BitmapLayer<ExtraPropsT extends {} = {}> extends Layer<
       },
       positions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         update: attribute => (attribute.value = this.state.mesh.positions),
         noAlloc

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -37,7 +37,6 @@ import {
   DefaultProps
 } from '@deck.gl/core';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 import ColumnGeometry from './column-geometry';
 
 import vs from './column-layer-vertex.glsl';
@@ -269,7 +268,7 @@ export default class ColumnLayer<DataT = any, ExtraPropsT extends {} = {}> exten
     attributeManager.addInstanced({
       instancePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
@@ -281,16 +280,14 @@ export default class ColumnLayer<DataT = any, ExtraPropsT extends {} = {}> exten
       },
       instanceFillColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceLineColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getLineColor',
         defaultValue: DEFAULT_COLOR

--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -20,7 +20,6 @@
 import {Layer, project32, picking, log, UNIT} from '@deck.gl/core';
 import {SamplerProps, Texture} from '@luma.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 import vs from './icon-layer-vertex.glsl';
 import fs from './icon-layer-fragment.glsl';
@@ -165,7 +164,7 @@ export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends
     attributeManager!.addInstanced({
       instancePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
@@ -190,15 +189,14 @@ export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       },
       instanceColorModes: {
         size: 1,
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         accessor: 'getIcon',
         // eslint-disable-next-line @typescript-eslint/unbound-method
         transform: this.getInstanceColorMode
       },
       instanceColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getColor',
         defaultValue: DEFAULT_COLOR

--- a/modules/layers/src/line-layer/line-layer.ts
+++ b/modules/layers/src/line-layer/line-layer.ts
@@ -34,7 +34,6 @@ import {
 } from '@deck.gl/core';
 import {Geometry} from '@luma.gl/engine';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 import vs from './line-layer-vertex.glsl';
 import fs from './line-layer-fragment.glsl';
@@ -144,22 +143,21 @@ export default class LineLayer<DataT = any, ExtraProps extends {} = {}> extends 
     attributeManager.addInstanced({
       instanceSourcePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getSourcePosition'
       },
       instanceTargetPositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getTargetPosition'
       },
       instanceColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getColor',
         defaultValue: [0, 0, 0, 255]

--- a/modules/layers/src/path-layer/path-layer.ts
+++ b/modules/layers/src/path-layer/path-layer.ts
@@ -21,7 +21,6 @@
 import {Layer, project32, picking, UNIT} from '@deck.gl/core';
 import {Geometry} from '@luma.gl/engine';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 import PathTesselator from './path-tesselator';
 
 import vs from './path-layer-vertex.glsl';
@@ -171,7 +170,7 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         size: 3,
         // Start filling buffer from 1 vertex in
         vertexOffset: 1,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPath',
@@ -195,7 +194,7 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       },
       instanceTypes: {
         size: 1,
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         // eslint-disable-next-line @typescript-eslint/unbound-method
         update: this.calculateSegmentTypes,
         noAlloc
@@ -208,15 +207,14 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       },
       instanceColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         accessor: 'getColor',
         transition: ATTRIBUTE_TRANSITION,
         defaultValue: DEFAULT_COLOR
       },
       instancePickingColors: {
         size: 4,
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         accessor: (object, {index, target: value}) =>
           this.encodePickingColor(object && object.__source ? object.__source.index : index, value)
       }

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -36,7 +36,6 @@ import {
   DefaultProps
 } from '@deck.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 import vs from './point-cloud-layer-vertex.glsl';
 import fs from './point-cloud-layer-fragment.glsl';
@@ -147,7 +146,7 @@ export default class PointCloudLayer<DataT = any, ExtraPropsT extends {} = {}> e
     this.getAttributeManager()!.addInstanced({
       instancePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
@@ -160,8 +159,7 @@ export default class PointCloudLayer<DataT = any, ExtraPropsT extends {} = {}> e
       },
       instanceColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: true,
         accessor: 'getColor',
         defaultValue: DEFAULT_COLOR

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -21,7 +21,6 @@
 import {Layer, project32, picking, UNIT} from '@deck.gl/core';
 import {Geometry} from '@luma.gl/engine';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 import vs from './scatterplot-layer-vertex.glsl';
 import fs from './scatterplot-layer-fragment.glsl';
@@ -193,7 +192,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT extends {} = {}> 
     this.getAttributeManager()!.addInstanced({
       instancePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
@@ -207,16 +206,14 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT extends {} = {}> 
       instanceFillColors: {
         size: this.props.colorFormat.length,
         transition: true,
-        normalized: true,
-        type: GL.UNSIGNED_BYTE,
+        type: 'unorm8',
         accessor: 'getFillColor',
         defaultValue: [0, 0, 0, 255]
       },
       instanceLineColors: {
         size: this.props.colorFormat.length,
         transition: true,
-        normalized: true,
-        type: GL.UNSIGNED_BYTE,
+        type: 'unorm8',
         accessor: 'getLineColor',
         defaultValue: [0, 0, 0, 255]
       },

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -20,7 +20,6 @@
 
 import {Layer, project32, gouraudLighting, picking, COORDINATE_SYSTEM} from '@deck.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 // Polygon geometry generation is managed by the polygon tesselator
 import PolygonTesselator from './polygon-tesselator';
@@ -212,7 +211,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}>
       },
       vertexPositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getPolygon',
@@ -232,7 +231,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}>
       },
       instanceVertexValid: {
         size: 1,
-        type: GL.UNSIGNED_SHORT,
+        type: 'uint16',
         divisor: 1,
         // eslint-disable-next-line @typescript-eslint/unbound-method
         update: this.calculateVertexValid,
@@ -250,8 +249,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}>
       },
       fillColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getFillColor',
         defaultValue: DEFAULT_COLOR,
@@ -263,8 +261,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}>
       },
       lineColors: {
         size: this.props.colorFormat.length,
-        type: GL.UNSIGNED_BYTE,
-        normalized: true,
+        type: 'unorm8',
         transition: ATTRIBUTE_TRANSITION,
         accessor: 'getLineColor',
         defaultValue: DEFAULT_COLOR,
@@ -276,7 +273,7 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}>
       },
       pickingColors: {
         size: 4,
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         accessor: (object, {index, target: value}) =>
           this.encodePickingColor(object && object.__source ? object.__source.index : index, value),
         shaderAttributes: {

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {GL} from '@luma.gl/constants';
 import {log} from '@deck.gl/core';
 import IconLayer from '../../icon-layer/icon-layer';
 
@@ -75,7 +74,7 @@ export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends 
         accessor: 'getIconOffsets'
       },
       instancePickingColors: {
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         size: 3,
         accessor: (object, {index, target: value}) => this.encodePickingColor(index, value)
       }

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
@@ -1,7 +1,6 @@
 import {Layer, project32, picking, UNIT} from '@deck.gl/core';
 import {Geometry} from '@luma.gl/engine';
 import {Model} from '@luma.gl/engine';
-import {GL} from '@luma.gl/constants';
 
 import vs from './text-background-layer-vertex.glsl';
 import fs from './text-background-layer-fragment.glsl';
@@ -77,7 +76,7 @@ export default class TextBackgroundLayer<DataT = any, ExtraPropsT extends {} = {
     this.getAttributeManager()!.addInstanced({
       instancePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getPosition'
@@ -105,16 +104,14 @@ export default class TextBackgroundLayer<DataT = any, ExtraPropsT extends {} = {
       instanceFillColors: {
         size: 4,
         transition: true,
-        normalized: true,
-        type: GL.UNSIGNED_BYTE,
+        type: 'unorm8',
         accessor: 'getFillColor',
         defaultValue: [0, 0, 0, 255]
       },
       instanceLineColors: {
         size: 4,
         transition: true,
-        normalized: true,
-        type: GL.UNSIGNED_BYTE,
+        type: 'unorm8',
         accessor: 'getLineColor',
         defaultValue: [0, 0, 0, 255]
       },

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -23,7 +23,6 @@ import type {Device} from '@luma.gl/core';
 import {pbr} from '@luma.gl/shadertools';
 import {ScenegraphNode, GroupNode, ModelNode} from '@luma.gl/engine';
 import {GLTFAnimator, PBREnvironment, createScenegraphsFromGLTF} from '@luma.gl/gltf';
-import {GL} from '@luma.gl/constants';
 import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
 import {waitForGLTFAssets} from './gltf-utils';
 
@@ -203,16 +202,15 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
     attributeManager!.addInstanced({
       instancePositions: {
         size: 3,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         accessor: 'getPosition',
         transition: true
       },
       instanceColors: {
-        type: GL.UNSIGNED_BYTE,
+        type: 'unorm8',
         size: this.props.colorFormat.length,
         accessor: 'getColor',
-        normalized: true,
         defaultValue: DEFAULT_COLOR,
         transition: true
       },

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -35,7 +35,6 @@ import {
 import {SamplerProps, Texture} from '@luma.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
 import {ParsedPBRMaterial} from '@luma.gl/gltf';
-import {GL} from '@luma.gl/constants';
 
 import {MATRIX_ATTRIBUTES, shouldComposeModelMatrix} from '../utils/matrix';
 
@@ -267,16 +266,15 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
     attributeManager!.addInstanced({
       instancePositions: {
         transition: true,
-        type: GL.DOUBLE,
+        type: 'float64',
         fp64: this.use64bitPositions(),
         size: 3,
         accessor: 'getPosition'
       },
       instanceColors: {
-        type: GL.UNSIGNED_BYTE,
+        type: 'unorm8',
         transition: true,
         size: this.props.colorFormat.length,
-        normalized: true,
         accessor: 'getColor',
         defaultValue: [0, 0, 0, 255]
       },

--- a/test/modules/core/lib/attribute/attribute-manager.spec.ts
+++ b/test/modules/core/lib/attribute/attribute-manager.spec.ts
@@ -20,7 +20,6 @@
 
 /* eslint-disable dot-notation, max-statements, no-unused-vars */
 import AttributeManager from '@deck.gl/core/lib/attribute/attribute-manager';
-import {GL} from '@luma.gl/constants';
 import test from 'tape-promise/tape';
 import {device} from '@deck.gl/test-utils';
 
@@ -213,7 +212,7 @@ test('AttributeManager.update - external virtual buffers', t => {
 
   attributeManager.add({
     positions: {size: 2, update: dummyUpdate},
-    colors: {size: 3, type: GL.UNSIGNED_BYTE, update: dummyUpdate}
+    colors: {size: 3, type: 'uint8', update: dummyUpdate}
   });
 
   // First update, should autoalloc and update the value array
@@ -268,7 +267,7 @@ test('AttributeManager.update - external logical buffers', t => {
 
   attributeManager.add({
     positions: {size: 2, accessor: 'getPosition'},
-    colors: {size: 4, type: GL.UNSIGNED_BYTE, accessor: 'getColor', defaultValue: [0, 0, 0, 255]},
+    colors: {size: 4, type: 'uint8', accessor: 'getColor', defaultValue: [0, 0, 0, 255]},
     types: {size: 1, accessor: 'getType', transform: x => x - 65}
   });
 
@@ -313,7 +312,7 @@ test('AttributeManager.update - external logical buffers - variable width', t =>
 
   attributeManager.add({
     positions: {size: 2, accessor: 'getPosition'},
-    colors: {size: 4, type: GL.UNSIGNED_BYTE, accessor: 'getColor', defaultValue: [0, 0, 0, 255]}
+    colors: {size: 4, type: 'uint8', accessor: 'getColor', defaultValue: [0, 0, 0, 255]}
   });
 
   // First update, should autoalloc and update the value array

--- a/test/modules/core/lib/attribute/attribute.spec.ts
+++ b/test/modules/core/lib/attribute/attribute.spec.ts
@@ -26,7 +26,6 @@ import {makeSpy} from '@probe.gl/test-utils';
 
 import Attribute from '@deck.gl/core/lib/attribute/attribute';
 import {Buffer} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
 
 test('Attribute#imports', t => {
   t.equals(typeof Attribute, 'function', 'Attribute import successful');
@@ -169,9 +168,8 @@ test('Attribute#setConstantValue', t => {
   attribute = new Attribute(device, {
     id: 'colors',
     size: 3,
-    type: GL.UNSIGNED_BYTE,
-    accessor: 'getColor',
-    normalized: true
+    type: 'unorm8',
+    accessor: 'getColor'
   });
 
   attribute.setConstantValue([255, 255, 0]);
@@ -217,7 +215,7 @@ test.skip('Attribute#allocate - partial', t => {
   // double precision
   positions = new Attribute(device, {
     id: 'positions64',
-    type: GL.DOUBLE,
+    type: 'float64',
     update: attr => {
       attr.value[0] = 179.9;
       attr.value[1] = 89.9;
@@ -325,7 +323,7 @@ test.skip('Attribute#updateBuffer', t => {
       title: 'standard accessor',
       attribute: new Attribute(device, {
         id: 'values',
-        type: GL.FLOAT,
+        type: 'float32',
         size: 1,
         accessor: 'getValue'
       }),
@@ -336,7 +334,7 @@ test.skip('Attribute#updateBuffer', t => {
       title: 'standard accessor with default value',
       attribute: new Attribute(device, {
         id: 'colors',
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         size: 4,
         accessor: 'getColor',
         defaultValue: [0, 0, 0, 255]
@@ -361,7 +359,7 @@ test.skip('Attribute#updateBuffer', t => {
       title: 'standard accessor with transform',
       attribute: new Attribute(device, {
         id: 'values',
-        type: GL.FLOAT,
+        type: 'float32',
         size: 1,
         accessor: 'getValue',
         transform: x => x * 2
@@ -557,7 +555,7 @@ test('Attribute#standard accessor - variable width', t => {
     {
       attribute: new Attribute(device, {
         id: 'values',
-        type: GL.FLOAT,
+        type: 'float32',
         size: 1,
         accessor: 'getValue'
       }),
@@ -566,7 +564,7 @@ test('Attribute#standard accessor - variable width', t => {
     {
       attribute: new Attribute(device, {
         id: 'colors',
-        type: GL.UNSIGNED_BYTE,
+        type: 'uint8',
         size: 4,
         defaultValue: [0, 0, 0, 255],
         accessor: 'getColor'
@@ -612,14 +610,14 @@ test('Attribute#updateBuffer - partial', t => {
 
   const ATTRIBUTE_1 = new Attribute(device, {
     id: 'values-1',
-    type: GL.FLOAT,
+    type: 'float32',
     size: 1,
     accessor: 'getValue'
   });
 
   const ATTRIBUTE_2 = new Attribute(device, {
     id: 'values-2',
-    type: GL.FLOAT,
+    type: 'float32',
     size: 1,
     accessor: 'getValue'
   });
@@ -773,7 +771,7 @@ test('Attribute#updateBuffer - partial', t => {
 test('Attribute#setExternalBuffer', t => {
   const attribute = new Attribute(device, {
     id: 'test-attribute',
-    type: GL.FLOAT,
+    type: 'float32',
     size: 3,
     update: () => {}
   });
@@ -801,10 +799,10 @@ test('Attribute#setExternalBuffer', t => {
 
   t.ok(attribute.setExternalBuffer(value1), 'should set external buffer to typed array');
   t.is(attribute.value, value1, 'external value is set');
-  t.is(attribute.getAccessor().type, GL.FLOAT, 'attribute type is set correctly');
+  t.is(attribute.getAccessor().type, 'float32', 'attribute type is set correctly');
 
   t.ok(attribute.setExternalBuffer(value2), 'should set external buffer to typed array');
-  t.is(attribute.getAccessor().type, GL.UNSIGNED_BYTE, 'attribute type is set correctly');
+  t.is(attribute.getAccessor().type, 'uint8', 'attribute type is set correctly');
 
   spy.reset();
   t.ok(
@@ -825,19 +823,19 @@ test('Attribute#setExternalBuffer', t => {
   t.is(attributeAccessor.offset, 4, 'attribute accessor is updated');
   t.is(attributeAccessor.stride, 8, 'attribute accessor is updated');
   t.is(attribute.value, value1, 'external value is set');
-  t.is(attributeAccessor.type, GL.FLOAT, 'attribute type is set correctly');
+  t.is(attributeAccessor.type, 'float32', 'attribute type is set correctly');
 
   t.ok(
     attribute.setExternalBuffer({
       offset: 4,
       stride: 8,
       value: value1,
-      type: GL.UNSIGNED_BYTE
+      type: 'uint8'
     }),
     'should set external buffer to attribute descriptor'
   );
   attributeAccessor = attribute.getAccessor();
-  t.is(attributeAccessor.type, GL.UNSIGNED_BYTE, 'attribute type is set correctly');
+  t.is(attributeAccessor.type, 'uint8', 'attribute type is set correctly');
 
   buffer.delete();
   attribute.delete();
@@ -848,9 +846,8 @@ test('Attribute#setExternalBuffer', t => {
 test('Attribute#setExternalBuffer#shaderAttributes', t => {
   const attribute = new Attribute(device, {
     id: 'test-attribute-with-shader-attributes',
-    type: GL.UNSIGNED_BYTE,
+    type: 'unorm8',
     size: 4,
-    normalized: true,
     update: () => {},
     shaderAttributes: {
       a: {size: 1, elementOffset: 1}
@@ -858,7 +855,7 @@ test('Attribute#setExternalBuffer#shaderAttributes', t => {
   });
   const attribute2 = new Attribute(device, {
     id: 'test-attribute-with-shader-attributes',
-    type: GL.DOUBLE,
+    type: 'float64',
     size: 4,
     vertexOffset: 1,
     update: () => {},
@@ -916,7 +913,7 @@ test('Attribute#setExternalBuffer#shaderAttributes', t => {
 test('Attribute#setBinaryValue', t => {
   let attribute = new Attribute(device, {
     id: 'test-attribute',
-    type: GL.FLOAT,
+    type: 'float32',
     size: 3,
     update: () => {}
   });
@@ -941,7 +938,7 @@ test('Attribute#setBinaryValue', t => {
 
   attribute = new Attribute(device, {
     id: 'test-attribute',
-    type: GL.FLOAT,
+    type: 'float32',
     size: 3,
     noAlloc: true,
     update: () => {}
@@ -952,7 +949,7 @@ test('Attribute#setBinaryValue', t => {
 
   attribute = new Attribute(device, {
     id: 'test-attribute-with-transform',
-    type: GL.UNSIGNED_BYTE,
+    type: 'uint8',
     size: 4,
     defaultValue: [0, 0, 0, 255],
     transform: x => x + 1,
@@ -1008,7 +1005,7 @@ test('Attribute#doublePrecision', t0 => {
   t0.test('Attribute#doublePrecision#fp64:true', t => {
     const attribute = new Attribute(device, {
       id: 'positions',
-      type: GL.DOUBLE,
+      type: 'float64',
       size: 3,
       accessor: 'getPosition'
     });
@@ -1051,7 +1048,7 @@ test('Attribute#doublePrecision', t0 => {
   t0.test('Attribute#doublePrecision#fp64:false', t => {
     const attribute = new Attribute(device, {
       id: 'positions',
-      type: GL.DOUBLE,
+      type: 'float64',
       fp64: false,
       size: 3,
       accessor: 'getPosition'
@@ -1097,7 +1094,7 @@ test('Attribute#doublePrecision', t0 => {
 test('Attribute#updateBuffer', t => {
   const attribute = new Attribute(device, {
     id: 'positions',
-    type: GL.DOUBLE,
+    type: 'float64',
     fp64: false,
     size: 3,
     accessor: 'getPosition'


### PR DESCRIPTION
For #7457 

#### Change List
- DataColumn class handles the new type
- Layer attribute definitions
- Tests
