### PR TITLE
Convert tests to use UBOs

### DIFF
--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -125,7 +125,7 @@ export type {PickingInfo, GetPickingInfoParams} from './lib/picking/pick-info';
 export type {ConstructorOf as _ConstructorOf} from './types/types';
 export type {BinaryAttribute} from './lib/attribute/attribute';
 export type {Effect, EffectContext, PreRenderOptions, PostRenderOptions} from './lib/effect';
-export type {PickingUniforms, ProjectUniforms} from './shaderlib/index';
+export type {PickingUniforms, ProjectProps, ProjectUniforms} from './shaderlib/index';
 export type {DefaultProps} from './lifecycle/prop-types';
 export type {LayersPassRenderOptions} from './passes/layers-pass';
 export type {Widget, WidgetPlacement} from './lib/widget-manager';

--- a/modules/core/src/shaderlib/index.ts
+++ b/modules/core/src/shaderlib/index.ts
@@ -37,7 +37,7 @@ export function getShaderAssembler() {
 export {layerUniforms, picking, project, project32, gouraudLighting, phongLighting, shadow};
 
 // Useful for custom shader modules
-export type {ProjectUniforms} from './project/viewport-uniforms';
+export type {ProjectProps, ProjectUniforms} from './project/viewport-uniforms';
 
 // TODO - these should be imported from luma.gl
 /* eslint-disable camelcase */

--- a/test/modules/core/shaderlib/project/project-32-64-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-32-64-glsl.spec.ts
@@ -70,7 +70,7 @@ void main()
 const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT mode',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
@@ -78,20 +78,20 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position_to_clipspace_world_position',
         vs: TRANSFORM_VS.project_position_to_clipspace_world_position,
-        input: {uPos: [-122.45, 37.78, 0]},
+        testProps: {uPos: [-122.45, 37.78, 0]},
         output: TEST_VIEWPORT.projectFlat([-122.45, 37.78]).concat([0, 1])
       },
       {
         name: 'project_position_to_clipspace',
         vs: TRANSFORM_VS.project_position_to_clipspace,
-        input: {uPos: [-122.45, 37.78, 0]},
+        testProps: {uPos: [-122.45, 37.78, 0]},
         output: TEST_VIEWPORT.project([-122.45, 37.78, 0]),
         precision: PIXEL_TOLERANCE
       },
       {
         name: 'project_position_to_clipspace (non-zero Z)',
         vs: TRANSFORM_VS.project_position_to_clipspace,
-        input: {uPos: [-122.45, 37.78, 100]},
+        testProps: {uPos: [-122.45, 37.78, 100]},
         output: TEST_VIEWPORT.project([-122.45, 37.78, 100]),
         precision: PIXEL_TOLERANCE
       }
@@ -99,7 +99,7 @@ const TEST_CASES: TestCase[] = [
   },
   {
     title: 'LNGLAT mode - high zoom',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT_HIGH_ZOOM,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
@@ -107,7 +107,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position_to_clipspace_world_position',
         vs: TRANSFORM_VS.project_position_to_clipspace_world_position,
-        input: {uPos: [-122.05, 37.92, 0]},
+        testProps: {uPos: [-122.05, 37.92, 0]},
         output: TEST_VIEWPORT_HIGH_ZOOM.projectFlat([-122.05, 37.92])
           .map((x, i) => x - TEST_VIEWPORT_HIGH_ZOOM.center[i])
           .concat([0, 1]),
@@ -116,7 +116,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position_to_clipspace',
         vs: TRANSFORM_VS.project_position_to_clipspace,
-        input: {uPos: [-122.05, 37.92, 0]},
+        testProps: {uPos: [-122.05, 37.92, 0]},
         output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 0]),
         precision: PIXEL_TOLERANCE
       }
