### PR TITLE
chore: Replace CartoLayer reference in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,7 +26,7 @@ body:
       - label: Python/Jupyter notebook
       - label: MapboxOverlay
       - label: GoogleMapsOverlay
-      - label: CartoLayer
+      - label: CARTO
       - label: ArcGIS
 - type: textarea
   attributes:


### PR DESCRIPTION
Replaces a CartoLayer reference in the issue template. As of deckgl 9.1, it has been replaced by various more specialized layer types.