### PR TITLE
chore: fix website build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -36,6 +36,7 @@
     "react-ace": "^6.1.4",
     "react-dom": "^18.0.0",
     "react-map-gl": "^7.1.0",
+    "react-virtualized-auto-sizer": "^1.0.2",
     "styled-components": "^5.3.3",
     "supercluster": "^8.0.1"
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8846,6 +8846,11 @@ react-transition-group@^4.4.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-virtualized-auto-sizer@^1.0.2:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.24.tgz#3ebdc92f4b05ad65693b3cc8e7d8dd54924c0227"
+  integrity sha512-3kCn7N9NEb3FlvJrSHWGQ4iVl+ydQObq2fHMn12i5wbtm74zHOPhz/i64OL3c1S1vi9i2GXtZqNqUJTQ+BnNfg==
+
 react@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
Overly aggressive dependency trimming in #8646

#### Change List
- Restore dependency `react-virtualized-auto-sizer` (required by playground)
