### PR TITLE
docs: fix broken link in "Learning Resources"

### DIFF
--- a/docs/get-started/learning-resources.md
+++ b/docs/get-started/learning-resources.md
@@ -23,7 +23,7 @@ PureJS examples in prototyping environments. These are great templates for featu
 * deck.gl [Codepen demos](https://codepen.io/vis-gl/)
 * deck.gl [Observable demos](https://beta.observablehq.com/@pessimistress)
 * [RandomFractals](https://github.com/RandomFractals) [Observable DeckGL collection](https://observablehq.com/collection/@randomfractals/deckgl)
-* [deck.gl Showcase](http://deck.gl/showcase)
+* [deck.gl Showcase](https://deck.gl/showcase)
 
 ## Community
 

--- a/docs/get-started/learning-resources.md
+++ b/docs/get-started/learning-resources.md
@@ -23,7 +23,7 @@ PureJS examples in prototyping environments. These are great templates for featu
 * deck.gl [Codepen demos](https://codepen.io/vis-gl/)
 * deck.gl [Observable demos](https://beta.observablehq.com/@pessimistress)
 * [RandomFractals](https://github.com/RandomFractals) [Observable DeckGL collection](https://observablehq.com/collection/@randomfractals/deckgl)
-* [One-page scripting examples](http://deck.gl/showcases/gallery/)
+* [deck.gl Showcase](http://deck.gl/showcase)
 
 ## Community
 


### PR DESCRIPTION
Minor edit to fix a broken link on the Learning Resources page of the deck.gl docs.