### PR TITLE
fix(scatterplot-layer): use numeric uniform for "filled" to avoid GPU driver bug

### DIFF
--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-fragment.glsl.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-fragment.glsl.ts
@@ -33,7 +33,7 @@ void main(void) {
       smoothedge(innerUnitRadius * outerRadiusPixels, distToCenter) :
       step(innerUnitRadius * outerRadiusPixels, distToCenter);
 
-    if (scatterplot.filled) {
+    if (scatterplot.filled > 0.5) {
       fragColor = mix(vFillColor, vLineColor, isLine);
     } else {
       if (isLine == 0.0) {
@@ -41,7 +41,7 @@ void main(void) {
       }
       fragColor = vec4(vLineColor.rgb, vLineColor.a * isLine);
     }
-  } else if (scatterplot.filled == false) {
+  } else if (scatterplot.filled < 0.5) {
     discard;
   } else {
     fragColor = vFillColor;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-uniforms.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-uniforms.ts
@@ -13,7 +13,7 @@ uniform scatterplotUniforms {
   float lineWidthMinPixels;
   float lineWidthMaxPixels;
   float stroked;
-  bool filled;
+  float filled;
   bool antialiasing;
   bool billboard;
   highp int radiusUnits;


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background

This PR addresses an issue with the scatterplot layer on certain Snapdragon GPUs. Specifically, when the `filled` property was defined as a boolean, the fragment shader misbehaved and discarded fragments regardless of whether `filled` was true or false. Converting the `filled` uniform to a float and modifying the conditional checks resolves this issue by avoiding a known GPU driver bug.







| As Is(Website Example) | To Be |
|--------|--------|
| ![Screenshot_20250310_220515_Firefox](https://github.com/user-attachments/assets/72ef00ef-f0a7-404f-aaed-7e4e27074ab7) | ![Screenshot_20250310_221321_Firefox](https://github.com/user-attachments/assets/0f6d8309-051e-4c22-b390-a6b1735d2952) |




<!-- For all the PRs -->
#### Change List
- **Uniform Update:**  
  - Changed the type of `filled` in `scatterplot-layer-uniforms.ts` from `bool` to `float`.
  
- **Shader Conditional Update:**  
  - Replaced boolean checks (`if (scatterplot.filled)` / `else if (scatterplot.filled == false)`) with numerical comparisons (`if (scatterplot.filled > 0.5)` / `else if (scatterplot.filled < 0.5)`).

### Motivation

Recent reports indicate that on WebGL running on new Snapdragon devices, using a boolean uniform for `filled` in the scatterplot fragment shader results in unintended `discard` behavior. This change avoids potential miscompilation/optimization issues on affected GPUs by using a numeric type for the uniform.

### Testing

- Verified that both filled and outlined(stroked) scatterplot points render correctly on affected devices.
- Confirmed no regression on platforms where the shader was previously working as expected.

### Additional Notes

This workaround is specific to GPU driver bugs affecting certain Snapdragon models. It may be possible to revert the change if the driver issue is resolved in future updates, but for now, using a float ensures compatibility and correct rendering behavior.
