### PR TITLE
fix(docs): fix invalid code syntax in Using deck.gl with React

### DIFF
--- a/docs/get-started/using-with-react.md
+++ b/docs/get-started/using-with-react.md
@@ -31,7 +31,7 @@ function App() {
       data: '/path/to/data.json',
       getSourcePosition: (d: DataType) => d.from,
       getTargetPosition: (d: DataType) => d.to,
-    });
+    })
   ];
 
   return <DeckGL


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

Quick fix for invalid code in `Using deck.gl with React` - object in an array was suffixed with a semicolon, which is invalid syntax.

<!-- For all the PRs -->
#### Change List
- `docs/get-stated/using-with-react.md` - small syntax fix in code example
