### PR TITLE
chore(pydeck): Disable broken Jupyter bindings in v0.9

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -141,11 +141,13 @@ class Deck(JSONMixin):
 
     def show(self):
         """Display current Deck object for a Jupyter notebook"""
-        if in_google_colab:
-            self.to_html(notebook_display=True)
-        else:
-            self.update()
-            return self.deck_widget
+        # TODO: Jupyter-specific features not currently supported in pydeck v0.9.
+        # if in_google_colab:
+        #     self.to_html(notebook_display=True)
+        # else:
+        #     self.update()
+        #     return self.deck_widget
+        return self.to_html(notebook_display=True)
 
     def update(self):
         """Update a deck.gl map to reflect the current configuration
@@ -155,19 +157,24 @@ class Deck(JSONMixin):
 
         Intended for use in a Jupyter environment.
         """
-        if not has_jupyter_extra():
-            raise ImportError(
-                "Install the Jupyter extra for pydeck with your package manager, e.g. `pip install pydeck[jupyter]`"
-            )
-        self.deck_widget.json_input = self.to_json()
-        has_binary = False
-        binary_data_sets = []
-        for layer in self.layers:
-            if layer.use_binary_transport:
-                binary_data_sets.extend(layer.get_binary_data())
-                has_binary = True
-        if has_binary:
-            self.deck_widget.data_buffer = binary_data_sets
+        # TODO: Jupyter-specific features not currently supported in pydeck v0.9.
+        # if not has_jupyter_extra():
+        #     raise ImportError(
+        #         "Install the Jupyter extra for pydeck with your package manager, e.g. `pip install pydeck[jupyter]`"
+        #     )
+        # self.deck_widget.json_input = self.to_json()
+        # has_binary = False
+        # binary_data_sets = []
+        # for layer in self.layers:
+        #     if layer.use_binary_transport:
+        #         binary_data_sets.extend(layer.get_binary_data())
+        #         has_binary = True
+        # if has_binary:
+        #     self.deck_widget.data_buffer = binary_data_sets
+        raise NotImplementedError(
+            "Jupyter-specific features not currently supported in pydeck v0.9."
+        )
+
 
     def to_html(
         self,

--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -175,7 +175,6 @@ class Deck(JSONMixin):
             "Jupyter-specific features not currently supported in pydeck v0.9."
         )
 
-
     def to_html(
         self,
         filename=None,

--- a/bindings/pydeck/tests/notebooks/test_nbconvert.py
+++ b/bindings/pydeck/tests/notebooks/test_nbconvert.py
@@ -16,5 +16,8 @@ def test_nbconvert():
         # NOTE skipping 03 (which contains live singapore taxi data) until I can provide a static version of that data
         if "04" in fname or "06" in fname or "03" in fname:
             continue
+        # NOTE Jupyter-specific features not currently supported in pydeck v0.9.
+        if "01" in fname or "02" in fname:
+            continue
         print(fname)
         assert nbconvert(fname)


### PR DESCRIPTION
Jupyter bindings are not currently working in pydeck, and won't make it into the pydeck v0.9 release. To make this less disorienting for users, I've made two changes here:

1. `.show()` should call `.to_html()` automatically, as it would in Colab or other environments
2. `.update()` should show a warning

This can certainly be revisited in upcoming releases, as we consider what to do about two-way bindings.