### PR TITLE
PointCloudLayer colors attribute type use 'unorm8'

### DIFF
--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -73,7 +73,8 @@ function normalizeData(data) {
     attributes.instanceNormals = attributes.NORMAL;
   }
   if (attributes.COLOR_0) {
-    attributes.instanceColors = attributes.COLOR_0;
+    const {size, value} = attributes.COLOR_0;
+    attributes.instanceColors = {size, type: 'unorm8', value};
   }
 }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/8582, fixes regression from https://github.com/visgl/deck.gl/pull/8572/

It may be worth considering updating the format emitted from loaders.gl @ibgreen to avoid passing GL constants

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- PointCloudLayer colors attribute type use 'unorm8'
