### PR TITLE
fix(aggregation-layers): Fix missing types export

### DIFF
--- a/modules/aggregation-layers/src/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/aggregation-layer.ts
@@ -24,7 +24,8 @@ import {
   LayerDataSource,
   _compareProps as compareProps,
   UpdateParameters,
-  CompositeLayerProps
+  CompositeLayerProps,
+  Attribute
 } from '@deck.gl/core';
 import {filterProps} from './utils/prop-utils';
 
@@ -75,7 +76,7 @@ export default abstract class AggregationLayer<
     this.setState({changedAttributes});
   }
 
-  getAttributes() {
+  getAttributes(): {[id: string]: Attribute} {
     return this.getAttributeManager()!.getAttributes();
   }
 

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -45,6 +45,7 @@ export {default as _PickLayersPass} from './passes/pick-layers-pass';
 export {default as Deck} from './lib/deck';
 
 export {default as LayerManager} from './lib/layer-manager';
+export {default as Attribute} from './lib/attribute/attribute';
 export {default as AttributeManager} from './lib/attribute/attribute-manager';
 export {default as Layer} from './lib/layer';
 export {default as CompositeLayer} from './lib/composite-layer';

--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -56,6 +56,7 @@ export {
   OrthographicController,
   _GlobeController,
   // For custom layers
+  Attribute,
   AttributeManager,
   // Shader modules
   picking,


### PR DESCRIPTION
The public API of the aggregation-layers module depends on a type that isn't exported from the core module. I've made the quick fix here to export that type, resolving the error:

```
 node_modules/@deck.gl/aggregation-layers/dist/aggregation-layer.d.ts:16:29:
   16 │ ...ring]: import("modules/core/src/lib/attribute/attribute").default;
      ╵                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR changes the the compiled types in `aggregation-layer.d.ts`:

```diff
-    getAttributes(): {
-        [id: string]: import("modules/core/src/lib/attribute/attribute").default;
-    };
+    getAttributes(): {
+        [id: string]: Attribute;
+    };
```

But this looks like the type of issue that could also possibly be fixed by a TS update or some of the types error detection that API-Extractor provides, if we want to go that direction.


Related:

- https://github.com/visgl/deck.gl/issues/8711
