### PR TITLE
website: Aggregation Layers move to API reference

### DIFF
--- a/docs/api-reference/aggregation-layers/overview.md
+++ b/docs/api-reference/aggregation-layers/overview.md
@@ -1,4 +1,4 @@
-# @deck.gl/aggregation-layers
+# Aggregation Layers
 
 Layers that aggregate the input data and visualize them in alternative representations, such as grid and hexagon binning, contour, and heatmap.
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -128,6 +128,17 @@
       },
       {
         "type": "category",
+        "label": "Aggregation Layers",
+        "items": [
+          "api-reference/aggregation-layers/overview",
+          "api-reference/aggregation-layers/aggregation-layer",
+          "api-reference/aggregation-layers/aggregator",
+          "api-reference/aggregation-layers/cpu-aggregator",
+          "api-reference/aggregation-layers/webgl-aggregator"
+        ]
+      },
+      {
+        "type": "category",
         "label": "Scripting Interface",
         "items": [
           "api-reference/core/deckgl"
@@ -209,17 +220,6 @@
     "type": "category",
     "label": "Submodule API Reference",
     "items": [
-      {
-        "type": "category",
-        "label": "@deck.gl/extensions",
-        "items": [
-          "api-reference/aggregation-layers/overview",
-          "api-reference/aggregation-layers/aggregation-layer",
-          "api-reference/aggregation-layers/aggregator",
-          "api-reference/aggregation-layers/cpu-aggregator",
-          "api-reference/aggregation-layers/webgl-aggregator"
-        ]
-      },
       {
         "type": "category",
         "label": "@deck.gl/arcgis",


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

For some reason the Aggregation Layers docs were under extensions

##### Before
<img width="305" alt="Screenshot 2024-12-17 at 15 08 45" src="https://github.com/user-attachments/assets/6c29b0bb-5c95-41bc-94aa-88bfad43d953" />

##### After

<img width="290" alt="Screenshot 2024-12-17 at 15 16 21" src="https://github.com/user-attachments/assets/14862a2b-6f91-456c-946a-dcaa00e12bcc" />

