### PR TITLE
feat(widgets) affect all views if not attached to specific view

### DIFF
--- a/docs/api-reference/widgets/compass-widget.md
+++ b/docs/api-reference/widgets/compass-widget.md
@@ -14,7 +14,7 @@ Unique identifier of the widget.
 
 Default: `null`
 
-The widget is attached to the view identified by this `viewId`. When assigned, the widget is placed within the specified view, and  exclusively interacts with it. Required when using [multiple views](../../developer-guide/views.md#using-multiple-views).
+The `viewId` prop controls how a widget interacts with views. If `viewId` is defined, the widget is placed in that view and interacts exclusively with it; otherwise, it is placed in the root widget container and affects all views.
 
 #### `placement` (string, optional) {#placement}
 

--- a/docs/api-reference/widgets/zoom-widget.md
+++ b/docs/api-reference/widgets/zoom-widget.md
@@ -14,7 +14,7 @@ Unique identifier of the widget.
 
 Default: `null`
 
-The widget is attached to the view identified by this `viewId`. When assigned, the widget is placed within the specified view, and  exclusively interacts with it. Required when using [multiple views](../../developer-guide/views.md#using-multiple-views).
+The `viewId` prop controls how a widget interacts with views. If `viewId` is defined, the widget is placed in that view and interacts exclusively with it; otherwise, it is placed in the root widget container and affects all views.
 
 #### `placement` (string, optional) {#placement}
 

--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -43,7 +43,7 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
   placement: WidgetPlacement = 'top-left';
   orientation: 'vertical' | 'horizontal' = 'vertical';
   viewId?: string | null = null;
-  viewport?: Viewport;
+  viewports: {[id: string]: Viewport} = {};
   deck?: Deck<any>;
   element?: HTMLDivElement;
 
@@ -98,14 +98,14 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
     Object.assign(this.props, props);
   }
 
-  onViewportChange(viewport) {
-    this.viewport = viewport;
+  onViewportChange(viewport: Viewport) {
+    this.viewports[viewport.id] = viewport;
   }
 
-  handleZoom(nextZoom: number) {
-    const viewId = this.viewId || this.viewport?.id || 'default-view';
+  handleZoom(viewport: Viewport, nextZoom: number) {
+    const viewId = this.viewId || viewport?.id || 'default-view';
     const nextViewState = {
-      ...this.viewport,
+      ...viewport,
       zoom: nextZoom,
       transitionDuration: this.props.transitionDuration,
       transitionInterpolator: new FlyToInterpolator()
@@ -115,14 +115,14 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
   }
 
   handleZoomIn() {
-    if (this.viewport) {
-      this.handleZoom(this.viewport.zoom + 1);
+    for (const viewport of Object.values(this.viewports)) {
+      this.handleZoom(viewport, viewport.zoom + 1);
     }
   }
 
   handleZoomOut() {
-    if (this.viewport) {
-      this.handleZoom(this.viewport.zoom - 1);
+    for (const viewport of Object.values(this.viewports)) {
+      this.handleZoom(viewport, viewport.zoom - 1);
     }
   }
 }

--- a/test/apps/widgets/app.js
+++ b/test/apps/widgets/app.js
@@ -102,10 +102,17 @@ export const deck = new Deck({
     })
   ],
   widgets: [
-    new ZoomWidget({style: widgetTheme, viewId: 'map'}),
-    new ZoomWidget({style: widgetTheme, orientation: 'horizontal', viewId: 'globe'}),
-    new CompassWidget({style: widgetTheme, viewId: 'map'}),
-    new CompassWidget({style: widgetTheme, viewId: 'globe'}),
+    new ZoomWidget({id: 'map-zoom', style: widgetTheme, viewId: 'map'}),
+    new ZoomWidget({
+      id: 'globe-zoom',
+      style: widgetTheme,
+      orientation: 'horizontal',
+      viewId: 'globe'
+    }),
+    new ZoomWidget({style: widgetTheme, placement: 'bottom-right'}),
+    new CompassWidget({id: 'map-compass', style: widgetTheme, viewId: 'map'}),
+    new CompassWidget({id: 'globe-compass', style: widgetTheme, viewId: 'globe'}),
+    new CompassWidget({style: widgetTheme, placement: 'bottom-right'}),
 
     new FullscreenWidget({}), // TODO: should viewId be on all widgets for multi-view placement?
     new FullscreenWidget({id: 'themed', style: widgetTheme}),

--- a/test/apps/widgets/package.json
+++ b/test/apps/widgets/package.json
@@ -4,9 +4,9 @@
     "start-local": "vite --config ../vite.config.local.mjs"
   },
   "dependencies": {
-    "@deck.gl/core": "^9.0.0-beta",
-    "@deck.gl/layers": "^9.0.0-beta",
-    "@deck.gl/widgets": "^9.0.0-beta"
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0",
+    "@deck.gl/widgets": "^9.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0"


### PR DESCRIPTION
<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Follow up on https://github.com/visgl/deck.gl/pull/8903#discussion_r1606873870

<!-- For other PRs without open issue -->
#### Background

The intended design of the `viewId` prop is:

- If a `viewId` prop is defined by a user, the widget is placed in that view (i.e. a mini-map) and changes that view.
- Otherwise, the widget is considered "multi-view"; it is placed in the root widget container and should change all views.

This PR implements this second bullet. Currently, a widget with an undefined `viewId` behaves in an unintuitive way: it affects the last viewport that changed.

<!-- For all the PRs -->
#### Change List
- Zoom and Compass widgets affect all views if not attached to specific view
- docs
