### PR TITLE
fix: mapboxOverlay's getDefaultPosition return type error

### DIFF
--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -22,7 +22,7 @@ export type MapboxOverlayProps = Omit<
 > & {
   interleaved?: boolean;
 };
-type ControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 /**
  * Implements Mapbox [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) interface

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -22,6 +22,7 @@ export type MapboxOverlayProps = Omit<
 > & {
   interleaved?: boolean;
 };
+type ControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
 /**
  * Implements Mapbox [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) interface
@@ -153,7 +154,7 @@ export default class MapboxOverlay implements IControl {
     removeDeckInstance(map);
   }
 
-  getDefaultPosition() {
+  getDefaultPosition(): ControlPosition {
     return 'top-left';
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes # none

<!-- For other PRs without open issue -->
#### Background
when use mapbox function   `map.addControl(deckOverlay);`
 versions:    
 "mapbox-gl": "^3.5.1",
 "@deck.gl/mapbox": "^9.0.21",

Parameters of type 'MapboxOverlay' cannot be assigned to parameters of type 'IControl'.
Among these types, the types returned by "getDefultPosition()" are incompatible.
Type 'string' cannot be assigned to type 'ControlPosition'.
<!-- For all the PRs -->
#### Change List
- mapbox-overlay.ts
