### PR TITLE
feat(carto): Respect `matchingColumn` prop when merging boundary data

### DIFF
--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -16,7 +16,11 @@ export function injectAccessToken(loadOptions: any, accessToken: string): void {
   }
 }
 
-export function mergeBoundaryData(geometry: VectorTile, properties: PropertiesTile): VectorTile {
+export function mergeBoundaryData(
+  geometry: VectorTile,
+  properties: PropertiesTile,
+  matchingColumn: string
+): VectorTile {
   const mapping = {};
   for (const {geoid, ...rest} of properties.properties) {
     if (geoid in mapping) {

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -90,8 +90,8 @@ export function mergeBoundaryData(
 
 export const TilejsonPropType = {
   type: 'object' as const,
-  value: null as null | TilejsonResult,
-  validate: (value: TilejsonResult, propType) =>
+  value: null as null | (TilejsonResult & {matchingColumn?: string}),
+  validate: (value: TilejsonResult & {matchingColumn?: string}, propType) =>
     (propType.optional && value === null) ||
     (typeof value === 'object' &&
       Array.isArray(value.tiles) &&

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -29,13 +29,10 @@ export function mergeBoundaryData(
         `Properties: Missing value for matchingKey with matchingColumn: ${matchingColumn}`
       )();
     }
-    const row = {...property};
-    delete row[matchingColumn];
-
     if (matchingKey in mapping) {
       log.warn('Properties: Duplicate key in boundary mapping, using first occurrence')();
     } else {
-      mapping[matchingKey] = row;
+      mapping[matchingKey] = property;
     }
   }
 

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -33,7 +33,7 @@ export function mergeBoundaryData(
     delete row[matchingColumn];
 
     if (matchingKey in mapping) {
-      log.warn('Properties: Duplicate key in boundary mapping, using first occurance')();
+      log.warn('Properties: Duplicate key in boundary mapping, using first occurrence')();
     } else {
       mapping[matchingKey] = row;
     }

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -47,7 +47,7 @@ export function mergeBoundaryData(
 
     geom.properties = geom.properties.map((property: Record<string, string>) => {
       const matchingKey = property[matchingColumn];
-      if (!matchingKey || matchingKey === '') {
+      if (!matchingKey) {
         log.warn(
           `Boundaries: Missing value for matchingKey with matchingColumn: ${matchingColumn}`
         )();

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -24,7 +24,7 @@ export function mergeBoundaryData(
   const mapping = {};
   for (const property of properties.properties) {
     const matchingKey = property[matchingColumn];
-    if (!matchingKey || matchingKey === '') {
+    if (!matchingKey) {
       log.warn(
         `Properties: Missing value for matchingKey with matchingColumn: ${matchingColumn}`
       )();

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -32,7 +32,10 @@ export type VectorTileLayerProps<FeaturePropertiesT = unknown> = _VectorTileLaye
 
 /** Properties added by VectorTileLayer. */
 type _VectorTileLayerProps = {
-  data: null | TilejsonResult | Promise<TilejsonResult>;
+  data:
+    | null
+    | (TilejsonResult & {matchingColumn?: string})
+    | Promise<TilejsonResult & {matchingColumn?: string}>;
 };
 
 // @ts-ignore
@@ -79,7 +82,7 @@ export default class VectorTileLayer<
 
   /* eslint-disable camelcase */
   async getTileData(tile: TileLoadProps) {
-    const tileJSON = this.props.data as TilejsonResult;
+    const tileJSON = this.props.data as TilejsonResult & {matchingColumn?: string};
     const {tiles, properties_tiles, matchingColumn} = tileJSON;
     const url = _getURLFromTemplate(tiles, tile);
     if (!url) {

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -80,7 +80,7 @@ export default class VectorTileLayer<
   /* eslint-disable camelcase */
   async getTileData(tile: TileLoadProps) {
     const tileJSON = this.props.data as TilejsonResult;
-    const {tiles, properties_tiles} = tileJSON;
+    const {tiles, properties_tiles, matchingColumn} = tileJSON;
     const url = _getURLFromTemplate(tiles, tile);
     if (!url) {
       return Promise.reject('Invalid URL');
@@ -111,7 +111,7 @@ export default class VectorTileLayer<
     const [geometry, attributes] = await Promise.all([geometryFetch, attributesFetch]);
     if (!geometry) return null;
 
-    return attributes ? mergeBoundaryData(geometry, attributes) : geometry;
+    return attributes ? mergeBoundaryData(geometry, attributes, matchingColumn!) : geometry;
   }
   /* eslint-enable camelcase */
 

--- a/modules/carto/src/sources/boundary-query-source.ts
+++ b/modules/carto/src/sources/boundary-query-source.ts
@@ -45,5 +45,11 @@ export const boundaryQuerySource = async function (
   if (queryParameters) {
     urlParameters.queryParameters = queryParameters;
   }
-  return baseSource<UrlParameters>('boundary', options, urlParameters) as Promise<TilejsonResult>;
+  const json = (await baseSource<UrlParameters>(
+    'boundary',
+    options,
+    urlParameters
+  )) as TilejsonResult;
+  json.matchingColumn = matchingColumn;
+  return json;
 };

--- a/modules/carto/src/sources/boundary-query-source.ts
+++ b/modules/carto/src/sources/boundary-query-source.ts
@@ -21,7 +21,7 @@ type UrlParameters = {
 
 export const boundaryQuerySource = async function (
   options: BoundaryQuerySourceOptions
-): Promise<TilejsonResult> {
+): Promise<TilejsonResult & {matchingColumn: string}> {
   const {
     columns,
     filters,
@@ -49,7 +49,7 @@ export const boundaryQuerySource = async function (
     'boundary',
     options,
     urlParameters
-  )) as TilejsonResult;
+  )) as TilejsonResult & {matchingColumn: string};
   json.matchingColumn = matchingColumn;
   return json;
 };

--- a/modules/carto/src/sources/boundary-table-source.ts
+++ b/modules/carto/src/sources/boundary-table-source.ts
@@ -32,5 +32,11 @@ export const boundaryTableSource = async function (
   if (filters) {
     urlParameters.filters = filters;
   }
-  return baseSource<UrlParameters>('boundary', options, urlParameters) as Promise<TilejsonResult>;
+  const json = (await baseSource<UrlParameters>(
+    'boundary',
+    options,
+    urlParameters
+  )) as TilejsonResult;
+  json.matchingColumn = matchingColumn;
+  return json;
 };

--- a/modules/carto/src/sources/boundary-table-source.ts
+++ b/modules/carto/src/sources/boundary-table-source.ts
@@ -18,7 +18,7 @@ type UrlParameters = {
 
 export const boundaryTableSource = async function (
   options: BoundaryTableSourceOptions
-): Promise<TilejsonResult> {
+): Promise<TilejsonResult & {matchingColumn: string}> {
   const {filters, tilesetTableName, columns, matchingColumn = 'id', propertiesTableName} = options;
   const urlParameters: UrlParameters = {
     tilesetTableName,
@@ -36,7 +36,7 @@ export const boundaryTableSource = async function (
     'boundary',
     options,
     urlParameters
-  )) as TilejsonResult;
+  )) as TilejsonResult & {matchingColumn: string};
   json.matchingColumn = matchingColumn;
   return json;
 };

--- a/modules/carto/src/sources/types.ts
+++ b/modules/carto/src/sources/types.ts
@@ -214,7 +214,7 @@ export interface VectorLayer {
   fields: Record<string, string>;
 }
 
-export type TilejsonResult = Tilejson & {accessToken: string; matchingColumn?: string};
+export type TilejsonResult = Tilejson & {accessToken: string};
 export type GeojsonResult = {type: 'FeatureCollection'; features: Feature[]};
 export type JsonResult = any[];
 export type QueryResult = {

--- a/modules/carto/src/sources/types.ts
+++ b/modules/carto/src/sources/types.ts
@@ -214,7 +214,7 @@ export interface VectorLayer {
   fields: Record<string, string>;
 }
 
-export type TilejsonResult = Tilejson & {accessToken: string};
+export type TilejsonResult = Tilejson & {accessToken: string; matchingColumn?: string};
 export type GeojsonResult = {type: 'FeatureCollection'; features: Feature[]};
 export type JsonResult = any[];
 export type QueryResult = {

--- a/test/modules/carto/index.ts
+++ b/test/modules/carto/index.ts
@@ -16,6 +16,7 @@ import './layers/point-label-layer.spec';
 import './layers/quadbin-layer.spec';
 import './layers/quadbin-tile-layer.spec';
 import './layers/quadbin-tileset-2d.spec';
+import './layers/utils.spec';
 import './layers/vector-tile-layer.spec';
 import './sources/boundary-query-source.spec';
 import './sources/boundary-table-source.spec';

--- a/test/modules/carto/layers/utils.spec.ts
+++ b/test/modules/carto/layers/utils.spec.ts
@@ -45,6 +45,9 @@ test('mergeBoundaryData', async t => {
   };
 
   const merged = mergeBoundaryData(geometry, properties, 'custom_id');
-  t.deepEqual(merged.polygons.properties, [{name: 'A'}, {name: 'B'}]);
+  t.deepEqual(merged.polygons.properties, [
+    {custom_id: 'a', name: 'A'},
+    {custom_id: 'b', name: 'B'}
+  ]);
   t.end();
 });

--- a/test/modules/carto/layers/utils.spec.ts
+++ b/test/modules/carto/layers/utils.spec.ts
@@ -1,0 +1,13 @@
+import test from 'tape-promise/tape';
+import {injectAccessToken} from '@deck.gl/carto/layers/utils';
+
+test('injectAccessToken', async t => {
+  let loadOptions = {} as any;
+  injectAccessToken(loadOptions, 'ACCESS-XXX');
+  t.equal(loadOptions.fetch.headers.Authorization, 'Bearer ACCESS-XXX');
+
+  loadOptions = {fetch: {headers: {Custom: 123}}};
+  injectAccessToken(loadOptions, 'ACCESS-XXX');
+  t.deepEqual(loadOptions.fetch.headers, {Authorization: 'Bearer ACCESS-XXX', Custom: 123});
+  t.end();
+});

--- a/test/modules/carto/layers/utils.spec.ts
+++ b/test/modules/carto/layers/utils.spec.ts
@@ -1,5 +1,7 @@
 import test from 'tape-promise/tape';
-import {injectAccessToken} from '@deck.gl/carto/layers/utils';
+import {injectAccessToken, mergeBoundaryData} from '@deck.gl/carto/layers/utils';
+import {Tile as PropertiesTile} from '/carto/layers/schema/carto-properties-tile';
+import {Tile as VectorTile} from '@deck.gl/carto/layers/schema/carto-tile';
 
 test('injectAccessToken', async t => {
   let loadOptions = {} as any;
@@ -9,5 +11,40 @@ test('injectAccessToken', async t => {
   loadOptions = {fetch: {headers: {Custom: 123}}};
   injectAccessToken(loadOptions, 'ACCESS-XXX');
   t.deepEqual(loadOptions.fetch.headers, {Authorization: 'Bearer ACCESS-XXX', Custom: 123});
+  t.end();
+});
+
+test('mergeBoundaryData', async t => {
+  const geometry: VectorTile = {
+    points: {positions: {value: new Float32Array(), size: 2}} as any,
+    lines: {positions: {value: new Float32Array(), size: 2}} as any,
+    polygons: {
+      positions: {
+        value: new Float32Array([
+          100, 0, 110, 0, 110, 10, 100, 10, 100, 0, 108, 8, 108, 2, 102, 2, 102, 8, 108, 8
+        ]),
+        size: 2
+      },
+      polygonIndices: {value: new Uint32Array([0, 10]), size: 1},
+      primitivePolygonIndices: {value: new Uint32Array([0, 5, 10]), size: 1},
+      properties: [{custom_id: 'a'}, {custom_id: 'b'}],
+      numericProps: {},
+      featureIds: {value: new Uint32Array([0, 1]), size: 1},
+      globalFeatureIds: {value: new Uint32Array([31, 32]), size: 1},
+      fields: [],
+      triangles: {value: new Uint32Array([0, 1]), size: 1}
+    }
+  };
+
+  const properties: PropertiesTile = {
+    properties: [
+      {custom_id: 'b', name: 'B'},
+      {custom_id: 'a', name: 'A'}
+    ],
+    numericProps: {}
+  };
+
+  const merged = mergeBoundaryData(geometry, properties, 'custom_id');
+  t.deepEqual(merged.polygons.properties, [{name: 'A'}, {name: 'B'}]);
   t.end();
 });

--- a/test/modules/carto/sources/boundary-query-source.spec.ts
+++ b/test/modules/carto/sources/boundary-query-source.spec.ts
@@ -8,7 +8,7 @@ test('boundaryQuerySource', async t => {
       connectionName: 'carto_dw',
       accessToken: '<token>',
       tilesetTableName: 'a.b.tileset_table',
-      matchingColumn: 'geoid',
+      matchingColumn: 'custom_id',
       columns: ['column1', 'column2'],
       propertiesSqlQuery: 'select * from `a.b.properties_table`'
     });
@@ -19,7 +19,7 @@ test('boundaryQuerySource', async t => {
 
     t.match(initCall.url, /v3\/maps\/carto_dw\/boundary/, 'connection');
     t.match(initCall.url, /tilesetTableName=a.b.tileset_table/, 'tilesetTableName');
-    t.match(initCall.url, /matchingColumn=geoid/, 'matchingColumn');
+    t.match(initCall.url, /matchingColumn=custom_id/, 'matchingColumn');
     t.match(
       initCall.url,
       /propertiesSqlQuery=select\+\*\+from\+%60a.b.properties_table%60/,
@@ -32,6 +32,7 @@ test('boundaryQuerySource', async t => {
     t.ok(tilejson, 'returns source');
     t.deepEqual(tilejson.tiles, ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'], 'source.tiles');
     t.equal(tilejson.accessToken, '<token>', 'source.accessToken');
+    t.equal(tilejson.matchingColumn, 'custom_id', 'source.matchingColumn');
   }).catch(t.fail);
   t.end();
 });

--- a/test/modules/carto/sources/boundary-table-source.spec.ts
+++ b/test/modules/carto/sources/boundary-table-source.spec.ts
@@ -8,7 +8,7 @@ test('boundaryTableSource', async t => {
       connectionName: 'carto_dw',
       accessToken: '<token>',
       tilesetTableName: 'a.b.tileset_table',
-      matchingColumn: 'geoid',
+      matchingColumn: 'custom_id',
       columns: ['column1', 'column2'],
       propertiesTableName: 'a.b.properties_table'
     });
@@ -19,7 +19,7 @@ test('boundaryTableSource', async t => {
 
     t.match(initCall.url, /v3\/maps\/carto_dw\/boundary/, 'connection');
     t.match(initCall.url, /tilesetTableName=a.b.tileset_table/, 'tilesetTableName');
-    t.match(initCall.url, /matchingColumn=geoid/, 'matchingColumn');
+    t.match(initCall.url, /matchingColumn=custom_id/, 'matchingColumn');
     t.match(initCall.url, /propertiesTableName=a.b.properties_table/, 'propertiesTableName');
     t.match(initCall.url, /columns=column1%2Ccolumn2/, 'columns');
 
@@ -28,6 +28,7 @@ test('boundaryTableSource', async t => {
     t.ok(tilejson, 'returns source');
     t.deepEqual(tilejson.tiles, ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'], 'source.tiles');
     t.equal(tilejson.accessToken, '<token>', 'source.accessToken');
+    t.equal(tilejson.matchingColumn, 'custom_id', 'source.matchingColumn');
   }).catch(t.fail);
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #8934

<!-- For all the PRs -->
#### Change List
- Pass `matchingColumn` prop down to `VectorTileLayer`
- Do not hardcode `'geoid'` in `mergeBoundaryData`
- Tests for `layer/utils`
