### PR TITLE
CARTO: Adapt fetchMap for supporting HeatmapTileLayer

### DIFF
--- a/modules/carto/src/api/layer-map.ts
+++ b/modules/carto/src/api/layer-map.ts
@@ -32,6 +32,7 @@ import {
   VisualChannelField,
   VisualChannels
 } from './types';
+import HeatmapTileLayer from '../layers/heatmap-tile-layer';
 
 const SCALE_FUNCS = {
   linear: scaleLinear,
@@ -144,8 +145,14 @@ export function getLayer(
   if (config.visConfig?.customMarkers) {
     basePropMap = mergePropMaps(sharedPropMap, customMarkersPropsMap);
   }
-  if (type === 'mvt' || type === 'tileset' || type === 'h3' || type === 'quadbin') {
-    return getTileLayer(dataset, basePropMap);
+  if (
+    type === 'mvt' ||
+    type === 'tileset' ||
+    type === 'h3' ||
+    type === 'quadbin' ||
+    type === 'heatmapTile'
+  ) {
+    return getTileLayer(dataset, basePropMap, type);
   }
 
   const geoColumn = dataset?.geoColumn;
@@ -202,31 +209,29 @@ export function getLayer(
 }
 
 export function layerFromTileDataset(
-  scheme: string,
-  type?: MapType
+  type: string
 ): typeof VectorTileLayer | typeof H3TileLayer | typeof QuadbinTileLayer {
   if (type === 'raster') {
     return RasterTileLayer;
   }
-  if (scheme === 'h3') {
+  if (type === 'h3') {
     return H3TileLayer;
   }
-  if (scheme === 'quadbin') {
+  if (type === 'quadbin') {
     return QuadbinTileLayer;
+  }
+  if (type === 'heatmapTile') {
+    return HeatmapTileLayer;
   }
 
   return VectorTileLayer;
 }
 
-function getTileLayer(dataset: MapDataset, basePropMap) {
-  const {
-    aggregationExp,
-    aggregationResLevel,
-    data: {scheme}
-  } = dataset;
+function getTileLayer(dataset: MapDataset, basePropMap, type: string) {
+  const {aggregationExp, aggregationResLevel} = dataset;
 
   return {
-    Layer: layerFromTileDataset(scheme),
+    Layer: layerFromTileDataset(type),
     propMap: basePropMap,
     defaultProps: {
       ...defaultProps,

--- a/test/apps/carto-map/app.ts
+++ b/test/apps/carto-map/app.ts
@@ -133,7 +133,10 @@ const examples = [
 
   // Quadbin
   'abfce395-d9ec-48d4-85ad-45ec7705a921', // Quadbin - Table - 588k Spatial Features Spain
-  '8ead73bb-aa1f-4bf6-91fc-52a50c682938' // Quadbin — Tileset 14M Spatial Features USA
+  '8ead73bb-aa1f-4bf6-91fc-52a50c682938', // Quadbin — Tileset 14M Spatial Features USA
+
+  // Heatmap
+  '0b3c86ad-3c14-4c89-986a-07ba23306c3d' // Quadbin - Tileset, represented through Heatmap
 ];
 const params = new URLSearchParams(location.search.slice(1));
 const id = params.has('id') ? params.get('id')! : examples[0];


### PR DESCRIPTION
#### Background
- After adding support for the [HeatmapTileLayer](https://deck.gl/docs/api-reference/carto/heatmap-tile-layer), we should update the [fetchMap](https://deck.gl/docs/api-reference/carto/fetch-map) functionality too

#### Change List
- Adapt `fetchMap` to support HeatmapTileLayer
