### PR TITLE
CARTO: Implement picking & autohighlight in RasterLayer

### DIFF
--- a/modules/carto/src/layers/raster-layer.ts
+++ b/modules/carto/src/layers/raster-layer.ts
@@ -139,4 +139,17 @@ export default class RasterLayer<DataT = any, ExtraProps = {}> extends Composite
       return accessor({properties: proxy}, info);
     };
   }
+
+  getPickingInfo(params: any) {
+    const info = super.getPickingInfo(params);
+
+    if (info.index !== -1) {
+      info.object = this.getSubLayerAccessor(x => x)(undefined, {
+        data: this.props,
+        index: info.index
+      });
+    }
+
+    return info;
+  }
 }

--- a/modules/carto/src/layers/raster-layer.ts
+++ b/modules/carto/src/layers/raster-layer.ts
@@ -148,6 +148,8 @@ export default class RasterLayer<DataT = any, ExtraProps = {}> extends Composite
         data: this.props,
         index: info.index
       });
+      debugger;
+      info.object.id = info.index;
     }
 
     return info;

--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -1,10 +1,10 @@
 import {CompositeLayer, CompositeLayerProps, DefaultProps, Layer, LayersList} from '@deck.gl/core';
 import RasterLayer, {RasterLayerProps} from './raster-layer';
 import QuadbinTileset2D from './quadbin-tileset-2d';
-import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import type {TilejsonResult} from '../sources/types';
 import {injectAccessToken, TilejsonPropType} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
