### PR TITLE
fix(layers): work around Samsung shader compilation failure

### DIFF
--- a/modules/layers/src/column-layer/column-layer-fragment.glsl.ts
+++ b/modules/layers/src/column-layer/column-layer-fragment.glsl.ts
@@ -36,6 +36,8 @@ in vec4 position_commonspace;
 
 void main(void) {
   fragColor = vColor;
+  // Fails to compile on some Android devices if geometry is never assigned (#8411)
+  geometry.uv = vec2(0.);
 #ifdef FLAT_SHADING
   if (extruded && !isStroke && !bool(picking.isActive)) {
     vec3 normal = normalize(cross(dFdx(position_commonspace.xyz), dFdy(position_commonspace.xyz)));

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-fragment.glsl.ts
@@ -30,6 +30,8 @@ out vec4 fragColor;
 
 void main(void) {
   fragColor = vColor;
+  // Fails to compile on some Android devices if geometry is never assigned (#8411)
+  geometry.uv = vec2(0.);
 
   DECKGL_FILTER_COLOR(fragColor, geometry);
 }


### PR DESCRIPTION
Closes #8411

Tested on BrowserStack, waiting for user confirmation

#### Change List
- Explicitly assign `geometry.uv` in the fragment shader
