### PR TITLE
fix(layers): Fix MVTLayer + pickMultipleObjects

### DIFF
--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -810,14 +810,14 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
     const externalColorAttribute =
       colors && data.attributes && (data.attributes[colors.id] as BinaryAttribute);
     if (externalColorAttribute && externalColorAttribute.value) {
-      const values = externalColorAttribute.value;
+      const {value, size = 1} = externalColorAttribute;
       const objectColor = this.encodePickingColor(objectIndex);
       for (let index = 0; index < data.length; index++) {
-        const i = colors.getVertexOffset(index);
+        const i = (colors.getVertexOffset(index) * size) / colors.size;
         if (
-          values[i] === objectColor[0] &&
-          values[i + 1] === objectColor[1] &&
-          values[i + 2] === objectColor[2]
+          value[i] === objectColor[0] &&
+          value[i + 1] === objectColor[1] &&
+          value[i + 2] === objectColor[2]
         ) {
           this._disablePickingIndex(index);
         }
@@ -1018,7 +1018,7 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   }
   /* eslint-enable max-statements */
 
-  /** (Internal) Called by manager when layer is about to be disposed 
+  /** (Internal) Called by manager when layer is about to be disposed
       Note: not guaranteed to be called on application shutdown */
   _finalize(): void {
     debug(TRACE_FINALIZE, this);

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -810,14 +810,14 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
     const externalColorAttribute =
       colors && data.attributes && (data.attributes[colors.id] as BinaryAttribute);
     if (externalColorAttribute && externalColorAttribute.value) {
-      const {value, size = 1} = externalColorAttribute;
+      const values = externalColorAttribute.value;
       const objectColor = this.encodePickingColor(objectIndex);
       for (let index = 0; index < data.length; index++) {
-        const i = (colors.getVertexOffset(index) * size) / colors.size;
+        const i = colors.getVertexOffset(index);
         if (
-          value[i] === objectColor[0] &&
-          value[i + 1] === objectColor[1] &&
-          value[i + 2] === objectColor[2]
+          values[i] === objectColor[0] &&
+          values[i + 1] === objectColor[1] &&
+          values[i + 2] === objectColor[2]
         ) {
           this._disablePickingIndex(index);
         }
@@ -1018,7 +1018,7 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   }
   /* eslint-enable max-statements */
 
-  /** (Internal) Called by manager when layer is about to be disposed
+  /** (Internal) Called by manager when layer is about to be disposed 
       Note: not guaranteed to be called on application shutdown */
   _finalize(): void {
     debug(TRACE_FINALIZE, this);

--- a/modules/layers/src/geojson-layer/geojson-binary.ts
+++ b/modules/layers/src/geojson-layer/geojson-binary.ts
@@ -74,13 +74,14 @@ export function calculatePickingColors(
   };
   for (const key in pickingColors) {
     const featureIds = geojsonBinary[key].globalFeatureIds.value;
-    pickingColors[key] = new Uint8ClampedArray(featureIds.length * 3);
+    pickingColors[key] = new Uint8ClampedArray(featureIds.length * 4);
     const pickingColor = [];
     for (let i = 0; i < featureIds.length; i++) {
       encodePickingColor(featureIds[i], pickingColor);
-      pickingColors[key][i * 3 + 0] = pickingColor[0];
-      pickingColors[key][i * 3 + 1] = pickingColor[1];
-      pickingColors[key][i * 3 + 2] = pickingColor[2];
+      pickingColors[key][i * 4 + 0] = pickingColor[0];
+      pickingColors[key][i * 4 + 1] = pickingColor[1];
+      pickingColors[key][i * 4 + 2] = pickingColor[2];
+      pickingColors[key][i * 4 + 3] = 255;
     }
   }
 

--- a/modules/layers/src/geojson-layer/geojson-layer-props.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer-props.ts
@@ -78,7 +78,7 @@ export function createLayerPropsFromBinary(
       ...points.attributes,
       getPosition: points.positions,
       instancePickingColors: {
-        size: 3,
+        size: 4,
         value: customPickingColors.points!
       }
     },
@@ -94,7 +94,7 @@ export function createLayerPropsFromBinary(
       ...lines.attributes,
       getPath: lines.positions,
       instancePickingColors: {
-        size: 3,
+        size: 4,
         value: customPickingColors.lines!
       }
     },
@@ -111,7 +111,7 @@ export function createLayerPropsFromBinary(
       ...polygons.attributes,
       getPolygon: polygons.positions,
       pickingColors: {
-        size: 3,
+        size: 4,
         value: customPickingColors.polygons!
       }
     },
@@ -131,7 +131,7 @@ export function createLayerPropsFromBinary(
       ...polygons.attributes,
       getPath: polygons.positions,
       instancePickingColors: {
-        size: 3,
+        size: 4,
         value: customPickingColors.polygons!
       }
     },

--- a/test/bench/layer.bench.js
+++ b/test/bench/layer.bench.js
@@ -111,8 +111,8 @@ export default function layerBench(suite) {
     })
     .add('calculate instance picking colors', () => {
       const numInstances = 1e6;
-      const target = new Uint8ClampedArray(numInstances * 3);
+      const target = new Uint8ClampedArray(numInstances * 4);
       testLayer.internalState = {};
-      testLayer.calculateInstancePickingColors({value: target, size: 3}, {numInstances});
+      testLayer.calculateInstancePickingColors({value: target, size: 4}, {numInstances});
     });
 }

--- a/test/modules/layers/data/fixtures.ts
+++ b/test/modules/layers/data/fixtures.ts
@@ -44,6 +44,13 @@ export const geoJSONData = [
 ];
 
 // prettier-ignore
-export const pickingColorsSample = Uint8ClampedArray.from([ 
-  1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 2, 0, 0, 2, 0, 0, 2, 0, 0, 2, 0, 0
+export const pickingColorsSample = Uint8ClampedArray.from([
+  1, 0, 0, 255,
+  1, 0, 0, 255,
+  1, 0, 0, 255,
+  1, 0, 0, 255,
+  2, 0, 0, 255,
+  2, 0, 0, 255,
+  2, 0, 0, 255,
+  2, 0, 0, 255,
 ]);


### PR DESCRIPTION
The `instancePickingColors` attribute has some hard-coded assumptions about size, such as...

https://github.com/visgl/deck.gl/blob/27d2010790691dae7589f537ff1cfd39c1b1d0b6/modules/core/src/lib/layer.ts#L879-L882

... but MVTLayer currently initializes the buffer with 3, not 4, components. This leads to a bug in `pickMultipleObjects` where `disablePickingIndex` fails to disable the previously selected object index (or goes out of bounds) and the operation just returns `depth` duplicate references to the top hit.

While we could try to handle multiple attribute sizes, I think it's probably preferable to just have one way to represent things. Here I've switched MVTLayer to 4-component picking colors, following [WebGL's 4-byte alignment best practices](https://www.khronos.org/opengl/wiki/Vertex_Specification_Best_Practices#Formatting_VBO_Data).

- Fixes #9228

#### Change List

- fix(layers): GeoJSONLayer and MVTLayer use 4-component instance picking colors
