### PR TITLE
fix(pydeck): Pin 'jupyterlab' dependency to v3.x

### DIFF
--- a/bindings/pydeck/requirements/requirements-dev.txt
+++ b/bindings/pydeck/requirements/requirements-dev.txt
@@ -11,7 +11,7 @@ flake8
 requests
 sphinx
 recommonmark
-jupyterlab
+jupyterlab<4.0.0
 ipython>=5.8.0;python_version<"3.4"
 semver # necessary for PEP440-compliant semantic versions
 sphinx-markdown-builder


### PR DESCRIPTION
Partial fix for #8469. Runtime errors remain, but pinning to jupyterlab <4 is required to build in any case.

