### PR TITLE
fix(deps): Update deps for deck.gl/carto and test app

### DIFF
--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -54,7 +54,7 @@
     "@types/d3-array": "^3.0.2",
     "@types/d3-color": "^1.4.2",
     "@types/d3-scale": "^3.0.0",
-    "cartocolor": "^5.0.0",
+    "cartocolor": "^5.0.2",
     "d3-array": "^3.2.0",
     "d3-color": "^3.1.0",
     "d3-format": "^3.1.0",

--- a/test/apps/carto-dynamic-tile/package.json
+++ b/test/apps/carto-dynamic-tile/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "deck.gl": "^8.0.0",
+    "maplibre-gl": "^4.3.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-map-gl": "^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,10 +4076,10 @@ caniuse-lite@^1.0.30001254:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz"
   integrity sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==
 
-cartocolor@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cartocolor/-/cartocolor-5.0.0.tgz#b2a8d42d640badb6ecf9e85aa86dfb60f98c5ea6"
-  integrity sha512-9nZipa0nvgoSZyXWIe5IBTOKgV3CwTbFwlx+G3B6PLmckiFlKBqBCMEtPW+VszoKbSJqgqoaglQApM34YEhBeA==
+cartocolor@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/cartocolor/-/cartocolor-5.0.2.tgz#182050da45abe7f14e075df9e3a732ea4489c153"
+  integrity sha512-Ihb/wU5V6BVbHwapd8l/zg7bnhZ4YPFVfa7quSpL86lfkPJSf4YuNBT+EvesPRP5vSqhl6vZVsQJwCR8alBooQ==
   dependencies:
     colorbrewer "1.5.6"
 


### PR DESCRIPTION
Pulls in a fix for the cartocolor module, and adds the missing `maplibre-gl` dependency in the carto-dynamic-tile test app. Confirmed rendering as expected:

<img width="1338" alt="Screenshot 2024-05-23 at 11 48 31 AM" src="https://github.com/visgl/deck.gl/assets/1848368/9ab240d5-2b1a-4498-a874-ee03c2a77c1e">
