### PR TITLE
website: Do not render Mapbox example in SSR

### DIFF
--- a/website/src/examples/mapbox.mdx
+++ b/website/src/examples/mapbox.mdx
@@ -1,5 +1,6 @@
 # Mapbox
 
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import Demo from './mapbox';
 
-<Demo />
+<BrowserOnly>{() => <Demo/>}</BrowserOnly>


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Staging build fails when trying to build Mapbox example. Follow same pattern as with `carto.mdx` as mark as `ClientOnly`