### PR TITLE
CARTO: Only clip polygon/line layers

### DIFF
--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -142,6 +142,7 @@ export default class VectorTileLayer<
     const subLayerProps = {
       ...props,
       autoHighlight: false,
+      // Do not perform clipping on points (#9059)
       _subLayerProps: {
         'polygons-fill': clipProps,
         'polygons-stroke': clipProps,

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -134,11 +134,19 @@ export default class VectorTileLayer<
     const tileBbox = props.tile.bbox as any;
     const {west, south, east, north} = tileBbox;
 
+    const clipProps = {
+      extensions: [new ClipExtension(), ...(props.extensions || [])],
+      clipBounds: [west, south, east, north]
+    };
+
     const subLayerProps = {
       ...props,
       autoHighlight: false,
-      extensions: [new ClipExtension(), ...(props.extensions || [])],
-      clipBounds: [west, south, east, north]
+      _subLayerProps: {
+        'polygons-fill': clipProps,
+        'polygons-stroke': clipProps,
+        linestrings: clipProps
+      }
     };
 
     const subLayer = new GeoJsonLayer(subLayerProps);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Related to https://github.com/visgl/deck.gl/issues/9059. Rather than fix the accuracy issue, we simply do not clip point layers, as it shouldn't be necessary anyway.


<!-- For all the PRs -->
#### Change List
- Only clip polygon/line layers in `VectorTileLayer`
