### PR TITLE
fix(geo-layers): HeatmapLayer crash with constant weight

### DIFF
--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -588,10 +588,8 @@ export default class HeatmapLayer<
     const attributeManager = this.getAttributeManager()!;
     const attributes = attributeManager.getAttributes();
     const moduleSettings = this.getModuleSettings();
-    const positions = attributes.positions.buffer;
     const uniforms = {radiusPixels, commonBounds, textureWidth: textureSize, weightsScale};
-    const weights = attributes.weights.buffer;
-    weightsTransform.model.setAttributes({positions, weights});
+    this._setModelAttributes(weightsTransform.model, attributes);
     weightsTransform.model.setVertexCount(this.getNumInstances());
     weightsTransform.model.setUniforms(uniforms);
     weightsTransform.model.updateModuleSettings(moduleSettings);


### PR DESCRIPTION
Closes #8960

`weights.buffer` is `null` if weight is a constant.

Note that HeatmapLayer is not working on master due to UBO work (#8997).
This patch has been tested on the `9.0-release` branch.

#### Change List
- HeatmapLayer handles constant attribute when updating weight map.
