### PR TITLE
Bug fix: Update scorecard to v2.3.1

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
#### Background

Fix Scorecard breaking due to not being able to sign the results. Scorecard uses Sigstore tool to sign its results and Sigstore has done an update (https://blog.sigstore.dev/tuf-root-update/). This update is not compatible with older Scorecard versions (for example, v.2.1.2 used here), but Scorecard v2.3.1 is compatible with Sigstore changes.

#### Change List
- Update scorecard from v2.1.2 to v2.3.1
