### PR TITLE
Fix interleaved canvas creation

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -368,7 +368,12 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       if (props.gl instanceof WebGLRenderingContext) {
         log.error('WebGL1 context not supported.')();
       }
-      deviceOrPromise = webgl2Adapter.attach(props.gl);
+      deviceOrPromise = luma.createDevice({
+        type: 'best-available',
+        adapters: [webgl2Adapter],
+        ...props.deviceProps,
+        createCanvasContext: {canvas: props.gl.canvas}
+      });
     }
 
     // Create a new device


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Fixes https://github.com/visgl/deck.gl/issues/9056#issuecomment-2524219538
@ibgreen I'm not clear on how the `attach` function is supposed to work, the `_handle` parameter [that is passed](https://github.com/visgl/luma.gl/blob/9.1-release/modules/webgl/src/adapter/webgl-adapter.ts#L55) to `WebGLDevice` appears to be ignored and this will [always crash](https://github.com/visgl/luma.gl/blob/9.1-release/modules/webgl/src/adapter/webgl-device.ts#L116) due to `createCanvasContext` not being set
 
<!-- For all the PRs -->
#### Change List
- Use `luma.createDevice` to attach existing context
