### PR TITLE
Correct operator precedence for clearColor in LayersPass

### DIFF
--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -62,7 +62,7 @@ export default class LayersPass extends Pass {
 
     // Explicitly specify clearColor and clearDepth, overriding render pass defaults.
     const clearCanvas = options.clearCanvas ?? true;
-    const clearColor = options.clearColor ?? clearCanvas ? [0, 0, 0, 0] : false;
+    const clearColor = options.clearColor ?? (clearCanvas ? [0, 0, 0, 0] : false);
     const clearDepth = clearCanvas ? 1 : false;
 
     const renderPass = this.device.beginRenderPass({


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
https://github.com/visgl/deck.gl/pull/8543 breaks `MaskPass` due to incorrect operator precedence causing `clearColor` to always be `[0, 0, 0, 0]` 

<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Correct operator precedence for clearColor in LayersPass
