### PR TITLE
Fixes line width default type description for geo and polygon layers

### DIFF
--- a/modules/layers/src/geojson-layer/geojson-layer.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer.ts
@@ -122,7 +122,7 @@ type _GeoJsonLayerStrokeProps<FeaturePropertiesT> = {
   /**
    * Line width value or accessor.
    *
-   * @default [0, 0, 0, 255]
+   * @default 1
    */
   getLineWidth?: Accessor<Feature<Geometry, FeaturePropertiesT>, number>;
 

--- a/modules/layers/src/polygon-layer/polygon-layer.ts
+++ b/modules/layers/src/polygon-layer/polygon-layer.ts
@@ -167,7 +167,7 @@ type _PolygonLayerProps<DataT = unknown> = {
   /**
    * Line width value or accessor.
    *
-   * @default [0, 0, 0, 255]
+   * @default 1
    */
   getLineWidth?: Accessor<DataT, number>;
 


### PR DESCRIPTION

#### Background

Simply corrects an incorrect type description for GeoJSONlayer and PolygonLayer typings.


#### Change List
- modules/layers/src/geojson-layer/geojson-layer.ts
- - ln. 125
- modules/layers/src/geojson-layer/polygon-layer.ts
- - ln. 170