@@ -124,7 +124,7 @@ const TEST_CASES: TestCase[] = [
   },
   {
     title: 'LNGLAT_OFFSETS mode',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
       coordinateOrigin: [-122.05, 37.92, 0]
@@ -133,7 +133,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position_to_clipspace_world_position',
         vs: TRANSFORM_VS.project_position_to_clipspace_world_position,
-        input: {uPos: [0.05, 0.08, 0]},
+        testProps: {uPos: [0.05, 0.08, 0]},
         output: getPixelOffset(
           TEST_VIEWPORT.projectPosition([-122, 38, 0]),
           TEST_VIEWPORT.projectPosition([-122.05, 37.92, 0])
@@ -142,7 +142,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position_to_clipspace',
         vs: TRANSFORM_VS.project_position_to_clipspace,
-        input: {uPos: [0.05, 0.08, 0]},
+        testProps: {uPos: [0.05, 0.08, 0]},
         output: TEST_VIEWPORT.project([-122, 38, 0]),
         precision: PIXEL_TOLERANCE
       }
@@ -156,7 +156,7 @@ test('project32&64#vs', async t => {
   for (const usefp64 of [false, true]) {
     /* eslint-disable max-nested-callbacks, complexity */
     for (const testCase of TEST_CASES) {
-      if (usefp64 && testCase.params.coordinateSystem !== COORDINATE_SYSTEM.LNGLAT) {
+      if (usefp64 && testCase.projectProps.coordinateSystem !== COORDINATE_SYSTEM.LNGLAT) {
         // Apply 64 bit projection only for LNGLAT_DEPRECATED
         return;
       }
@@ -178,11 +178,11 @@ test('project32&64#vs', async t => {
           varying: 'outValue',
           vertexCount: 1,
           shaderInputProps: {
-            project: testCase.params,
-            project64: testCase.params,
+            project: testCase.projectProps,
+            project64: testCase.projectProps,
             test: {
-              uPos: c.input.uPos!,
-              uPos64Low: c.input.uPos!.map(fp64LowPart) as NumberArray3
+              uPos: c.testProps.uPos!,
+              uPos64Low: c.testProps.uPos!.map(fp64LowPart) as NumberArray3
             }
           },
           uniforms

--- a/test/modules/core/shaderlib/project/project-32-64-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-32-64-glsl.spec.ts
@@ -150,7 +150,7 @@ const TEST_CASES: TestCase[] = [
   }
 ];
 
-test.only('project32&64#vs', async t => {
+test('project32&64#vs', async t => {
   const oldEpsilon = config.EPSILON;
 
   for (const usefp64 of [false, true]) {

--- a/test/modules/core/shaderlib/project/project-32-64-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-32-64-glsl.spec.ts
@@ -5,7 +5,7 @@
 import test from 'tape-promise/tape';
 
 // import {COORDINATE_SYSTEM, Viewport, WebMercatorViewport} from 'deck.gl';
-import {COORDINATE_SYSTEM, WebMercatorViewport, project, project32} from '@deck.gl/core';
+import {COORDINATE_SYSTEM, WebMercatorViewport, project32} from '@deck.gl/core';
 import {project64} from '@deck.gl/extensions';
 // import {Matrix4, config} from '@math.gl/core';
 import {config, NumberArray3} from '@math.gl/core';
@@ -127,7 +127,7 @@ const TEST_CASES: TestCase[] = [
     params: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
-      coordinateOrigin: [-122.05, 37.92]
+      coordinateOrigin: [-122.05, 37.92, 0]
     },
     tests: [
       {
@@ -166,7 +166,8 @@ test.only('project32&64#vs', async t => {
       let uniforms = {};
       if (usefp64) {
         // fp64arithmetic uniform
-        uniforms = {...uniforms, ONE: 1.0};
+        // TODO remove when https://github.com/visgl/luma.gl/pull/2262 landed
+        uniforms = {ONE: 1.0};
       }
 
       for (const c of testCase.tests) {

--- a/test/modules/core/shaderlib/project/project-functions.spec.ts
+++ b/test/modules/core/shaderlib/project/project-functions.spec.ts
@@ -32,7 +32,7 @@ const TEST_COORDINATE_ORIGIN: NumberArray3 = [-122.45, 37.78, 0];
 export type TestCase = {
   title: string;
   position: NumberArray3;
-  projectProps: ProjectProps & {fromCoordinateSystem: number};
+  projectProps: ProjectProps & {fromCoordinateSystem?: number};
   result: NumberArray3;
 };
 const TEST_CASES: TestCase[] = [
@@ -94,7 +94,7 @@ const TEST_CASES: TestCase[] = [
     projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
-      coordinateOrigin: [-122.5, 38.8]
+      coordinateOrigin: [-122.5, 38.8, 0]
     },
     result: [-0.07111111111110802, 0.10954078583623073, 0.0008212863345433337]
   },
@@ -104,7 +104,7 @@ const TEST_CASES: TestCase[] = [
     projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
-      coordinateOrigin: [-122.5, 38.8]
+      coordinateOrigin: [-122.5, 38.8, 0]
     },
     result: [-0.0016412509100689476, 0.00492356632304336, 0.0008206254565218747]
   },

--- a/test/modules/core/shaderlib/project/project-functions.spec.ts
+++ b/test/modules/core/shaderlib/project/project-functions.spec.ts
@@ -32,14 +32,14 @@ const TEST_COORDINATE_ORIGIN: NumberArray3 = [-122.45, 37.78, 0];
 export type TestCase = {
   title: string;
   position: NumberArray3;
-  params: ProjectProps & {fromCoordinateSystem: number};
+  projectProps: ProjectProps & {fromCoordinateSystem: number};
   result: NumberArray3;
 };
 const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT:WEB_MERCATOR',
     position: [-70, 41, 1000],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT_2,
       coordinateSystem: COORDINATE_SYSTEM.DEFAULT
     },
@@ -48,7 +48,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT:WEB_MERCATOR_AUTO_OFFSET',
     position: [-122.46, 37.8, 1000],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.DEFAULT
     },
@@ -57,7 +57,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'CARTESIAN:IDENTITY',
     position: [-10, 10, 10],
-    params: {
+    projectProps: {
       viewport: new OrthographicViewport({
         width: 1,
         height: 1,
@@ -71,7 +71,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'CARTESIAN:WEB_MERCATOR',
     position: [256, 256, 0],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT_2,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
       coordinateOrigin: [0, 0, 0]
@@ -81,7 +81,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'CARTESIAN:WEB_MERCATOR_AUTO_OFFSET',
     position: [0, 0, 0],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
       coordinateOrigin: [256, 256, 0]
@@ -91,7 +91,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT_OFFSETS',
     position: [-0.05, 0.06, 50],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
       coordinateOrigin: [-122.5, 38.8]
@@ -101,7 +101,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'METER_OFFSETS',
     position: [-100, 300, 50],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
       coordinateOrigin: [-122.5, 38.8]
@@ -111,7 +111,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT to METER_OFFSETS',
     position: [-122.46, 37.8, 1000],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
       coordinateOrigin: TEST_COORDINATE_ORIGIN,
@@ -122,7 +122,7 @@ const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT to LNGLAT_OFFSETS',
     position: [-122.46, 37.8, 1000],
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
       coordinateOrigin: TEST_COORDINATE_ORIGIN,
@@ -136,7 +136,7 @@ test('project#projectPosition', t => {
   config.EPSILON = 1e-7;
 
   TEST_CASES.forEach(testCase => {
-    const result = projectPosition(testCase.position, testCase.params);
+    const result = projectPosition(testCase.position, testCase.projectProps);
     t.comment(result);
     t.comment(testCase.result);
     t.ok(equals(result, testCase.result), testCase.title);
@@ -145,7 +145,7 @@ test('project#projectPosition', t => {
   t.end();
 });
 
-test.only('project#projectPosition vs project_position', async t => {
+test('project#projectPosition vs project_position', async t => {
   config.EPSILON = 1e-5;
 
   const vs = `\
@@ -160,10 +160,10 @@ void main()
 }
 `;
 
-  for (const {title, position, params} of TEST_CASES.filter(
-    testCase => !testCase.params.fromCoordinateSystem
+  for (const {title, position, projectProps} of TEST_CASES.filter(
+    testCase => !testCase.projectProps.fromCoordinateSystem
   )) {
-    const cpuResult = projectPosition(position, params);
+    const cpuResult = projectPosition(position, projectProps);
     const testProps: TestProps = {
       uPos: position,
       uPos64Low: position.map(fp64LowPart) as NumberArray3
@@ -173,7 +173,7 @@ void main()
       varying: 'outValue',
       modules: [project, testUniforms],
       vertexCount: 1,
-      shaderInputProps: {project: params, test: testProps}
+      shaderInputProps: {project: projectProps, test: testProps}
     });
 
     t.is(verifyGPUResult(shaderResult, cpuResult), true, title);

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {equals, NumericArray} from '@math.gl/core';
+import {equals, NumericArray, NumberArray2, NumberArray3, NumberArray4} from '@math.gl/core';
 import type {UniformValue} from '@luma.gl/core';
+import type {ShaderModule} from '@luma.gl/shadertools';
+
 import {BufferTransform, BufferTransformProps} from '@luma.gl/engine';
 import {device} from '@deck.gl/test-utils';
 
@@ -12,6 +14,40 @@ export function getPixelOffset(p1, p2) {
 }
 
 const OUT_BUFFER = device.createBuffer({byteLength: 4 * 16});
+
+// TODO move to separate file?
+const uniformBlock = /* glsl */ `\
+uniform testUniforms {
+  vec4 uCommonPos;
+  vec3 uDirUp;
+  vec3 uInput;
+  vec3 uPos;
+  vec3 uPos64Low;
+  vec3 uWorldPos;
+} test;
+`;
+
+export type TestOptions = {
+  uCommonPos?: NumberArray4;
+  uDirUp?: NumberArray3;
+  uInput?: NumberArray3;
+  uPos?: NumberArray3;
+  uPos64Low?: NumberArray3;
+  uWorldPos?: NumberArray3;
+};
+
+export const testUniforms = {
+  name: 'test',
+  vs: uniformBlock,
+  uniformTypes: {
+    uCommonPos: 'vec4<f32>',
+    uDirUp: 'vec3<f32>',
+    uInput: 'vec3<f32>',
+    uPos: 'vec3<f32>',
+    uPos64Low: 'vec3<f32>',
+    uWorldPos: 'vec3<f32>'
+  }
+} as const satisfies ShaderModule<TestOptions>;
 
 export async function runOnGPU({
   shaderInputProps,
@@ -26,10 +62,11 @@ export async function runOnGPU({
   const transform = new BufferTransform(device, {
     ...transformProps,
     feedbackBuffers: {[varying]: OUT_BUFFER},
-    varyings: [varying]
+    varyings: [varying],
+    modules: [...transformProps.modules, testUniforms]
   });
   transform.model.setUniforms(uniforms);
-  transform.model.shaderInputs.setProps(shaderInputProps);
+  transform.model.shaderInputs.setProps({...shaderInputProps, test: uniforms});
   transform.run({
     discard: true
   });

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -21,6 +21,9 @@ uniform testUniforms {
   vec4 uCommonPos;
   vec3 uDirUp;
   vec3 uInput;
+  float uMeterSize1;
+  vec2 uMeterSize2;
+  vec3 uMeterSize3;
   vec3 uPos;
   vec3 uPos64Low;
   vec3 uWorldPos;
@@ -31,6 +34,9 @@ export type TestOptions = {
   uCommonPos?: NumberArray4;
   uDirUp?: NumberArray3;
   uInput?: NumberArray3;
+  uMeterSize1?: number;
+  uMeterSize2?: NumberArray2;
+  uMeterSize3?: NumberArray3;
   uPos?: NumberArray3;
   uPos64Low?: NumberArray3;
   uWorldPos?: NumberArray3;
@@ -43,6 +49,9 @@ export const testUniforms = {
     uCommonPos: 'vec4<f32>',
     uDirUp: 'vec3<f32>',
     uInput: 'vec3<f32>',
+    uMeterSize1: 'f32',
+    uMeterSize2: 'vec2<f32>',
+    uMeterSize3: 'vec3<f32>',
     uPos: 'vec3<f32>',
     uPos64Low: 'vec3<f32>',
     uWorldPos: 'vec3<f32>'

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -67,6 +67,7 @@ export async function runOnGPU({
 }: BufferTransformProps & {
   shaderInputProps: {
     project: ProjectProps;
+    test: TestProps;
   };
   uniforms: Record<string, UniformValue>;
   varying: string;
@@ -78,7 +79,7 @@ export async function runOnGPU({
     modules: [...transformProps.modules, testUniforms]
   });
   transform.model.setUniforms(uniforms); // TODO delete
-  transform.model.shaderInputs.setProps({...shaderInputProps, test: uniforms});
+  transform.model.shaderInputs.setProps(shaderInputProps);
   transform.run({
     discard: true
   });

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -7,6 +7,7 @@ import type {UniformValue} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
 import {BufferTransform, BufferTransformProps} from '@luma.gl/engine';
+import {ProjectProps} from '@deck.gl/core';
 import {device} from '@deck.gl/test-utils';
 
 export function getPixelOffset(p1, p2) {
@@ -30,7 +31,7 @@ uniform testUniforms {
 } test;
 `;
 
-export type TestOptions = {
+export type TestProps = {
   uCommonPos?: NumberArray4;
   uDirUp?: NumberArray3;
   uInput?: NumberArray3;
@@ -56,7 +57,7 @@ export const testUniforms = {
     uPos64Low: 'vec3<f32>',
     uWorldPos: 'vec3<f32>'
   }
-} as const satisfies ShaderModule<TestOptions>;
+} as const satisfies ShaderModule<TestProps>;
 
 export async function runOnGPU({
   shaderInputProps,
@@ -64,7 +65,9 @@ export async function runOnGPU({
   varying,
   ...transformProps
 }: BufferTransformProps & {
-  shaderInputProps: Record<string, Record<string, any>>;
+  shaderInputProps: {
+    project: ProjectProps;
+  };
   uniforms: Record<string, UniformValue>;
   varying: string;
 }): Promise<Float32Array> {
@@ -74,7 +77,7 @@ export async function runOnGPU({
     varyings: [varying],
     modules: [...transformProps.modules, testUniforms]
   });
-  transform.model.setUniforms(uniforms);
+  transform.model.setUniforms(uniforms); // TODO delete
   transform.model.shaderInputs.setProps({...shaderInputProps, test: uniforms});
   transform.run({
     discard: true

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -61,7 +61,6 @@ export const testUniforms = {
 
 export async function runOnGPU({
   shaderInputProps,
-  uniforms,
   varying,
   ...transformProps
 }: BufferTransformProps & {
@@ -69,20 +68,15 @@ export async function runOnGPU({
     project: ProjectProps;
     test: TestProps;
   };
-  uniforms: Record<string, UniformValue>;
   varying: string;
 }): Promise<Float32Array> {
   const transform = new BufferTransform(device, {
     ...transformProps,
     feedbackBuffers: {[varying]: OUT_BUFFER},
-    varyings: [varying],
-    modules: [...transformProps.modules, testUniforms]
+    varyings: [varying]
   });
-  transform.model.setUniforms(uniforms); // TODO delete
   transform.model.shaderInputs.setProps(shaderInputProps);
-  transform.run({
-    discard: true
-  });
+  transform.run({discard: true});
 
   const result: Uint8Array = await OUT_BUFFER.readAsync();
   return new Float32Array(result.buffer);

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -3,7 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 import {equals, NumericArray, NumberArray2, NumberArray3, NumberArray4} from '@math.gl/core';
-import type {UniformValue} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
 import {BufferTransform, BufferTransformProps} from '@luma.gl/engine';
@@ -16,7 +15,6 @@ export function getPixelOffset(p1, p2) {
 
 const OUT_BUFFER = device.createBuffer({byteLength: 4 * 16});
 
-// TODO move to separate file?
 const uniformBlock = /* glsl */ `\
 uniform testUniforms {
   vec4 uCommonPos;

--- a/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
+++ b/test/modules/core/shaderlib/project/project-glsl-test-utils.ts
@@ -66,6 +66,7 @@ export async function runOnGPU({
 }: BufferTransformProps & {
   shaderInputProps: {
     project: ProjectProps;
+    project64?: ProjectProps;
     test: TestProps;
   };
   varying: string;

--- a/test/modules/core/shaderlib/project/project-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.ts
@@ -95,7 +95,7 @@ void main()
 `
 };
 
-type TestCase = {
+export type TestCase = {
   title: string;
   params: ProjectProps;
   tests: {
@@ -323,7 +323,7 @@ const TEST_CASES: TestCase[] = [
   }
 ];
 
-test.only('project#vs', async t => {
+test('project#vs', async t => {
   const oldEpsilon = config.EPSILON;
 
   for (const testCase of TEST_CASES) {

--- a/test/modules/core/shaderlib/project/project-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.ts
@@ -15,7 +15,13 @@ import {Matrix4, Vector3, config, equals, NumericArray, NumberArray3} from '@mat
 import {fp64} from '@luma.gl/shadertools';
 const {fp64LowPart} = fp64;
 
-import {getPixelOffset, runOnGPU, TestProps, verifyGPUResult} from './project-glsl-test-utils';
+import {
+  getPixelOffset,
+  runOnGPU,
+  TestProps,
+  testUniforms,
+  verifyGPUResult
+} from './project-glsl-test-utils';
 const PIXEL_TOLERANCE = 1e-4;
 
 const TEST_VIEWPORT = new WebMercatorViewport({
@@ -328,7 +334,7 @@ test.only('project#vs', async t => {
       let actual: NumericArray = await runOnGPU({
         vs,
         varying: 'outValue',
-        modules: [project],
+        modules: [project, testUniforms],
         vertexCount: 1,
         shaderInputProps: {
           project: testCase.params,
@@ -360,7 +366,7 @@ void main() {
     const result = await runOnGPU({
       vs,
       varying: 'outValue',
-      modules: [project],
+      modules: [project, testUniforms],
       vertexCount: 1,
       shaderInputProps: {
         project: {

--- a/test/modules/core/shaderlib/project/project-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.ts
@@ -44,42 +44,36 @@ const TRANSFORM_VS = {
   project_size: (type: 'float' | 'vec2' | 'vec3') => `\
 #version 300 es
 
-uniform vec3 uWorldPos;
-uniform vec4 uCommonPos;
 uniform ${type} uMeterSize;
 out ${type} outValue;
 
 void main()
 {
-  geometry.worldPosition = uWorldPos;
-  geometry.position = uCommonPos;
+  geometry.worldPosition = test.uWorldPos;
+  geometry.position = test.uCommonPos;
   outValue = project_size(uMeterSize);
 }
 `,
   project_position: `\
 #version 300 es
 
-uniform vec3 uPos;
-uniform vec3 uPos64Low;
-
 out vec4 outValue;
 
 void main()
 {
-  geometry.worldPosition = uPos;
-  outValue = project_position(vec4(uPos, 1.0), uPos64Low);
+  geometry.worldPosition = test.uPos;
+  outValue = project_position(vec4(test.uPos, 1.0), test.uPos64Low);
 }
 `,
   project_common_position_to_clipspace: `\
 #version 300 es
 
-uniform vec3 uPos;
 out vec3 outValue;
 
 void main()
 {
-  geometry.worldPosition = uPos;
-  vec4 pos = project_position(vec4(uPos, 1.0), vec3(0.));
+  geometry.worldPosition = test.uPos;
+  vec4 pos = project_position(vec4(test.uPos, 1.0), vec3(0.));
   vec4 glPos = project_common_position_to_clipspace(pos);
   outValue = glPos.xyz / glPos.w;
   outValue = vec3(
@@ -319,7 +313,7 @@ const TEST_CASES: TestCase[] = [
   }
 ];
 
-test('project#vs', async t => {
+test.only('project#vs', async t => {
   const oldEpsilon = config.EPSILON;
 
   for (const testCase of TEST_CASES) {
@@ -348,13 +342,11 @@ test('project#vs#project_get_orientation_matrix', async t => {
   const vs = `\
 #version 300 es
 
-uniform vec3 uDirUp;
-uniform vec3 uInput;
 out vec3 outValue;
 
 void main() {
-  mat3 transform = project_get_orientation_matrix(uDirUp);
-  outValue = transform * uInput;
+  mat3 transform = project_get_orientation_matrix(test.uDirUp);
+  outValue = transform * test.uInput;
 }
   `;
   const shaderInputProps = {

--- a/test/modules/core/shaderlib/project/project-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.ts
@@ -97,12 +97,12 @@ void main()
 
 export type TestCase = {
   title: string;
-  params: ProjectProps;
+  projectProps: ProjectProps;
   tests: {
     name: string;
     vs: string;
     precision?: number;
-    input: TestProps;
+    testProps: TestProps;
     output: any;
     output64?: any;
   }[];
@@ -110,7 +110,7 @@ export type TestCase = {
 const TEST_CASES: TestCase[] = [
   {
     title: 'LNGLAT mode',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
@@ -118,7 +118,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_size(float)',
         vs: TRANSFORM_VS.project_size(1),
-        input: {
+        testProps: {
           uWorldPos: [TEST_VIEWPORT.longitude, TEST_VIEWPORT.latitude, 0],
           uCommonPos: [0, 0, 0, 0],
           uMeterSize1: 1
@@ -128,7 +128,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_size(vec2)',
         vs: TRANSFORM_VS.project_size(2),
-        input: {
+        testProps: {
           uWorldPos: [TEST_VIEWPORT.longitude, TEST_VIEWPORT.latitude, 0],
           uCommonPos: [0, 0, 0, 0],
           uMeterSize2: [1, 1]
@@ -138,7 +138,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_size(vec3)',
         vs: TRANSFORM_VS.project_size(3),
-        input: {
+        testProps: {
           uWorldPos: [TEST_VIEWPORT.longitude, TEST_VIEWPORT.latitude, 0],
           uCommonPos: [0, 0, 0, 0],
           uMeterSize3: [1, 1, 1]
@@ -148,7 +148,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position',
         vs: TRANSFORM_VS.project_position,
-        input: {
+        testProps: {
           uPos: [-122.45, 37.78, 0],
           uPos64Low: [fp64LowPart(-122.45), fp64LowPart(37.78), 0]
         },
@@ -158,7 +158,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace(vec4)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [-122.45, 37.78, 0]
         },
         output: TEST_VIEWPORT.project([-122.45, 37.78, 0]),
@@ -167,7 +167,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace (vec4, non-zero z)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [-122.45, 37.78, 100]
         },
         output: TEST_VIEWPORT.project([-122.45, 37.78, 100]),
@@ -177,7 +177,7 @@ const TEST_CASES: TestCase[] = [
   },
   {
     title: 'LNGLAT mode - auto offset',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT_HIGH_ZOOM,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT
     },
@@ -185,7 +185,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position',
         vs: TRANSFORM_VS.project_position,
-        input: {
+        testProps: {
           uPos: [-122.05, 37.92, 0],
           uPos64Low: [0, 0, 0]
         },
@@ -203,7 +203,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace(vec4)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [-122.05, 37.92, 0]
         },
         output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 0]),
@@ -212,7 +212,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace (vec4, non-zero z)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [-122.05, 37.92, 100]
         },
         output: TEST_VIEWPORT_HIGH_ZOOM.project([-122.05, 37.92, 100]),
@@ -222,7 +222,7 @@ const TEST_CASES: TestCase[] = [
   },
   {
     title: 'METER_OFFSETS mode',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
       coordinateOrigin: [-122.05, 37.92, 0],
@@ -232,7 +232,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position',
         vs: TRANSFORM_VS.project_position,
-        input: {
+        testProps: {
           uPos: [1000, 1000, 0],
           uPos64Low: [0, 0, 0]
         },
@@ -248,7 +248,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace(vec4)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [1000, 1000, 0]
         },
         output: TEST_VIEWPORT.project([-122.0385984916185, 37.92899265369385, 100]),
@@ -258,7 +258,7 @@ const TEST_CASES: TestCase[] = [
   },
   {
     title: 'LNGLAT_OFFSETS mode',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS,
       coordinateOrigin: [-122.05, 37.92, 0]
@@ -267,7 +267,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position',
         vs: TRANSFORM_VS.project_position,
-        input: {
+        testProps: {
           uPos: [0.05, 0.08, 0],
           uPos64Low: [0, 0, 0]
         },
@@ -281,7 +281,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace(vec4)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [0.05, 0.08, 0]
         },
         output: TEST_VIEWPORT.project([-122, 38, 0]),
@@ -291,7 +291,7 @@ const TEST_CASES: TestCase[] = [
   },
   {
     title: 'IDENTITY mode with modelMatrix',
-    params: {
+    projectProps: {
       viewport: TEST_VIEWPORT_ORTHO,
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
       modelMatrix: new Matrix4().rotateZ(Math.PI / 2).translate([0, 0, 10])
@@ -300,7 +300,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_position',
         vs: TRANSFORM_VS.project_position,
-        input: {
+        testProps: {
           uPos: [200, 200, 0],
           uPos64Low: [0, 0, 0]
         },
@@ -314,7 +314,7 @@ const TEST_CASES: TestCase[] = [
       {
         name: 'project_common_position_to_clipspace(vec4)',
         vs: TRANSFORM_VS.project_common_position_to_clipspace,
-        input: {
+        testProps: {
           uPos: [200, 200, 0]
         },
         output: TEST_VIEWPORT_ORTHO.project([-200, 200, 10]),
@@ -330,7 +330,7 @@ test('project#vs', async t => {
   for (const testCase of TEST_CASES) {
     t.comment(testCase.title);
 
-    for (const {name, vs, input, output, precision = 1e-7} of testCase.tests) {
+    for (const {name, vs, testProps, output, precision = 1e-7} of testCase.tests) {
       config.EPSILON = precision;
       let actual: NumericArray = await runOnGPU({
         vs,
@@ -338,8 +338,8 @@ test('project#vs', async t => {
         modules: [project, testUniforms],
         vertexCount: 1,
         shaderInputProps: {
-          project: testCase.params,
-          test: input
+          project: testCase.projectProps,
+          test: testProps
         }
       });
 

--- a/test/modules/core/shaderlib/project/project-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.ts
@@ -340,8 +340,7 @@ test('project#vs', async t => {
         shaderInputProps: {
           project: testCase.params,
           test: input
-        },
-        uniforms: {}
+        }
       });
 
       t.is(verifyGPUResult(actual, output), true, name);
@@ -375,8 +374,7 @@ void main() {
           coordinateSystem: COORDINATE_SYSTEM.LNGLAT
         },
         test: {uDirUp: up as NumberArray3, uInput: v as NumberArray3}
-      },
-      uniforms: {}
+      }
     });
     return new Vector3(result.slice(0, 3));
   };

--- a/test/modules/core/shaderlib/project/project-glsl.spec.ts
+++ b/test/modules/core/shaderlib/project/project-glsl.spec.ts
@@ -104,6 +104,7 @@ export type TestCase = {
     precision?: number;
     input: TestProps;
     output: any;
+    output64?: any;
   }[];
 };
 const TEST_CASES: TestCase[] = [


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Remove remaining instances of `setUniforms` in tests

<!-- For all the PRs -->
#### Change List
- Port `hexbin` & `project` spec tests, adding UBOs to replace individual uniforms
- Export `ProjectProps` type
- Add typing
- Rename & tidy to match new conventions
