### PR TITLE
CI release on 8.9-release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,9 @@
   "engines": {
     "node": ">=14"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "volta": {
+    "node": "16.20.0",
+    "yarn": "1.22.19"
+  }
 }


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

8.9 branch is missing `yarn publish-prod` commands making it impossible to publish new packages via CI

<!-- For all the PRs -->
#### Change List
- Copy across changes from https://github.com/visgl/deck.gl/pull/8828
- Copy .github workflows from master branch
- Add volta definition to package.json
- Fix type
