### PR TITLE
fix(carto): Clean up and add unit tests for requestWithParameters cache

### DIFF
--- a/modules/carto/src/api/request-with-parameters.ts
+++ b/modules/carto/src/api/request-with-parameters.ts
@@ -10,7 +10,7 @@ function encodeParameter(name: string, value: string | boolean | number): string
 }
 
 const REQUEST_CACHE = new Map<string, Promise<unknown>>();
-export async function requestWithParameters<T extends {accessToken?: string}>({
+export async function requestWithParameters<T = any>({
   accessToken,
   baseUrl,
   parameters,

--- a/modules/carto/src/api/request-with-parameters.ts
+++ b/modules/carto/src/api/request-with-parameters.ts
@@ -24,44 +24,49 @@ export async function requestWithParameters<T extends {accessToken?: string}>({
   errorContext: APIErrorContext;
 }): Promise<T> {
   const key = createCacheKey(baseUrl, parameters || {}, customHeaders || {});
-  if (REQUEST_CACHE.has(key)) {
-    // Cached requests do not share access tokens.
-    return (REQUEST_CACHE.get(key) as Promise<T>).then(json => ({
-      ...json,
-      ...(accessToken && {accessToken})
-    }));
+
+  if (!REQUEST_CACHE.has(key)) {
+    const url = parameters ? createURLWithParameters(baseUrl, parameters) : baseUrl;
+    const headers = {...DEFAULT_HEADERS, ...customHeaders};
+
+    /* global fetch */
+    const fetchPromise =
+      url.length > MAX_GET_LENGTH
+        ? fetch(baseUrl, {method: 'POST', body: JSON.stringify(parameters), headers})
+        : fetch(url, {headers});
+
+    let response: Response | undefined;
+    const jsonPromise: Promise<T> = fetchPromise
+      .then((_response: Response) => {
+        response = _response;
+        return response.json();
+      })
+      .then((json: any) => {
+        if (!response || !response.ok) {
+          throw new Error(json.error);
+        }
+        return json;
+      })
+      .catch((error: Error) => {
+        REQUEST_CACHE.delete(key);
+        throw new CartoAPIError(error, errorContext, response);
+      });
+
+    REQUEST_CACHE.set(key, jsonPromise);
   }
 
-  const url = parameters ? createURLWithParameters(baseUrl, parameters) : baseUrl;
-  const headers = {...DEFAULT_HEADERS, ...customHeaders};
-
-  /* global fetch */
-  const fetchPromise =
-    url.length > MAX_GET_LENGTH
-      ? fetch(baseUrl, {method: 'POST', body: JSON.stringify(parameters), headers})
-      : fetch(url, {headers});
-
-  let response: Response | undefined;
-  const jsonPromise: Promise<T> = fetchPromise
-    .then((_response: Response) => {
-      response = _response;
-      return response.json();
-    })
-    .then((json: any) => {
-      if (!response || !response.ok) {
-        throw new Error(json.error);
-      }
-      return json;
-    })
+  // Cached requests do not share access tokens and error context.
+  return (REQUEST_CACHE.get(key) as Promise<T>)
+    .then(json => ({
+      ...json,
+      ...(accessToken && {accessToken})
+    }))
     .catch((error: Error) => {
-      REQUEST_CACHE.delete(key);
-      throw new CartoAPIError(error, errorContext, response);
+      if (error instanceof CartoAPIError) {
+        throw new CartoAPIError(error.error, errorContext, error.response);
+      }
+      throw new CartoAPIError(error, errorContext);
     });
-
-  REQUEST_CACHE.set(key, jsonPromise);
-
-  // Cached requests do not share access tokens.
-  return jsonPromise.then(json => ({...json, ...(accessToken && {accessToken})}));
 }
 
 function createCacheKey(

--- a/modules/carto/src/api/request-with-parameters.ts
+++ b/modules/carto/src/api/request-with-parameters.ts
@@ -11,13 +11,11 @@ function encodeParameter(name: string, value: string | boolean | number): string
 
 const REQUEST_CACHE = new Map<string, Promise<unknown>>();
 export async function requestWithParameters<T = any>({
-  accessToken,
   baseUrl,
   parameters,
   headers: customHeaders,
   errorContext
 }: {
-  accessToken?: string;
   baseUrl: string;
   parameters?: Record<string, string>;
   headers: Record<string, string>;
@@ -56,17 +54,12 @@ export async function requestWithParameters<T = any>({
   }
 
   // Cached requests do not share access tokens and error context.
-  return (REQUEST_CACHE.get(key) as Promise<T>)
-    .then(json => ({
-      ...json,
-      ...(accessToken && {accessToken})
-    }))
-    .catch((error: Error) => {
-      if (error instanceof CartoAPIError) {
-        throw new CartoAPIError(error.error, errorContext, error.response);
-      }
-      throw new CartoAPIError(error, errorContext);
-    });
+  return (REQUEST_CACHE.get(key) as Promise<T>).catch((error: Error) => {
+    if (error instanceof CartoAPIError) {
+      throw new CartoAPIError(error.error, errorContext, error.response);
+    }
+    throw new CartoAPIError(error, errorContext);
+  });
 }
 
 function createCacheKey(

--- a/modules/carto/src/sources/base-source.ts
+++ b/modules/carto/src/sources/base-source.ts
@@ -56,12 +56,15 @@ export async function baseSource<UrlParameters extends Record<string, string>>(
   errorContext.requestType = 'Map data';
 
   if (format === 'tilejson') {
-    return await requestWithParameters<TilejsonResult>({
-      accessToken,
+    const json = await requestWithParameters<TilejsonResult>({
       baseUrl: dataUrl,
       headers,
       errorContext
     });
+    if (accessToken) {
+      json.accessToken = accessToken;
+    }
+    return json;
   }
 
   return await requestWithParameters<GeojsonResult | JsonResult>({

--- a/test/modules/carto/api/request-with-parameters.spec.ts
+++ b/test/modules/carto/api/request-with-parameters.spec.ts
@@ -60,39 +60,6 @@ test('requestWithParameters#cacheParameters', async t => {
   t.end();
 });
 
-test('requestWithParameters#nocacheAccessToken', async t => {
-  await withMockFetchMapsV3(async calls => {
-    t.equals(calls.length, 0, '0 initial calls');
-
-    const responses = await Promise.all([
-      requestWithParameters({
-        baseUrl: 'https://example.com/v1/accessToken',
-        accessToken: '<TOKEN#1>'
-      }),
-      requestWithParameters({
-        baseUrl: 'https://example.com/v1/accessToken',
-        accessToken: '<TOKEN#2>'
-      }),
-      requestWithParameters({
-        baseUrl: 'https://example.com/v1/accessToken',
-        accessToken: '<TOKEN#3>'
-      }),
-      requestWithParameters({
-        baseUrl: 'https://example.com/v1/accessToken',
-        accessToken: ''
-      })
-    ]);
-
-    t.equals(calls.length, 1, '1 unique request');
-    t.equals(responses.length, 4, '4 responses');
-    t.equals(responses[0].accessToken, '<TOKEN#1>', 'response #1');
-    t.equals(responses[1].accessToken, '<TOKEN#2>', 'response #2');
-    t.equals(responses[2].accessToken, '<TOKEN#3>', 'response #3');
-    t.equals(responses[3].accessToken, undefined, 'response #4');
-  });
-  t.end();
-});
-
 test('requestWithParameters#nocacheErrorContext', async t => {
   await withMockFetchMapsV3(
     async calls => {

--- a/test/modules/carto/api/request-with-parameters.spec.ts
+++ b/test/modules/carto/api/request-with-parameters.spec.ts
@@ -1,0 +1,93 @@
+import test from 'tape-catch';
+import {requestWithParameters} from '@deck.gl/carto/api/request-with-parameters';
+import {withMockFetchMapsV3} from '../mock-fetch';
+
+test('requestWithParameters#cacheBaseURL', async t => {
+  await withMockFetchMapsV3(async calls => {
+    t.equals(calls.length, 0, '0 initial calls');
+
+    await Promise.all([
+      requestWithParameters({baseUrl: 'https://example.com/v1/baseURL', headers: {}}),
+      requestWithParameters({baseUrl: 'https://example.com/v2/baseURL', headers: {}}),
+      requestWithParameters({baseUrl: 'https://example.com/v2/baseURL', headers: {}})
+    ]);
+
+    t.equals(calls.length, 2, '2 unique requests');
+  });
+  t.end();
+});
+
+test('requestWithParameters#cacheHeaders', async t => {
+  await withMockFetchMapsV3(async calls => {
+    t.equals(calls.length, 0, '0 initial calls');
+
+    await Promise.all([
+      requestWithParameters({baseUrl: 'https://example.com/v1/headers', headers: {a: 1}}),
+      requestWithParameters({baseUrl: 'https://example.com/v1/headers', headers: {a: 1}}),
+      requestWithParameters({baseUrl: 'https://example.com/v1/headers', headers: {b: 1}})
+    ]);
+
+    t.equals(calls.length, 2, '2 unique requests');
+  });
+  t.end();
+});
+
+test('requestWithParameters#cacheParameters', async t => {
+  await withMockFetchMapsV3(async calls => {
+    t.equals(calls.length, 0, '0 initial calls');
+
+    await Promise.all([
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/params',
+        headers: {},
+        parameters: {}
+      }),
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/params',
+        headers: {},
+        parameters: {}
+      }),
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/params',
+        headers: {},
+        parameters: {a: 1}
+      })
+    ]);
+
+    t.equals(calls.length, 2, '2 unique requests');
+  });
+  t.end();
+});
+
+test('requestWithParameters#cacheAccessToken', async t => {
+  await withMockFetchMapsV3(async calls => {
+    t.equals(calls.length, 0, '0 initial calls');
+
+    const responses = await Promise.all([
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/accessToken',
+        accessToken: '<TOKEN#1>'
+      }),
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/accessToken',
+        accessToken: '<TOKEN#2>'
+      }),
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/accessToken',
+        accessToken: '<TOKEN#3>'
+      }),
+      requestWithParameters({
+        baseUrl: 'https://example.com/v1/accessToken',
+        accessToken: ''
+      })
+    ]);
+
+    t.equals(calls.length, 1, '1 unique request');
+    t.equals(responses.length, 4, '4 responses');
+    t.equals(responses[0].accessToken, '<TOKEN#1>', 'response 1');
+    t.equals(responses[1].accessToken, '<TOKEN#2>', 'response 2');
+    t.equals(responses[2].accessToken, '<TOKEN#3>', 'response 3');
+    t.equals(responses[3].accessToken, undefined, 'response 4');
+  });
+  t.end();
+});

--- a/test/modules/carto/index.ts
+++ b/test/modules/carto/index.ts
@@ -2,6 +2,7 @@ import './api/carto-api-error.spec';
 import './api/fetch-map.spec';
 import './api/layer-map.spec';
 import './api/parse-map.spec';
+import './api/request-with-parameters.spec';
 import './utils.spec';
 import './layers/carto-vector-tile.spec';
 import './layers/h3-tile-layer.spec';


### PR DESCRIPTION
Related:

- #8648

Adds unit tests for `requestWithParameters`.

`requestWithParameters()` does not include the given `accessToken` in the request, but appends it to the response body. This behaves confusingly with the cache — a second caller may get the first caller's access token — and only one caller to `requestWithParameters()` currently provides that parameter, so I've removed the access token parameter and applied it in the calling function instead.

***

OUTDATED: ~~While requestWithParameters() caches unique requests, it should apply accessToken and errorContext separately for each invocation, regardless of whether separate requests were made.~~
