### PR TITLE
Introducing deck.gl Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
   <a href='https://coveralls.io/github/visgl/deck.gl?branch=master'>
     <img src='https://img.shields.io/coveralls/visgl/deck.gl.svg?style=flat-square' alt='Coverage Status' />
   </a>
+  <a href="https://gurubase.io/g/deck-gl">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20deck.gl%20Guru-006BFF" alt="Gurubase" />
+  </a>
 </p>
 
 <h1 align="center">deck.gl | <a href="https://deck.gl">Website</a></h1>


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [deck.gl Guru](https://gurubase.io/g/deck-gl) has been manually added to Gurubase. deck.gl Guru uses the data from this repo and data from the [docs](https://deck.gl/docs) to answer questions by leveraging the LLM.

This PR introduces the "deck.gl Guru", showcasing that deck.gl now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "deck.gl Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the deck.gl documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable deck.gl Guru in Gurubase, just let us know that's totally fine.
