### PR TITLE
feat(mapbox): support Mapbox v3 Standard style slot

### DIFF
--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -36,7 +36,7 @@ map.once('load', () => {
         getPosition: d => d.position,
         getFillColor: [255, 0, 0, 100],
         getRadius: 1000,
-        beforeId: 'waterway-label' // In interleaved mode render the layer under map labels
+        beforeId: 'waterway-label' // In interleaved mode render the layer under map labels. Replace with `slot: 'bottom'` if using Mapbox v3 Standard Style.
       })
     ]
   });
@@ -72,7 +72,7 @@ function App() {
       getPosition: d => d.position,
       getFillColor: [255, 0, 0, 100],
       getRadius: 1000,
-      beforeId: 'waterway-label' // In interleaved mode render the layer under map labels
+      beforeId: 'waterway-label' // In interleaved mode render the layer under map labels. Replace with `slot: 'bottom'` if using Mapbox v3 Standard Style.
     })
   ];
 
@@ -118,7 +118,7 @@ The constructor additionally accepts the following option:
 
 - `interleaved` (boolean) - If `false`, a dedicated deck.gl canvas is added on top of the base map. If `true`, deck.gl layers are inserted into mapbox-gl's layer stack, and share the same `WebGL2RenderingContext` as the base map. Default is `false`. Note that interleaving with basemaps such as mapbox-gl-js v1 that only support WebGL 1 is not supported, see [compatibility](./overview#interleaved-renderer-compatibility).
 
-When using `interleaved: true`, you may optionally add a `beforeId` prop to a layer to specify its position in the Mapbox layer stack. If multiple deck.gl layers have the same `beforeId`, they are rendered in the order that is passed into the `layers` array.
+When using `interleaved: true`, you may control the ordering of layers in the Mapbox/MapLibre stack by optionally add a `beforeId` prop to a layer. If multiple deck.gl layers have the same `beforeId`, they are rendered in the order that is passed into the `layers` array. If used with Mapbox v3 Standard Style, supply a [slot](https://docs.mapbox.com/mapbox-gl-js/guides/migrate/#layer-slots) prop to layers instead.
 
 ## Methods
 

--- a/modules/mapbox/src/mapbox-layer.ts
+++ b/modules/mapbox/src/mapbox-layer.ts
@@ -10,12 +10,16 @@ export type MapboxLayerProps<LayerT extends Layer> = Partial<LayerT['props']> & 
   id: string;
   renderingMode?: '2d' | '3d';
   deck?: Deck;
+  /* Mapbox v3 Standard style */
+  slot?: 'bottom' | 'middle' | 'top';
 };
 
 export default class MapboxLayer<LayerT extends Layer> implements CustomLayerInterface {
   id: string;
   type: 'custom';
   renderingMode: '2d' | '3d';
+  /* Mapbox v3 Standard style */
+  slot?: 'bottom' | 'middle' | 'top';
   map: Map | null;
   deck: Deck | null;
   props: MapboxLayerProps<LayerT>;
@@ -29,6 +33,7 @@ export default class MapboxLayer<LayerT extends Layer> implements CustomLayerInt
     this.id = props.id;
     this.type = 'custom';
     this.renderingMode = props.renderingMode || '3d';
+    this.slot = props.slot;
     this.map = null;
     this.deck = null;
     this.props = props;

--- a/modules/mapbox/src/resolve-layers.ts
+++ b/modules/mapbox/src/resolve-layers.ts
@@ -52,7 +52,12 @@ export function resolveLayers(
       layerInstance.setProps(layer.props);
     } else {
       map.addLayer(
-        new MapboxLayer({id: layer.id, deck}),
+        new MapboxLayer({
+          id: layer.id,
+          deck,
+          // @ts-expect-error slot is not defined in LayerProps
+          slot: layer.props.slot
+        }),
         // @ts-expect-error beforeId is not defined in LayerProps
         layer.props.beforeId
       );


### PR DESCRIPTION

#### Background

In Mapbox v3 `slot` replaces `beforeId`:
https://docs.mapbox.com/mapbox-gl-js/guides/migrate/#layer-slots

#### Change List
- Allow layers in `MapboxOverlay` to supply an optional `slot` prop
- Documentation
