### PR TITLE
carto: RasterLayer fix perf issue caused by spurious data changes

### DIFF
--- a/modules/carto/src/layers/raster-layer.ts
+++ b/modules/carto/src/layers/raster-layer.ts
@@ -81,6 +81,15 @@ type _RasterLayerProps = {
   tileIndex: bigint;
 };
 
+type RasterColumnLayerData = {
+  data: Raster;
+  length: number;
+};
+
+function wrappedDataComparator(oldData: RasterColumnLayerData, newData: RasterColumnLayerData) {
+  return oldData.data === newData.data && oldData.length === newData.length;
+}
+
 // Adapter layer around RasterColumnLayer that converts data & accessors into correct format
 export default class RasterLayer<DataT = any, ExtraProps = {}> extends CompositeLayer<
   Required<RasterLayerProps<DataT>> & ExtraProps
@@ -130,6 +139,7 @@ export default class RasterLayer<DataT = any, ExtraProps = {}> extends Composite
           data, // Pass through data for getSubLayerAccessor()
           length: blockSize * blockSize
         },
+        dataComparator: wrappedDataComparator,
         offset,
         lineWidthScale, // Re-use widthScale prop to pass cell scale,
         highlightedObjectIndex,


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background

Fix performance regression in Carto's RasterLayer caused by unnecessary buffer updates.

RasterLayer wraps `data` passed to ColumnLayer in temporary object and by default this was detected as data change in all ColumnLayers on each layer update (like opacity).

<!-- For all the PRs -->
#### Change List
- carto: RasterLayer doesn't update buffers on each render
