### PR TITLE
fix(react): move types to devDependencies

### DIFF
--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -36,9 +36,12 @@
   "scripts": {},
   "peerDependencies": {
     "@deck.gl/core": "^9.0.0-beta",
-    "@types/react": "^18.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -36,12 +36,14 @@
   "scripts": {},
   "peerDependencies": {
     "@deck.gl/core": "^9.0.0-beta",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0"
+    "@types/react-dom": "^18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,6 +3387,22 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
+"@types/react-dom@^18.2.0":
+  version "18.2.21"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.21.tgz#b8c81715cebdebb2994378616a8d54ace54f043a"
+  integrity sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "18.2.65"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.65.tgz#54eb311fa9aba173c9e163d42ec188d5a42878b8"
+  integrity sha512-98TsY0aW4jqx/3RqsUXwMDZSWR1Z4CUlJNue8ueS2/wcxZOsz4xmW1X8ieaWVRHcmmQM3R8xVA4XWB3dJnWwDQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^18.2.0":
   version "18.2.48"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.48.tgz#11df5664642d0bd879c1f58bc1d37205b064e8f1"


### PR DESCRIPTION
Non-TypeScript users should not be forced to install types

#### Change List
- Revert overly strict peer dependency versions from #8451
- Move `@types/react` and `@types/react-dom` to devDependencies
