### PR TITLE
fix DeckGLOverlay example for Google Maps

### DIFF
--- a/docs/developer-guide/base-maps/using-with-google-maps.md
+++ b/docs/developer-guide/base-maps/using-with-google-maps.md
@@ -86,7 +86,7 @@ import {GoogleMapsOverlay} from '@deck.gl/google-maps';
 
 function DeckGLOverlay(props: DeckProps) {
   const map = useMap();
-  const overlay = useMemo(() => new GoogleMapsOverlay(props));
+  const overlay = useMemo(() => new GoogleMapsOverlay(props), []);
 
   useEffect(() => {
     overlay.setMap(map);


### PR DESCRIPTION
#### Background
The useMemo for the GoogleMapsOverlay creation was missing an empty dependency array so it was being re-created on every render and thus failing to render anything.


#### Change List
- Adds a missing empty dependency array in some Google Maps example code