### PR TITLE
website: Fix Syntax Error in layerFilter 

### DIFF
--- a/docs/developer-guide/views.md
+++ b/docs/developer-guide/views.md
@@ -790,9 +790,9 @@ const deck = new Deck({
       // ...
     })
   ],
-  layerFilter: ({layer, viewport} => {
+  layerFilter: ({layer, viewport}) => {
     return layer.id === `tiles-for-${viewport.id}`;
-  });
+  }
 });
 ```
 
@@ -819,9 +819,9 @@ const deck = new Deck<[MapView, MapView]>({
       // ...
     })
   ],
-  layerFilter: ({layer, viewport} => {
+  layerFilter: ({layer, viewport}) => {
     return layer.id === `tiles-for-${viewport.id}`;
-  });
+  }
 });
 ```
 


### PR DESCRIPTION
Fix for a syntax error in the `layerFilter` function in the [Views Developer Guide](https://deck.gl/docs/developer-guide/views).
