### PR TITLE
chore(carto): Remove dependency on @luma.gl/constants

### DIFF
--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -47,7 +47,6 @@
     "@loaders.gl/mvt": "^4.2.0",
     "@loaders.gl/schema": "^4.2.0",
     "@loaders.gl/tiles": "^4.2.0",
-    "@luma.gl/constants": "^9.0.14",
     "@luma.gl/core": "^9.0.14",
     "@luma.gl/shadertools": "^9.0.14",
     "@math.gl/web-mercator": "^4.0.0",

--- a/modules/carto/src/api/parse-map.ts
+++ b/modules/carto/src/api/parse-map.ts
@@ -1,4 +1,4 @@
-import {GL} from '@luma.gl/constants';
+import {ColorParameters} from '@luma.gl/core';
 import {Layer, log} from '@deck.gl/core';
 import {
   AGGREGATION,
@@ -83,13 +83,18 @@ export function parseMap(json) {
   };
 }
 
-function createParametersProp(layerBlending, parameters: Record<string, any>) {
+function createParametersProp(layerBlending: string, parameters: ColorParameters) {
   if (layerBlending === 'additive') {
-    parameters.blendFunc = [GL.SRC_ALPHA, GL.DST_ALPHA];
-    parameters.blendEquation = GL.FUNC_ADD;
+    parameters.blendColorSrcFactor = parameters.blendAlphaSrcFactor = 'src-alpha';
+    parameters.blendColorDstFactor = parameters.blendAlphaDstFactor = 'dst-alpha';
+    parameters.blendColorOperation = parameters.blendAlphaOperation = 'add';
   } else if (layerBlending === 'subtractive') {
-    parameters.blendFunc = [GL.ONE, GL.ONE_MINUS_DST_COLOR, GL.SRC_ALPHA, GL.DST_ALPHA];
-    parameters.blendEquation = [GL.FUNC_SUBTRACT, GL.FUNC_ADD];
+    parameters.blendColorSrcFactor = 'one';
+    parameters.blendColorDstFactor = 'one-minus-dst-color';
+    parameters.blendAlphaSrcFactor = 'src-alpha';
+    parameters.blendAlphaDstFactor = 'dst-alpha';
+    parameters.blendColorOperation = 'subtract';
+    parameters.blendAlphaOperation = 'add';
   }
 
   return Object.keys(parameters).length ? {parameters} : {};


### PR DESCRIPTION
No particular urgency here, but seemed good to update the blending code for WebGPU and this was the last reference to `@luma.gl/constants` in the package. 

~~Tests pass but I want to check the rendering results locally and haven't done that yet; marking as draft in the meantime.~~ Checked against #8957.