### PR TITLE
docs: postprocess imports from luma.gl/effects

### DIFF
--- a/docs/api-reference/core/post-process-effect.md
+++ b/docs/api-reference/core/post-process-effect.md
@@ -23,7 +23,7 @@ Parameters:
 ## Example
 
 ```js
-import {brightnessContrast} from '@luma.gl/shadertools';
+import {brightnessContrast} from '@luma.gl/effects';
 import {PostProcessEffect} from '@deck.gl/core';
 
 const postProcessEffect = new PostProcessEffect(brightnessContrast, {

--- a/docs/developer-guide/using-effects.md
+++ b/docs/developer-guide/using-effects.md
@@ -160,13 +160,13 @@ The post-processing effect applies screen space pixel manipulation effects to th
 *Interactive demo of PostProcessEffect*
 
 
-`@luma.gl/shadertools` provides a collection of [shader modules](https://luma.gl/docs/api-reference/shadertools/shader-passes/image-processing) that implements some common image processing algorithms. You may also refer to their source code to see how to implement your own.
+`@luma.gl/effects` provides a collection of [shader modules](https://luma.gl/docs/api-reference/shadertools/shader-passes/image-processing) that implements some common image processing algorithms. You may also refer to their source code to see how to implement your own.
 
 <Tabs groupId="language">
   <TabItem value="js" label="JavaScript">
 
 ```js
-import {brightnessContrast} from '@luma.gl/shadertools';
+import {brightnessContrast} from '@luma.gl/effects';
 import {Deck, PostProcessEffect} from '@deck.gl/core';
 
 const postProcessEffect = new PostProcessEffect(brightnessContrast, {
@@ -190,7 +190,7 @@ const deckInstance = new Deck({
   <TabItem value="ts" label="TypeScript">
 
 ```ts
-import {brightnessContrast, BrightnessContrastProps} from '@luma.gl/shadertools';
+import {brightnessContrast, BrightnessContrastProps} from '@luma.gl/effects';
 import {Deck, PostProcessEffect} from '@deck.gl/core';
 
 const postProcessEffect = new PostProcessEffect(brightnessContrast, {
@@ -210,7 +210,7 @@ const deckInstance = new Deck({
 ```tsx
 import React from 'react';
 import DeckGL from '@deck.gl/react';
-import {brightnessContrast, BrightnessContrastProps} from '@luma.gl/shadertools';
+import {brightnessContrast, BrightnessContrastProps} from '@luma.gl/effects';
 import {PostProcessEffect} from '@deck.gl/core';
 
 const postProcessEffect = new PostProcessEffect(brightnessContrast, {


### PR DESCRIPTION
#### Background

luma 9.1 changed the export path for PP effects: https://github.com/visgl/luma.gl/pull/2336

<!-- For all the PRs -->
#### Change List
- Update docs to use `@luma.gl/effects`
