### PR TITLE
fix(extensions): PathStyleExtension random artifact

### DIFF
--- a/modules/extensions/src/path-style/path-style-extension.ts
+++ b/modules/extensions/src/path-style/path-style-extension.ts
@@ -177,6 +177,7 @@ export default class PathStyleExtension extends LayerExtension<PathStyleExtensio
 
       prevP = p;
     }
+    result[geometrySize - 1] = 0;
     return result;
   }
 }

--- a/test/render/test-cases/geojson-layer.js
+++ b/test/render/test-cases/geojson-layer.js
@@ -12,8 +12,7 @@ import daynight from 'deck.gl-test/data/daynight.geo.json';
 import capitals from 'deck.gl-test/data/us-state-capitals.geo.json';
 import {iconAtlas as iconMapping} from 'deck.gl-test/data';
 import {parseColor, setOpacity} from '../../../examples/layer-browser/src/utils/color';
-// TODO v9
-// import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
+import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {SphereGeometry} from '@luma.gl/engine';
 
 import {OS} from '../constants';
@@ -234,8 +233,6 @@ export default [
     ],
     goldenImage: './test/render/golden-images/geojson-large.png'
   },
-  // TODO v9
-  /*
   {
     name: 'geojson-hole-and-lighting',
     viewState: {
@@ -281,7 +278,6 @@ export default [
     ],
     goldenImage: './test/render/golden-images/geojson-hole-and-lighting.png'
   },
-  */
   {
     name: 'geojson-wrap-longitude',
     viewState: {


### PR DESCRIPTION
PathStyleExtension does not pack the attribute at full length and assumes that the rest will be padded with 0s. This is not true when the attribute buffer is reused.

#### Change List
- Explicitly set `instanceDashOffsets` attribute at full length
- Re-enable flimsy render test
