### PR TITLE
fix(pydeck-carto): Fix missing global for pydeck-carto in 8.9 release

### DIFF
--- a/bindings/pydeck-carto/pydeck_carto/layer.py
+++ b/bindings/pydeck-carto/pydeck_carto/layer.py
@@ -1,7 +1,7 @@
 import pydeck as pdk
 
 H3_VERSION = "~3.7.*"
-DECKGL_VERSION = "~8.8.*"
+DECKGL_VERSION = "~8.9.*"
 
 LIBRARIES_TO_INCLUDE = [
     f"npm/h3-js@{H3_VERSION}/dist/h3-js.umd.js",

--- a/bindings/pydeck/pydeck/frontend_semver.py
+++ b/bindings/pydeck/pydeck/frontend_semver.py
@@ -1,1 +1,1 @@
-DECKGL_SEMVER = "~8.8.*"
+DECKGL_SEMVER = "~8.9.*"

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -21,7 +21,8 @@ def in_jupyter():
 
 
 def convert_js_bool(py_bool):
-    if type(py_bool) is bool:
+    """Serializes Python booleans to JavaScript. Returns non-boolean values unchanged."""
+    if type(py_bool) is not bool:
         return py_bool
     return "true" if py_bool else "false"
 

--- a/bindings/pydeck/requirements/requirements-dev.txt
+++ b/bindings/pydeck/requirements/requirements-dev.txt
@@ -11,7 +11,7 @@ flake8
 requests
 sphinx
 recommonmark
-jupyterlab
+jupyterlab<4.0.0
 ipython>=5.8.0;python_version<"3.4"
 semver # necessary for PEP440-compliant semantic versions
 sphinx-markdown-builder

--- a/modules/carto/bundle.ts
+++ b/modules/carto/bundle.ts
@@ -3,3 +3,7 @@ import * as CartoUtils from './src';
 export * from '../layers/bundle/peer-dependency';
 
 export const carto = CartoUtils;
+
+// Export carto layer library for pydeck integration
+// More info: https://github.com/ajduberstein/pydeck_custom_layer
+globalThis.CartoLayerLibrary = CartoUtils;


### PR DESCRIPTION
Patch for the `8.9-release` branch, restoring a missing global for the pydeck-carto integration. I've included some known fixes added since the last release as well.

Related:

- https://github.com/visgl/deck.gl/pull/7546 (global export lost here)
- #8756
- #8780