### PR TITLE
CARTO: HeatmapTileLayer fix palette updating

### DIFF
--- a/modules/carto/src/layers/heatmap-tile-layer.ts
+++ b/modules/carto/src/layers/heatmap-tile-layer.ts
@@ -322,7 +322,7 @@ class HeatmapTileLayer<DataT = any, ExtraProps extends {} = {}> extends Composit
 
     if (colorTexture && colorTexture?.width === colorRange.length) {
       // TODO(v9): Unclear whether `setSubImageData` is a public API, or what to use if not.
-      (colorTexture as any).setSubImageData({data: colors});
+      (colorTexture as any).setTexture2DData({data: colors});
     } else {
       colorTexture?.destroy();
       // @ts-ignore TODO v9.1


### PR DESCRIPTION
#### Background
9.1 broke palette updating, as the API changed. Fixing in line with [HeatmapLayer](https://github.com/visgl/deck.gl/blob/master/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts#L561)


<!-- For all the PRs -->
#### Change List
- Use `setTexture2DData`