### PR TITLE
CollisionFilterEffect: Explicitly pass isPicking to preRender

### DIFF
--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -493,7 +493,8 @@ export default class DeckPicker {
       effects,
       pass,
       pickZ,
-      preRenderStats: {}
+      preRenderStats: {},
+      isPicking: true
     };
 
     for (const effect of effects) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes https://github.com/visgl/deck.gl/issues/9410

<!-- For other PRs without open issue -->
#### Background

As the `isPicking` flag was not being passed the `CollisionFilterEffect` destroyed the FBO for the non-pickable layers, leading to the layers to then disappear in the render pass


https://github.com/user-attachments/assets/41527ef6-ecee-4105-854e-9a8745bc3ea7



<!-- For all the PRs -->
#### Change List
- Explicitly pass `isPicking = true` when invoking `Effect.preRender` from the deck picker