### PR TITLE
Fix Issue #9371 - Set default map style if not provided

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -8,7 +8,11 @@ from ..settings import settings as pydeck_settings
 from .view import View
 from .view_state import ViewState
 from .base_map_provider import BaseMapProvider
-from .map_styles import DARK, get_from_map_identifier
+from .map_styles import DARK, get_from_map_identifier, get_default_map_identifier
+
+
+# Special default value to for querying the default style for a map provider.
+_DEFAULT_MAP_STYLE_SENTINEL = '__MAP_STYLE__'
 
 
 def has_jupyter_extra():
@@ -29,7 +33,7 @@ class Deck(JSONMixin):
         self,
         layers=None,
         views=[View(type="MapView", controller=True)],
-        map_style=DARK,
+        map_style=_DEFAULT_MAP_STYLE_SENTINEL,
         api_keys=None,
         initial_view_state=ViewState(latitude=0, longitude=0, zoom=1),
         width="100%",
@@ -61,8 +65,11 @@ class Deck(JSONMixin):
             Values can be ``carto``, ``mapbox`` or ``google_maps``
         map_style : str or dict, default 'dark'
             One of 'light', 'dark', 'road', 'satellite', 'dark_no_labels', and 'light_no_labels', a URI for a basemap
-            style, which varies by provider, or a dict that follows the Mapbox style `specification <https://docs.mapbox.com/mapbox-gl-js/style-spec/>`.
-            The default is Carto's Dark Matter map. For Mapbox examples, see  Mapbox's `gallery <https://www.mapbox.com/gallery/>`.
+            style, which varies by provider, or a dict that follows the Mapbox style `specification <https://docs.mapbox.com/mapbox-gl-js/style-spec/>`_.
+            If ``map_provider='google_maps'``, the default is the ``roadmap`` map type.
+            if ``map_provider='mapbox'``, the default is `Mapbox Dark <https://www.mapbox.com/maps/dark>`_ style.
+            Otherwise, the default is Carto's Dark Matter map.
+            For Mapbox examples, see  Mapbox's `gallery <https://www.mapbox.com/gallery/>`_.
             If not using a basemap, set ``map_provider=None``.
         initial_view_state : pydeck.ViewState, default ``pydeck.ViewState(latitude=0, longitude=0, zoom=1)``
             Initial camera angle relative to the map, defaults to a fully zoomed out 0, 0-centered map
@@ -119,6 +126,8 @@ class Deck(JSONMixin):
             assert map_provider == BaseMapProvider.MAPBOX.value, custom_map_style_error
             self.map_style = map_style
         else:
+            if map_provider and map_style == _DEFAULT_MAP_STYLE_SENTINEL:
+                map_style = get_default_map_identifier(map_provider)
             self.map_style = get_from_map_identifier(map_style, map_provider)
 
         self.parameters = parameters

--- a/bindings/pydeck/pydeck/bindings/map_styles.py
+++ b/bindings/pydeck/pydeck/bindings/map_styles.py
@@ -1,4 +1,4 @@
-import warnings
+from .base_map_provider import BaseMapProvider
 
 
 DARK = "dark"
@@ -31,6 +31,12 @@ styles = {
     SATELLITE: {"mapbox": MAPBOX_SATELLITE, "google_maps": GOOGLE_SATELLITE},
 }
 
+_default_map_identifers = {
+    BaseMapProvider.CARTO: DARK,
+    BaseMapProvider.MAPBOX: DARK,
+    BaseMapProvider.GOOGLE_MAPS: GOOGLE_ROAD,
+}
+
 
 def get_from_map_identifier(map_identifier: str, provider: str) -> str:
     """Attempt to get a style URI by map provider, otherwise pass the map identifier
@@ -57,3 +63,12 @@ def get_from_map_identifier(map_identifier: str, provider: str) -> str:
         return styles[map_identifier][provider]
     except KeyError:
         return map_identifier
+
+
+def get_default_map_identifier(provider: str):
+    try:
+        provider_enum = BaseMapProvider(provider)
+    except KeyError:
+        return DARK
+
+    return _default_map_identifers[provider_enum]

--- a/bindings/pydeck/tests/bindings/test_deck.py
+++ b/bindings/pydeck/tests/bindings/test_deck.py
@@ -9,6 +9,8 @@ except ImportError:
     from mock import MagicMock
 
 from pydeck import Deck
+from pydeck import map_styles
+from pydeck.bindings.base_map_provider import BaseMapProvider
 from IPython.display import HTML
 
 from . import pydeck_examples
@@ -21,6 +23,22 @@ def test_deck_layer_args():
     for [args, expected_output] in CASES:
         r = Deck(**args)
         assert r.layers == expected_output
+
+
+@pytest.mark.parametrize(
+    "map_provider_enum, expected_map_style",
+    (
+        (BaseMapProvider.CARTO, map_styles.CARTO_DARK),
+        (BaseMapProvider.MAPBOX, map_styles.MAPBOX_DARK),
+        (BaseMapProvider.GOOGLE_MAPS, map_styles.GOOGLE_ROAD),
+    ),
+    ids=[BaseMapProvider.CARTO, BaseMapProvider.MAPBOX, BaseMapProvider.GOOGLE_MAPS],
+)
+def test_deck_default_map_style(map_provider_enum: BaseMapProvider, expected_map_style: str):
+    """Verify the a default map style is provided for all map providers."""
+    r = Deck(**{"layers": [], "map_provider": map_provider_enum.value})
+    assert r.map_provider == map_provider_enum.value
+    assert r.map_style == expected_map_style
 
 
 def test_json_output():


### PR DESCRIPTION
Tested with Google Maps in 
[this notebook](https://github.com/user-attachments/files/18739710/pydeck_test_issue_9371.pdf)

Closes #9371

#### Change List
- Added `get_default_map_identifier` to `map_styles.py` to determine map identifier key based on map provider
- Extended `Deck` constructor to choose a default map style for all 3 providers (as `DARK` is not an appropriate default for Google Maps)
    - Using a "sentinel" value as default to still allow disabling style (using `None`) if no base map is used.
- Added unit test to `test_deck.py` to verify default map style for major map providers if none is provided
