### PR TITLE
website: Disable lineColor transition to fix highway example

### DIFF
--- a/examples/website/highway/app.jsx
+++ b/examples/website/highway/app.jsx
@@ -138,9 +138,10 @@ export default function App({roads = DATA_URL.ROADS, year, accidents, mapStyle =
         getLineWidth: {year}
       },
 
+      // TODO(v9) Re-enable once attribute transitions working (#8392)
       transitions: {
-        getLineColor: 1000,
-        getLineWidth: 1000
+        // getLineColor: 1000, // <- broken
+        getLineWidth: 1000 // <- working
       }
     })
   ];


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/8582 fixes highway example by disabling color transition for now.

@donmccurdy as you worked on https://github.com/visgl/deck.gl/pull/8392 could you take a look and see if you can figure out why one transition works and the other not? `vec3` vs `float`?
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Disable lineColor transition
