### PR TITLE
feat(carto): requestWithParameters to store received json response in CartoAPIError

### DIFF
--- a/modules/carto/src/api/carto-api-error.ts
+++ b/modules/carto/src/api/carto-api-error.ts
@@ -16,7 +16,15 @@ export class CartoAPIError extends Error {
   /** Response from server */
   response?: Response;
 
-  constructor(error: Error, errorContext: APIErrorContext, response?: Response) {
+  /** JSON Response from server */
+  responseJson?: any;
+
+  constructor(
+    error: Error,
+    errorContext: APIErrorContext,
+    response?: Response,
+    responseJson?: any
+  ) {
     let responseString = 'Failed to connect';
     if (response) {
       responseString = 'Server returned: ';
@@ -46,6 +54,7 @@ export class CartoAPIError extends Error {
 
     this.name = 'CartoAPIError';
     this.response = response;
+    this.responseJson = responseJson;
     this.error = error;
     this.errorContext = errorContext;
   }

--- a/modules/carto/src/api/request-with-parameters.ts
+++ b/modules/carto/src/api/request-with-parameters.ts
@@ -41,12 +41,14 @@ export async function requestWithParameters<T = any>({
       : fetch(url, {headers});
 
   let response: Response | undefined;
+  let responseJson;
   const jsonPromise: Promise<T> = fetchPromise
     .then((_response: Response) => {
       response = _response;
       return response.json();
     })
     .then((json: any) => {
+      responseJson = json;
       if (!response || !response.ok) {
         throw new Error(json.error);
       }
@@ -54,7 +56,7 @@ export async function requestWithParameters<T = any>({
     })
     .catch((error: Error) => {
       REQUEST_CACHE.delete(key);
-      throw new CartoAPIError(error, errorContext, response);
+      throw new CartoAPIError(error, errorContext, response, responseJson);
     });
 
   REQUEST_CACHE.set(key, jsonPromise);

--- a/test/modules/carto/api/request-with-parameters.spec.ts
+++ b/test/modules/carto/api/request-with-parameters.spec.ts
@@ -88,6 +88,12 @@ test('requestWithParameters#nocacheErrorContext', async t => {
         error2 = error as Error;
       }
 
+      t.deepEquals(
+        (error1 as CartoAPIError).responseJson,
+        {error: 'CustomError', customData: {abc: 'def'}},
+        'responseJson',
+        'propagates actual JSON error response '
+      );
       t.equals(calls.length, 2, '2 unique requests, failures not cached');
       t.true(error1 instanceof CartoAPIError, 'error #1 type');
       t.is((error1 as CartoAPIError).errorContext.requestType, 'Map data', 'error #1 context');
@@ -96,7 +102,10 @@ test('requestWithParameters#nocacheErrorContext', async t => {
     },
     // @ts-ignore
     (url: string, headers: HeadersInit) => {
-      return Promise.reject(new Error('404 Not Found'));
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({error: 'CustomError', customData: {abc: 'def'}})
+      });
     }
   );
   t.end();


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

In case of errors, Carto APIs return information that is useful for applications and now we almost completly hide it in new sources. This PR exposes whole response in `CartoAPIError.responseJson` property.

(note, we do expose `response` object, but we can't get full json content as it was already consumed in `requestWithParameters`)

<!-- For all the PRs -->
#### Change List
- feat(carto): requestWithParameters to store received json response in CartoAPIError