+import {TileLayer, TileLayerProps} from '@deck.gl/geo-layers';
 
 export const renderSubLayers = props => {
   const tileIndex = props.tile?.index?.q;
@@ -23,7 +23,7 @@ export type RasterTileLayerProps<DataT = unknown> = _RasterTileLayerProps<DataT>
 
 /** Properties added by RasterTileLayer. */
 type _RasterTileLayerProps<DataT> = Omit<RasterLayerProps<DataT>, 'data'> &
-  Omit<SpatialIndexTileLayerProps<DataT>, 'data'> & {
+  Omit<TileLayerProps<DataT>, 'data'> & {
     data: null | TilejsonResult | Promise<TilejsonResult>;
   };
 
@@ -48,7 +48,7 @@ export default class RasterTileLayer<
     const {tiles: data, minzoom: minZoom, maxzoom: maxZoom} = tileJSON;
     return [
       // @ts-ignore
-      new SpatialIndexTileLayer(this.props, {
+      new TileLayer(this.props, {
         id: `raster-tile-layer-${this.props.id}`,
         data,
         // TODO: Tileset2D should be generic over TileIndex type

--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -75,6 +75,7 @@ export default class SpatialIndexTileLayer<
       // Quick check for whether id is within tile. data.findIndex is expensive
       !this._featureInTile(tile, hoveredFeatureId!)
     ) {
+      return hoveredFeatureId;
       return -1;
     }
 

--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -1,5 +1,5 @@
 import {registerLoaders} from '@loaders.gl/core';
-import {DefaultProps} from '@deck.gl/core';
+import {DefaultProps, LayerProps} from '@deck.gl/core';
 import CartoRasterTileLoader from './schema/carto-raster-tile-loader';
 import CartoSpatialTileLoader from './schema/carto-spatial-tile-loader';
 registerLoaders([CartoRasterTileLoader, CartoSpatialTileLoader]);
@@ -57,7 +57,7 @@ export default class SpatialIndexTileLayer<
     }
   }
 
-  getSubLayerPropsByTile(tile: Tile2DHeader) {
+  getSubLayerPropsByTile(tile: Tile2DHeader): Partial<LayerProps> | null {
     return {
       highlightedObjectIndex: this.getHighlightedObjectIndex(tile),
       highlightColor: this.state.highlightColor
@@ -75,7 +75,6 @@ export default class SpatialIndexTileLayer<
       // Quick check for whether id is within tile. data.findIndex is expensive
       !this._featureInTile(tile, hoveredFeatureId!)
     ) {
-      return hoveredFeatureId;
       return -1;
     }
 

--- a/modules/carto/src/utils.ts
+++ b/modules/carto/src/utils.ts
@@ -22,6 +22,14 @@ export function createBinaryProxy(
 
     has(target, property) {
       return property in numericProps || property in target;
+    },
+
+    ownKeys(target) {
+      return [...Object.keys(numericProps), ...Reflect.ownKeys(target)];
+    },
+
+    getOwnPropertyDescriptor(target, prop) {
+      return {enumerable: true, configurable: true};
     }
   });
 }

--- a/test/apps/carto-dynamic-tile/app.tsx
+++ b/test/apps/carto-dynamic-tile/app.tsx
@@ -15,17 +15,23 @@ import datasets from './datasets';
 import {Layer} from '@deck.gl/core';
 
 const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json';
-const INITIAL_VIEW_STATE = {longitude: -87.65, latitude: 41.82, zoom: 10};
+const INITIAL_VIEW_STATE = {
+  latitude: 50.0755,
+    longitude: 14.4378,
+      zoom: 12,
+        bearing: 0,
+          pitch: 0
+  };
 
 const apiBaseUrl = 'https://gcp-us-east1.api.carto.com';
-const connectionName = 'bigquery';
+const connectionName = 'carto_dw';
 
-const accessToken = 'XXX';
+const accessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRVNGNZTHAwaThjYnVMNkd0LTE0diJ9.eyJodHRwOi8vYXBwLmNhcnRvLmNvbS9lbWFpbCI6ImZwYWxtZXJAY2FydG9kYi5jb20iLCJodHRwOi8vYXBwLmNhcnRvLmNvbS9hY2NvdW50X2lkIjoiYWNfN3hoZnd5bWwiLCJpc3MiOiJodHRwczovL2F1dGguY2FydG8uY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA3OTY5NjU1OTI5NjExMjIxNDg2IiwiYXVkIjoiY2FydG8tY2xvdWQtbmF0aXZlLWFwaSIsImlhdCI6MTcyMTgxODQ2MSwiZXhwIjoxNzIxOTA0ODYxLCJhenAiOiIwZHhiOEhSM0FUWEN4SmlQT0pWSHNMb0hvQXRiUlg2dSIsInBlcm1pc3Npb25zIjpbImV4ZWN1dGU6d29ya2Zsb3dzIiwicmVhZDphY2NvdW50IiwicmVhZDphcHBzIiwicmVhZDpjb25uZWN0aW9ucyIsInJlYWQ6Y3VycmVudF91c2VyIiwicmVhZDppbXBvcnRzIiwicmVhZDpsaXN0ZWRfYXBwcyIsInJlYWQ6bWFwcyIsInJlYWQ6dGlsZXNldHMiLCJyZWFkOnRva2VucyIsInJlYWQ6d29ya2Zsb3dzIiwidXBkYXRlOmN1cnJlbnRfdXNlciIsIndyaXRlOmFwcHMiLCJ3cml0ZTpjYXJ0by1kdy1ncmFudHMiLCJ3cml0ZTpjb25uZWN0aW9ucyIsIndyaXRlOmltcG9ydHMiLCJ3cml0ZTptYXBzIiwid3JpdGU6dG9rZW5zIiwid3JpdGU6d29ya2Zsb3dzIl19.dY9SuyLMKbEQ42IqVTIFmQx5zFM4eXZ83xTyHz7J-7KQW0KnNtDXItusRU4Z5Kju-ctC4FF14ZlBy5XBvDu7h0JChebdUxbR33WRgLRQND-aBikTObRCxgnTPgua3E_Z-5Btn4qLdSpm7JkX9w3tp07OvIKou-5Q6kekOWLs6AtT1JnWZ9_cbOWNdpsNWBY6WbqbFzOhijxATDwJEqCV4TtW-Sp9GWpW0lddX-TMaTSY72jZeVFNi1wnGt-_z-vgd3eFVramfpcw1-MYyzaCjOFyNiLm0TIokaKLKCUJOFRd_n7-9xWqcQ2ROdNbv7OsyU63fSqj3jtc0K9awkL66A';
 
 const globalOptions = {accessToken, apiBaseUrl, connectionName}; // apiBaseUrl not required
 
 function Root() {
-  const [dataset, setDataset] = useState(Object.keys(datasets)[0]);
+  const [dataset, setDataset] = useState(Object.keys(datasets)[8]);
   const datasource = datasets[dataset];
   let layers: Layer[] = [];
 
@@ -49,8 +55,8 @@ function Root() {
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}
         layers={layers}
-        getTooltip={({object}) => {
-          const properties = object?.properties;
+        getTooltip={(info) => {
+          const properties = info.object?.properties;
           if (!properties) return null;
           return Object.entries(properties)
             .map(([k, v]) => `${k}: ${v}\n`)
@@ -118,6 +124,7 @@ function useRasterLayer(datasource) {
     id: 'carto',
     data: tilejson, // TODO how to correctly specify data type?
     pickable: true,
+    autoHighlight: true,
     getFillColor
   });
 }

--- a/test/apps/carto-dynamic-tile/app.tsx
+++ b/test/apps/carto-dynamic-tile/app.tsx
@@ -15,23 +15,17 @@ import datasets from './datasets';
 import {Layer} from '@deck.gl/core';
 
 const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json';
-const INITIAL_VIEW_STATE = {
-  latitude: 50.0755,
-    longitude: 14.4378,
-      zoom: 12,
-        bearing: 0,
-          pitch: 0
-  };
+const INITIAL_VIEW_STATE = {longitude: -87.65, latitude: 41.82, zoom: 10};
 
 const apiBaseUrl = 'https://gcp-us-east1.api.carto.com';
-const connectionName = 'carto_dw';
+const connectionName = 'bigquery';
 
-const accessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRVNGNZTHAwaThjYnVMNkd0LTE0diJ9.eyJodHRwOi8vYXBwLmNhcnRvLmNvbS9lbWFpbCI6ImZwYWxtZXJAY2FydG9kYi5jb20iLCJodHRwOi8vYXBwLmNhcnRvLmNvbS9hY2NvdW50X2lkIjoiYWNfN3hoZnd5bWwiLCJpc3MiOiJodHRwczovL2F1dGguY2FydG8uY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA3OTY5NjU1OTI5NjExMjIxNDg2IiwiYXVkIjoiY2FydG8tY2xvdWQtbmF0aXZlLWFwaSIsImlhdCI6MTcyMTgxODQ2MSwiZXhwIjoxNzIxOTA0ODYxLCJhenAiOiIwZHhiOEhSM0FUWEN4SmlQT0pWSHNMb0hvQXRiUlg2dSIsInBlcm1pc3Npb25zIjpbImV4ZWN1dGU6d29ya2Zsb3dzIiwicmVhZDphY2NvdW50IiwicmVhZDphcHBzIiwicmVhZDpjb25uZWN0aW9ucyIsInJlYWQ6Y3VycmVudF91c2VyIiwicmVhZDppbXBvcnRzIiwicmVhZDpsaXN0ZWRfYXBwcyIsInJlYWQ6bWFwcyIsInJlYWQ6dGlsZXNldHMiLCJyZWFkOnRva2VucyIsInJlYWQ6d29ya2Zsb3dzIiwidXBkYXRlOmN1cnJlbnRfdXNlciIsIndyaXRlOmFwcHMiLCJ3cml0ZTpjYXJ0by1kdy1ncmFudHMiLCJ3cml0ZTpjb25uZWN0aW9ucyIsIndyaXRlOmltcG9ydHMiLCJ3cml0ZTptYXBzIiwid3JpdGU6dG9rZW5zIiwid3JpdGU6d29ya2Zsb3dzIl19.dY9SuyLMKbEQ42IqVTIFmQx5zFM4eXZ83xTyHz7J-7KQW0KnNtDXItusRU4Z5Kju-ctC4FF14ZlBy5XBvDu7h0JChebdUxbR33WRgLRQND-aBikTObRCxgnTPgua3E_Z-5Btn4qLdSpm7JkX9w3tp07OvIKou-5Q6kekOWLs6AtT1JnWZ9_cbOWNdpsNWBY6WbqbFzOhijxATDwJEqCV4TtW-Sp9GWpW0lddX-TMaTSY72jZeVFNi1wnGt-_z-vgd3eFVramfpcw1-MYyzaCjOFyNiLm0TIokaKLKCUJOFRd_n7-9xWqcQ2ROdNbv7OsyU63fSqj3jtc0K9awkL66A';
+const accessToken = 'XXX';
 
 const globalOptions = {accessToken, apiBaseUrl, connectionName}; // apiBaseUrl not required
 
 function Root() {
-  const [dataset, setDataset] = useState(Object.keys(datasets)[8]);
+  const [dataset, setDataset] = useState(Object.keys(datasets)[0]);
   const datasource = datasets[dataset];
   let layers: Layer[] = [];
 
@@ -55,8 +49,8 @@ function Root() {
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}
         layers={layers}
-        getTooltip={(info) => {
-          const properties = info.object?.properties;
+        getTooltip={({object}) => {
+          const properties = object?.properties;
           if (!properties) return null;
           return Object.entries(properties)
             .map(([k, v]) => `${k}: ${v}\n`)
@@ -124,7 +118,6 @@ function useRasterLayer(datasource) {
     id: 'carto',
     data: tilejson, // TODO how to correctly specify data type?
     pickable: true,
-    autoHighlight: true,
     getFillColor
   });
 }

--- a/test/apps/carto-dynamic-tile/datasets.ts
+++ b/test/apps/carto-dynamic-tile/datasets.ts
@@ -102,10 +102,10 @@ export default {
   },
   raster: {
     source: rasterSource,
-    tableName: 'cartodb-data-engineering-team.jarroyo_raster.sdsc23_5_quadbin',
+    tableName: 'cartobq.public_account.temperature_raster_int8_new',
     getFillColor: colorBins({
       attr: 'band_1',
-      domain: [0, 5, 10, 15, 20, 25, 30],
+      domain: [15, 18, 22, 25, 28, 30, 35],
       colors: 'Temps'
     })
   },


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes https://github.com/visgl/deck.gl/issues/9045

<!-- For other PRs without open issue -->
#### Background

Because of the low-level data format used, picking was not working

https://github.com/user-attachments/assets/a5d8d0f0-e6d4-40ec-9bca-565aca7aa329

<!-- For all the PRs -->
#### Change List
- No longer extends `SpatialIndexTileLayer` as no functionality used
- Custom `_updateAutoHighlight` that works directly with index
- Generate correct object in `getPickingInfo`
- Improve `createBinaryProxy` so that `Object.keys(object.properties)` et al work
