### PR TITLE
refactor(carto): Refactor fetchMap() for deck.gl v9.1

### DIFF
--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env=dev"
   },
   "dependencies": {
-    "@carto/api-client": "^0.4.0-alpha.5",
+    "@carto/api-client": "^0.4.0",
     "@loaders.gl/gis": "^4.2.0",
     "@loaders.gl/loader-utils": "^4.2.0",
     "@loaders.gl/mvt": "^4.2.0",

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "npm run build-bundle && npm run build-bundle -- --env=dev"
   },
   "dependencies": {
-    "@carto/api-client": "^0.4.0-alpha.4",
+    "@carto/api-client": "^0.4.0-alpha.5",
     "@loaders.gl/gis": "^4.2.0",
     "@loaders.gl/loader-utils": "^4.2.0",
     "@loaders.gl/mvt": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,10 +1083,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@carto/api-client@^0.4.0-alpha.5":
-  version "0.4.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@carto/api-client/-/api-client-0.4.0-alpha.5.tgz#2250591a11a3877422746f021cba32d37900e941"
-  integrity sha512-jH2EsgH9TSzb0wFrN26DYeNC3vN6Y24PiXOQcGwrCWDGuEx5CHmVbdWFz9wPztGPbpHE39tjqij5JuFfBy9Rfw==
+"@carto/api-client@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@carto/api-client/-/api-client-0.4.0.tgz#853469e70dcfa5ce14083f6ad9348911d08046fa"
+  integrity sha512-zFn4/cBBVNvpSqS9di72XuRUl5qrWHEW2KsuWK3fzR5Sng8jXoTFESf6poY0nyhxlAutkMNZIAhpHm+wdc7y/w==
   dependencies:
     "@turf/bbox-clip" "^7.1.0"
     "@turf/bbox-polygon" "^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,10 +1083,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@carto/api-client@^0.4.0-alpha.4":
-  version "0.4.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@carto/api-client/-/api-client-0.4.0-alpha.4.tgz#32af6a903624a1cf1c930002a6640116d756750d"
-  integrity sha512-Bm+hoKfMwzruFMvbowypB/CoBQUOl8zqE3XmBHodU0akE341xdSLx8B9w7f4jtqYylXh0wk1irz2sFfW37N2HQ==
+"@carto/api-client@^0.4.0-alpha.5":
+  version "0.4.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@carto/api-client/-/api-client-0.4.0-alpha.5.tgz#2250591a11a3877422746f021cba32d37900e941"
+  integrity sha512-jH2EsgH9TSzb0wFrN26DYeNC3vN6Y24PiXOQcGwrCWDGuEx5CHmVbdWFz9wPztGPbpHE39tjqij5JuFfBy9Rfw==
   dependencies:
     "@turf/bbox-clip" "^7.1.0"
     "@turf/bbox-polygon" "^7.1.0"


### PR DESCRIPTION
A followup to #9230, this PR does some internal refactoring of `fetchMap()` to reduce the (repeated) use of optional parameters with defaults imported from `SOURCE_DEFAULTS`, and tries to decouple the file somewhat from the baseSource() implementation. User-facing API is unchanged.

It probably also makes sense to move this function into `@carto/api-client` at some point, but I don't think we're ready to tackle that for v9.1.