### PR TITLE
feat(core): Explicitly set stepMode in Attribute layout

### DIFF
--- a/docs/api-reference/core/attribute-manager.md
+++ b/docs/api-reference/core/attribute-manager.md
@@ -52,7 +52,7 @@ the attributes that should be auto-calculated.
 ```js
 attributeManager.add({
   positions: {size: 2, accessor: 'getPosition', update: calculatePositions},
-  colors: {size: 4, type: GL.UNSIGNED_BYTE, accessor: 'getColor', update: calculateColors}
+  colors: {size: 4, type: 'unorm8', accessor: 'getColor', update: calculateColors}
 });
 ```
 
@@ -61,13 +61,10 @@ Takes a single parameter as a map of attribute descriptor objects:
 * keys are attribute names
 * values are objects with attribute definitions:
   - luma.gl [accessor parameters](https://luma.gl/docs/api-reference-legacy/classes/accessor):
-    * `type` (string, optional) - data type of the attribute, see "Remarks" section below.
+    * `type` (string, optional) - data type of the attribute, see "Remarks" section below. Default `'float32'`.
     * `size` (number) - number of elements per vertex
-    * `normalized` (boolean) - default `false`
-    * `integer` (boolean) - WebGL2 only, default `false`
-    * `divisor` (boolean, optional) - `1` if this is an instanced attribute
-      (a.k.a. divisor). Default to `0`.
   - deck.gl attribute configurations:
+    * `stepMode` (string, optional) - One of `'vertex'`, `'instance'` and `'dynamic'`. If set to `'dynamic'`, will be resolved to `'instance'` when this attribute is applied to an instanced model, and `'vertex'` otherwise. Default `'vertex'`.
     * `isIndexed` (boolean, optional) - if this is an index attribute
       (a.k.a. indices). Default to `false`.
     * `accessor` (string | string[] | Function) - accessor name(s) that will
@@ -85,12 +82,10 @@ Takes a single parameter as a map of attribute descriptor objects:
     * `size` (number) - number of elements per vertex
     * `vertexOffset` (number) - offset of the attribute by vertex (stride). Default `0`.
     * `elementOffset` (number) - offset of the attribute by element. default `0`.
-    * `divisor` (boolean, optional) - `1` if this is an instanced attribute
-      (a.k.a. divisor). Default to `0`.
 
 #### `addInstanced` {#addinstanced}
 
-Shorthand for `add()` in which all attributes `instanced` field are set to `true`.
+Shorthand for `add()` in which all attributes `stepMode` field are set to `'instance'`.
 
 
 #### `remove` {#remove}
@@ -152,6 +147,16 @@ Notes:
 * Any preallocated buffers in "buffers" matching registered attribute names will be used. No update will happen in this case.
 * Calls onUpdateStart and onUpdateEnd log callbacks before and after.
 
+#### `getBufferLayouts`
+
+Returns WebGPU-style buffer layout descriptors.
+
+Parameters:
+
+* `modelInfo` (object) - a luma.gl `Model` or a similarly shaped object
+  + `isInstanced` (boolean) - used to resolve `stepMode: 'dynamic'`
+
+
 ## Remarks
 
 ### Attribute Type
@@ -160,15 +165,20 @@ The following `type` values are supported for attribute definitions:
 
 | type | value array type | notes |
 | ---- | ---------------- | ----- |
-| `GL.FLOAT` | `Float32Array` | |
-| `GL.DOUBLE` | `Float64Array` | Because 64-bit floats are not supported by WebGL, the value is converted to an interleaved `Float32Array` before uploading to the GPU. It is exposed to the vertex shader as two attributes, `<attribute_name>` and `<attribute_name>64Low`, the sum of which is the 64-bit value. |
-| `GL.BYTE` | `Int8Array` | |
-| `GL.SHORT` | `Int16Array` | |
-| `GL.INT` | `Int32Array` | |
-| `GL.UNSIGNED_BYTE` | `Uint8ClampedArray` | |
-| `GL.UNSIGNED_SHORT` | `Uint16Array` | |
-| `GL.UNSIGNED_INT` | `Uint32Array` | |
+| `float32` | `Float32Array` | |
+| `float64` | `Float64Array` | Because 64-bit floats are not supported by WebGL, the value is converted to an interleaved `Float32Array` before uploading to the GPU. It is exposed to the vertex shader as two attributes, `<attribute_name>` and `<attribute_name>64Low`, the sum of which is the 64-bit value. |
+| `sint8`   | `Int8Array`    | |
+| `snorm8`  | `Int8Array`    | Normalized |
+| `uint8`   | `Uint8ClampedArray` | |
+| `unorm8`  | `Uint8ClampedArray` | Normalized |
+| `sint16`  | `Int16Array`   | |
+| `snorm16` | `Int16Array`   | Normalized |
+| `uint16`  | `Uint16Array`  | |
+| `unorm16` | `Uint16Array`  | Normalized |
+| `sint32`  | `Int32Array`   | |
+| `uint32`  | `Uint32Array`   | |
 
+      
 ## Source
 
 [modules/core/src/lib/attribute-manager.ts](https://github.com/visgl/deck.gl/blob/master/modules/core/src/lib/attribute/attribute-manager.ts)

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -52,6 +52,7 @@ class MyLayer {
 While the 9.0 release of deck.gl does not yet support WebGPU, our goal is to enable WebGPU soon in a 9.x release. A number of changes will be required to deck.gl curtom layers:
 
 - deck.gl now uses uniform buffers instead of global uniforms. It is not yet required to use uniform buffers but it will be necessary if you would like to run deck.gl on WebGPU in future releases.
+- When defining an attribute, `type` is now a WebGPU-style [string format](https://luma.gl/docs/api-guide/gpu/gpu-attributes#vertexformat) instead of GL constant, and `divisor` is replaced by `stepMode`. See [AttributeManager.add](./api-reference/core/attribute-manager.md#add)
 - WebGL draw modes `GL.TRIANGLE_FAN` and `GL.LINE_LOOP` are not supported on WebGPU. Select a different topology when creating geometries.
 - The luma picking module now [uses uniform buffers](https://github.com/visgl/luma.gl/blob/master/modules/shadertools/src/modules/engine/picking/picking.ts#L34-L50). To access picking state in shaders use `picking.isActive` rather than `picking_isActive`
 

--- a/modules/core/src/lib/attribute/attribute-manager.ts
+++ b/modules/core/src/lib/attribute/attribute-manager.ts
@@ -311,7 +311,10 @@ export default class AttributeManager {
   /** Generate WebGPU-style buffer layout descriptors from all attributes */
   getBufferLayouts(
     /** A luma.gl Model-shaped object that supplies additional hint to attribute resolution */
-    modelInfo?: {isInstanced?: boolean}
+    modelInfo?: {
+      /** Whether the model is instanced */
+      isInstanced?: boolean;
+    }
   ): BufferLayout[] {
     return Object.values(this.getAttributes()).map(attribute =>
       attribute.getBufferLayout(modelInfo)
@@ -320,42 +323,28 @@ export default class AttributeManager {
 
   // PRIVATE METHODS
 
-  // Used to register an attribute
+  /** Register new attributes */
   private _add(
+    /** A map from attribute name to attribute descriptors */
     attributes: {[id: string]: AttributeOptions},
+    /** Additional attribute settings to pass to all attributes */
     overrideOptions?: Partial<AttributeOptions>
   ) {
     for (const attributeName in attributes) {
       const attribute = attributes[attributeName];
 
+      const props: AttributeOptions = {
+        ...attribute,
+        id: attributeName,
+        size: (attribute.isIndexed && 1) || attribute.size || 1,
+        ...overrideOptions
+      };
+
       // Initialize the attribute descriptor, with WebGL and metadata fields
-      this.attributes[attributeName] = this._createAttribute(
-        attributeName,
-        attribute,
-        overrideOptions
-      );
+      this.attributes[attributeName] = new Attribute(this.device, props);
     }
 
     this._mapUpdateTriggersToAttributes();
-  }
-  /* eslint-enable max-statements */
-
-  private _createAttribute(
-    name: string,
-    attribute: AttributeOptions,
-    overrideOptions?: Partial<AttributeOptions>
-  ) {
-    // For expected default values see:
-    // https://github.com/visgl/luma.gl/blob/1affe21352e289eeaccee2a876865138858a765c/modules/webgl/src/classes/accessor.js#L5-L13
-    // and https://deck.gl/docs/api-reference/core/attribute-manager#add
-    const props: AttributeOptions = {
-      ...attribute,
-      id: name,
-      size: (attribute.isIndexed && 1) || attribute.size || 1,
-      ...overrideOptions
-    };
-
-    return new Attribute(this.device, props);
   }
 
   // build updateTrigger name to attribute name mapping

--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -22,8 +22,6 @@ export type BufferAccessor = {
   type?: DataType;
   /** The number of elements per vertex attribute. */
   size?: number;
-  /** 1 if instanced. */
-  divisor?: 1 | 0;
   /** Offset of the first vertex attribute into the buffer, in bytes. */
   offset?: number;
   /** The offset between the beginning of consecutive vertex attributes, in bytes. */
@@ -261,7 +259,7 @@ export default class DataColumn<Options, State> {
     return result;
   }
 
-  getBufferLayout(
+  protected _getBufferLayout(
     attributeName: string = this.id,
     options: Partial<ShaderAttributeOptions> | null = null
   ): BufferLayout {

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -771,7 +771,7 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
     if (bufferLayoutChanged) {
       // AttributeManager is always defined when this method is called
       const attributeManager = this.getAttributeManager()!;
-      model.setBufferLayout(attributeManager.getBufferLayouts());
+      model.setBufferLayout(attributeManager.getBufferLayouts(model));
       // All attributes must be reset after buffer layout change
       changedAttributes = attributeManager.getAttributes();
     }

--- a/modules/extensions/src/brushing/brushing-extension.ts
+++ b/modules/extensions/src/brushing/brushing-extension.ts
@@ -69,15 +69,8 @@ export default class BrushingExtension extends LayerExtension {
       attributeManager.add({
         brushingTargets: {
           size: 2,
-          accessor: 'getBrushingTarget',
-          shaderAttributes: {
-            brushingTargets: {
-              divisor: 0
-            },
-            instanceBrushingTargets: {
-              divisor: 1
-            }
-          }
+          stepMode: 'dynamic',
+          accessor: 'getBrushingTarget'
         }
       });
     }

--- a/modules/extensions/src/brushing/shader-module.ts
+++ b/modules/extensions/src/brushing/shader-module.ts
@@ -37,11 +37,7 @@ const vs = glsl`
   uniform vec2 brushing_mousePos;
   uniform float brushing_radius;
 
-  #ifdef NON_INSTANCED_MODEL
   in vec2 brushingTargets;
-  #else
-  in vec2 instanceBrushingTargets;
-  #endif
 
   out float brushing_isVisible;
 
@@ -89,11 +85,7 @@ const inject = {
     } else if (brushing_target == 1) {
       brushingTarget = geometry.worldPositionAlt.xy;
     } else {
-      #ifdef NON_INSTANCED_MODEL
       brushingTarget = brushingTargets;
-      #else
-      brushingTarget = instanceBrushingTargets;
-      #endif
     }
     bool visible;
     if (brushing_target == 3) {

--- a/modules/extensions/src/collision-filter/collision-filter-extension.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-extension.ts
@@ -68,11 +68,8 @@ export default class CollisionFilterExtension extends LayerExtension {
     attributeManager!.add({
       collisionPriorities: {
         size: 1,
-        accessor: 'getCollisionPriority',
-        shaderAttributes: {
-          collisionPriorities: {divisor: 0},
-          instanceCollisionPriorities: {divisor: 1}
-        }
+        stepMode: 'dynamic',
+        accessor: 'getCollisionPriority'
       }
     });
   }

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -4,11 +4,7 @@ import {project} from '@deck.gl/core';
 import {glsl} from '../utils/syntax-tags';
 
 const vs = glsl`
-#ifdef NON_INSTANCED_MODEL
 in float collisionPriorities;
-#else
-in float instanceCollisionPriorities;
-#endif
 
 uniform sampler2D collision_texture;
 uniform bool collision_sort;
@@ -60,11 +56,7 @@ const inject = {
 `,
   'vs:DECKGL_FILTER_GL_POSITION': glsl`
   if (collision_sort) {
-    #ifdef NON_INSTANCED_MODEL
     float collisionPriority = collisionPriorities;
-    #else
-    float collisionPriority = instanceCollisionPriorities;
-    #endif
     position.z = -0.001 * collisionPriority * position.w; // Support range -1000 -> 1000
   }
 

--- a/modules/extensions/src/data-filter/data-filter-extension.ts
+++ b/modules/extensions/src/data-filter/data-filter-extension.ts
@@ -167,15 +167,8 @@ export default class DataFilterExtension extends LayerExtension<
           filterValues: {
             size: filterSize,
             type: fp64 ? 'float64' : 'float32',
-            accessor: 'getFilterValue',
-            shaderAttributes: {
-              filterValues: {
-                divisor: 0
-              },
-              instanceFilterValues: {
-                divisor: 1
-              }
-            }
+            stepMode: 'dynamic',
+            accessor: 'getFilterValue'
           }
         });
       }
@@ -184,19 +177,12 @@ export default class DataFilterExtension extends LayerExtension<
         attributeManager.add({
           filterCategoryValues: {
             size: categorySize,
+            stepMode: 'dynamic',
             accessor: 'getFilterCategory',
             transform:
               categorySize === 1
                 ? d => extension._getCategoryKey.call(this, d, 0)
-                : d => d.map((x, i) => extension._getCategoryKey.call(this, x, i)),
-            shaderAttributes: {
-              filterCategoryValues: {
-                divisor: 0
-              },
-              instanceFilterCategoryValues: {
-                divisor: 1
-              }
-            }
+                : d => d.map((x, i) => extension._getCategoryKey.call(this, x, i))
           }
         });
       }

--- a/modules/extensions/src/fill-style/fill-style-extension.ts
+++ b/modules/extensions/src/fill-style/fill-style-extension.ts
@@ -110,41 +110,20 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
       attributeManager!.add({
         fillPatternFrames: {
           size: 4,
+          stepMode: 'dynamic',
           accessor: 'getFillPattern',
-          transform: extension.getPatternFrame.bind(this),
-          shaderAttributes: {
-            fillPatternFrames: {
-              divisor: 0
-            },
-            instanceFillPatternFrames: {
-              divisor: 1
-            }
-          }
+          transform: extension.getPatternFrame.bind(this)
         },
         fillPatternScales: {
           size: 1,
+          stepMode: 'dynamic',
           accessor: 'getFillPatternScale',
-          defaultValue: 1,
-          shaderAttributes: {
-            fillPatternScales: {
-              divisor: 0
-            },
-            instanceFillPatternScales: {
-              divisor: 1
-            }
-          }
+          defaultValue: 1
         },
         fillPatternOffsets: {
           size: 2,
-          accessor: 'getFillPatternOffset',
-          shaderAttributes: {
-            fillPatternOffsets: {
-              divisor: 0
-            },
-            instanceFillPatternOffsets: {
-              divisor: 1
-            }
-          }
+          stepMode: 'dynamic',
+          accessor: 'getFillPatternOffset'
         }
       });
     }

--- a/modules/extensions/src/fill-style/shader-module.ts
+++ b/modules/extensions/src/fill-style/shader-module.ts
@@ -9,19 +9,9 @@ import {glsl} from '../utils/syntax-tags';
  * fill pattern shader module
  */
 const patternVs = glsl`
-#ifdef NON_INSTANCED_MODEL
-  #define FILL_PATTERN_FRAME_ATTRIB fillPatternFrames
-  #define FILL_PATTERN_SCALE_ATTRIB fillPatternScales
-  #define FILL_PATTERN_OFFSET_ATTRIB fillPatternOffsets
-#else
-  #define FILL_PATTERN_FRAME_ATTRIB instanceFillPatternFrames
-  #define FILL_PATTERN_SCALE_ATTRIB instanceFillPatternScales
-  #define FILL_PATTERN_OFFSET_ATTRIB instanceFillPatternOffsets
-#endif
-
-in vec4 FILL_PATTERN_FRAME_ATTRIB;
-in float FILL_PATTERN_SCALE_ATTRIB;
-in vec2 FILL_PATTERN_OFFSET_ATTRIB;
+in vec4 fillPatternFrames;
+in float fillPatternScales;
+in vec2 fillPatternOffsets;
 
 uniform bool fill_patternEnabled;
 uniform vec2 fill_patternTextureSize;
@@ -52,9 +42,9 @@ const inject = {
 
   'vs:DECKGL_FILTER_COLOR': glsl`
     if (fill_patternEnabled) {
-      fill_patternBounds = FILL_PATTERN_FRAME_ATTRIB / vec4(fill_patternTextureSize, fill_patternTextureSize);
-      fill_patternPlacement.xy = FILL_PATTERN_OFFSET_ATTRIB;
-      fill_patternPlacement.zw = FILL_PATTERN_SCALE_ATTRIB * FILL_PATTERN_FRAME_ATTRIB.zw;
+      fill_patternBounds = fillPatternFrames / vec4(fill_patternTextureSize, fill_patternTextureSize);
+      fill_patternPlacement.xy = fillPatternOffsets;
+      fill_patternPlacement.zw = fillPatternScales * fillPatternFrames.zw;
     }
   `,
 

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.ts
@@ -25,14 +25,15 @@ uniform bool isWireframe;
 uniform float elevationScale;
 uniform float opacity;
 
+in vec4 fillColors;
+in vec4 lineColors;
+in vec3 pickingColors;
+
 out vec4 vColor;
 
 struct PolygonProps {
-  vec4 fillColors;
-  vec4 lineColors;
   vec3 positions;
   vec3 positions64Low;
-  vec3 pickingColors;
   vec3 normal;
   float elevations;
 };
@@ -50,10 +51,10 @@ void calculatePosition(PolygonProps props) {
   vec3 pos = props.positions;
   vec3 pos64Low = props.positions64Low;
   vec3 normal = props.normal;
-  vec4 colors = isWireframe ? props.lineColors : props.fillColors;
+  vec4 colors = isWireframe ? lineColors : fillColors;
 
   geometry.worldPosition = props.positions;
-  geometry.pickingColor = props.pickingColors;
+  geometry.pickingColor = pickingColors;
 
   if (extruded) {
     pos.z += props.elevations * elevationScale;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-side.glsl.ts
@@ -27,14 +27,11 @@ export default `\
 
 in vec2 positions;
 
-in vec3 instancePositions;
-in vec3 instanceNextPositions;
-in vec3 instancePositions64Low;
-in vec3 instanceNextPositions64Low;
-in float instanceElevations;
-in vec4 instanceFillColors;
-in vec4 instanceLineColors;
-in vec3 instancePickingColors;
+in vec3 vertexPositions;
+in vec3 nextVertexPositions;
+in vec3 vertexPositions64Low;
+in vec3 nextVertexPositions64Low;
+in float elevations;
 in float instanceVertexValid;
 
 ${main}
@@ -53,15 +50,15 @@ void main(void) {
   vec3 nextPos64Low;
 
   #if RING_WINDING_ORDER_CW == 1
-    pos = instancePositions;
-    pos64Low = instancePositions64Low;
-    nextPos = instanceNextPositions;
-    nextPos64Low = instanceNextPositions64Low;
+    pos = vertexPositions;
+    pos64Low = vertexPositions64Low;
+    nextPos = nextVertexPositions;
+    nextPos64Low = nextVertexPositions64Low;
   #else
-    pos = instanceNextPositions;
-    pos64Low = instanceNextPositions64Low;
-    nextPos = instancePositions;
-    nextPos64Low = instancePositions64Low;
+    pos = nextVertexPositions;
+    pos64Low = nextVertexPositions64Low;
+    nextPos = vertexPositions;
+    nextPos64Low = vertexPositions64Low;
   #endif
 
   props.positions = mix(pos, nextPos, positions.x);
@@ -72,10 +69,7 @@ void main(void) {
     nextPos.x - pos.x + (nextPos64Low.x - pos64Low.x),
     0.0);
 
-  props.elevations = instanceElevations * positions.y;
-  props.fillColors = instanceFillColors;
-  props.lineColors = instanceLineColors;
-  props.pickingColors = instancePickingColors;
+  props.elevations = elevations * positions.y;
 
   calculatePosition(props);
 }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-top.glsl.ts
@@ -27,9 +27,6 @@ export default `\
 in vec3 vertexPositions;
 in vec3 vertexPositions64Low;
 in float elevations;
-in vec4 fillColors;
-in vec4 lineColors;
-in vec3 pickingColors;
 
 ${main}
 
@@ -39,9 +36,6 @@ void main(void) {
   props.positions = vertexPositions;
   props.positions64Low = vertexPositions64Low;
   props.elevations = elevations;
-  props.fillColors = fillColors;
-  props.lineColors = lineColors;
-  props.pickingColors = pickingColors;
   props.normal = vec3(0.0, 0.0, 1.0);
 
   calculatePosition(props);

--- a/test/modules/core/lib/attribute/attribute.spec.ts
+++ b/test/modules/core/lib/attribute/attribute.spec.ts
@@ -253,13 +253,10 @@ test('Attribute#shaderAttributes', t => {
     id: 'positions',
     update,
     size: 3,
+    stepMode: 'instance',
     shaderAttributes: {
-      instancePositions: {
-        divisor: 1
-      },
-      instanceNextPositions: {
-        vertexOffset: 1,
-        divisor: 1
+      nextPositions: {
+        vertexOffset: 1
       }
     }
   });
@@ -271,15 +268,12 @@ test('Attribute#shaderAttributes', t => {
   t.is(attributeLayout.format, 'float32x3', 'Attribute position has correct format');
   t.is(attributeLayout.byteOffset, 0, 'Attribute position has correct offset');
   attributeLayout = bufferLayout.attributes[1];
-  t.is(attributeLayout.format, 'float32x3', 'Attribute instancePositions has correct format');
-  t.is(attributeLayout.byteOffset, 0, 'Attribute instancePositions has correct offset');
-  attributeLayout = bufferLayout.attributes[2];
-  t.is(attributeLayout.format, 'float32x3', 'Attribute instanceNextPositions has correct format');
-  t.is(attributeLayout.byteOffset, 12, 'Attribute instanceNextPositions has correct offset');
+  t.is(attributeLayout.format, 'float32x3', 'Attribute nextPositions has correct format');
+  t.is(attributeLayout.byteOffset, 12, 'Attribute nextPositions has correct offset');
 
   t.deepEquals(
     attribute.getValue(),
-    {positions: buffer1, instancePositions: buffer1, instanceNextPositions: buffer1},
+    {positions: buffer1, nextPositions: buffer1},
     'Attribute has buffer'
   );
 


### PR DESCRIPTION
Closes #8849

This proposed fix adds a `stepMode` attribute setting. If set to `dynamic`, it will be resolved to one of `vertex` and `instance` based on whether the target model is instanced. With this change I'm able to remove much redundancy from layers/extensions where the same buffer is shared between instanced and non-instanced models.

#### Change List
- Remove `divisor` from attribute and shader attribute settings. While this is a breaking change,
	+ Setting it does nothing as of v9.0
	+ Moving forward, we won't be able to make it work exactly like v8, due to luma API changes
	+ Most custom layers use `AttributeManager.add` and `AttributeManager.addInstanced` instead of explicitly setting `divisor`, so the impact will be low
- Add `stepMode` to attribute settings
- SolidPolygonLayer
- BrushingExtension
- DataFilterExtension
- CollisionFilterExtension
- FillStyleExtension
- Unit tests
- Documentation and upgrade guide