### PR TITLE
fix(carto): Make point labels non-interactive, avoid flicker

### DIFF
--- a/modules/carto/src/api/parse-map.ts
+++ b/modules/carto/src/api/parse-map.ts
@@ -347,6 +347,9 @@ function createChannelProps(
         extensions: [collisionFilterExtension],
         collisionEnabled: true,
         collisionGroup,
+        // Make labels non-interactive, avoiding deck.gl issue:
+        // https://github.com/visgl/deck.gl/issues/9410
+        pickable: false,
 
         // getPointRadius already has radiusScale baked in, so only pass one or the other
         ...(result.getPointRadius


### PR DESCRIPTION
A workaround for:

- https://github.com/visgl/deck.gl/issues/9410

By making labels on point layers non-interactive, we can avoid a bug in which the labels appear and disappear unexpectedly. Interactive labels can be restored if we can find another way to solve that label visibility issue.