### PR TITLE
fix(core): Deck.finalize removes externally created canvas

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -433,7 +433,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
     this.widgetManager?.finalize();
     this.widgetManager = null;
 
-    if (!this.props.canvas && !this.props.device && this.canvas) {
+    if (!this.props.canvas && !this.props.device && !this.props.gl && this.canvas) {
       // remove internally created canvas
       this.canvas.parentElement?.removeChild(this.canvas);
       this.canvas = null;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #8768

<!-- For all the PRs -->
#### Change List
- Do not remove canvas if using user-supplied `gl`
