### PR TITLE
fix(widgets): ZoomWidget: Prevent crash when used with OrthographicView

### DIFF
--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -117,14 +117,15 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
 
   handleZoom(viewport: Viewport, nextZoom: number) {
     const viewId = this.viewId || viewport?.id || 'default-view';
-    const nextViewState = {
+    const nextViewState: Record<string, unknown> = {
       ...viewport,
       zoom: nextZoom,
-      transitionDuration: this.props.transitionDuration,
-      transitionInterpolator: new FlyToInterpolator()
     };
-    // @ts-ignore Using private method temporary until there's a public one
-    this.deck._onViewStateChange({viewId, viewState: nextViewState, interactionState: {}});
+    if ('latitude' in nextViewState) {
+      nextViewState.transitionDuration = this.props.transitionDuration,
+        nextViewState.transitionInterpolator = new FlyToInterpolator()
+    }
+    this.setViewState(viewId, nextViewState);
   }
 
   handleZoomIn() {
@@ -137,6 +138,14 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
     for (const viewport of Object.values(this.viewports)) {
       this.handleZoom(viewport, viewport.zoom - 1);
     }
+  }
+
+  /** 
+   * @todo - move to deck or widget manager 
+   */
+  private setViewState(viewId: string, viewState: Record<string, unknown>): void {
+    // @ts-ignore Using private method temporary until there's a public one
+    this.deck._onViewStateChange({viewId, viewState, interactionState: {}});
   }
 
   private update() {

--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -5,6 +5,7 @@
 /* global document */
 import {
   FlyToInterpolator,
+  LinearInterpolator,
   _deepEqual as deepEqual,
   _applyStyles as applyStyles,
   _removeStyles as removeStyles
@@ -36,7 +37,7 @@ export type ZoomWidgetProps = {
    */
   zoomOutLabel?: string;
   /**
-   * Zoom transition duration in ms.
+   * Zoom transition duration in ms. 0 disables the transition
    */
   transitionDuration?: number;
   /**
@@ -51,12 +52,24 @@ export type ZoomWidgetProps = {
 
 export class ZoomWidget implements Widget<ZoomWidgetProps> {
   id = 'zoom';
-  props: ZoomWidgetProps;
+  props: Required<ZoomWidgetProps>;
   placement: WidgetPlacement = 'top-left';
   viewId?: string | null = null;
   viewports: {[id: string]: Viewport} = {};
   deck?: Deck<any>;
   element?: HTMLDivElement;
+
+  static defaultProps: Required<ZoomWidgetProps> = {
+    id: 'zoom-widget',
+    style: {},
+    placement: 'top-left',
+    className: undefined!,
+    orientation: 'vertical',
+    transitionDuration: 200,
+    zoomInLabel: 'Zoom In',
+    zoomOutLabel: 'Zoom Out',
+    viewId: undefined!
+  };
 
   constructor(props: ZoomWidgetProps = {}) {
     this.id = props.id ?? this.id;
@@ -64,12 +77,8 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
     this.placement = props.placement ?? this.placement;
 
     this.props = {
-      ...props,
-      orientation: props.orientation ?? 'vertical',
-      transitionDuration: props.transitionDuration ?? 200,
-      zoomInLabel: props.zoomInLabel ?? 'Zoom In',
-      zoomOutLabel: props.zoomOutLabel ?? 'Zoom Out',
-      style: props.style ?? {}
+      ...ZoomWidget.defaultProps,
+      ...props
     };
   }
 
@@ -119,11 +128,12 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
     const viewId = this.viewId || viewport?.id || 'default-view';
     const nextViewState: Record<string, unknown> = {
       ...viewport,
-      zoom: nextZoom,
+      zoom: nextZoom
     };
-    if ('latitude' in nextViewState) {
-      nextViewState.transitionDuration = this.props.transitionDuration,
-        nextViewState.transitionInterpolator = new FlyToInterpolator()
+    if (this.props.transitionDuration > 0) {
+      nextViewState.transitionDuration = this.props.transitionDuration;
+      nextViewState.transitionInterpolator =
+        'latitude' in nextViewState ? new FlyToInterpolator() : new LinearInterpolator();
     }
     this.setViewState(viewId, nextViewState);
   }
@@ -140,8 +150,8 @@ export class ZoomWidget implements Widget<ZoomWidgetProps> {
     }
   }
 
-  /** 
-   * @todo - move to deck or widget manager 
+  /**
+   * @todo - move to deck or widget manager
    */
   private setViewState(viewId: string, viewState: Record<string, unknown>): void {
     // @ts-ignore Using private method temporary until there's a public one


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background
- FlyToInterpolator doesn't support orthographic viewports
- This is a quick fix to unbreak
- The ideal solution would presumably be to fix FlyToInterpolator to support more viewports

<!-- For all the PRs -->
#### Change List
- Avoid adding FlyToInterpolator if `latitude` is not present in view state.
