### PR TITLE
chore(carto): Update cartocolor to v5

### DIFF
--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -54,7 +54,7 @@
     "@types/d3-array": "^3.0.2",
     "@types/d3-color": "^1.4.2",
     "@types/d3-scale": "^3.0.0",
-    "cartocolor": "^4.0.2",
+    "cartocolor": "^5.0.0",
     "d3-array": "^3.2.0",
     "d3-color": "^3.1.0",
     "d3-format": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,12 +4076,12 @@ caniuse-lite@^1.0.30001254:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz"
   integrity sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==
 
-cartocolor@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cartocolor/-/cartocolor-4.0.2.tgz#ef1aa12860f6eeedc8d2420e2b9d7337937c4993"
-  integrity sha512-+Gh9mb6lFxsDOLQlBLPxAHCnWXlg2W8q3AcVwqRcy95TdBbcOU89Wrb6h2Hd/6Ww1Kc1pzXmUdpnWD+xeCG0dg==
+cartocolor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cartocolor/-/cartocolor-5.0.0.tgz#b2a8d42d640badb6ecf9e85aa86dfb60f98c5ea6"
+  integrity sha512-9nZipa0nvgoSZyXWIe5IBTOKgV3CwTbFwlx+G3B6PLmckiFlKBqBCMEtPW+VszoKbSJqgqoaglQApM34YEhBeA==
   dependencies:
-    colorbrewer "1.0.0"
+    colorbrewer "1.5.6"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -4309,10 +4309,10 @@ color@4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colorbrewer@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/colorbrewer/-/colorbrewer-1.0.0.tgz#4f97333b969ba7612382be4bc3394b341fb4c8a2"
-  integrity sha512-NZuIOVdErK/C6jDH3jWT/roxWJbJAinMiqEpbuWniKvQAoWdg6lGra3pPrSHvaIf8PlX8wLs/RAC6nULFJbgmg==
+colorbrewer@1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/colorbrewer/-/colorbrewer-1.5.6.tgz#5b6c81bcf2ee584642375143b210a9049d9e5ab5"
+  integrity sha512-fONg2pGXyID8zNgKHBlagW8sb/AMShGzj4rRJfz5biZ7iuHQZYquSCLE/Co1oSQFmt/vvwjyezJCejQl7FG/tg==
 
 colorette@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Updates the `cartocolor` dependency (color palettes) to v5.0.0.

Changes in `cartocolor`:

- Update license to [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/)
- Add ESM and CJS builds