### PR TITLE
Allow 0s for maxCacheSize and maxCacheByteSize

### DIFF
--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -281,6 +281,8 @@ If not supplied, the `maxCacheSize` is calculated as `5` times the number of til
 
 The maximum memory used for caching tiles. If this limit is supplied, `getTileData` must return an object that contains a `byteLength` field.
 
+If not supplied, the `maxCacheByteSize` is set to `Infinity`.
+
 - Default: `null`
 
 

--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -147,7 +147,7 @@ export class Tileset2D {
 
     this.onTileLoad = tile => {
       this.opts.onTileLoad?.(tile);
-      if (this.opts.maxCacheByteSize) {
+      if (this.opts.maxCacheByteSize != null) {
         this._cacheByteSize += tile.byteLength;
         this._resizeCache();
       }
@@ -469,10 +469,10 @@ export class Tileset2D {
     const {_cache, opts} = this;
 
     const maxCacheSize =
-      opts.maxCacheSize ||
+      opts.maxCacheSize ??
       // @ts-expect-error called only when selectedTiles is initialized
-      (opts.maxCacheByteSize ? Infinity : DEFAULT_CACHE_SCALE * this.selectedTiles.length);
-    const maxCacheByteSize = opts.maxCacheByteSize || Infinity;
+      (opts.maxCacheByteSize != null ? Infinity : DEFAULT_CACHE_SCALE * this.selectedTiles.length);
+    const maxCacheByteSize = opts.maxCacheByteSize ?? Infinity;
 
     const overflown = _cache.size > maxCacheSize || this._cacheByteSize > maxCacheByteSize;
 
@@ -480,7 +480,7 @@ export class Tileset2D {
       for (const [id, tile] of _cache) {
         if (!tile.isVisible && !tile.isSelected) {
           // delete tile
-          this._cacheByteSize -= opts.maxCacheByteSize ? tile.byteLength : 0;
+          this._cacheByteSize -= opts.maxCacheByteSize != null ? tile.byteLength : 0;
           _cache.delete(id);
           this.opts.onTileUnload?.(tile);
         }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes [#9155](https://github.com/visgl/deck.gl/issues/9155)

<!-- For other PRs without open issue -->
#### Background
It is sometimes desirable to disable the cache of TileLayer.

<!-- For all the PRs -->
#### Change List
- 0 values are now possible for maxCacheSize and maxCacheByteSize by using nullish coalescing and non-strict comparison with null.
