### PR TITLE
fix(extensions): Use lodMaxClamp to disable mips

### DIFF
--- a/modules/extensions/src/fill-style/fill-style-extension.ts
+++ b/modules/extensions/src/fill-style/fill-style-extension.ts
@@ -19,11 +19,7 @@ const defaultProps: DefaultProps<FillStyleExtensionProps> = {
     type: 'image',
     value: null,
     async: true,
-    parameters: {
-      // Override default mipmap filter 'linear', i.e. set MIN_FILTER to LINEAR instead of LINEAR_MIPMAP_LINEAR
-      // @ts-expect-error invalid value for type `SamplerProps` - luma.gl should allow unset
-      mipmapFilter: ''
-    }
+    parameters: {lodMaxClamp: 0}
   },
   fillPatternMapping: {type: 'object', value: {}, async: true},
   fillPatternMask: true,


### PR DESCRIPTION
Luma is mirroring the WebGPU spec, in which all samplers have `mipmapFilter`, but we can restrict the range of mipmaps used with `lodMinClamp` / `lodMaxClamp`. 

Related:

- https://github.com/visgl/deck.gl/pull/8668


