### PR TITLE
CARTO: Move cluster stats into data.points.attributes

### DIFF
--- a/modules/carto/src/layers/cluster-tile-layer.ts
+++ b/modules/carto/src/layers/cluster-tile-layer.ts
@@ -147,7 +147,6 @@ class ClusterGeoJsonLayer<
     if (needsUpdate) {
       const stats = computeAggregationStats(data, properties);
       const binaryData = clustersToBinary(data);
-      // @ts-expect-error extending BinaryFeatureCollection with attributes
       binaryData.points.attributes = {stats};
       this.setState({data: binaryData});
     }

--- a/modules/carto/src/layers/cluster-tile-layer.ts
+++ b/modules/carto/src/layers/cluster-tile-layer.ts
@@ -146,10 +146,10 @@ class ClusterGeoJsonLayer<
 
     if (needsUpdate) {
       const stats = computeAggregationStats(data, properties);
-      for (const d of data) {
-        d.stats = stats;
-      }
-      this.setState({data: clustersToBinary(data)});
+      const binaryData = clustersToBinary(data);
+      // @ts-expect-error extending BinaryFeatureCollection with attributes
+      binaryData.points.attributes = {stats};
+      this.setState({data: binaryData});
     }
 
     const props = {

--- a/modules/carto/src/layers/cluster-utils.ts
+++ b/modules/carto/src/layers/cluster-utils.ts
@@ -12,7 +12,6 @@ export type ClusteredFeaturePropertiesT<FeaturePropertiesT> = FeaturePropertiesT
   id: bigint;
   count: number;
   position: [number, number];
-  stats: Record<keyof FeaturePropertiesT, {min: number; max: number}>;
 };
 export type ParsedQuadbinCell<FeaturePropertiesT> = {id: bigint; properties: FeaturePropertiesT};
 export type ParsedQuadbinTile<FeaturePropertiesT> = ParsedQuadbinCell<FeaturePropertiesT>[];

--- a/modules/carto/src/layers/cluster-utils.ts
+++ b/modules/carto/src/layers/cluster-utils.ts
@@ -142,9 +142,20 @@ const EMPTY_BINARY_PROPS = {
   globalFeatureIds: {value: EMPTY_UINT16ARRAY, size: 1}
 };
 
+type BinaryFeatureCollectionWithStats<FeaturePropertiesT> = Omit<
+  BinaryFeatureCollection,
+  'points'
+> & {
+  points: BinaryFeatureCollection['points'] & {
+    attributes?: {
+      stats: Record<keyof FeaturePropertiesT, {min: number; max: number}>;
+    };
+  };
+};
+
 export function clustersToBinary<FeaturePropertiesT>(
   data: ClusteredFeaturePropertiesT<FeaturePropertiesT>[]
-): BinaryFeatureCollection {
+): BinaryFeatureCollectionWithStats<FeaturePropertiesT> {
   const positions = new Float32Array(data.length * 2);
   const featureIds = new Uint16Array(data.length);
   for (let i = 0; i < data.length; i++) {

--- a/modules/carto/src/style/color-bins-style.ts
+++ b/modules/carto/src/style/color-bins-style.ts
@@ -42,8 +42,8 @@ export default function colorBins<DataT = Feature>({
 
   const color = scaleThreshold<number, Color>().domain(domain).range(palette);
 
-  return d => {
-    const value = getAttrValue(attr, d);
+  return (d, info) => {
+    const value = getAttrValue(attr, d, info);
     return typeof value === 'number' && Number.isFinite(value) ? color(value) : nullColor;
   };
 }

--- a/modules/carto/src/style/color-categories-style.ts
+++ b/modules/carto/src/style/color-categories-style.ts
@@ -48,8 +48,8 @@ export default function colorCategories<DataT = Feature>({
     colorsByCategory[c] = palette[i];
   }
 
-  return d => {
-    const value = getAttrValue(attr, d);
+  return (d, info) => {
+    const value = getAttrValue(attr, d, info);
     return (typeof value === 'number' && Number.isFinite(value)) || typeof value === 'string'
       ? colorsByCategory[value] || othersColor
       : nullColor;

--- a/modules/carto/src/style/color-continuous-style.ts
+++ b/modules/carto/src/style/color-continuous-style.ts
@@ -41,8 +41,8 @@ export default function colorContinuous<DataT = Feature>({
   const palette = typeof colors === 'string' ? getPalette(colors, domain.length) : colors;
   const color = scaleLinear<Color>().domain(domain).range(palette);
 
-  return d => {
-    const value = getAttrValue(attr, d);
+  return (d, info) => {
+    const value = getAttrValue(attr, d, info);
     return typeof value === 'number' && Number.isFinite(value) ? color(value) : nullColor;
   };
 }

--- a/modules/carto/src/style/utils.ts
+++ b/modules/carto/src/style/utils.ts
@@ -3,18 +3,21 @@ import {assert} from '../utils';
 
 const ALLOWED_ATTR_TYPES = Object.freeze(['function', 'string']);
 
-export type AttributeSelector<DataT = Feature, OutT = any> = string | ((d: DataT) => OutT);
+export type AttributeSelector<DataT = Feature, OutT = any> =
+  | string
+  | ((d: DataT, info: any) => OutT);
 
 export function getAttrValue<DataT = Feature, OutT = any>(
   attr: string | AttributeSelector<DataT, OutT>,
-  d: DataT
+  d: DataT,
+  info: any
 ): OutT {
   assert(typeof d === 'object', 'Expected "data" to be an object');
   assert(ALLOWED_ATTR_TYPES.includes(typeof attr), 'Expected "attr" to be a function or string');
 
   // Is function
   if (typeof attr === 'function') {
-    return attr(d);
+    return attr(d, info);
   }
   return (d as unknown as Feature)?.properties?.[attr] as OutT;
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Followup to https://github.com/visgl/deck.gl/pull/8957

<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
- Move `stats` from feature to `data.attributes`
- Update color helpers to pass through `objectInfo`