### PR TITLE
Move publish target to es2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,9 @@
     "transpileOnly": true
   },
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2020",
     "module": "es2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "jsx": "react",
     "strict": true,
     "noImplicitAny": false,


### PR DESCRIPTION
See #9183

Input:

```ts
export default class Deck {
   static defaultProps = defaultProps;
   static VERSION = VERSION; 
}
```

Output targeting ES2022:

```js
export default class Deck {
    static { this.defaultProps = defaultProps; }
    static { this.VERSION = VERSION; }
}
```

Output targeting ES2020:

```js
class Deck {
}
Deck.defaultProps = defaultProps;
Deck.VERSION = VERSION;
export default Deck;

```
