### PR TITLE
CARTO: Fix off-by-one raster vertex shader error

### DIFF
--- a/modules/carto/src/layers/raster-layer-vertex.glsl.ts
+++ b/modules/carto/src/layers/raster-layer-vertex.glsl.ts
@@ -28,7 +28,7 @@ void main(void) {
 
   int yIndex = - (gl_InstanceID / BLOCK_WIDTH);
   int xIndex = gl_InstanceID + (yIndex * BLOCK_WIDTH);
-  common_position += scale * vec2(float(xIndex), float(yIndex));
+  common_position += scale * vec2(float(xIndex), float(yIndex - 1));
 
   vec4 color = column.isStroke ? instanceLineColors : instanceFillColors;
 

--- a/test/apps/carto-dynamic-tile/app.tsx
+++ b/test/apps/carto-dynamic-tile/app.tsx
@@ -8,12 +8,7 @@ import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
-import {
-  H3TileLayer,
-  RasterTileLayer,
-  QuadbinTileLayer,
-  VectorTileLayer
-} from '@deck.gl/carto';
+import {H3TileLayer, RasterTileLayer, QuadbinTileLayer, VectorTileLayer} from '@deck.gl/carto';
 
 import {query} from '@carto/api-client';
 import datasets from './datasets';

--- a/test/apps/carto-dynamic-tile/app.tsx
+++ b/test/apps/carto-dynamic-tile/app.tsx
@@ -12,9 +12,10 @@ import {
   H3TileLayer,
   RasterTileLayer,
   QuadbinTileLayer,
-  query,
   VectorTileLayer
 } from '@deck.gl/carto';
+
+import {query} from '@carto/api-client';
 import datasets from './datasets';
 import {Layer} from '@deck.gl/core';
 


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

The cells were being positioned incorrectly, see comparison with tile bounds:

![raster-offset](https://github.com/user-attachments/assets/579f6412-ee30-411a-a67a-16916806076e)


<!-- For all the PRs -->
#### Change List
- Fix off by one error introduced by axis inversion
- Fix import in test app
