### PR TITLE
docs(CARTO): remove matching column prop from API reference

### DIFF
--- a/docs/api-reference/carto/data-sources.md
+++ b/docs/api-reference/carto/data-sources.md
@@ -163,7 +163,6 @@ type RasterTilesetSourceOptions = {
 type BoundaryTableSourceOptions = {
   tilesetTableName: string;
   columns?: string[];
-  matchingColumn?: string;
   propertiesTableName: string;
 }
 ```
@@ -173,7 +172,6 @@ type BoundaryTableSourceOptions = {
 ```ts
 type BoundaryQuerySourceOptions = {
   tilesetTableName: string;
-  matchingColumn?: string;
   propertiesSqlQuery: string;
   queryParameters?: QueryParameters;
 }

--- a/docs/api-reference/carto/data-sources.md
+++ b/docs/api-reference/carto/data-sources.md
@@ -157,6 +157,8 @@ type RasterTilesetSourceOptions = {
 }
 ```
 
+Boundary sources are experimental sources where both the tileset and the properties props need a specific schema to work. [Read more about Boundaries in the CARTO documentation](https://docs.carto.com/carto-for-developers/guides/use-boundaries-in-your-application).
+
 #### boundaryTableSource (Experimental)
 
 ```ts


### PR DESCRIPTION
<!-- For other PRs without open issue -->
In https://github.com/visgl/deck.gl/pull/8971 we removed a `matchingColumn` prop from the CARTO module, specifically for the `boundaryQuerySource` and `boundaryTableSource`. 

We need to reflect this in the API reference documentation

#### Changelog

- Remove `matchingColumn` from the CARTO sources API reference
- Add a small comment to guide developers when using Boundary sources
