### PR TITLE
fix(pydeck-carto): Use local isPureObject

### DIFF
--- a/modules/carto/src/api/request-with-parameters.ts
+++ b/modules/carto/src/api/request-with-parameters.ts
@@ -1,4 +1,4 @@
-import {isPureObject} from '@loaders.gl/core';
+import {isPureObject} from '../utils';
 import {CartoAPIError} from './carto-api-error';
 import {DEFAULT_HEADERS, DEFAULT_PARAMETERS, MAX_GET_LENGTH} from './common';
 import type {APIErrorContext} from './types';

--- a/modules/carto/src/utils.ts
+++ b/modules/carto/src/utils.ts
@@ -59,3 +59,8 @@ export function scaleIdentity() {
 
   return scale;
 }
+
+export const isObject: (x: unknown) => boolean = x => x !== null && typeof x === 'object';
+
+export const isPureObject: (x: any) => boolean = x =>
+  isObject(x) && x.constructor === {}.constructor;

--- a/test/modules/carto/utils.spec.ts
+++ b/test/modules/carto/utils.spec.ts
@@ -1,5 +1,5 @@
 import test from 'tape-promise/tape';
-import {createBinaryProxy, getWorkerUrl, scaleIdentity} from '@deck.gl/carto/utils';
+import {createBinaryProxy, getWorkerUrl, scaleIdentity, isObject, isPureObject} from '@deck.gl/carto/utils';
 
 test('createBinaryProxy', async t => {
   const binary = {
@@ -52,5 +52,23 @@ test('scaleIdentity', async t => {
   t.equal(scaleCopy(null), -2, 'copies set "unknown"');
   t.equal(scale(null), -1, 'copies do not affect "unknown" for original');
 
+  t.end();
+});
+
+test('isObject', t => {
+  class TestClass {}
+  t.equal(isObject({}), true, 'object is object');
+  t.equal(isObject(3), false, 'number is not object');
+  t.equal(isObject([]), true, 'array is object');
+  t.equal(isObject(new TestClass()), true, 'class instance is object');
+  t.end();
+});
+
+test('isPureObject', t => {
+  class TestClass {}
+  t.equal(isPureObject({}), true, 'object is pure');
+  t.equal(isPureObject(3), false, 'number is not pure');
+  t.equal(isPureObject([]), false, 'array is not pure');
+  t.equal(isPureObject(new TestClass()), false, 'class instance is not pure');
   t.end();
 });

--- a/test/modules/carto/utils.spec.ts
+++ b/test/modules/carto/utils.spec.ts
@@ -1,5 +1,11 @@
 import test from 'tape-promise/tape';
-import {createBinaryProxy, getWorkerUrl, scaleIdentity, isObject, isPureObject} from '@deck.gl/carto/utils';
+import {
+  createBinaryProxy,
+  getWorkerUrl,
+  scaleIdentity,
+  isObject,
+  isPureObject
+} from '@deck.gl/carto/utils';
 
 test('createBinaryProxy', async t => {
   const binary = {


### PR DESCRIPTION
Loading the latest version of pydeck-carto in a Python notebook environment, a function imported from `@loaders.gl/core` is not available, and throws an error when calling requestWithParameters:

![Screenshot 2024-05-09 at 3 12 29 PM](https://github.com/visgl/deck.gl/assets/1848368/6943ed44-4059-4002-9aa7-042f758dc6b5)

There's some nuance in how the Python packages load dependencies from CDNs, which could benefit from a closer look, but in the meantime ... the function is very short, and maybe importing it from `@loaders.gl/core` is unnecessary. To resolve the bug, I've copied `isObject` and `isPureObject` into the CARTO module, both are one-liners.

Publishing a patch release of `@deck.gl/carto` will be enough to fix the bug — pydeck-carto does not require an update.

<!-- For other PRs without open issue -->
#### Background

- https://github.com/visgl/deck.gl/pull/8865

<!-- For all the PRs -->
#### Change List

- Copies `isObject` and `isPureObject` from `@loaders.gl/core`
- Updates unit tests
