### PR TITLE
[#9165] H3HexagonLayer / Elevation of hexagons above the ground

### DIFF
--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -191,11 +191,11 @@ Hexagon radius multiplier, between 0 - 1. When `coverage` = 1, hexagon is render
 
 ### Data Accessors
 
-#### `getHexagon` ([Accessor&lt;string&gt;](../../developer-guide/using-layers.md#accessors), optional) {#gethexagon}
+#### `getHexagon` ([Accessor&lt;string | [string, number]&gt;](../../developer-guide/using-layers.md#accessors), optional) {#gethexagon}
 
 * Default: `object => object.hexagon`
 
-Method called to retrieve the [H3](https://h3geo.org/) hexagon index of each object. Note that all hexagons within one `H3HexagonLayer` must use the same [resolution](https://h3geo.org/docs/core-library/restable).
+Method called to retrieve the [H3](https://h3geo.org/) hexagon index of each object. Optionally, it may return `[string, number]` tuple, where the first element is the hexagon index, and the second one is the hexagon base elevation over the ground. Note that all hexagons within one `H3HexagonLayer` must use the same [resolution](https://h3geo.org/docs/core-library/restable).
 
 
 ## Sub Layers


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #9165

<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
- **H3HexagonLayer:** Allows to elevate hexagons above the ground.
