### PR TITLE
fix(core): conflicting resize logic when using non-default useDevicePixels

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -380,9 +380,8 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
         ...props.deviceProps,
         createCanvasContext: {
           canvas: this._createCanvas(props),
-          // Disable primitive auto-resizing provided by the CanvasContext class
-          // which does not take `useDevicePixels` into account
-          // Resizing is instead handled by AnimationLoop's `autoResizeDrawingBuffer` setting on every frame
+          useDevicePixels: this.props.useDevicePixels,
+          // TODO v9.2 - replace AnimationLoop's `autoResizeDrawingBuffer` with CanvasContext's `autoResize`
           autoResize: false
         }
       });

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -378,7 +378,13 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
         type: 'best-available',
         adapters: [webgl2Adapter],
         ...props.deviceProps,
-        createCanvasContext: {canvas: this._createCanvas(props)}
+        createCanvasContext: {
+          canvas: this._createCanvas(props),
+          // Disable primitive auto-resizing provided by the CanvasContext class
+          // which does not take `useDevicePixels` into account
+          // Resizing is instead handled by AnimationLoop's `autoResizeDrawingBuffer` setting on every frame
+          autoResize: false
+        }
       });
     }
 


### PR DESCRIPTION
#### Background

Canvas resize events are being responded to by two independent code paths:
- `CanvasContext` with `autoResize: true` sets up resize observer which calls `resize` without the correct `useDevicePixels` setting
- `AnimationLoop` with `autoResizeDrawingBuffer: true` checks canvas size before each render frame with the correct `useDevicePixels` setting

If the user sets `useDevicePixels` to a value that is not `window.devicePixelRatio` the canvas ends up getting resized twice to different dimensions.

#### Change List
- Disable `autoResize` when creating the context
