### PR TITLE
chore(website) import mapbox as react component

### DIFF
--- a/website/src/examples/mapbox.js
+++ b/website/src/examples/mapbox.js
@@ -1,6 +1,6 @@
 import React, {Component, createRef} from 'react';
 import {DATA_URI, GITHUB_TREE} from '../constants/defaults';
-import {renderToDOM} from 'website-examples/mapbox/app';
+import App from 'website-examples/mapbox/app';
 
 import {makeExample} from '../components';
 
@@ -31,31 +31,9 @@ class MapboxDemo extends Component {
 
   _containerRef = createRef();
 
-  componentDidMount() {
-    /* global document */
-    // Attach mapbox stylesheet
-    const style = document.createElement('link');
-    style.setAttribute('rel', 'stylesheet');
-    style.setAttribute('href', 'https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.css');
-    document.head.appendChild(style);
-
-    this._view = renderToDOM(this._containerRef.current, this.props.data);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.data && !prevProps.data && this._view) {
-      this._view.update(this.props.data);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this._view) {
-      this._view.remove();
-    }
-  }
-
   render() {
-    return <div ref={this._containerRef} style={{width: '100%', height: '100%'}} />;
+    const {data, ...otherProps} = this.props;
+    return <App {...otherProps} data={data}/>;
   }
 }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Follow up on #8600 
<!-- For other PRs without open issue -->
#### Background
@felixpalmer noticed a crash with the Mapbox example in the website that hadn't occurred in the standalone version. The issue was introduced in #8557 when it was ported to react. The root cause should be resolved by importing the `App` component in the website instead of `renderToDOM`.
<!-- For all the PRs -->
#### Change List
- import mapbox as react component
