### PR TITLE
chore: pin ubuntu CI version to fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check_branch
     permissions:
       contents: write


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

GitHub action’s ubuntu-latest image has switched to 24, which by default blocks puppeteer / chrome test mode from running. Easiest solution for now is to pin CI to ubuntu-22.04
