### PR TITLE
add generic data types in GetPickingInfoParams

### DIFF
--- a/modules/core/src/lib/picking/pick-info.ts
+++ b/modules/core/src/lib/picking/pick-info.ts
@@ -38,8 +38,8 @@ export type PickingInfo<DataT = any, ExtraInfo = {}> = ExtraInfo & {
   pixelRatio: number;
 };
 
-export interface GetPickingInfoParams {
-  info: PickingInfo;
+export interface GetPickingInfoParams<DataT = any, ExtraInfo = {}> {
+  info: PickingInfo<DataT, ExtraInfo>;
   mode: string;
   sourceLayer: Layer | null;
 }


### PR DESCRIPTION
For [#https://github.com/visgl/deck.gl/issues/8708](https://github.com/visgl/deck.gl/issues/8708)

<!-- For all the PRs -->
#### Change List
- Support generic data typings in GetPickingInfoParams
