### PR TITLE
Export BufferTransform from luma.gl

### DIFF
--- a/modules/core/src/scripting/lumagl.ts
+++ b/modules/core/src/scripting/lumagl.ts
@@ -4,6 +4,7 @@
 export {Device, Buffer, Texture, Framebuffer} from '@luma.gl/core';
 export {
   Model,
+  BufferTransform,
   TextureTransform,
 
   // Geometry


### PR DESCRIPTION
#### Background

https://github.com/visgl/deck.gl/pull/8574 in v9 limited luma.gl exports only to a few selected classes. There is a removed TODO "Cherry-pick luma core exports that are relevant to deck". Following this reasoning, can we export BufferTransform as well? It's used in GPUInterpolationTransition.

My need for it is driven by a custom layer in a pure-JS environment, where deck.gl is imported with a script tag. As parts of luma.gl are still exported, it seems this case is still supported. Otherwise it would be necessary to import a full luma.gl bundle with a matching version.

#### Change List
- Export BufferTransform from luma.gl