### PR TITLE
chore(docs): should use MapboxOverlay instead of DeckOverlay

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -61,8 +61,8 @@ While the 9.0 release of deck.gl does not yet support WebGPU, our goal is to ena
 
 ```ts
 // deck.gl v9
-import {DeckOverlay} from '@deck.gl/mapbox'
-map.addControl(new DeckOverlay({
+import {MapboxOverlay} from '@deck.gl/mapbox'
+map.addControl(new MapboxOverlay({
   interleaved: true,
   layers: [new ArcLayer({...})]
 }))


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #8793 

<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
- docs/update-guide.md
  + in `@deck.gl/mapbox` section
    * DeckOverlay should be replaced to MapboxOverlay
