### PR TITLE
fix(carto): Use tile.content in HeatmapTileLayer

### DIFF
--- a/modules/carto/src/layers/heatmap-tile-layer.ts
+++ b/modules/carto/src/layers/heatmap-tile-layer.ts
@@ -153,9 +153,9 @@ class HeatmapTileLayer<DataT = any, ExtraProps extends {} = {}> extends Composit
 
     let tileZ = 0;
     let maxDensity = 0;
-    const tiles = [...this.state.tiles].filter(t => t.isVisible && t.data);
+    const tiles = [...this.state.tiles].filter(t => t.isVisible && t.content);
     for (const tile of tiles) {
-      const cell = tile.data[0];
+      const cell = tile.content[0];
       const unitDensity = unitDensityForCell(cell.id);
       maxDensity = Math.max(tile.userData!.maxWeight * unitDensity, maxDensity);
       tileZ = Math.max(tile.zoom, tileZ);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Follow up to #8703 

`t.data` can return a Promise if the content isn't yet loaded, leading to a crash

<!-- For all the PRs -->
#### Change List
- Use tile.content rather than tile.data to avoid Promise
