### PR TITLE
chore(ci): Add dependabot groups for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    groups:
+      non-major:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
Configures Dependabot to update github-actions dependencies in groups, rather than opening a PR for each dependency. I've set it to do separate PRs for major versions, and a weekly batch PR for non-major versions, but this isn't a strongly-held preference.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates

Minor formatting changes by Prettier.
