### PR TITLE
fix(pydeck): Fix cell height in Google Colab

### DIFF
--- a/bindings/pydeck/docs/contributing.rst
+++ b/bindings/pydeck/docs/contributing.rst
@@ -36,7 +36,40 @@ enable pydeck to run on JupyterLab and Jupyter Notebook locally:
         make init
         make prepare-jupyter
 
-At this point, verify that this new local copy of pydeck works by running ``make test``. 
+Verify that this new local copy of pydeck works by running ``make test``.
+
+Local development in Jupyter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To test local changes to Pydeck in a Jupyter notebook, set up a virtual environment as
+described above, then start a local Jupyter notebook:
+
+.. code-block:: bash
+
+        jupyter notebook
+
+.. CAUTION::
+   Additional steps (TODO) required to include local changes to deck.gl in a local Pydeck build.
+
+Local development in Google Colab
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To test local changes to Pydeck in a Google Colab notebook, first start a Jupyter runtime with
+additional flags to trust WebSocket connections from the Colab frontend:
+
+.. code-block:: bash
+
+        jupyter notebook \
+            --NotebookApp.allow_origin='https://colab.research.google.com' \
+            --port=8888 \
+            --NotebookApp.port_retries=0
+
+After the notebook starts, copy the full (localhost) URL printed to the console. In a Google
+Colab notebook, select *Connect to a local runtime* from the additional connection options
+dropdown, and provide the local URL when prompted. After a reload, the Colab notebook will have
+access to the local Jupyter runtime and its local Pydeck build.
+
+For more information, refer to Google Colab's `documentation for local runtimes <https://research.google.com/colaboratory/local-runtimes.html>`__.
 
 Submitting a PR
 ^^^^^^^^^^^^^^^

--- a/bindings/pydeck/pydeck/io/html.py
+++ b/bindings/pydeck/pydeck/io/html.py
@@ -113,7 +113,7 @@ def iframe_with_srcdoc(html_str, width="100%", height=500):
 def render_for_colab(html_str, iframe_height):
     from IPython.display import HTML, Javascript  # noqa
 
-    js_height_snippet = f"google.colab.output.setIframeHeight({iframe_height}, true, {{minHeight: {iframe_height}}})"
+    js_height_snippet = f"google.colab.output.setIframeHeight({iframe_height}, true, {{minHeight: {iframe_height}, maxHeight: {iframe_height}}})"
     display(Javascript(js_height_snippet))  # noqa
     display(HTML(html_str))  # noqa
 


### PR DESCRIPTION
Currently when using Pydeck in Google Colab, the `iframe_height` argument sets the minimum height, the iframe renders at that height, and then it incrementally becomes taller until reaching the maximum cell height allowed by colab, 1000px:

[colab_height_bug.webm](https://github.com/visgl/deck.gl/assets/1848368/cc1223e9-40c6-4998-a2e9-ac3eb7b6b9fe)

I believe this is the fix, but haven't found a way to test local builds against Google Colab environments yet. I'll look a bit more into that, and perhaps test on an alpha release if that's not possible. Perhaps there's also some CSS padding or margin contributing to the problem.

#### Change List
- Set both minHeight and maxHeight in Google Colab cell size
