### PR TITLE
Fix SolidPolygonLayer lighting

### DIFF
--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.ts
@@ -49,7 +49,7 @@ vec3 project_offset_normal(vec3 vector) {
 void calculatePosition(PolygonProps props) {
   vec3 pos = props.positions;
   vec3 pos64Low = props.positions64Low;
-  vec3 normal;
+  vec3 normal = props.normal;
   vec4 colors = isWireframe ? props.lineColors : props.fillColors;
 
   geometry.worldPosition = props.positions;
@@ -63,7 +63,12 @@ void calculatePosition(PolygonProps props) {
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   if (extruded) {
-    geometry.normal = props.normal;
+  #ifdef IS_SIDE_VERTEX
+    normal = project_offset_normal(normal);
+  #else
+    normal = project_normal(normal);
+  #endif
+    geometry.normal = normal;
     vec3 lightColor = lighting_getLightColor(colors.rgb, project_uCameraPosition, geometry.position.xyz, geometry.normal);
     vColor = vec4(lightColor, colors.a * opacity);
   } else {

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.ts
@@ -23,6 +23,7 @@ import main from './solid-polygon-layer-vertex-main.glsl';
 export default `\
 #version 300 es
 #define SHADER_NAME solid-polygon-layer-vertex-shader-side
+#define IS_SIDE_VERTEX
 
 in vec2 positions;
 
@@ -66,11 +67,10 @@ void main(void) {
   props.positions = mix(pos, nextPos, positions.x);
   props.positions64Low = mix(pos64Low, nextPos64Low, positions.x);
 
-  vec3 normal = vec3(
+  props.normal = vec3(
     pos.y - nextPos.y + (pos64Low.y - nextPos64Low.y),
     nextPos.x - pos.x + (nextPos64Low.x - pos64Low.x),
     0.0);
-  props.normal = project_offset_normal(normal);
 
   props.elevations = instanceElevations * positions.y;
   props.fillColors = instanceFillColors;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.ts
@@ -42,7 +42,7 @@ void main(void) {
   props.fillColors = fillColors;
   props.lineColors = lineColors;
   props.pickingColors = pickingColors;
-  props.normal = project_normal(vec3(0.0, 0.0, 1.0));
+  props.normal = vec3(0.0, 0.0, 1.0);
 
   calculatePosition(props);
 }

--- a/test/render/test-cases/polygon-layer.js
+++ b/test/render/test-cases/polygon-layer.js
@@ -173,43 +173,43 @@ export default [
       })
     ],
     goldenImage: './test/render/golden-images/polygon-globe.png'
+  },
+  {
+    name: 'polygon-globe-extruded',
+    views: [new GlobeView()],
+    viewState: {
+      latitude: 0,
+      longitude: 50,
+      zoom: 0
+    },
+    layers: [
+      new PolygonLayer({
+        id: 'polygon-globe',
+        data: [
+          [
+            [
+              [60, 40],
+              [30, -30],
+              [-60, -40],
+              [-30, 30]
+            ],
+            [
+              [10, 10],
+              [20, -20],
+              [-10, -10],
+              [-20, 20]
+            ]
+          ]
+        ],
+        getPolygon: d => d,
+        extruded: true,
+        wireframe: true,
+        getElevation: 1e6,
+        getLineColor: [0, 0, 0],
+        getFillColor: [160, 160, 0],
+        widthMinPixels: 4
+      })
+    ],
+    goldenImage: './test/render/golden-images/polygon-globe-extruded.png'
   }
-  // {
-  //   name: 'polygon-globe-extruded',
-  //   views: [new GlobeView()],
-  //   viewState: {
-  //     latitude: 0,
-  //     longitude: 50,
-  //     zoom: 0
-  //   },
-  //   layers: [
-  //     new PolygonLayer({
-  //       id: 'polygon-globe',
-  //       data: [
-  //         [
-  //           [
-  //             [60, 40],
-  //             [30, -30],
-  //             [-60, -40],
-  //             [-30, 30]
-  //           ],
-  //           [
-  //             [10, 10],
-  //             [20, -20],
-  //             [-10, -10],
-  //             [-20, 20]
-  //           ]
-  //         ]
-  //       ],
-  //       getPolygon: d => d,
-  //       extruded: true,
-  //       wireframe: true,
-  //       getElevation: 1e6,
-  //       getLineColor: [0, 0, 0],
-  //       getFillColor: [160, 160, 0],
-  //       widthMinPixels: 4
-  //     })
-  //   ],
-  //   goldenImage: './test/render/golden-images/polygon-globe-extruded.png'
-  // }
 ];


### PR DESCRIPTION
Broken by refactor in #8153 - `project_normal` must be called after `geometry.position` is populated

#### Change List
- Call `project_normal` after project position
- Restore render test
