### PR TITLE
feat(carto): Export types for generic source options

### DIFF
--- a/modules/carto/src/index.ts
+++ b/modules/carto/src/index.ts
@@ -83,7 +83,13 @@ export {
 };
 
 export type {
+  GeojsonResult,
+  JsonResult,
   TilejsonResult,
+  SourceOptions,
+  QuerySourceOptions,
+  TableSourceOptions,
+  TilesetSourceOptions,
   BoundaryQuerySourceOptions,
   BoundaryTableSourceOptions,
   H3QuerySourceOptions,
@@ -96,6 +102,4 @@ export type {
   VectorQuerySourceOptions,
   VectorTableSourceOptions,
   VectorTilesetSourceOptions,
-  GeojsonResult,
-  JsonResult
 } from './sources/index';

--- a/modules/carto/src/index.ts
+++ b/modules/carto/src/index.ts
@@ -101,5 +101,5 @@ export type {
   QuadbinTilesetSourceOptions,
   VectorQuerySourceOptions,
   VectorTableSourceOptions,
-  VectorTilesetSourceOptions,
+  VectorTilesetSourceOptions
 } from './sources/index';

--- a/modules/carto/src/sources/index.ts
+++ b/modules/carto/src/sources/index.ts
@@ -36,3 +36,10 @@ export type {VectorTableSourceOptions} from './vector-table-source';
 
 export {vectorTilesetSource} from './vector-tileset-source';
 export type {VectorTilesetSourceOptions} from './vector-tileset-source';
+
+export type {
+  SourceOptions,
+  QuerySourceOptions,
+  TableSourceOptions,
+  TilesetSourceOptions
+} from './types';


### PR DESCRIPTION
I think access to these generic source option types (SourceOptions, QuerySourceOptions, ...) would be helpful. We can certainly work around not having them, but they do make things a bit easier to type.

