### PR TITLE
GoogleMapsOverlay: fix initial layer position on raster basemaps

### DIFF
--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -217,8 +217,9 @@ export default class GoogleMapsOverlay {
     );
 
     const canvas = deck.getCanvas();
-    if (canvas?.parentElement) {
-      const parentStyle = canvas.parentElement.style;
+    const parent = canvas?.parentElement || deck.props.parent;
+    if (parent) {
+      const parentStyle = parent.style;
       parentStyle.left = `${left}px`;
       parentStyle.top = `${top}px`;
     }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #8891

<!-- For other PRs without open issue -->
#### Background

Seems like with raster basemaps, initial render happens when canvas is not yet attached to any parent.
This patch ensures that we use _declared_ canvas parent, even before canvas is attached to DOM.

<!-- For all the PRs -->
#### Change List
- GoogleMapsOverlay fix initial layer position on raster basemaps
