### PR TITLE
fix(repo): Rename 'v8' release tags to 'v8-latest'

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "carto",

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "carto",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -3,6 +3,10 @@
   "description": "Jupyter widget for rendering deck.gl in a Jupyter notebook",
   "license": "MIT",
   "version": "8.9.36",
+  "publishConfig": {
+    "access": "public",
+    "tag": "v8-lts"
+  },
   "keywords": [
     "jupyter",
     "jupyterlab",

--- a/modules/jupyter-widget/package.json
+++ b/modules/jupyter-widget/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "jupyter",

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -3,6 +3,10 @@
   "description": "A suite of 3D-enabled data visualization overlays, suitable for react-map-gl",
   "license": "MIT",
   "version": "8.9.36",
+  "publishConfig": {
+    "access": "public",
+    "tag": "v8-lts"
+  },
   "keywords": [
     "webgl",
     "visualization",

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8"
+    "tag": "v8-lts"
   },
   "keywords": [
     "webgl",

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -5,7 +5,7 @@
   "version": "8.9.36",
   "publishConfig": {
     "access": "public",
-    "tag": "v8-lts"
+    "tag": "v8-latest"
   },
   "keywords": [
     "webgl",


### PR DESCRIPTION
Targets the `8.9-release` branch.

Previously (in #8813) the 'tag' entry was missing from modules that didn't already have a 'publishConfig' entry — 'main' and 'jupyter-widget' — which was my mistake.

Additionally, I've learned that npm enforces a rule `"Tag name must not be a valid SemVer range: v8"` when running `npm dist-tag add` but not when running `npm run publish`. So we need some sort of prefix or suffix rather than just "v8". I've opted for "v8-lts" here, matching the convention of the Angular project.