### PR TITLE
The correct property name is useWebGL2

### DIFF
--- a/docs/api-reference/mapbox/overview.md
+++ b/docs/api-reference/mapbox/overview.md
@@ -66,7 +66,7 @@ The following table details renderer support across different versions of mapbox
 | Library                       | Overlaid (default) | Interleaved       |
 |-------------------------------|--------------------|-------------------|
 | mapbox-gl-js (before v2.13)   | ✓                  |                   |
-| mapbox-gl-js v2.13+           | ✓                  | ✓ with `useWebGl2: true` |
+| mapbox-gl-js v2.13+           | ✓                  | ✓ with `useWebGL2: true` |
 | mapbox-gl-js v3+              | ✓                  | ✓                 |
 | maplibre-gl-js (before v3)    | ✓                  |                   |
 | maplibre-gl-js v3+            | ✓                  | ✓*                |


### PR DESCRIPTION
Just spent some time figuring out why this didn't work.

As you can see [here](https://github.com/mapbox/mapbox-gl-js/blob/d7652ba8eda70a97809840364beed81bad07930d/src/ui/map.js#L242), the correct property name is `useWebGL2`.