### PR TITLE
fix(geo-layers): TileLayer default autoHighlight

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -154,6 +154,8 @@ export type TileLayerPickingInfo<
   tile?: Tile2DHeader<DataT>;
   /** the tile that emitted the picking event */
   sourceTile: Tile2DHeader<DataT>;
+  /** a layer created by props.renderSubLayer() that emitted the picking event */
+  sourceTileSubLayer: Layer;
 };
 
 /**
@@ -341,22 +343,20 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   }
 
   getPickingInfo(params: GetPickingInfoParams): TileLayerPickingInfo<DataT> {
-    const sourceTile: Tile2DHeader<DataT> = (params.sourceLayer as any).props.tile;
+    // TileLayer does not directly render anything, sourceLayer cannot be null
+    const sourceLayer = params.sourceLayer!;
+    const sourceTile: Tile2DHeader<DataT> = (sourceLayer.props as any).tile;
     const info = params.info as TileLayerPickingInfo<DataT>;
     if (info.picked) {
       info.tile = sourceTile;
     }
     info.sourceTile = sourceTile;
+    info.sourceTileSubLayer = sourceLayer;
     return info;
   }
 
-  protected _updateAutoHighlight(info: PickingInfo): void {
-    const sourceTile = (info as any).sourceTile as Tile2DHeader;
-    if (sourceTile && sourceTile.layers) {
-      for (const layer of sourceTile.layers) {
-        layer.updateAutoHighlight(info);
-      }
-    }
+  protected _updateAutoHighlight(info: TileLayerPickingInfo<DataT>): void {
+    info.sourceTileSubLayer.updateAutoHighlight(info);
   }
 
   renderLayers(): Layer | null | LayersList {


### PR DESCRIPTION
Closes #8787

`CompositeLayer` by default auto highlights all sub layers, assuming they all share the same data. This is true for most layers except overridden in `GeoJsonLayer` (which selectively passes highlight down depending on the feature), and in tiled layers. The basic `TileLayer` does not have any knowledge of how `renderSubLayers` uses the data, therefore there isn't a default behavior that will work for every use case. However, it is safer (and more correct?) to only highlight the sub layer that is being picked, than to assume that all sublayers should be highlighted at the same picked index.

For discussion: this is technically a breaking change (bug originally introduced in a 8.8 patch #7650), is it ok to include it as a patch?

#### Change List
- Add picked sub layer to `TileLayerPickingInfo`
- Only auto highlight the picked sub layer
