### PR TITLE
chore(tests): Restore more in-browser tests

### DIFF
--- a/test/browser.ts
+++ b/test/browser.ts
@@ -32,7 +32,7 @@ if (window.browserTestDriver_finish && window.browserTestDriver_fail) {
     window.browserTestDriver_fail();
   });
 } else {
-  console.warn('Use Google Chrome for Testing to report test completion.')
+  console.warn('Use Google Chrome for Testing to report test completion.');
 }
 
 // tap-browser-color alternative

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -25,11 +25,15 @@ import {_enableDOMLogging as enableDOMLogging} from '@probe.gl/test-utils';
 // import '@luma.gl/debug';
 
 let failed = false;
-test.onFinish(window.browserTestDriver_finish);
-test.onFailure(() => {
-  failed = true;
-  window.browserTestDriver_fail();
-});
+if (window.browserTestDriver_finish && window.browserTestDriver_fail) {
+  test.onFinish(window.browserTestDriver_finish);
+  test.onFailure(() => {
+    failed = true;
+    window.browserTestDriver_fail();
+  });
+} else {
+  console.warn('Use Google Chrome for Testing to report test completion.')
+}
 
 // tap-browser-color alternative
 enableDOMLogging({
@@ -42,18 +46,5 @@ enableDOMLogging({
 });
 
 import './modules';
-
-// Tests currently only work in browser
-import './modules/json/json-render.spec';
-import './modules/main/bundle';
-// import './modules/aggregation-layers/utils/gpu-grid-aggregator.spec';
-// import './modules/aggregation-layers/gpu-cpu-aggregator.spec';
-// import './modules/aggregation-layers/gpu-grid-layer/gpu-grid-layer.spec';
-// import './modules/aggregation-layers/heatmap-layer/heatmap-layer.spec';
-// TODO disabled for v9, restore ASAP
-// import './modules/carto/layers/raster-tile-layer.spec';
-// import './modules/core/lib/pick-layers.spec';
-
 import './render';
-// TODO disabled for v9, restore ASAP
-// import './interaction';
+import './interaction';

--- a/test/modules/aggregation-layers/index.ts
+++ b/test/modules/aggregation-layers/index.ts
@@ -18,21 +18,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import './aggregation-layer.spec';
 // import './contour-layer/contour-layer.spec';
 import './contour-layer/marching-squares.spec';
+// import './cpu-grid-layer/cpu-grid-layer.spec';
+// import './gpu-cpu-aggregator.spec';
 // import './gpu-grid-layer/gpu-grid-cell-layer-vertex.spec';
 // import './gpu-grid-layer/gpu-grid-cell-layer.spec';
-// import './cpu-grid-layer/cpu-grid-layer.spec';
+// import './gpu-grid-layer/gpu-grid-layer.spec';
+// import './grid-aggregation-layer.spec';
 import './grid-aggregator.spec';
+// import './grid-layer.spec';
+// import './heatmap-layer/heatmap-layer.spec';
+import './heatmap-layer/heatmap-layer-utils.spec';
 // import './hexagon-layer.spec';
 import './hexagon-aggregator.spec';
-// import './grid-layer.spec';
 // import './screen-grid-layer.spec';
-import './utils/scale-utils.spec';
-import './utils/color-utils.spec';
-import './utils/bin-sorter.spec';
-import './utils/aggregation-operation-utils.spec';
-import './heatmap-layer/heatmap-layer-utils.spec';
 // import './screengrid-cell-layer.spec';
-import './aggregation-layer.spec';
-// import './grid-aggregation-layer.spec';
+import './utils/aggregation-operation-utils.spec';
+import './utils/bin-sorter.spec';
+import './utils/color-utils.spec';
+// import './utils/gpu-grid-aggregator.spec';
+import './utils/scale-utils.spec';

--- a/test/modules/carto/index.ts
+++ b/test/modules/carto/index.ts
@@ -7,6 +7,7 @@ import './layers/carto-vector-tile.spec';
 import './layers/h3-tile-layer.spec';
 import './layers/h3-tileset-2d.spec';
 import './layers/raster.spec';
+import './layers/raster-tile-layer.spec';
 import './layers/spatialjson.spec';
 import './layers/point-label-layer.spec';
 import './layers/quadbin-layer.spec';

--- a/test/modules/carto/layers/raster-tile-layer.spec.ts
+++ b/test/modules/carto/layers/raster-tile-layer.spec.ts
@@ -52,7 +52,7 @@ test('RasterTileLayer tilejson', async t => {
   t.end();
 });
 
-test('RasterLayer', async t => {
+test.skip('RasterLayer', async t => {
   const testCases = [
     {
       Layer: RasterLayer,

--- a/test/modules/core/lib/index.ts
+++ b/test/modules/core/lib/index.ts
@@ -30,6 +30,7 @@ import './deck-picker.spec';
 // import './transition-manager.spec';
 // import './uniform-transition-manager.spec';
 // import './effect-manager.spec';
+// import './pick-layers.spec';
 // import './picking.spec';
 // import './view-manager.spec';
 // import './widget-manager.spec';

--- a/test/modules/geo-layers/index.ts
+++ b/test/modules/geo-layers/index.ts
@@ -29,8 +29,7 @@ import {
   S2Layer,
   TileLayer,
   TripsLayer,
-  // TODO v9
-  // TerrainLayer,
+  TerrainLayer,
   GeohashLayer
 } from '@deck.gl/geo-layers';
 
@@ -43,8 +42,7 @@ test('Top-level imports', t => {
   t.ok(TileLayer, 'TileLayer symbol imported');
   t.ok(WMSLayer, 'WMSLayer symbol imported');
   t.ok(TripsLayer, 'TripsLayer symbol imported');
-  // TODO v9
-  // t.ok(TerrainLayer, 'TerrainLayer symbol imported');
+  t.ok(TerrainLayer, 'TerrainLayer symbol imported');
   t.ok(GeohashLayer, 'GeohashLayer symbol imported');
   t.end();
 });
@@ -56,9 +54,8 @@ import './s2-layer.spec';
 import './trips-layer.spec';
 import './great-circle-layer.spec';
 import './h3-layers.spec';
-// TODO v9
-// import './tile-3d-layer';
-// import './terrain-layer.spec';
+import './tile-3d-layer';
+import './terrain-layer.spec';
 import './mvt-layer.spec';
 import './geohash-layer.spec';
 

--- a/test/modules/google-maps/google-maps-overlay.spec.ts
+++ b/test/modules/google-maps/google-maps-overlay.spec.ts
@@ -136,7 +136,8 @@ for (const interleaved of [true, false]) {
   });
 }
 
-test('GoogleMapsOverlay#style', t => {
+// TODO v9
+test.skip('GoogleMapsOverlay#style', t => {
   const map = new mapsApi.Map({
     width: 1,
     height: 1,

--- a/test/modules/index.ts
+++ b/test/modules/index.ts
@@ -18,18 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './imports-spec';
-import './core';
-
-import './layers';
 import './aggregation-layers';
+import './core';
 // import './carto';
-// import './geo-layers';
-import './mesh-layers';
-
-// import './google-maps';
-// import './mapbox';
-// import './json';
-// import './react';
-// import './jupyter-widget';
 // import './extensions';
+// import './geo-layers';
+import './google-maps';
+import './imports-spec';
+import './json';
+// import './jupyter-widget';
+import './layers';
+import './main/bundle';
+// import './mapbox';
+import './mesh-layers';
+// import './react';

--- a/test/modules/json/json-render.spec.ts
+++ b/test/modules/json/json-render.spec.ts
@@ -5,8 +5,7 @@ import configuration from './json-configuration-for-deck';
 import JSON_DATA from './data/deck-props.json';
 import {gl} from '@deck.gl/test-utils';
 
-// TODO(v9): Re-check after PR#8334
-test.skip('JSONConverter#render', t => {
+test('JSONConverter#render', t => {
   const jsonConverter = new JSONConverter({configuration});
   t.ok(jsonConverter, 'JSONConverter created');
 


### PR DESCRIPTION
Running `yarn test browser` in stable Chrome, on macOS:

- before: 1748 tests, 3 failures
- after: 1939 tests, 2 failures

Related:

- https://github.com/visgl/deck.gl/issues/8592