### PR TITLE
CARTO: do not reduce position precision to 32bit

### DIFF
--- a/modules/carto/src/layers/schema/carto-tile.ts
+++ b/modules/carto/src/layers/schema/carto-tile.ts
@@ -33,14 +33,14 @@ export class PropertiesReader {
 // Doubles ========================================
 
 interface Doubles {
-  value: Float32Array;
+  value: Float64Array;
   size: number;
 }
 
 class DoublesReader {
   static read(pbf, end?: number): Doubles {
     const {value, size} = pbf.readFields(DoublesReader._readField, {value: [], size: 0}, end);
-    return {value: new Float32Array(value), size};
+    return {value, size};
   }
   static _readField(this: void, tag: number, obj, pbf) {
     if (tag === 1) readPackedTypedArray(Float64Array, pbf, obj);


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

Bug where 64bit positions were converted to 32bit

<!-- For all the PRs -->
#### Change List
- Do not reduce position precision to 32bit
