### PR TITLE
CARTO: HeatmapTileLayer full colorRange

### DIFF
--- a/modules/carto/src/layers/heatmap-tile-layer.ts
+++ b/modules/carto/src/layers/heatmap-tile-layer.ts
@@ -3,6 +3,7 @@ import {getResolution} from 'quadbin';
 
 import {
   Accessor,
+  Color,
   CompositeLayer,
   CompositeLayerProps,
   DefaultProps,
@@ -18,7 +19,10 @@ import {TilejsonPropType} from './utils';
 import {TilejsonResult} from '../sources';
 import {_Tile2DHeader as Tile2DHeader} from '@deck.gl/geo-layers';
 import {Texture, TextureProps} from '@luma.gl/core';
-import {colorRangeToFlatArray} from '../../../aggregation-layers/src/utils/color-utils';
+import {
+  defaultColorRange,
+  colorRangeToFlatArray
+} from '../../../aggregation-layers/src/utils/color-utils';
 
 const TEXTURE_PROPS: TextureProps = {
   format: 'rgba8unorm',
@@ -105,6 +109,7 @@ const defaultProps: DefaultProps<HeatmapTileLayerProps> = {
   getWeight: {type: 'accessor', value: 1},
   onMaxDensityChange: {type: 'function', optional: true, value: null},
   colorDomain: {type: 'array', value: [0, 1]},
+  colorRange: defaultColorRange,
   intensity: {type: 'number', value: 1},
   radiusPixels: {type: 'number', min: 0, max: 100, value: 20}
 };
@@ -118,6 +123,13 @@ export type HeatmapTileLayerProps<DataT = unknown> = _HeatmapTileLayerProps<Data
 /** Properties added by HeatmapTileLayer. */
 type _HeatmapTileLayerProps<DataT> = QuadbinTileLayerProps<DataT> &
   HeatmapProps & {
+    /**
+     * Specified as an array of colors [color1, color2, ...].
+     *
+     * @default `6-class YlOrRd` - [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6)
+     */
+    colorRange: Color[];
+
     /**
      * The weight of each object.
      *

--- a/modules/carto/src/layers/heatmap-tile-layer.ts
+++ b/modules/carto/src/layers/heatmap-tile-layer.ts
@@ -206,7 +206,6 @@ class HeatmapTileLayer<DataT = any, ExtraProps extends {} = {}> extends Composit
     if (typeof onMaxDensityChange === 'function') {
       onMaxDensityChange(maxDensity);
     }
-    window.colorTexture = this.state.colorTexture;
     return new PostProcessQuadbinTileLayer(
       tileLayerProps as Omit<QuadbinTileLayerProps, 'data'>,
       this.getSubLayerProps({

--- a/modules/carto/src/layers/heatmap-tile-layer.ts
+++ b/modules/carto/src/layers/heatmap-tile-layer.ts
@@ -1,7 +1,14 @@
 import type {ShaderModule} from '@luma.gl/shadertools';
 import {getResolution} from 'quadbin';
 
-import {Accessor, CompositeLayer, CompositeLayerProps, DefaultProps, Layer} from '@deck.gl/core';
+import {
+  Accessor,
+  CompositeLayer,
+  CompositeLayerProps,
+  DefaultProps,
+  Layer,
+  UpdateParameters
+} from '@deck.gl/core';
 import {SolidPolygonLayer} from '@deck.gl/layers';
 
 import {HeatmapProps, heatmap} from './heatmap';

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -20,10 +20,7 @@ uniform heatmapUniforms {
   float radiusPixels;
 } heatmap;
 
-
 uniform sampler2D colorTexture;
-
-const vec4 STOPS = vec4(0.2, 0.4, 0.6, 0.8);
 
 vec3 colorGradient(float value) {
   return texture(colorTexture, vec2(value, 0.5)).rgb;
@@ -93,15 +90,6 @@ vec4 heatmap_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
 }
 `;
 
-const defaultColorRange: [number, number, number][] = [
-  [255, 255, 178],
-  [254, 217, 118],
-  [254, 178, 76],
-  [253, 141, 60],
-  [240, 59, 32],
-  [189, 0, 38]
-];
-
 export type HeatmapProps = {
   /**
    * Radius of the heatmap blur in pixels, to which the weight of a cell is distributed.
@@ -110,18 +98,21 @@ export type HeatmapProps = {
    */
   radiusPixels?: number;
   /**
-   * Controls how weight values are mapped to the `colorRange`, as an array of two numbers [`minValue`, `maxValue`].
+   * Controls how weight values are mapped to the colors in `colorTexture`, as an array of two numbers [`minValue`, `maxValue`].
    *
    * @default [0, 1]
    */
   colorDomain?: [number, number];
   /**
+<<<<<<< HEAD
    * Specified as an array of colors [color1, color2, ...].
    *
    * @default `6-class YlOrRd` - [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6)
    */
   colorRange: [number, number, number][];
   /**
+=======
+>>>>>>> 015e44185 (Tidy)
    * Value that is multiplied with the total weight at a pixel to obtain the final weight. A value larger than 1 biases the output color towards the higher end of the spectrum, and a value less than 1 biases the output color towards the lower end of the spectrum.
    */
   intensity?: number;

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -6,16 +6,18 @@ const glsl = (s: TemplateStringsArray) => `${s}`;
  * @filter       Heatmap
  * @param radiusPixels Blur radius in pixels, controls smoothness of heatmap
  * @param colorDomain Domain to apply to values prior to applying color scale
- * @param color1-6 Colors to use in color scale
+ * @param colorTexture 1D RGB lookup texture for color scale
+ * @param intensity Multiplier to apply to value
+ * @param opacity Output opacity
  */
 
 const fs = glsl`\
 uniform heatmapUniforms {
-  vec2 delta;
-  float radiusPixels;
   vec2 colorDomain;
+  vec2 delta;
   float intensity;
   float opacity;
+  float radiusPixels;
 } heatmap;
 
 
@@ -131,46 +133,45 @@ export type HeatmapProps = {
 };
 
 export type HeatmapUniforms = {
-  delta?: [number, number];
-  radiusPixels?: number;
   colorDomain?: [number, number];
+  delta?: [number, number];
   intensity: number;
   opacity?: number;
+  radiusPixels?: number;
 };
 
 export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
   name: 'heatmap',
   uniformPropTypes: {
-    delta: {value: [0, 1]},
-    radiusPixels: {value: 20, min: 0, softMax: 100},
     colorDomain: {value: [0, 1]},
+    delta: {value: [0, 1]},
     intensity: {value: 1, min: 0.1, max: 10},
-    opacity: {value: 1, min: 0, max: 1}
+    opacity: {value: 1, min: 0, max: 1},
+    radiusPixels: {value: 20, min: 0, softMax: 100}
   },
   uniformTypes: {
-    delta: 'vec2<f32>',
-    radiusPixels: 'f32',
     colorDomain: 'vec2<f32>',
+    delta: 'vec2<f32>',
     intensity: 'f32',
-    opacity: 'f32'
+    opacity: 'f32',
+    radiusPixels: 'f32'
   },
   getUniforms: opts => {
     const {
-      delta = [1, 0],
-      colorRange = defaultColorRange,
-      radiusPixels = 20,
       colorDomain = [0, 1],
+      colorTexture,
+      delta = [1, 0],
       intensity = 1,
       opacity = 1,
-      colorTexture
+      radiusPixels = 20
     } = opts as HeatmapProps & {delta: [number, number]};
     return {
-      delta,
-      radiusPixels,
       colorDomain,
+      colorTexture,
+      delta,
       intensity,
       opacity,
-      colorTexture
+      radiusPixels
     };
   },
   fs,

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -202,7 +202,8 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
       radiusPixels = 20,
       colorDomain = [0, 1],
       intensity = 1,
-      opacity = 1
+      opacity = 1,
+      colorTexture
     } = opts as HeatmapProps & {delta: [number, number]};
     const [color1, color2, color3, color4, color5, color6] = colorRange;
     return {
@@ -216,12 +217,9 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
       radiusPixels,
       colorDomain,
       intensity,
-      opacity
+      opacity,
+      colorTexture
     };
-  },
-  getBindings: opts => {
-    const {colorTexture} = opts;
-    return {colorTexture};
   },
   fs,
   passes: [

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -219,6 +219,10 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
       opacity
     };
   },
+  getBindings: opts => {
+    const {colorTexture} = opts;
+    return {colorTexture};
+  },
   fs,
   passes: [
     {sampler: true, uniforms: {delta: [1, 0]}},

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -14,12 +14,6 @@ uniform heatmapUniforms {
   vec2 delta;
   float radiusPixels;
   vec2 colorDomain;
-  vec3 color1;
-  vec3 color2;
-  vec3 color3;
-  vec3 color4;
-  vec3 color5;
-  vec3 color6;
   float intensity;
   float opacity;
 } heatmap;
@@ -31,28 +25,6 @@ const vec4 STOPS = vec4(0.2, 0.4, 0.6, 0.8);
 
 vec3 colorGradient(float value) {
   return texture(colorTexture, vec2(value, 0.5)).rgb;
-  vec3 c1;
-  vec3 c2;
-  vec2 range;
-  if (value < STOPS.x) {
-    range = vec2(0.0, STOPS.x);
-    c1 = heatmap.color1; c2 = heatmap.color2;
-  } else if (value < STOPS.y) {
-    range = STOPS.xy;
-    c1 = heatmap.color2; c2 = heatmap.color3;
-  } else if (value < STOPS.z) {
-    range = STOPS.yz;
-    c1 = heatmap.color3; c2 = heatmap.color4;
-  } else if (value < STOPS.w) {
-    range = STOPS.zw;
-    c1 = heatmap.color4; c2 = heatmap.color5;
-  } else {
-    range = vec2(STOPS.w, 1.0);
-    c1 = heatmap.color5; c2 = heatmap.color6;
-  }
-
-  float f = (clamp(value, 0.0, 1.0) - range.x) / (range.y - range.x);
-  return mix(c1, c2, f) / 255.0;
 }
 
 const vec3 SHIFT = vec3(1.0, 256.0, 256.0 * 256.0);
@@ -162,12 +134,6 @@ export type HeatmapUniforms = {
   delta?: [number, number];
   radiusPixels?: number;
   colorDomain?: [number, number];
-  color1?: [number, number, number];
-  color2?: [number, number, number];
-  color3?: [number, number, number];
-  color4?: [number, number, number];
-  color5?: [number, number, number];
-  color6?: [number, number, number];
   intensity: number;
   opacity?: number;
 };
@@ -178,12 +144,6 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
     delta: {value: [0, 1]},
     radiusPixels: {value: 20, min: 0, softMax: 100},
     colorDomain: {value: [0, 1]},
-    color1: {value: [0, 0, 0]},
-    color2: {value: [0, 0, 0]},
-    color3: {value: [0, 0, 0]},
-    color4: {value: [0, 0, 0]},
-    color5: {value: [0, 0, 0]},
-    color6: {value: [0, 0, 0]},
     intensity: {value: 1, min: 0.1, max: 10},
     opacity: {value: 1, min: 0, max: 1}
   },
@@ -191,12 +151,6 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
     delta: 'vec2<f32>',
     radiusPixels: 'f32',
     colorDomain: 'vec2<f32>',
-    color1: 'vec3<f32>',
-    color2: 'vec3<f32>',
-    color3: 'vec3<f32>',
-    color4: 'vec3<f32>',
-    color5: 'vec3<f32>',
-    color6: 'vec3<f32>',
     intensity: 'f32',
     opacity: 'f32'
   },
@@ -210,15 +164,8 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
       opacity = 1,
       colorTexture
     } = opts as HeatmapProps & {delta: [number, number]};
-    const [color1, color2, color3, color4, color5, color6] = colorRange;
     return {
       delta,
-      color1,
-      color2,
-      color3,
-      color4,
-      color5,
-      color6,
       radiusPixels,
       colorDomain,
       intensity,

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -23,9 +23,13 @@ uniform heatmapUniforms {
   float opacity;
 } heatmap;
 
+
+uniform sampler2D colorTexture;
+
 const vec4 STOPS = vec4(0.2, 0.4, 0.6, 0.8);
 
 vec3 colorGradient(float value) {
+  return texture(colorTexture, vec2(value, 0.5)).rgb;
   vec3 c1;
   vec3 c2;
   vec2 range;

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -1,4 +1,5 @@
 import type {ShaderPass} from '@luma.gl/shadertools';
+import {Texture} from '@luma.gl/core';
 const glsl = (s: TemplateStringsArray) => `${s}`;
 
 /**
@@ -150,6 +151,10 @@ export type HeatmapProps = {
    * Value that is multiplied with the total weight at a pixel to obtain the final weight. A value larger than 1 biases the output color towards the higher end of the spectrum, and a value less than 1 biases the output color towards the lower end of the spectrum.
    */
   intensity?: number;
+  /**
+   * Color LUT for color gradient
+   */
+  colorTexture: Texture;
   opacity: number;
 };
 

--- a/modules/carto/src/layers/heatmap.ts
+++ b/modules/carto/src/layers/heatmap.ts
@@ -104,15 +104,6 @@ export type HeatmapProps = {
    */
   colorDomain?: [number, number];
   /**
-<<<<<<< HEAD
-   * Specified as an array of colors [color1, color2, ...].
-   *
-   * @default `6-class YlOrRd` - [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6)
-   */
-  colorRange: [number, number, number][];
-  /**
-=======
->>>>>>> 015e44185 (Tidy)
    * Value that is multiplied with the total weight at a pixel to obtain the final weight. A value larger than 1 biases the output color towards the higher end of the spectrum, and a value less than 1 biases the output color towards the lower end of the spectrum.
    */
   intensity?: number;
@@ -123,15 +114,11 @@ export type HeatmapProps = {
   opacity: number;
 };
 
-export type HeatmapUniforms = {
-  colorDomain?: [number, number];
-  delta?: [number, number];
-  intensity: number;
-  opacity?: number;
-  radiusPixels?: number;
+type PassProps = {
+  delta: [number, number];
 };
 
-export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
+export const heatmap = {
   name: 'heatmap',
   uniformPropTypes: {
     colorDomain: {value: [0, 1]},
@@ -148,6 +135,7 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
     radiusPixels: 'f32'
   },
   getUniforms: opts => {
+    if (!opts) return {};
     const {
       colorDomain = [0, 1],
       colorTexture,
@@ -155,7 +143,7 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
       intensity = 1,
       opacity = 1,
       radiusPixels = 20
-    } = opts as HeatmapProps & {delta: [number, number]};
+    } = opts;
     return {
       colorDomain,
       colorTexture,
@@ -170,4 +158,4 @@ export const heatmap: ShaderPass<HeatmapProps, HeatmapUniforms> = {
     {sampler: true, uniforms: {delta: [1, 0]}},
     {sampler: true, uniforms: {delta: [0, 1]}}
   ]
-};
+} as const satisfies ShaderPass<HeatmapProps & PassProps>;

--- a/modules/core/src/passes/screen-pass.ts
+++ b/modules/core/src/passes/screen-pass.ts
@@ -59,6 +59,9 @@ export default class ScreenPass extends Pass {
       screen: screenProps,
       ...options.moduleProps
     });
+    if (window.colorTexture) {
+      this.model.setBindings({colorTexture: window.colorTexture});
+    }
     const renderPass = this.device.beginRenderPass({
       framebuffer: outputBuffer,
       parameters: {viewport: [0, 0, ...texSize]},

--- a/modules/core/src/passes/screen-pass.ts
+++ b/modules/core/src/passes/screen-pass.ts
@@ -59,9 +59,6 @@ export default class ScreenPass extends Pass {
       screen: screenProps,
       ...options.moduleProps
     });
-    if (window.colorTexture) {
-      this.model.setBindings({colorTexture: window.colorTexture});
-    }
     const renderPass = this.device.beginRenderPass({
       framebuffer: outputBuffer,
       parameters: {viewport: [0, 0, ...texSize]},


### PR DESCRIPTION
Followup to https://github.com/visgl/deck.gl/pull/8703

#### Background

<img width="508" alt="Screenshot 2024-08-02 at 13 59 42" src="https://github.com/user-attachments/assets/6bf72b6b-6b36-4662-a852-559c71971d92">


Previous version only supported 6 colors in color map via explicit unifroms. With this change a `colorTexture` is used instead, like in the `HeatmapLayer` to provide an unlimited number of colors

<!-- For all the PRs -->
#### Change List
- Generate `colorTexture` from passed `colorRange` in Layer
- Replace `colorRange` with `colorTexture` in shader module
