### PR TITLE
feat(pydeck-carto): Update H3, Quadbin, and styling examples for deck.gl v9

### DIFF
--- a/bindings/pydeck-carto/Makefile
+++ b/bindings/pydeck-carto/Makefile
@@ -16,6 +16,9 @@ lint:
 test:
 	$(BIN)/pytest tests --cov=pydeck_carto
 
+test-scripts:
+	for file in examples/scripts/*.py; do $(BIN)/python "$$file"; done
+
 publish-pypi:
 	rm -rf $(DIST) $(BUILD) *.egg-info
 	$(BIN)/python setup.py sdist bdist_wheel

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_geo_query.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_geo_query.py
@@ -7,6 +7,7 @@ Render cloud data from a query.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
@@ -21,7 +22,7 @@ data = pdkc.sources.vector_query_source(
 
 layer = pdk.Layer(
     "VectorTileLayer",
-    data=data.serialize(), # TODO(donmccurdy): How to automate this?
+    data=data,
     get_fill_color=[238, 77, 90],
     point_radius_min_pixels=2.5,
     pickable=True,
@@ -30,4 +31,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=0, longitude=0, zoom=1)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_geo_query.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_geo_query.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_geo_query_param.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_geo_query_param.py
@@ -7,19 +7,24 @@ Render cloud data with query parameters.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
-layer = pdk.Layer(
-    "CartoLayer",
-    data="SELECT geom, event FROM carto-demo-data.demo_tables"
+data = pdkc.sources.vector_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="SELECT geom, event FROM carto-demo-data.demo_tables"
     ".spain_earthquakes where depth > ?",
     query_parameters=[2],
-    type_=pdkc.MapType.QUERY,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
+)
+
+layer = pdk.Layer(
+    "VectorTileLayer",
+    data=data,
     get_fill_color=[238, 77, 90],
     point_radius_min_pixels=2.5,
     pickable=True,
@@ -28,4 +33,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=36, longitude=-7.44, zoom=5)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_geo_query_param.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_geo_query_param.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_geo_table.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_geo_table.py
@@ -7,6 +7,7 @@ Render cloud data from a table.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
@@ -21,7 +22,7 @@ data = pdkc.sources.vector_table_source(
 
 layer = pdk.Layer(
     "VectorTileLayer",
-    data=data.serialize(), # TODO(donmccurdy): How to automate this?
+    data=data,
     get_fill_color=[200, 0, 80],
     point_radius_min_pixels=2,
     pickable=True,
@@ -30,4 +31,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=0, longitude=0, zoom=1)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_geo_table.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_geo_table.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_geo_tileset.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_geo_tileset.py
@@ -7,6 +7,7 @@ Render cloud data from a tileset.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
@@ -21,7 +22,7 @@ data = pdkc.sources.vector_tileset_source(
 
 layer = pdk.Layer(
     "VectorTileLayer",
-    data=data.serialize(), # TODO(donmccurdy): How to automate this?
+    data=data,
     get_fill_color=[200, 0, 80],
     stroked=False,
     point_radius_min_pixels=2,
@@ -31,4 +32,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=36, longitude=-7.44, zoom=5)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_geo_tileset.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_geo_tileset.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_h3_query.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_h3_query.py
@@ -20,7 +20,6 @@ data = pdkc.sources.h3_query_source(
     sql_query="select * from carto-demo-data.demo_tables"
     ".derived_spatialfeatures_usa_h3res8_v1_yearly_v2",
     aggregation_exp="sum(population) as population_sum",
-    spatial_data_column="h3",
 )
 
 layer = pdk.Layer(

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_h3_query.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_h3_query.py
@@ -7,19 +7,25 @@ Render cloud data in H3 grid from a query.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
+
+data = pdkc.sources.h3_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="select * from carto-demo-data.demo_tables"
+    ".derived_spatialfeatures_usa_h3res8_v1_yearly_v2",
+    aggregation_exp="sum(population) as population_sum",
+    spatial_data_column="h3",
+)
 
 layer = pdk.Layer(
-    "CartoLayer",
-    data="select * from carto-demo-data.demo_tables"
-    ".derived_spatialfeatures_usa_h3res8_v1_yearly_v2",
-    type_=pdkc.MapType.QUERY,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
-    geo_column=pdkc.GeoColumnType.H3,
+    "H3TileLayer",
+    data=data,
     get_fill_color=[200, 0, 80],
     pickable=True,
 )
@@ -27,4 +33,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=44, longitude=-122, zoom=3)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_h3_query.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_h3_query.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_h3_table.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_h3_table.py
@@ -17,7 +17,8 @@ data = pdkc.sources.h3_table_source(
     access_token=carto_auth.get_access_token(),
     api_base_url=carto_auth.get_api_base_url(),
     connection_name="carto_dw",
-    table_name="carto-demo-data.demo_tables.derived_spatialfeatures_esp_h3res8_v1_yearly_v2",
+    table_name="carto-demo-data.demo_tables"
+    ".derived_spatialfeatures_esp_h3res8_v1_yearly_v2",
     aggregation_exp="sum(population) as population_sum",
 )
 

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_h3_table.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_h3_table.py
@@ -7,18 +7,23 @@ Render cloud data in H3 grid from a table.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
+
+data = pdkc.sources.h3_table_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    table_name="carto-demo-data.demo_tables.derived_spatialfeatures_esp_h3res8_v1_yearly_v2",
+    aggregation_exp="sum(population) as population_sum",
+)
 
 layer = pdk.Layer(
-    "CartoLayer",
-    data="carto-demo-data.demo_tables.derived_spatialfeatures_esp_h3res8_v1_yearly_v2",
-    type_=pdkc.MapType.TABLE,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
-    geo_column=pdkc.GeoColumnType.H3,
+    "H3TileLayer",
+    data=data,
     get_fill_color=[200, 0, 80],
     pickable=True,
 )
@@ -26,4 +31,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=36, longitude=-7.44, zoom=5)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_h3_table.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_h3_table.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_h3_tileset.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_h3_tileset.py
@@ -7,18 +7,24 @@ Render cloud data in H3 grid from a tileset.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
+
+data = pdkc.sources.h3_tileset_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    table_name="carto-demo-data.demo_tilesets"
+    ".derived_spatialfeatures_usa_h3res8_v1_yearly_v2_tileset",
+    aggregation_exp="sum(population) as population_sum",
+)
 
 layer = pdk.Layer(
-    "CartoLayer",
-    data="carto-demo-data.demo_tilesets"
-    ".derived_spatialfeatures_usa_h3res8_v1_yearly_v2_tileset",
-    type_=pdkc.MapType.TILESET,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
+    "H3TileLayer",
+    data=data,
     get_fill_color=[200, 0, 80],
     pickable=True,
 )
@@ -26,4 +32,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=44, longitude=-122, zoom=3)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_h3_tileset.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_h3_tileset.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_query.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_query.py
@@ -7,10 +7,11 @@ Render cloud data in Quadbin grid from a query.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -27,4 +28,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=44, longitude=-122, zoom=3)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_quadbin_query.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_quadbin_query.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_query.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_query.py
@@ -13,14 +13,18 @@ carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
-layer = pdk.Layer(
-    "CartoLayer",
-    data="select * from carto-demo-data.demo_tables"
+data = pdkc.sources.quadbin_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="select * from carto-demo-data.demo_tables"
     ".derived_spatialfeatures_usa_quadbin15_v1_yearly_v2",
-    type_=pdkc.MapType.QUERY,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
-    geo_column=pdkc.GeoColumnType.QUADBIN,
+    aggregation_exp="sum(population) as population_sum",
+)
+
+layer = pdk.Layer(
+    "QuadbinTileLayer",
+    data=data,
     get_fill_color=[200, 0, 80],
     pickable=True,
 )

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_table.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_table.py
@@ -13,14 +13,18 @@ carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
-layer = pdk.Layer(
-    "CartoLayer",
-    data="carto-demo-data.demo_tables"
+data = pdkc.sources.quadbin_table_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    table_name="carto-demo-data.demo_tables"
     ".derived_spatialfeatures_esp_quadbin15_v1_yearly_v2",
-    type_=pdkc.MapType.TABLE,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
-    geo_column=pdkc.GeoColumnType.QUADBIN,
+    aggregation_exp="sum(population) as population_sum",
+)
+
+layer = pdk.Layer(
+    "QuadbinTileLayer",
+    data=data,
     get_fill_color=[200, 0, 80],
     pickable=True,
 )

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_table.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_table.py
@@ -7,10 +7,11 @@ Render cloud data in Quadbin grid from a table.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -27,4 +28,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=36, longitude=-7.44, zoom=5)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_quadbin_table.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_quadbin_table.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_tileset.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_tileset.py
@@ -7,10 +7,11 @@ Render cloud data in Quadbin grid from a tileset.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -26,4 +27,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=44, longitude=-122, zoom=3)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_layer_quadbin_tileset.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_layer_quadbin_tileset.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_tileset.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_layer_quadbin_tileset.py
@@ -13,13 +13,18 @@ carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
-layer = pdk.Layer(
-    "CartoLayer",
-    data="carto-demo-data.demo_tilesets"
+data = pdkc.sources.quadbin_tileset_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    table_name="carto-demo-data.demo_tilesets"
     ".derived_spatialfeatures_usa_quadbin15_v1_yearly_v2_tileset",
-    type_=pdkc.MapType.TILESET,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
+    aggregation_exp="sum(population) as population_sum",
+)
+
+layer = pdk.Layer(
+    "QuadbinTileLayer",
+    data=data,
     get_fill_color=[200, 0, 80],
     pickable=True,
 )

--- a/bindings/pydeck-carto/examples/scripts/carto_styles_color_bins.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_styles_color_bins.py
@@ -7,10 +7,11 @@ Render cloud data with color bins style.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -30,4 +31,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=38, longitude=-98, zoom=3)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_styles_color_bins.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_styles_color_bins.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_styles_color_bins.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_styles_color_bins.py
@@ -13,13 +13,17 @@ carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
-layer = pdk.Layer(
-    "CartoLayer",
-    data="SELECT geom, pct_higher_ed "
+data = pdkc.sources.vector_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="SELECT geom, pct_higher_ed "
     "FROM `cartobq.public_account.higher_edu_by_county`",
-    type_=pdkc.MapType.QUERY,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
+)
+
+layer = pdk.Layer(
+    "VectorTileLayer",
+    data=data,
     get_fill_color=pdkc.styles.color_bins(
         "pct_higher_ed", [0, 20, 30, 40, 50, 60, 70], "PinkYl"
     ),

--- a/bindings/pydeck-carto/examples/scripts/carto_styles_color_categories.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_styles_color_categories.py
@@ -7,10 +7,11 @@ Render cloud data with color categories style.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -43,4 +44,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=40.715, longitude=-73.959, zoom=14)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.LIGHT, initial_view_state=view_state)
-r.to_html("carto_styles_color_categories.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_styles_color_categories.html"))

--- a/bindings/pydeck-carto/examples/scripts/carto_styles_color_categories.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_styles_color_categories.py
@@ -13,12 +13,16 @@ carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
+data = pdkc.sources.vector_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="SELECT geom, landuse_type FROM `cartobq.public_account.wburg_parcels`",
+)
+
 layer = pdk.Layer(
-    "CartoLayer",
-    data="SELECT geom, landuse_type FROM `cartobq.public_account.wburg_parcels`",
-    type_=pdkc.MapType.QUERY,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
+    "VectorTileLayer",
+    data=data,
     get_fill_color=pdkc.styles.color_categories(
         "landuse_type",
         [

--- a/bindings/pydeck-carto/examples/scripts/carto_styles_color_continuous.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_styles_color_continuous.py
@@ -13,12 +13,17 @@ carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
+data = pdkc.sources.vector_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="SELECT geom, value FROM cartobq.public_account.temps",
+)
+
+
 layer = pdk.Layer(
-    "CartoLayer",
-    data="SELECT geom, value FROM cartobq.public_account.temps",
-    type_=pdkc.MapType.QUERY,
-    connection=pdkc.CartoConnection.CARTO_DW,
-    credentials=pdkc.get_layer_credentials(carto_auth),
+    "VectorTileLayer",
+    data=data,
     get_fill_color=pdkc.styles.color_continuous(
         "value", [70, 75, 80, 85, 90, 95, 100], "Peach"
     ),

--- a/bindings/pydeck-carto/examples/scripts/carto_styles_color_continuous.py
+++ b/bindings/pydeck-carto/examples/scripts/carto_styles_color_continuous.py
@@ -7,10 +7,11 @@ Render cloud data with color continuous style.
 import pydeck as pdk
 import pydeck_carto as pdkc
 from carto_auth import CartoAuth
+from os.path import join, dirname
 
 carto_auth = CartoAuth.from_oauth()
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -27,4 +28,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=34, longitude=-98, zoom=3)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("carto_styles_color_continuous.html", open_browser=True)
+r.to_html(join(dirname(__file__), "carto_styles_color_continuous.html"))

--- a/bindings/pydeck-carto/examples/scripts/hello_world.py
+++ b/bindings/pydeck-carto/examples/scripts/hello_world.py
@@ -7,20 +7,23 @@ https://docs.carto.com/deck-gl/examples/basic-examples/hello-world/
 
 import pydeck as pdk
 import pydeck_carto as pdkc
+from carto_auth import CartoAuth
+from os.path import join, dirname
+
+carto_auth = CartoAuth.from_oauth()
 
 pdkc.register_layers()
 
+data = pdkc.sources.vector_query_source(
+    access_token=carto_auth.get_access_token(),
+    api_base_url=carto_auth.get_api_base_url(),
+    connection_name="carto_dw",
+    sql_query="SELECT geom, name FROM cartobq.public_account.populated_places",
+)
+
 layer = pdk.Layer(
-    "CartoLayer",
-    data="SELECT geom, name FROM cartobq.public_account.populated_places",
-    type_=pdkc.MapType.QUERY,
-    connection=pdk.types.String("bqconnection"),
-    credentials={
-        "apiBaseUrl": "https://gcp-us-east1.api.carto.com",
-        "accessToken": "eyJhbGciOiJIUzI1NiJ9"
-        ".eyJhIjoiYWNfN3hoZnd5bWwiLCJqdGkiOiIwMGQ1NmFiMyJ9"
-        ".zqsprFkxiafKXQ91PDB8845nVeWGVnuLg22v49J3Wiw",
-    },
+    "VectorTileLayer",
+    data=data,
     get_fill_color=[238, 77, 90],
     point_radius_min_pixels=2.5,
 )

--- a/bindings/pydeck-carto/examples/scripts/hello_world.py
+++ b/bindings/pydeck-carto/examples/scripts/hello_world.py
@@ -8,7 +8,7 @@ https://docs.carto.com/deck-gl/examples/basic-examples/hello-world/
 import pydeck as pdk
 import pydeck_carto as pdkc
 
-pdkc.register_carto_layer()
+pdkc.register_layers()
 
 layer = pdk.Layer(
     "CartoLayer",
@@ -28,4 +28,4 @@ layer = pdk.Layer(
 view_state = pdk.ViewState(latitude=0, longitude=0, zoom=1)
 
 r = pdk.Deck(layer, map_style=pdk.map_styles.ROAD, initial_view_state=view_state)
-r.to_html("hello_world.html", open_browser=True)
+r.to_html(join(dirname(__file__), "hello_world.html"))

--- a/bindings/pydeck-carto/pydeck_carto/sources.py
+++ b/bindings/pydeck-carto/pydeck_carto/sources.py
@@ -1,5 +1,5 @@
 import pydeck as pdk
-from typing import Any, TypedDict, List
+from typing import Any, TypedDict, List, Union
 from typing_extensions import NotRequired, Unpack, assert_type
 
 # TYPES
@@ -20,9 +20,15 @@ class TableSourceOptions(BaseSourceOptions):
     spatial_data_column: NotRequired[str]
 
 
+QueryParameterValue = Union[str, int, float, bool]
+
+
 class QuerySourceOptions(BaseSourceOptions):
     sql_query: str
     spatial_data_column: NotRequired[str]
+    query_parameters: NotRequired[
+        List[Union[QueryParameterValue, List[QueryParameterValue]]]
+    ]
 
 
 class TilesetSourceOptions(BaseSourceOptions):
@@ -44,9 +50,7 @@ class AggregationOptions(Options):
 # 'get_type_hints' to provide type hints in the future.
 
 
-def validate_str(
-    interface: Any, args: Options, arg: str, required: bool = True
-):
+def validate_str(interface: Any, args: Options, arg: str, required: bool = True):
     """Validates given key on an options object is a string."""
     if arg not in args and required:
         raise AssertionError('Missing argument "{}".'.format(arg))
@@ -54,9 +58,7 @@ def validate_str(
         assert type(args[arg]) is str, "Argument {} must be of type str".format(arg)
 
 
-def validate_int(
-    interface: Any, args: Options, arg: str, required: bool = True
-):
+def validate_int(interface: Any, args: Options, arg: str, required: bool = True):
     """Validates given key on an options object is an int."""
     if arg not in args and required:
         raise AssertionError('Missing argument "{}".'.format(arg))
@@ -86,7 +88,11 @@ def table_options(**kwargs: Unpack[TableSourceOptions]):
     validate_str(TableSourceOptions, kwargs, "spatial_data_column", False)
     return {
         "tableName": kwargs.get("table_name"),
-        **({"spatialDataColumn": kwargs["spatial_data_column"]} if "spatial_data_column" in kwargs else {}),
+        **(
+            {"spatialDataColumn": kwargs["spatial_data_column"]}
+            if "spatial_data_column" in kwargs
+            else {}
+        ),
         **base_options(**kwargs),
     }
 
@@ -97,7 +103,16 @@ def query_options(**kwargs: Unpack[QuerySourceOptions]):
     validate_str(TableSourceOptions, kwargs, "spatial_data_column", False)
     return {
         "sqlQuery": kwargs.get("sql_query"),
-        **({"spatialDataColumn": kwargs["spatial_data_column"]} if "spatial_data_column" in kwargs else {}),
+        **(
+            {"spatialDataColumn": kwargs["spatial_data_column"]}
+            if "spatial_data_column" in kwargs
+            else {}
+        ),
+        **(
+            {"queryParameters": kwargs["query_parameters"]}
+            if "query_parameters" in kwargs
+            else {}
+        ),
         **base_options(**kwargs),
     }
 
@@ -122,7 +137,11 @@ def aggregation_options(**kwargs: Unpack[AggregationOptions]):
     validate_int(AggregationOptions, kwargs, "aggregation_res_level", False)
     return {
         "aggregationExp": kwargs["aggregation_exp"],
-        **({"aggregationResLevel": kwargs["aggregation_res_level"]} if "aggregation_res_level" in kwargs else {}),
+        **(
+            {"aggregationResLevel": kwargs["aggregation_res_level"]}
+            if "aggregation_res_level" in kwargs
+            else {}
+        ),
     }
 
 
@@ -144,17 +163,19 @@ class VectorTilesetSourceOptions(TilesetSourceOptions):
 def vector_table_source(**kwargs: Unpack[VectorTableSourceOptions]):
     return pdk.types.Function(
         "vectorTableSource", **{**column_options(**kwargs), **table_options(**kwargs)}
-    )
+    ).serialize()  # TODO Required?
 
 
 def vector_query_source(**kwargs: Unpack[VectorQuerySourceOptions]):
     return pdk.types.Function(
         "vectorQuerySource", **{**column_options(**kwargs), **query_options(**kwargs)}
-    )
+    ).serialize()  # TODO Required?
 
 
 def vector_tileset_source(**kwargs: Unpack[VectorTilesetSourceOptions]):
-    return pdk.types.Function("vectorTilesetSource", **tileset_options(**kwargs))
+    return pdk.types.Function(
+        "vectorTilesetSource", **tileset_options(**kwargs)
+    ).serialize()  # TODO Required?
 
 
 # H3
@@ -175,20 +196,19 @@ class H3TilesetSourceOptions(TilesetSourceOptions, AggregationOptions):
 def h3_table_source(**kwargs: Unpack[H3TableSourceOptions]):
     return pdk.types.Function(
         "h3TableSource", **{**aggregation_options(**kwargs), **table_options(**kwargs)}
-    )
+    ).serialize()  # TODO Required?
 
 
 def h3_query_source(**kwargs: Unpack[H3QuerySourceOptions]):
     return pdk.types.Function(
         "h3QuerySource", **{**aggregation_options(**kwargs), **query_options(**kwargs)}
-    )
+    ).serialize()  # TODO Required?
 
 
 def h3_tileset_source(**kwargs: Unpack[H3TilesetSourceOptions]):
     return pdk.types.Function(
-        "h3TilesetSource",
-        **tileset_options(**kwargs)
-    )
+        "h3TilesetSource", **tileset_options(**kwargs)
+    ).serialize()  # TODO Required?
 
 
 # QUADBIN
@@ -210,21 +230,20 @@ def quadbin_table_source(**kwargs: Unpack[QuadbinTableSourceOptions]):
     return pdk.types.Function(
         "quadbinTableSource",
         **{**aggregation_options(**kwargs), **table_options(**kwargs)}
-    )
+    ).serialize()  # TODO Required?
 
 
 def quadbin_query_source(**kwargs: Unpack[QuadbinQuerySourceOptions]):
     return pdk.types.Function(
         "quadbinQuerySource",
         **{**aggregation_options(**kwargs), **query_options(**kwargs)}
-    )
+    ).serialize()  # TODO Required?
 
 
 def quadbin_tileset_source(**kwargs: Unpack[QuadbinTilesetSourceOptions]):
     return pdk.types.Function(
-        "quadbinTilesetSource",
-        **tileset_options(**kwargs)
-    )
+        "quadbinTilesetSource", **tileset_options(**kwargs)
+    ).serialize()  # TODO Required?
 
 
 # RASTER (EXPERIMENTAL)

--- a/bindings/pydeck-carto/tests/test_sources.py
+++ b/bindings/pydeck-carto/tests/test_sources.py
@@ -32,7 +32,7 @@ def test_vector_table_source():
         table_name="project.database.table",
         spatial_data_column="geom",
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "vectorTableSource",
         "tableName": "project.database.table",
         "spatialDataColumn": "geom",
@@ -45,7 +45,7 @@ def test_vector_query_source():
         sql_query="select * from project.database.table",
         spatial_data_column="geom",
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "vectorQuerySource",
         "sqlQuery": "select * from project.database.table",
         "spatialDataColumn": "geom",
@@ -57,7 +57,7 @@ def test_vector_tileset_source():
     assert vector_tileset_source(
         table_name="project.database.table",
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "vectorTilesetSource",
         "tableName": "project.database.table",
         **base_options_serialized,
@@ -74,7 +74,7 @@ def test_h3_table_source():
         aggregation_exp="SUM(pop) AS total_population",
         aggregation_res_level=6,
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "h3TableSource",
         "tableName": "project.database.table",
         "spatialDataColumn": "geom",
@@ -91,7 +91,7 @@ def test_h3_query_source():
         aggregation_exp="SUM(pop) AS total_population",
         aggregation_res_level=6,
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "h3QuerySource",
         "sqlQuery": "select * from project.database.table",
         "spatialDataColumn": "geom",
@@ -102,10 +102,7 @@ def test_h3_query_source():
 
 
 def test_h3_tileset_source():
-    assert h3_tileset_source(
-        table_name="project.database.table",
-        **base_options,
-    ).serialize() == {
+    assert h3_tileset_source(table_name="project.database.table", **base_options,) == {
         "@@function": "h3TilesetSource",
         "tableName": "project.database.table",
         **base_options_serialized,
@@ -122,7 +119,7 @@ def test_quadbin_table_source():
         aggregation_exp="SUM(pop) AS total_population",
         aggregation_res_level=6,
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "quadbinTableSource",
         "tableName": "project.database.table",
         "spatialDataColumn": "geom",
@@ -139,7 +136,7 @@ def test_quadbin_query_source():
         aggregation_exp="SUM(pop) AS total_population",
         aggregation_res_level=6,
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "quadbinQuerySource",
         "sqlQuery": "select * from project.database.table",
         "spatialDataColumn": "geom",
@@ -153,7 +150,7 @@ def test_quadbin_tileset_source():
     assert quadbin_tileset_source(
         table_name="project.database.table",
         **base_options,
-    ).serialize() == {
+    ) == {
         "@@function": "quadbinTilesetSource",
         "tableName": "project.database.table",
         **base_options_serialized,


### PR DESCRIPTION
PR targets branch of https://github.com/visgl/deck.gl/pull/8577.

Changes:

- add `make test-scripts` macro for quickly testing pydeck-carto examples
- update example scripts to output HTML in the scripts directory, for testing with `npx serve`
- update H3, quadbin, and styling examples for deck v9
- miscellaneous fixes for CARTO sources in pydeck-carto