### PR TITLE
feat(geo-layers): Allow layers extending MVTLayer to override isWGS84

### DIFF
--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -146,7 +146,7 @@ export default class VectorTileLayer<
   }
 
   protected override _isWGS84(): boolean {
-    // MVT coordinates are tile-relative; CARTO binary coordinates are [lat, lng].
+    // CARTO binary tile coordinates are [lng, lat], not tile-relative like MVT.
     if (this.state.mvt) return super._isWGS84();
     return true;
   }

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -14,9 +14,6 @@ import {
   _TileLoadProps as TileLoadProps
 } from '@deck.gl/geo-layers';
 import {GeoJsonLayer} from '@deck.gl/layers';
-import {binaryToGeojson} from '@loaders.gl/gis';
-import type {BinaryFeatureCollection} from '@loaders.gl/schema';
-import type {Feature, Geometry} from 'geojson';
 
 import type {TilejsonResult} from '../sources/types';
 import {TilejsonPropType, injectAccessToken, mergeBoundaryData} from './utils';
@@ -148,22 +145,8 @@ export default class VectorTileLayer<
     return subLayer;
   }
 
-  getPickingInfo(params) {
-    const info = super.getPickingInfo(params);
-
-    // MVT tiles use tile-relative coordinates, handled by MVTLayer#getPickingInfo.
-    if (this.state.mvt) {
-      return info;
-    }
-
-    // CARTO tiles use [lat, lng], so overwrite `info.object`.
-    if (this.state.binary && info.index !== -1) {
-      const {data} = params.sourceLayer!.props;
-      info.object = binaryToGeojson(data as BinaryFeatureCollection, {
-        globalFeatureId: info.index
-      }) as Feature<Geometry, FeaturePropertiesT>;
-    }
-
-    return info;
+  protected override _isWGS84(): boolean {
+    if (!this.state.mvt) return true;
+    return super._isWGS84();
   }
 }

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -146,7 +146,8 @@ export default class VectorTileLayer<
   }
 
   protected override _isWGS84(): boolean {
-    if (!this.state.mvt) return true;
-    return super._isWGS84();
+    // MVT coordinates are tile-relative; CARTO binary coordinates are [lat, lng].
+    if (this.state.mvt) return super._isWGS84();
+    return true;
   }
 }

--- a/modules/geo-layers/src/mvt-layer/mvt-layer.ts
+++ b/modules/geo-layers/src/mvt-layer/mvt-layer.ts
@@ -303,10 +303,12 @@ export default class MVTLayer<
     }
   }
 
+  protected _isWGS84(): boolean {
+    return Boolean(this.context.viewport.resolution);
+  }
+
   getPickingInfo(params: GetPickingInfoParams): MVTLayerPickingInfo<FeaturePropertiesT> {
     const info = super.getPickingInfo(params);
-
-    const isWGS84 = Boolean(this.context.viewport.resolution);
 
     if (this.state.binary && info.index !== -1) {
       const {data} = params.sourceLayer!.props;
@@ -314,7 +316,7 @@ export default class MVTLayer<
         globalFeatureId: info.index
       }) as Feature;
     }
-    if (info.object && !isWGS84) {
+    if (info.object && !this._isWGS84()) {
       info.object = transformTileCoordsToWGS84(
         info.object,
         info.tile!.bbox as GeoBoundingBox, // eslint-disable-line

--- a/test/modules/carto/layers/vector-tile-layer.spec.ts
+++ b/test/modules/carto/layers/vector-tile-layer.spec.ts
@@ -8,7 +8,7 @@ import {withMockFetchMapsV3} from '../mock-fetch';
 test(`VectorTileLayer#picking`, async t => {
   await withMockFetchMapsV3(async () => {
     await testPickingLayer({
-      // CARTO binary tile coordinates are [lat, lng], not tile-relative like MVT.
+      // CARTO binary tile coordinates are [lng, lat], not tile-relative like MVT.
       layer: createTestVectorTileLayer([-123, 45], 'binary'),
       viewport: new WebMercatorViewport({
         latitude: 0,


### PR DESCRIPTION
Changes:

- feat(geo-layers): Expose protected method, _isWGS84
- chore(carto): Use _isWGS84 to avoid building picking info twice

Related:

- https://github.com/visgl/deck.gl/pull/8926
