### PR TITLE
fix(mapbox) Remove type dependency on mapbox-gl

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -5,7 +5,7 @@
 import {Deck, WebMercatorViewport, MapView, _flatten as flatten} from '@deck.gl/core';
 import type {DeckProps, MapViewState, Layer} from '@deck.gl/core';
 import type MapboxLayer from './mapbox-layer';
-import type {Map} from 'mapbox-gl';
+import type {Map} from './types';
 
 import {lngLatToWorld, unitsPerMeter} from '@math.gl/web-mercator';
 import {GL} from '@luma.gl/constants';

--- a/modules/mapbox/src/mapbox-layer.ts
+++ b/modules/mapbox/src/mapbox-layer.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {getDeckInstance, addLayer, removeLayer, updateLayer, drawLayer} from './deck-utils';
-import type {Map, CustomLayerInterface} from 'mapbox-gl';
+import type {Map, CustomLayerInterface} from './types';
 import type {Deck, Layer} from '@deck.gl/core';
 
 export type MapboxLayerProps<LayerT extends Layer> = Partial<LayerT['props']> & {
@@ -58,6 +58,6 @@ export default class MapboxLayer<LayerT extends Layer> implements CustomLayerInt
   }
 
   render() {
-    drawLayer(this.deck!, this.map, this);
+    drawLayer(this.deck!, this.map!, this);
   }
 }

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -255,7 +255,7 @@ export default class MapboxOverlay implements IControl {
 
     switch (mockEvent.type) {
       case 'mousedown':
-        deck._onPointerDown(mockEvent as any as MjolnirPointerEvent);
+        deck._onPointerDown(mockEvent as unknown as MjolnirPointerEvent);
         this._lastMouseDownPoint = {
           ...event.point,
           clientX: event.originalEvent.clientX,
@@ -265,38 +265,38 @@ export default class MapboxOverlay implements IControl {
 
       case 'dragstart':
         mockEvent.type = 'panstart';
-        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'drag':
         mockEvent.type = 'panmove';
-        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'dragend':
         mockEvent.type = 'panend';
-        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'click':
         mockEvent.tapCount = 1;
-        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'dblclick':
         mockEvent.type = 'click';
         mockEvent.tapCount = 2;
-        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as unknown as MjolnirGestureEvent);
         break;
 
       case 'mousemove':
         mockEvent.type = 'pointermove';
-        deck._onPointerMove(mockEvent as any as MjolnirPointerEvent);
+        deck._onPointerMove(mockEvent as unknown as MjolnirPointerEvent);
         break;
 
       case 'mouseout':
         mockEvent.type = 'pointerleave';
-        deck._onPointerMove(mockEvent as any as MjolnirPointerEvent);
+        deck._onPointerMove(mockEvent as unknown as MjolnirPointerEvent);
         break;
 
       default:

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -5,7 +5,7 @@
 import {Deck, assert} from '@deck.gl/core';
 import {getViewState, getDeckInstance, removeDeckInstance, getInterleavedProps} from './deck-utils';
 
-import type {Map, IControl, MapMouseEvent} from 'mapbox-gl';
+import type {Map, IControl, MapMouseEvent, ControlPosition} from './types';
 import type {MjolnirGestureEvent, MjolnirPointerEvent} from 'mjolnir.js';
 import type {DeckProps} from '@deck.gl/core';
 import {log} from '@deck.gl/core';
@@ -26,7 +26,6 @@ export type MapboxOverlayProps = Omit<
 > & {
   interleaved?: boolean;
 };
-type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 /**
  * Implements Mapbox [IControl](https://docs.mapbox.com/mapbox-gl-js/api/markers/#icontrol) interface
@@ -256,7 +255,7 @@ export default class MapboxOverlay implements IControl {
 
     switch (mockEvent.type) {
       case 'mousedown':
-        deck._onPointerDown(mockEvent as MjolnirPointerEvent);
+        deck._onPointerDown(mockEvent as any as MjolnirPointerEvent);
         this._lastMouseDownPoint = {
           ...event.point,
           clientX: event.originalEvent.clientX,
@@ -266,38 +265,38 @@ export default class MapboxOverlay implements IControl {
 
       case 'dragstart':
         mockEvent.type = 'panstart';
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
         break;
 
       case 'drag':
         mockEvent.type = 'panmove';
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
         break;
 
       case 'dragend':
         mockEvent.type = 'panend';
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
         break;
 
       case 'click':
         mockEvent.tapCount = 1;
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
         break;
 
       case 'dblclick':
         mockEvent.type = 'click';
         mockEvent.tapCount = 2;
-        deck._onEvent(mockEvent as MjolnirGestureEvent);
+        deck._onEvent(mockEvent as any as MjolnirGestureEvent);
         break;
 
       case 'mousemove':
         mockEvent.type = 'pointermove';
-        deck._onPointerMove(mockEvent as MjolnirPointerEvent);
+        deck._onPointerMove(mockEvent as any as MjolnirPointerEvent);
         break;
 
       case 'mouseout':
         mockEvent.type = 'pointerleave';
-        deck._onPointerMove(mockEvent as MjolnirPointerEvent);
+        deck._onPointerMove(mockEvent as any as MjolnirPointerEvent);
         break;
 
       default:

--- a/modules/mapbox/src/resolve-layers.ts
+++ b/modules/mapbox/src/resolve-layers.ts
@@ -6,7 +6,7 @@ import {_flatten as flatten} from '@deck.gl/core';
 import MapboxLayer from './mapbox-layer';
 
 import type {Deck, LayersList, Layer} from '@deck.gl/core';
-import type {Map} from 'mapbox-gl';
+import type {Map} from './types';
 
 const UNDEFINED_BEFORE_ID = '__UNDEFINED__';
 

--- a/modules/mapbox/src/types.ts
+++ b/modules/mapbox/src/types.ts
@@ -1,0 +1,123 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// Types that offer basic interface compatible with mapbox-gl and maplibre-gl
+
+type Listener = (event?: any) => any;
+
+export interface Evented {
+  on(type: string, listener: Listener);
+
+  off(type?: string | any, listener?: Listener);
+
+  once(type: string, listener: Listener);
+}
+
+export type Point = {
+  x: number;
+  y: number;
+};
+
+export type LngLat = {
+  lng: number;
+  lat: number;
+};
+
+export type PaddingOptions = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+};
+
+export type FreeCameraOptions = {
+  position?: {
+    x: number;
+    y: number;
+    z: number;
+  };
+};
+
+export interface IControl {
+  onAdd(map: Map): HTMLElement;
+
+  onRemove(map: Map): void;
+
+  getDefaultPosition?: (() => string) | undefined;
+}
+
+export type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export interface CustomLayerInterface {
+  id: string;
+  type: 'custom';
+  renderingMode?: '2d' | '3d';
+
+  onRemove?(map: Map, gl: WebGLRenderingContext): void;
+  onAdd?(map: Map, gl: WebGLRenderingContext): void;
+
+  prerender?(gl: WebGLRenderingContext, matrix: number[]): void;
+  render(gl: WebGLRenderingContext, matrix: number[]): void;
+}
+
+export type MapMouseEvent = {
+  type: string;
+  target: Map;
+  originalEvent: MouseEvent;
+  point: Point;
+  lngLat: LngLat;
+};
+
+/**
+ * A minimal type that represents Mapbox.Map or Maplibre.Map
+ * Only losely typed for compatibility
+ */
+export interface Map extends Evented {
+  addControl(control: IControl, position?: ControlPosition);
+
+  removeControl(control: IControl);
+
+  hasControl(control: IControl): boolean;
+
+  resize(): this;
+
+  isStyleLoaded(): boolean | void;
+
+  addSource(id: string, source: any);
+
+  removeSource(id: string): this;
+
+  getSource(id: string): any;
+
+  addLayer(layer: any, before?: string);
+
+  moveLayer(id: string, beforeId?: string);
+
+  removeLayer(id: string);
+
+  getLayer(id: string): any;
+
+  getContainer(): HTMLElement;
+
+  getCanvas(): HTMLCanvasElement;
+
+  getCenter(): LngLat;
+  getZoom(): number;
+  getBearing(): number;
+  getPitch(): number;
+  getPadding(): PaddingOptions;
+  getRenderWorldCopies(): boolean;
+
+  // mapbox v2+, maplibre v3+
+  getTerrain?(): any;
+  // mapbox v2+
+  getFreeCameraOptions?(): FreeCameraOptions;
+
+  // This is not a public property
+  transform?: any;
+
+  remove(): void;
+
+  triggerRepaint(): void;
+}


### PR DESCRIPTION
Closes #9211

Dependency `@types/mapbox-gl` was removed in v9.0 (unintentionally?) by #8204
It wouldn't be compatible with maplibre-gl anyways...

#### Change List
- Remove type dependency on mapbox-gl
