### PR TITLE
fix(carto): Fix broken encoding in POST requests

### DIFF
--- a/modules/carto/src/api/request-with-parameters.ts
+++ b/modules/carto/src/api/request-with-parameters.ts
@@ -1,3 +1,4 @@
+import {isPureObject} from '@loaders.gl/core';
 import {CartoAPIError} from './carto-api-error';
 import {DEFAULT_HEADERS, DEFAULT_PARAMETERS, MAX_GET_LENGTH} from './common';
 import type {APIErrorContext} from './types';
@@ -5,8 +6,17 @@ import type {APIErrorContext} from './types';
 /**
  * Simple encode parameter
  */
-function encodeParameter(name: string, value: string | boolean | number): string {
-  return `${name}=${encodeURIComponent(value)}`;
+function encodeParameter(name: string, value: unknown): string {
+  if (Array.isArray(value)) {
+    return `${name}=${encodeURIComponent(value.join(','))}`;
+  }
+  if (isPureObject(value)) {
+    return `${name}=${encodeURIComponent(JSON.stringify(value))}`;
+  }
+  if (typeof value === 'string' || typeof value === 'boolean' || typeof value === 'number') {
+    return `${name}=${encodeURIComponent(value)}`;
+  }
+  throw new Error(`Unexpected type: ${value}`);
 }
 
 const REQUEST_CACHE = new Map<string, Promise<unknown>>();
@@ -17,10 +27,11 @@ export async function requestWithParameters<T = any>({
   errorContext
 }: {
   baseUrl: string;
-  parameters?: Record<string, string>;
+  parameters?: Record<string, unknown>;
   headers: Record<string, string>;
   errorContext: APIErrorContext;
 }): Promise<T> {
+  parameters = {...DEFAULT_PARAMETERS, ...parameters};
   const key = createCacheKey(baseUrl, parameters || {}, customHeaders || {});
   if (REQUEST_CACHE.has(key)) {
     return REQUEST_CACHE.get(key) as Promise<T>;
@@ -58,7 +69,7 @@ export async function requestWithParameters<T = any>({
 
 function createCacheKey(
   baseUrl: string,
-  parameters: Record<string, string>,
+  parameters: Record<string, unknown>,
   headers: Record<string, string>
 ): string {
   const parameterEntries = Object.entries(parameters).sort(([a], [b]) => (a > b ? 1 : -1));
@@ -66,11 +77,9 @@ function createCacheKey(
   return JSON.stringify({baseUrl, parameters: parameterEntries, headers: headerEntries});
 }
 
-function createURLWithParameters(baseUrl: string, parameters: Record<string, string>): string {
-  const encodedParameters = Object.entries({...DEFAULT_PARAMETERS, ...parameters}).map(
-    ([key, value]) => {
-      return encodeParameter(key, value);
-    }
+function createURLWithParameters(baseUrl: string, parameters: Record<string, unknown>): string {
+  const encodedParameters = Object.entries(parameters).map(([key, value]) =>
+    encodeParameter(key, value)
   );
   return `${baseUrl}?${encodedParameters.join('&')}`;
 }

--- a/modules/carto/src/sources/base-source.ts
+++ b/modules/carto/src/sources/base-source.ts
@@ -19,7 +19,7 @@ export const SOURCE_DEFAULTS: SourceOptionalOptions = {
   headers: {}
 };
 
-export async function baseSource<UrlParameters extends Record<string, string>>(
+export async function baseSource<UrlParameters extends Record<string, unknown>>(
   endpoint: MapType,
   options: Partial<SourceOptionalOptions> & SourceRequiredOptions,
   urlParameters: UrlParameters

--- a/modules/carto/src/sources/boundary-query-source.ts
+++ b/modules/carto/src/sources/boundary-query-source.ts
@@ -10,13 +10,12 @@ export type BoundaryQuerySourceOptions = SourceOptions &
     propertiesSqlQuery: string;
     queryParameters?: QueryParameters;
   };
-type UrlParameters = {
+type UrlParameters = FilterOptions & {
   columns?: string;
-  filters?: string;
   tilesetTableName: string;
   matchingColumn: string;
   propertiesSqlQuery: string;
-  queryParameters?: string;
+  queryParameters?: QueryParameters;
 };
 
 export const boundaryQuerySource = async function (
@@ -40,10 +39,10 @@ export const boundaryQuerySource = async function (
     urlParameters.columns = columns.join(',');
   }
   if (filters) {
-    urlParameters.filters = JSON.stringify(filters);
+    urlParameters.filters = filters;
   }
   if (queryParameters) {
-    urlParameters.queryParameters = JSON.stringify(queryParameters);
+    urlParameters.queryParameters = queryParameters;
   }
   return baseSource<UrlParameters>('boundary', options, urlParameters) as Promise<TilejsonResult>;
 };

--- a/modules/carto/src/sources/boundary-table-source.ts
+++ b/modules/carto/src/sources/boundary-table-source.ts
@@ -8,8 +8,7 @@ export type BoundaryTableSourceOptions = SourceOptions &
     matchingColumn?: string;
     propertiesTableName: string;
   };
-type UrlParameters = {
-  filters?: string;
+type UrlParameters = FilterOptions & {
   tilesetTableName: string;
   columns?: string;
   matchingColumn: string;
@@ -30,7 +29,7 @@ export const boundaryTableSource = async function (
     urlParameters.columns = columns.join(',');
   }
   if (filters) {
-    urlParameters.filters = JSON.stringify(filters);
+    urlParameters.filters = filters;
   }
   return baseSource<UrlParameters>('boundary', options, urlParameters) as Promise<TilejsonResult>;
 };

--- a/modules/carto/src/sources/h3-query-source.ts
+++ b/modules/carto/src/sources/h3-query-source.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { QueryParameters } from '../api';
 import {DEFAULT_AGGREGATION_RES_LEVEL_H3} from '../constants';
 import {baseSource} from './base-source';
 import type {
@@ -16,7 +17,7 @@ type UrlParameters = {
   spatialDataType: SpatialDataType;
   spatialDataColumn?: string;
   q: string;
-  queryParameters?: string;
+  queryParameters?: QueryParameters;
 };
 
 export const h3QuerySource = async function (
@@ -40,7 +41,7 @@ export const h3QuerySource = async function (
     urlParameters.aggregationResLevel = String(aggregationResLevel);
   }
   if (queryParameters) {
-    urlParameters.queryParameters = JSON.stringify(queryParameters);
+    urlParameters.queryParameters = queryParameters;
   }
   return baseSource<UrlParameters>('query', options, urlParameters) as Promise<TilejsonResult>;
 };

--- a/modules/carto/src/sources/quadbin-query-source.ts
+++ b/modules/carto/src/sources/quadbin-query-source.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { QueryParameters } from '../api';
 import {DEFAULT_AGGREGATION_RES_LEVEL_QUADBIN} from '../constants';
 import {baseSource} from './base-source';
 import type {
@@ -17,7 +18,7 @@ type UrlParameters = {
   spatialDataType: SpatialDataType;
   spatialDataColumn?: string;
   q: string;
-  queryParameters?: string;
+  queryParameters?: QueryParameters;
 };
 
 export const quadbinQuerySource = async function (
@@ -41,7 +42,7 @@ export const quadbinQuerySource = async function (
     urlParameters.aggregationResLevel = String(aggregationResLevel);
   }
   if (queryParameters) {
-    urlParameters.queryParameters = JSON.stringify(queryParameters);
+    urlParameters.queryParameters = queryParameters;
   }
   return baseSource<UrlParameters>('query', options, urlParameters) as Promise<TilejsonResult>;
 };

--- a/modules/carto/src/sources/vector-query-source.ts
+++ b/modules/carto/src/sources/vector-query-source.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { QueryParameters } from '../api';
 import {DEFAULT_TILE_RESOLUTION} from '../constants';
 import {baseSource} from './base-source';
 import type {
@@ -15,14 +16,13 @@ export type VectorQuerySourceOptions = SourceOptions &
   FilterOptions &
   ColumnsOption;
 
-type UrlParameters = {
+type UrlParameters = FilterOptions & {
   columns?: string;
-  filters?: string;
   spatialDataType: SpatialDataType;
   spatialDataColumn?: string;
   tileResolution?: string;
   q: string;
-  queryParameters?: string;
+  queryParameters?: QueryParameters;
 };
 
 export const vectorQuerySource = async function (
@@ -48,10 +48,10 @@ export const vectorQuerySource = async function (
     urlParameters.columns = columns.join(',');
   }
   if (filters) {
-    urlParameters.filters = JSON.stringify(filters);
+    urlParameters.filters = filters;
   }
   if (queryParameters) {
-    urlParameters.queryParameters = JSON.stringify(queryParameters);
+    urlParameters.queryParameters = queryParameters;
   }
   return baseSource<UrlParameters>('query', options, urlParameters) as Promise<TilejsonResult>;
 };

--- a/modules/carto/src/sources/vector-table-source.ts
+++ b/modules/carto/src/sources/vector-table-source.ts
@@ -14,9 +14,8 @@ export type VectorTableSourceOptions = SourceOptions &
   TableSourceOptions &
   FilterOptions &
   ColumnsOption;
-type UrlParameters = {
+type UrlParameters = FilterOptions & {
   columns?: string;
-  filters?: string;
   spatialDataType: SpatialDataType;
   spatialDataColumn?: string;
   tileResolution?: string;
@@ -45,7 +44,7 @@ export const vectorTableSource = async function (
     urlParameters.columns = columns.join(',');
   }
   if (filters) {
-    urlParameters.filters = JSON.stringify(filters);
+    urlParameters.filters = filters;
   }
   return baseSource<UrlParameters>('table', options, urlParameters) as Promise<TilejsonResult>;
 };


### PR DESCRIPTION
Fixes two issues occurring when URL lengths exceed the limit for GET requests, and we switch to POST requests.

- Ensure `DEFAULT_PARAMETERS` are applied the same way for GET and POST requests
- Defer `JSON.stringify()` encoding in `fooBarSource()` functions, because we don't know yet whether the request will be GET or POST. Ensure that `requestWithParameters` handles step (for GET requests only) instead.

I'm wondering if the same should be done for this line...

```js
urlParameters.columns = columns.join(',');
```

... but we don't have any bug reports about that, so I've deferred for now. This is PR is intended as a quick fix for a known issue, but I intend to follow up with tests covering these cases.