### PR TITLE
Docs: Fix Subclassed Layers example

### DIFF
--- a/docs/developer-guide/custom-layers/subclassed-layers.md
+++ b/docs/developer-guide/custom-layers/subclassed-layers.md
@@ -12,7 +12,6 @@ good technique to add it.
 ```js
 // Example to add per-segment color to PathLayer
 import {PathLayer} from '@deck.gl/layers';
-import GL from '@luma.gl/constants';
 
 // Allow accessor: `getColor` (Function, optional)
 // Returns an color (array of numbers, RGBA) or array of colors (array of arrays).
@@ -22,7 +21,7 @@ export default class MultiColorPathLayer extends PathLayer {
     this.getAttributeManager().addInstanced({
       instanceColors: {
         size: 4,
-        type: GL.UNSIGNED_BYTE,
+        type: "unorm8",
         normalized: true,
         update: this.calculateColors
       }


### PR DESCRIPTION
Closes #9106

#### Background
There is an [example](https://deck.gl/docs/developer-guide/custom-layers/subclassed-layers#overriding-attribute-calculation) in the documentation for Subclassed Layers which implements a multi coloured path layer, it is broken with version 9 of deck.gl.

The changes I have made fix the code in my case.

#### Change List
- fix the broken example in the documentation
