### PR TITLE
fix(chore): Disable constant attributes under WebGPU

### DIFF
--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -425,7 +425,7 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
       // @ts-ignore TODO(ibgreen) add to types?
       if (this.context.device.type !== 'webgpu') {
         return;
-      } 
+      }
     }
     const {settings, state, value, size, startIndices} = attribute;
 

--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -255,7 +255,9 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
   // Use generic value
   // Returns true if successful
   setConstantValue(value?: NumericArray): boolean {
-    if (value === undefined || typeof value === 'function') {
+    // TODO(ibgreen): WebGPU does not support constant values
+    const isWebGPU = this.device.type === 'webgpu';
+    if (isWebGPU || value === undefined || typeof value === 'function') {
       return false;
     }
 

--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -422,6 +422,7 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
     }
   ): void {
     if (attribute.constant) {
+      // @ts-ignore TODO(ibgreen) add to types?
       if (this.context.device.type !== 'webgpu') {
         return;
       } 

--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -422,16 +422,21 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
     }
   ): void {
     if (attribute.constant) {
-      return;
+      if (this.context.device.type !== 'webgpu') {
+        return;
+      } 
     }
     const {settings, state, value, size, startIndices} = attribute;
 
     const {accessor, transform} = settings;
-    const accessorFunc: Accessor<any, any> =
+    let accessorFunc: Accessor<any, any> =
       state.binaryAccessor ||
       // @ts-ignore
       (typeof accessor === 'function' ? accessor : props[accessor]);
-
+    // TODO(ibgreen) WebGPU needs buffers, generate an accessor function from a constant
+    if (typeof accessorFunc !== 'function') {
+      accessorFunc = () => accessorFunc;
+    }
     assert(typeof accessorFunc === 'function', `accessor "${accessor}" is not a function`);
 
     let i = attribute.getVertexOffset(startRow);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background
- WebGPU doesn't support constant attributes. 
- Simply treating constant values as `() => value` will cause buffers to be generated and unblocks us until we can implement more advanced shader generation to handle constants.

<!-- For all the PRs -->
#### Change List
-
