### PR TITLE
Avoid adding props to global function prototype. Doing so breaks the react-three-fiber reconciler

### DIFF
--- a/modules/core/src/lifecycle/create-props.ts
+++ b/modules/core/src/lifecycle/create-props.ts
@@ -69,9 +69,9 @@ function getPropsPrototype(componentClass, extensions?: any[]) {
   // Bail out if we're not looking at a component - for two reasons:
   // 1. There's no reason for an ancestor of component to have props
   // 2. If we don't bail out, we'll follow the prototype chain all the way back to the global
-  // function prototype and add _mergedDefaultProps to it, which may break other frameworks 
+  // function prototype and add _mergedDefaultProps to it, which may break other frameworks
   // (e.g. the react-three-fiber reconciler)
-  if (!(componentClass instanceof Component.constructor)) return {}
+  if (!(componentClass instanceof Component.constructor)) return {};
 
   // A string that uniquely identifies the extensions involved
   let cacheKey = MergedDefaultPropsCacheKey;

--- a/modules/core/src/lifecycle/create-props.ts
+++ b/modules/core/src/lifecycle/create-props.ts
@@ -98,6 +98,10 @@ function createPropsPrototypeAndTypes(
   }
 
   const parentClass = Object.getPrototypeOf(componentClass);
+  if (parentClass === Function.prototype) {
+    // don't add props to the global function prototype
+    return null;
+  }
   const parentDefaultProps = getPropsPrototype(parentClass);
 
   // Parse propTypes from Component.defaultProps


### PR DESCRIPTION
Closes #9206

Change List
- create-props.ts Changed `createPropsPrototypeAndTypes` to bail out if the parent class of the passed component class is the global function prototype so that it doesn't get polluted.

There may well be a better and cleaner way to do this, but this fixes the bug I'm experiencing.

Note that I was not able to get tests to run locally or on my fork via Github Actions, but the errors appear unrelated to my changes and seem to be occurring on some workflow runs on the main repo.

P.S. deck.gl is an absolutely amazing piece of software!