### PR TITLE
fix(react) component default size

### DIFF
--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -229,7 +229,7 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
   const currentViewports =
     thisRef.deck && thisRef.deck.isInitialized ? thisRef.deck.getViewports() : undefined;
 
-  const {ContextProvider, width, height, id, style} = props;
+  const {ContextProvider, width = '100%', height = '100%', id, style} = props;
 
   const {containerStyle, canvasStyle} = useMemo(
     () => extractStyles({width, height, style}),


### PR DESCRIPTION
`FunctionComponent.defaultProps` has been deprecated by React. `DeckGL.defaultProps` was removed in #8763 without providing fallbacks causing the canvas to be 0x0.

#### Change List
- Use React's recommended approach to supply default width and height
