### PR TITLE
feat(layers): Simplify ArcLayer

### DIFF
--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -265,6 +265,7 @@ export default class ArcLayer<DataT = any, ExtraPropsT extends {} = {}> extends 
       id: this.props.id,
       bufferLayout: this.getAttributeManager()!.getBufferLayouts(),
       topology: 'triangle-strip',
+      vertexCount: numSegments * 2,
       isInstanced: true
     });
 


### PR DESCRIPTION
Taking advantage of our move to es300.

#### Change List
- Removes `positions` attribute, use `gl_VertexID` instead
- No longer rebuilds model on `numSegments` change
