### PR TITLE
fix(pydeck): Fix pydeck tooltip serialization

### DIFF
--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -21,7 +21,8 @@ def in_jupyter():
 
 
 def convert_js_bool(py_bool):
-    if type(py_bool) is bool:
+    """Serializes Python booleans to JavaScript. Returns non-boolean values unchanged."""
+    if type(py_bool) is not bool:
         return py_bool
     return "true" if py_bool else "false"
 


### PR DESCRIPTION
Appears to have been a typo in https://github.com/visgl/deck.gl/pull/8034. Boolean values of 'tooltip' should be converted to JavaScript booleans, all other values should be returned as-is. With this change, pydeck is now working locally when using 'to_html'. With 'show' I'm still seeing errors running locally related to bindings, but this is enough to make more progress on Deck v9 support.