### PR TITLE
Improve view types

### DIFF
--- a/modules/arcgis/src/commons.ts
+++ b/modules/arcgis/src/commons.ts
@@ -22,9 +22,6 @@ async function createDeckInstance(gl: WebGL2RenderingContext): Promise<{
 }> {
   return new Promise(resolve => {
     const deckInstance = new Deck({
-      // The view state will be set dynamically to track the MapView current extent.
-      viewState: {},
-
       // Input is handled by the ArcGIS API for JavaScript.
       controller: false,
 

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -116,8 +116,8 @@ export type {OrbitViewState, OrbitViewProps} from './views/orbit-view';
 export type {OrthographicViewState, OrthographicViewProps} from './views/orthographic-view';
 export type {GlobeViewState, GlobeViewProps} from './views/globe-view';
 export type {ChangeFlags} from './lib/layer-state';
-export type {LayersList} from './lib/layer-manager';
-export type {LayerContext} from './lib/layer-manager';
+export type {LayersList, LayerContext} from './lib/layer-manager';
+export type {ViewStateMap} from './lib/view-manager';
 export type {UpdateParameters} from './lib/layer';
 export type {DeckProps} from './lib/deck';
 export type {

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -57,7 +57,7 @@ import type {PickingInfo} from './picking/pick-info';
 import type {PickByPointOptions, PickByRectOptions} from './deck-picker';
 import type {LayersList} from './layer-manager';
 import type {TooltipContent} from './tooltip';
-import type {ViewStateMap, AnyViewStateOf, ViewOrViews} from './view-manager';
+import type {ViewStateMap, AnyViewStateOf, ViewOrViews, ViewStateObject} from './view-manager';
 
 /* global document */
 
@@ -90,7 +90,7 @@ type CursorState = {
   isDragging: boolean;
 };
 
-export type DeckProps<ViewsT extends ViewOrViews = ViewOrViews> = {
+export type DeckProps<ViewsT extends ViewOrViews = null> = {
   /** Id of this Deck instance */
   id?: string;
   /** Width of the canvas, a number in pixels or a valid CSS string.
@@ -314,7 +314,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
   protected animationLoop: AnimationLoop | null = null;
 
   /** Internal view state if no callback is supplied */
-  protected viewState: ViewStateMap<ViewsT> | null;
+  protected viewState: ViewStateObject<ViewsT> | null;
   protected cursorState: CursorState = {
     isHovering: false,
     isDragging: false
@@ -473,7 +473,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       width: number;
       height: number;
       views: View[];
-      viewState: ViewStateMap<ViewsT>;
+      viewState: ViewStateObject<ViewsT> | null;
     } = Object.create(this.props);
     Object.assign(resolvedProps, {
       views: this._getViews(),
@@ -826,8 +826,8 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
   // Get the most relevant view state: props.viewState, if supplied, shadows internal viewState
   // TODO: For backwards compatibility ensure numeric width and height is added to the viewState
-  private _getViewState(): ViewStateMap<ViewsT> {
-    return this.props.viewState || this.viewState || {};
+  private _getViewState(): ViewStateObject<ViewsT> | null {
+    return this.props.viewState || this.viewState;
   }
 
   // Get the view descriptor list

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -288,7 +288,7 @@ const defaultProps = {
 };
 
 /* eslint-disable max-statements */
-export default class Deck<ViewsT extends ViewOrViews = ViewOrViews> {
+export default class Deck<ViewsT extends ViewOrViews = null> {
   static defaultProps = defaultProps;
   // This is used to defeat tree shaking of init.js
   // https://github.com/visgl/deck.gl/issues/3213

--- a/modules/core/src/lib/effect.ts
+++ b/modules/core/src/lib/effect.ts
@@ -10,7 +10,7 @@ export type PostRenderOptions = LayersPassRenderOptions & {
   swapBuffer: Framebuffer;
 };
 export type EffectContext = {
-  deck: Deck;
+  deck: Deck<any>;
   device: Device;
 };
 

--- a/modules/core/src/lib/layer-manager.ts
+++ b/modules/core/src/lib/layer-manager.ts
@@ -41,7 +41,7 @@ const TRACE_ACTIVATE_VIEWPORT = 'layerManager.activateViewport';
 export type LayerContext = {
   layerManager: LayerManager;
   resourceManager: ResourceManager;
-  deck?: Deck;
+  deck?: Deck<any>;
   device: Device;
   shaderAssembler: ShaderAssembler;
   defaultShaderModules: ShaderModule[];
@@ -59,7 +59,7 @@ export type LayerContext = {
 export type LayersList = (Layer | undefined | false | null | LayersList)[];
 
 export type LayerManagerProps = {
-  deck?: Deck;
+  deck?: Deck<any>;
   stats?: Stats;
   viewport?: Viewport;
   timeline?: Timeline;

--- a/modules/core/src/lib/tooltip.ts
+++ b/modules/core/src/lib/tooltip.ts
@@ -50,11 +50,11 @@ export default class Tooltip implements Widget {
   placement: WidgetPlacement = 'fill';
   props = {};
   isVisible: boolean = false;
-  deck?: Deck;
+  deck?: Deck<any>;
   element?: HTMLDivElement;
   lastViewport?: Viewport;
 
-  onAdd({deck}: {deck: Deck}): HTMLDivElement {
+  onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {
     const el = document.createElement('div');
     el.className = 'deck-tooltip';
     Object.assign(el.style, defaultStyle);

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -45,10 +45,18 @@ export type ViewStateMap<ViewsT extends ViewOrViews> = ViewsT extends null
   ? ViewStateOf<ViewsT>
   : {[viewId: string]: AnyViewStateOf<ViewsT>};
 
+/** This is a very lose type of all "acceptable" viewState
+ * It's not good for type hinting but matches what may exist internally
+ */
+export type ViewStateObject<ViewsT extends ViewOrViews> =
+  | ViewStateMap<ViewsT>
+  | AnyViewStateOf<ViewsT>
+  | {[viewId: string]: AnyViewStateOf<ViewsT>};
+
 /** ViewManager props directly supplied by the user */
 type ViewManagerProps<ViewsT extends ViewOrViews> = {
   views: ViewsT;
-  viewState: ViewStateMap<ViewsT>;
+  viewState: ViewStateObject<ViewsT> | null;
   onViewStateChange?: (params: ViewStateChangeParameters<AnyViewStateOf<ViewsT>>) => void;
   onInteractionStateChange?: (state: InteractionState) => void;
   width?: number;
@@ -59,7 +67,7 @@ export default class ViewManager<ViewsT extends View[]> {
   width: number;
   height: number;
   views: View[];
-  viewState: ViewStateMap<ViewsT>;
+  viewState: ViewStateObject<ViewsT>;
   controllers: {[viewId: string]: Controller<any> | null};
   timeline: Timeline;
 
@@ -186,7 +194,6 @@ export default class ViewManager<ViewsT extends View[]> {
       typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
     // Backward compatibility: view state for single view
     const viewState = (view && this.viewState[view.getViewStateId()]) || this.viewState;
-    // @ts-expect-error we are assuming viewState can be used as fallback but it is not guaranteed
     return view ? view.filterViewState(viewState) : viewState;
   }
 
@@ -285,7 +292,7 @@ export default class ViewManager<ViewsT extends View[]> {
     this.views = views;
   }
 
-  private _setViewState(viewState: ViewStateMap<ViewsT>): void {
+  private _setViewState(viewState: ViewStateObject<ViewsT>): void {
     if (viewState) {
       // depth = 3 when comparing viewStates: viewId.position.0
       const viewStateChanged = !deepEqual(viewState, this.viewState, 3);

--- a/modules/core/src/lib/widget-manager.ts
+++ b/modules/core/src/lib/widget-manager.ts
@@ -28,7 +28,7 @@ export interface Widget<PropsT = any> {
    * @returns an optional UI element that should be appended to the Deck container */
   onAdd: (params: {
     /** The Deck instance that the widget is attached to */
-    deck: Deck;
+    deck: Deck<any>;
     /** The id of the view that the widget is attached to */
     viewId: string | null;
   }) => HTMLDivElement | null;
@@ -68,7 +68,7 @@ export type WidgetPlacement = keyof typeof PLACEMENTS;
 const ROOT_CONTAINER_ID = '__root';
 
 export class WidgetManager {
-  deck: Deck;
+  deck: Deck<any>;
   parentElement?: HTMLElement | null;
 
   /** Widgets added via the imperative API */
@@ -83,7 +83,7 @@ export class WidgetManager {
   /** Viewport provided to widget on redraw */
   private lastViewports: {[id: string]: Viewport} = {};
 
-  constructor({deck, parentElement}: {deck: Deck; parentElement?: HTMLElement | null}) {
+  constructor({deck, parentElement}: {deck: Deck<any>; parentElement?: HTMLElement | null}) {
     this.deck = deck;
     this.parentElement = parentElement;
   }

--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -27,7 +27,19 @@ const defaultProps = {
   interleaved: true
 };
 
-export type GoogleMapsOverlayProps = DeckProps & {
+export type GoogleMapsOverlayProps = Omit<
+  DeckProps,
+  | 'width'
+  | 'height'
+  | 'gl'
+  | 'glOptions'
+  | 'parent'
+  | 'canvas'
+  | '_customRender'
+  | 'viewState'
+  | 'initialViewState'
+  | 'controller'
+> & {
   interleaved?: boolean;
 };
 

--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -125,6 +125,7 @@ export function getInterleavedProps(currProps: DeckProps) {
       blendEquation: GL.FUNC_ADD,
       ...currProps.parameters
     } as any,
+    // @ts-ignore views prop is hidden by the types because it is not expected to work the same way as in standalone Deck, see documentation
     views: currProps.views || [new MapView({id: 'mapbox'})]
   };
 

--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -18,15 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 import * as React from 'react';
-import {
-  createElement,
-  useRef,
-  useState,
-  useMemo,
-  useEffect,
-  useImperativeHandle,
-  forwardRef
-} from 'react';
+import {createElement, useRef, useState, useMemo, useEffect, useImperativeHandle} from 'react';
 import {Deck} from '@deck.gl/core';
 import useIsomorphicLayoutEffect from './utils/use-isomorphic-layout-effect';
 
@@ -35,11 +27,13 @@ import positionChildrenUnderViews from './utils/position-children-under-views';
 import extractStyles from './utils/extract-styles';
 
 import type {DeckGLContextValue} from './utils/position-children-under-views';
-import type {DeckProps, Viewport} from '@deck.gl/core';
+import type {DeckProps, View, Viewport} from '@deck.gl/core';
+
+export type ViewOrViews = View | View[] | null;
 
 /* eslint-disable max-statements, accessor-pairs */
-type DeckInstanceRef = {
-  deck?: Deck;
+type DeckInstanceRef<ViewsT extends ViewOrViews> = {
+  deck?: Deck<ViewsT>;
   redrawReason?: string | null;
   lastRenderedViewports?: Viewport[];
   viewStateUpdateRequested?: any;
@@ -51,25 +45,28 @@ type DeckInstanceRef = {
 
 // Remove prop types in the base Deck class that support externally supplied canvas/WebGLContext
 /** DeckGL React component props */
-export type DeckGLProps = Omit<
-  DeckProps,
+export type DeckGLProps<ViewsT extends ViewOrViews = null> = Omit<
+  DeckProps<ViewsT>,
   'width' | 'height' | 'gl' | 'parent' | 'canvas' | '_customRender'
 > & {
   Deck?: typeof Deck;
   width?: string | number;
   height?: string | number;
   children?: React.ReactNode | DeckGLRenderCallback;
+  ref?: React.Ref<DeckGLRef<ViewsT>>;
   ContextProvider?: React.Context<DeckGLContextValue>['Provider'];
 };
 
-export type DeckGLRef = {
-  deck?: Deck;
+export type DeckGLRef<ViewsT extends ViewOrViews = null> = {
+  deck?: Deck<ViewsT>;
   pickObject: Deck['pickObject'];
   pickObjects: Deck['pickObjects'];
   pickMultipleObjects: Deck['pickMultipleObjects'];
 };
 
-function getRefHandles(thisRef: DeckInstanceRef): DeckGLRef {
+function getRefHandles<ViewsT extends ViewOrViews>(
+  thisRef: DeckInstanceRef<ViewsT>
+): DeckGLRef<ViewsT> {
   return {
     get deck() {
       return thisRef.deck;
@@ -81,7 +78,7 @@ function getRefHandles(thisRef: DeckInstanceRef): DeckGLRef {
   };
 }
 
-function redrawDeck(thisRef: DeckInstanceRef) {
+function redrawDeck(thisRef: DeckInstanceRef<any>) {
   if (thisRef.redrawReason) {
     // Only redraw if we have received a dirty flag
     // @ts-expect-error accessing protected method
@@ -90,11 +87,11 @@ function redrawDeck(thisRef: DeckInstanceRef) {
   }
 }
 
-function createDeckInstance(
-  thisRef: DeckInstanceRef,
+function createDeckInstance<ViewsT extends ViewOrViews>(
+  thisRef: DeckInstanceRef<ViewsT>,
   DeckClass: typeof Deck,
-  props: DeckProps
-): Deck {
+  props: DeckProps<ViewsT>
+): Deck<ViewsT> {
   const deck = new DeckClass({
     ...props,
     // The Deck's animation loop is independent from React's render cycle, causing potential
@@ -120,11 +117,11 @@ function createDeckInstance(
   return deck;
 }
 
-const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
+function DeckGL<ViewsT extends ViewOrViews = null>(props: DeckGLProps<ViewsT>) {
   // A mechanism to force redraw
   const [version, setVersion] = useState(0);
   // A reference to persistent states
-  const _thisRef = useRef<DeckInstanceRef>({
+  const _thisRef = useRef<DeckInstanceRef<ViewsT>>({
     control: null,
     version,
     forceUpdate: () => setVersion(v => v + 1)
@@ -143,7 +140,7 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
   // Callbacks
   let inRender = true;
 
-  const handleViewStateChange: DeckProps['onViewStateChange'] = params => {
+  const handleViewStateChange: DeckProps<ViewsT>['onViewStateChange'] = params => {
     if (inRender && props.viewState) {
       // Callback may invoke a state update. Defer callback to after render() to avoid React error
       // In React StrictMode, render is executed twice and useEffect/useLayoutEffect is executed once
@@ -155,7 +152,7 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
     return props.onViewStateChange?.(params);
   };
 
-  const handleInteractionStateChange: DeckProps['onInteractionStateChange'] = params => {
+  const handleInteractionStateChange: DeckProps<ViewsT>['onInteractionStateChange'] = params => {
     if (inRender) {
       // Callback may invoke a state update. Defer callback to after render() to avoid React error
       // In React StrictMode, render is executed twice and useEffect/useLayoutEffect is executed once
@@ -171,7 +168,7 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
   // the next animation frame.
   // Needs to be called both from initial mount, and when new props are received
   const deckProps = useMemo(() => {
-    const forwardProps: DeckProps = {
+    const forwardProps: DeckProps<ViewsT> = {
       ...props,
       // Override user styling props. We will set the canvas style in render()
       style: null,
@@ -180,7 +177,7 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
       parent: containerRef.current,
       canvas: canvasRef.current,
       layers: jsxProps.layers,
-      views: jsxProps.views,
+      views: jsxProps.views as ViewsT,
       onViewStateChange: handleViewStateChange,
       onInteractionStateChange: handleInteractionStateChange
     };
@@ -224,7 +221,7 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
     }
   });
 
-  useImperativeHandle(ref, () => getRefHandles(thisRef), []);
+  useImperativeHandle(props.ref, () => getRefHandles(thisRef), []);
 
   const currentViewports =
     thisRef.deck && thisRef.deck.isInitialized ? thisRef.deck.getViewports() : undefined;
@@ -274,7 +271,7 @@ const DeckGL = forwardRef<DeckGLRef, DeckGLProps>((props, ref) => {
 
   inRender = false;
   return thisRef.control;
-});
+}
 
 DeckGL.defaultProps = Deck.defaultProps;
 

--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -117,7 +117,10 @@ function createDeckInstance<ViewsT extends ViewOrViews>(
   return deck;
 }
 
-function DeckGL<ViewsT extends ViewOrViews = null>(props: DeckGLProps<ViewsT>) {
+function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
+  props: DeckGLProps<ViewsT>,
+  ref: React.Ref<DeckGLRef<ViewsT>>
+) {
   // A mechanism to force redraw
   const [version, setVersion] = useState(0);
   // A reference to persistent states
@@ -221,7 +224,7 @@ function DeckGL<ViewsT extends ViewOrViews = null>(props: DeckGLProps<ViewsT>) {
     }
   });
 
-  useImperativeHandle(props.ref, () => getRefHandles(thisRef), []);
+  useImperativeHandle(ref, () => getRefHandles(thisRef), []);
 
   const currentViewports =
     thisRef.deck && thisRef.deck.isInitialized ? thisRef.deck.getViewports() : undefined;
@@ -273,6 +276,8 @@ function DeckGL<ViewsT extends ViewOrViews = null>(props: DeckGLProps<ViewsT>) {
   return thisRef.control;
 }
 
-DeckGL.defaultProps = Deck.defaultProps;
+const DeckGL = React.forwardRef(DeckGLWithRef) as <ViewsT extends ViewOrViews>(
+  props: DeckGLProps<ViewsT>
+) => React.ReactElement;
 
 export default DeckGL;

--- a/modules/react/src/utils/position-children-under-views.ts
+++ b/modules/react/src/utils/position-children-under-views.ts
@@ -4,6 +4,7 @@ import {View} from '@deck.gl/core';
 import {inheritsFrom} from './inherits-from';
 import evaluateChildren, {isComponent} from './evaluate-children';
 
+import type {ViewOrViews} from '../deckgl';
 import type {Deck, DeckProps, Viewport} from '@deck.gl/core';
 import type {EventManager} from 'mjolnir.js';
 
@@ -16,13 +17,13 @@ export type DeckGLContextValue = {
 
 // Iterate over views and reposition children associated with views
 // TODO - Can we supply a similar function for the non-React case?
-export default function positionChildrenUnderViews({
+export default function positionChildrenUnderViews<ViewsT extends ViewOrViews>({
   children,
   deck,
   ContextProvider
 }: {
   children: React.ReactNode[];
-  deck?: Deck;
+  deck?: Deck<ViewsT>;
   ContextProvider?: React.Context<DeckGLContextValue>['Provider'];
 }): React.ReactNode[] {
   // @ts-expect-error accessing protected property

--- a/modules/test-utils/src/test-runner.ts
+++ b/modules/test-utils/src/test-runner.ts
@@ -23,7 +23,7 @@
 import {Deck, DeckProps, MapView} from '@deck.gl/core';
 import type {Device} from '@luma.gl/core';
 
-const DEFAULT_DECK_PROPS: DeckProps = {
+const DEFAULT_DECK_PROPS: DeckProps<any> = {
   ...Deck.defaultProps,
   id: 'deckgl-render-test',
   width: 800,
@@ -63,8 +63,8 @@ const DEFAULT_TEST_OPTIONS: TestOptions<TestCase, unknown> = {
 };
 
 export abstract class TestRunner<TestCaseT extends TestCase, ResultT, ExtraOptions = {}> {
-  deck: Deck | null = null;
-  props: DeckProps;
+  deck: Deck<any> | null = null;
+  props: DeckProps<any>;
   isHeadless: boolean;
   isRunning: boolean = false;
   testOptions: TestOptions<TestCaseT, ResultT> & ExtraOptions;

--- a/modules/widgets/src/compass-widget.tsx
+++ b/modules/widgets/src/compass-widget.tsx
@@ -34,7 +34,7 @@ export class CompassWidget implements Widget<CompassWidgetProps> {
   placement: WidgetPlacement = 'top-left';
   viewId?: string | null = null;
   viewport?: Viewport;
-  deck?: Deck;
+  deck?: Deck<any>;
   element?: HTMLDivElement;
 
   constructor(props: CompassWidgetProps) {
@@ -56,7 +56,7 @@ export class CompassWidget implements Widget<CompassWidgetProps> {
     this.update();
   }
 
-  onAdd({deck}: {deck: Deck}): HTMLDivElement {
+  onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {
     const {style, className} = this.props;
     const element = document.createElement('div');
     element.classList.add('deck-widget', 'deck-widget-compass');

--- a/modules/widgets/src/fullscreen-widget.tsx
+++ b/modules/widgets/src/fullscreen-widget.tsx
@@ -36,7 +36,7 @@ export class FullscreenWidget implements Widget<FullscreenWidgetProps> {
   props: FullscreenWidgetProps;
   placement: WidgetPlacement = 'top-left';
 
-  deck?: Deck;
+  deck?: Deck<any>;
   element?: HTMLDivElement;
 
   fullscreen: boolean = false;
@@ -50,7 +50,7 @@ export class FullscreenWidget implements Widget<FullscreenWidgetProps> {
     this.props = props;
   }
 
-  onAdd({deck}: {deck: Deck}): HTMLDivElement {
+  onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {
     const {style, className} = this.props;
     const el = document.createElement('div');
     el.classList.add('deck-widget', 'deck-widget-fullscreen');

--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -44,7 +44,7 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
   orientation: 'vertical' | 'horizontal' = 'vertical';
   viewId?: string | null = null;
   viewport?: Viewport;
-  deck?: Deck;
+  deck?: Deck<any>;
   element?: HTMLDivElement;
 
   constructor(props: ZoomWidgetProps) {
@@ -59,7 +59,7 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
     this.props = props;
   }
 
-  onAdd({deck}: {deck: Deck}): HTMLDivElement {
+  onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {
     const {style, className} = this.props;
     const element = document.createElement('div');
     element.classList.add('deck-widget', 'deck-widget-zoom');


### PR DESCRIPTION
#### Change List
- Deck class generic parameter `ViewsT` should default to `null` (matches default `props.views`)
- Tightening the type for `viewState`/`initialViewState`: only use id-to-state map if `ViewsT` is an array

Before, very confusing hints:

![Screen Shot 2024-04-05 at 10 28 26 PM](https://github.com/visgl/deck.gl/assets/2059298/7eed2367-d735-42fd-aad4-e6b75f3d3c82)

![Screen Shot 2024-04-05 at 10 27 03 PM](https://github.com/visgl/deck.gl/assets/2059298/3c05af26-1caa-437c-ad5d-03667e775f3d)

After:

![Screen Shot 2024-04-05 at 10 27 47 PM](https://github.com/visgl/deck.gl/assets/2059298/96f55aa9-03d6-432f-9ffb-f4ac479a44b6)

![Screen Shot 2024-04-05 at 10 28 03 PM](https://github.com/visgl/deck.gl/assets/2059298/f8b95abf-9839-4020-ad79-351366c19a18)

With a single non-map view:

![Screen Shot 2024-04-05 at 10 38 11 PM](https://github.com/visgl/deck.gl/assets/2059298/9092c878-1b67-42a3-8ee4-57822fecf23e)

With multiple views:

![Screen Shot 2024-04-05 at 10 40 13 PM](https://github.com/visgl/deck.gl/assets/2059298/2adf93db-a77e-4080-a047-483f6ca5ec1d)
