### PR TITLE
Add d3-dsv library to mask-extension example's dependencies

### DIFF
--- a/examples/website/mask-extension/package.json
+++ b/examples/website/mask-extension/package.json
@@ -14,6 +14,7 @@
     "@material-ui/icons": "^4.9.1",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "d3-dsv": "^3.0.1",
     "deck.gl": "^9.0.0",
     "maplibre-gl": "^3.0.0",
     "react": "^18.0.0",


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
It was missing to install `d3-dsv` library in the `mask-extension` example. The example code doesn't run without it.

<!-- For all the PRs -->
#### Change List
- Include d3-dsv in the dependencies list.
