### PR TITLE
ignore bindings directory when running linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@ mapbox-gl.js
 .docusaurus
 examples/
 test/apps/
+bindings/


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #8595
<!-- For other PRs without open issue -->
#### Background
I've been building pydeck locally which seems to have caused `yarn test` to throw the error described in #8595. To resolve I've just added the `bindings/` dir to .eslintignore
<!-- For all the PRs -->
#### Change List
- added `bindings/` to .eslintignore
