### PR TITLE
Remove NaN uniform

### DIFF
--- a/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/aggregation-transform-uniforms.ts
+++ b/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/aggregation-transform-uniforms.ts
@@ -15,7 +15,6 @@ export type AggregatorTransformProps = {
   binIdRange: NumberArray4;
   isCount: NumberArray3;
   isMean: NumberArray3;
-  naN: number;
   bins: Texture;
 };
 
@@ -25,7 +24,6 @@ export const aggregatorTransformUniforms = {
   uniformTypes: {
     binIdRange: 'vec4<i32>',
     isCount: 'vec3<f32>',
-    isMean: 'vec3<f32>',
-    naN: 'f32'
+    isMean: 'vec3<f32>'
   }
 } as const satisfies ShaderModule<AggregatorTransformProps>;

--- a/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregation-transform.ts
+++ b/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregation-transform.ts
@@ -206,7 +206,7 @@ void main() {
 #else
   value3.x = values;
 #endif
-  if (isnan(values.x)) discard;
+  if (isnan(value3.x)) discard;
   // This shader renders into a 2x1 texture with blending=max
   // The left pixel yields the max value of each channel
   // The right pixel yields the min value of each channel


### PR DESCRIPTION
#### Background
Avoid sending NaN as uniform as it is believed to cause issues in some browsers.

Int value `-1` (all ones) is NaN when interpreted as float32: https://en.wikipedia.org/wiki/Single-precision_floating-point_format#Exponent_encoding

According [intBitsToFloat](https://registry.khronos.org/OpenGL-Refpages/gl4/html/intBitsToFloat.xhtml) this solution may subject to GPU-specific behavior:

> If the encoding of a NaN is passed in x, it will not signal and the resulting value will be undefined.

#### Change List
- Avoid sending NaN as uniform.
