### PR TITLE
chore(repo): Set 'v8' release tags for all modules on 8.9-release branch

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "carto",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "version": "8.9.35",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "keywords": [
     "webgl",


### PR DESCRIPTION
Adds a 'v8' dist tag to all modules on the `8.9-release` branch, so that we can make patch releases without overwriting `latest` on npm.