### PR TITLE
fix(extensions): DataFilterExtension not setting category uniforms

### DIFF
--- a/modules/extensions/src/data-filter/data-filter-extension.ts
+++ b/modules/extensions/src/data-filter/data-filter-extension.ts
@@ -250,7 +250,7 @@ export default class DataFilterExtension extends LayerExtension<
         attributeManager.attributes.filterCategoryValues.needsUpdate() ||
         !deepEqual(props.filterCategories, oldProps.filterCategories, 2);
       if (categoryBitMaskNeedsUpdate) {
-        this.setState({categoryBitMaskNeedsUpdate});
+        this.setState({categoryBitMask: null});
       }
 
       // Need to recreate category map if categorySize has changed
@@ -270,13 +270,14 @@ export default class DataFilterExtension extends LayerExtension<
     const filterFBO = this.state.filterFBO as Framebuffer;
     const filterModel = this.state.filterModel as Model;
     const filterNeedsUpdate = this.state.filterNeedsUpdate as boolean;
-    const categoryBitMaskNeedsUpdate = this.state.categoryBitMaskNeedsUpdate as boolean;
 
     const {onFilteredItemsChange} = this.props;
 
-    if (categoryBitMaskNeedsUpdate) {
+    if (!this.state.categoryBitMask) {
       extension._updateCategoryBitMask.call(this, params, extension);
     }
+    /* eslint-disable-next-line camelcase */
+    params.uniforms.filter_categoryBitMask = this.state.categoryBitMask;
     if (filterNeedsUpdate && onFilteredItemsChange && filterModel) {
       const {
         attributes: {filterValues, filterCategoryValues, filterIndices}
@@ -353,9 +354,7 @@ export default class DataFilterExtension extends LayerExtension<
         }
       }
     }
-    /* eslint-disable-next-line camelcase */
-    params.uniforms.filter_categoryBitMask = categoryBitMask;
-    this.state.categoryBitMaskNeedsUpdate = false;
+    this.state.categoryBitMask = categoryBitMask;
   }
 
   /**

--- a/modules/extensions/src/data-filter/data-filter-extension.ts
+++ b/modules/extensions/src/data-filter/data-filter-extension.ts
@@ -336,6 +336,7 @@ export default class DataFilterExtension extends LayerExtension<
     extension: this
   ): void {
     const {categorySize} = extension.opts;
+    if (!categorySize) return;
     const {filterCategories} = this.props;
     const categoryBitMask = new Uint32Array([0, 0, 0, 0]);
     const categoryFilters = (


### PR DESCRIPTION
Closes #8937

The category filter uniform is only set once on prop change. `IconLayer` and `ScenegraphLayer` have conditional draw calls where `uniforms` are not applied until the texture loads.

#### Change List
- `DataFilterExtension` should set the necessary uniforms in every draw call
