### PR TITLE
Add instructions for local development of @deck.gl/jupyter-widget

### DIFF
--- a/bindings/pydeck/docs/contributing.rst
+++ b/bindings/pydeck/docs/contributing.rst
@@ -38,6 +38,22 @@ enable pydeck to run on JupyterLab and Jupyter Notebook locally:
 
 Verify that this new local copy of pydeck works by running ``make test``.
 
+Local development of @deck.gl/jupyter-widget
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To test local changes to ``@deck.gl/jupyter-widget``, open a separate terminal, rebuild
+and start a local web server as follows:
+
+.. code-block:: bash
+
+        cd deckl.gl/modules/jupyter-widget
+        yarn run build
+        # select any port you wish
+        PYDECK_DEV_PORT=8000
+        python -m http.server $PYDECK_DEV_PORT
+
+Note the ``PYDECK_DEV_PORT`` which will be referenced in the instructions below.
+
 Local development in Jupyter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -49,7 +65,7 @@ described above, then start a local Jupyter notebook:
         jupyter notebook
 
 .. CAUTION::
-   Additional steps (TODO) required to include local changes to deck.gl in a local Pydeck build.
+   Set ``export PYDECK_DEV_PORT=<port>`` before running the above command to include local changes to ``@deck.gl/jupyter-widget``.
 
 Local development in Google Colab
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,6 +79,9 @@ additional flags to trust WebSocket connections from the Colab frontend:
             --NotebookApp.allow_origin='https://colab.research.google.com' \
             --port=8888 \
             --NotebookApp.port_retries=0
+
+.. CAUTION::
+   Set ``export PYDECK_DEV_PORT=<port>`` before running the above command to include local changes to ``@deck.gl/jupyter-widget``.
 
 After the notebook starts, copy the full (localhost) URL printed to the console. In a Google
 Colab notebook, select *Connect to a local runtime* from the additional connection options


### PR DESCRIPTION
For #9370 and #9064

#### Background

As discussed during the [OpenViz meeting on 2025-01-30](https://docs.google.com/presentation/d/1hs4GgKPo7J4P54cuxToqZ7HrYxk8vrHsE9u42ENMIfc/edit#slide=id.g32b27f74c35_1_10), content could be added to clarify how to do local development between both python and Javascript.

#### Change List
- Update `pydeck` contribution docs to provide guidance on local development for `@deck.gl/jupyter-widget` module.  This uses the `PYDECK_DEV_PORT` environment variable for which logic was added in PR #4632

