### PR TITLE
chore: WebGPU plumbing

### DIFF
--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -281,19 +281,31 @@ export default class DataColumn<Options, State> {
         options || {}
       );
       attributes.push(
-        getBufferAttributeLayout(attributeName, {...accessor, ...doubleShaderAttributeDefs.high}),
-        getBufferAttributeLayout(`${attributeName}64Low`, {
-          ...accessor,
-          ...doubleShaderAttributeDefs.low
-        })
+        getBufferAttributeLayout(
+          attributeName,
+          {...accessor, ...doubleShaderAttributeDefs.high},
+          this.device.type
+        ),
+        getBufferAttributeLayout(
+          `${attributeName}64Low`,
+          {
+            ...accessor,
+            ...doubleShaderAttributeDefs.low
+          },
+          this.device.type
+        )
       );
     } else if (options) {
       const shaderAttributeDef = resolveShaderAttribute(accessor, options);
       attributes.push(
-        getBufferAttributeLayout(attributeName, {...accessor, ...shaderAttributeDef})
+        getBufferAttributeLayout(
+          attributeName,
+          {...accessor, ...shaderAttributeDef},
+          this.device.type
+        )
       );
     } else {
-      attributes.push(getBufferAttributeLayout(attributeName, accessor));
+      attributes.push(getBufferAttributeLayout(attributeName, accessor, this.device.type));
     }
     return result;
   }

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -26,13 +26,13 @@ export function getBufferAttributeLayout(
   name: string,
   accessor: BufferAccessor
 ): BufferAttributeLayout {
+  // TODO(ibgreen): WebGPU change. Currently we always use normalized 8 bit integers
+  const type = accessor.type === 'uint8' ? 'unorm8' : accessor.type;
   return {
     attribute: name,
     // @ts-expect-error Not all combinations are valid vertex formats; it's up to DataColumn to ensure
     format:
-      (accessor.size as number) > 1
-        ? (`${accessor.type}x${accessor.size}` as VertexFormat)
-        : accessor.type,
+      (accessor.size as number) > 1 ? (`${type}x${accessor.size}` as VertexFormat) : accessor.type,
     byteOffset: accessor.offset || 0
     // Note stride is set on the top level
   };

--- a/modules/core/src/lib/attribute/gl-utils.ts
+++ b/modules/core/src/lib/attribute/gl-utils.ts
@@ -24,10 +24,11 @@ export const dataTypeFromTypedArray = getDataTypeFromTypedArray;
 
 export function getBufferAttributeLayout(
   name: string,
-  accessor: BufferAccessor
+  accessor: BufferAccessor,
+  deviceType: 'webgpu' | 'wegbgl' | string
 ): BufferAttributeLayout {
   // TODO(ibgreen): WebGPU change. Currently we always use normalized 8 bit integers
-  const type = accessor.type === 'uint8' ? 'unorm8' : accessor.type;
+  const type = deviceType === 'webgpu' && accessor.type === 'uint8' ? 'unorm8' : accessor.type;
   return {
     attribute: name,
     // @ts-expect-error Not all combinations are valid vertex formats; it's up to DataColumn to ensure


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

- Colors should be normalized in the shader. It would be good to align WebGL but there are a lot of moving pieces and this unblocks WebGPU.

<!-- For all the PRs -->
#### Change List
- Use `unorm8` attributes for colors in WebGPU
