### PR TITLE
remove widget manager viewport optimization

### DIFF
--- a/modules/core/src/lib/widget-manager.ts
+++ b/modules/core/src/lib/widget-manager.ts
@@ -242,7 +242,6 @@ export class WidgetManager {
       acc[v.id] = v;
       return acc;
     }, {});
-    const {lastViewports} = this;
 
     for (const widget of this.getWidgets()) {
       const {viewId} = widget;
@@ -250,7 +249,7 @@ export class WidgetManager {
         // Attached to a specific view
         const viewport = viewportsById[viewId];
         if (viewport) {
-          if (widget.onViewportChange && !viewport.equals(lastViewports[viewId])) {
+          if (widget.onViewportChange) {
             widget.onViewportChange(viewport);
           }
           widget.onRedraw?.({viewports: [viewport], layers});
@@ -259,10 +258,7 @@ export class WidgetManager {
         // Not attached to a specific view
         if (widget.onViewportChange) {
           for (const viewport of viewports) {
-            // eslint-disable-next-line max-depth
-            if (!viewport.equals(lastViewports[viewport.id])) {
-              widget.onViewportChange(viewport);
-            }
+            widget.onViewportChange(viewport);
           }
         }
         widget.onRedraw?.({viewports, layers});

--- a/modules/widgets/src/compass-widget.tsx
+++ b/modules/widgets/src/compass-widget.tsx
@@ -77,8 +77,11 @@ export class CompassWidget implements Widget<CompassWidgetProps> {
   }
 
   onViewportChange(viewport: Viewport) {
-    this.viewports[viewport.id] = viewport;
-    this.update();
+    // no need to update if viewport is the same
+    if (!viewport.equals(this.viewports[viewport.id])) {
+      this.viewports[viewport.id] = viewport;
+      this.update();
+    }
   }
 
   onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {


### PR DESCRIPTION
For #9278

#### Background

This PR addresses an issue in `onViewportChange` where an optimization can prevent widgets from receiving a viewport. The issue was first noticed in the react environment because `lastViewports` is set before all widgets are fully mounted, leaving some widgets in an uninitialized state.

To resolve this, the guard logic in `onViewportChange` has been removed and the responsibility for handling performance concerns, such as avoiding excessive calls to `onViewportChange`, is pushed to individual widgets.

#### Change List
- Removed guard conditions in `onViewportChange` that previously compared `lastViewports`.
- Prevent excessive updates to the Compass widget when viewports change.
