### PR TITLE
CARTO: RasterLayer improve shader precision at high zooms

### DIFF
--- a/modules/carto/src/layers/raster-layer-vertex.glsl.ts
+++ b/modules/carto/src/layers/raster-layer-vertex.glsl.ts
@@ -41,10 +41,14 @@ void main(void) {
   // Get position directly from quadbin, rather than projecting
   // Important to set geometry.position before using project_ methods below
   // as geometry.worldPosition is not set (we don't know our lat/long)
-  geometry.position = vec4(tileOrigin + cellCenter, 0.0, 1.0);
+  geometry.position = vec4(tileOrigin, 0.0, 1.0);
   if (project.projectionMode == PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET) {
     geometry.position.xyz -= project.commonOrigin;
   }
+
+  // Important to apply after tileOrigin & commonOrigin as they are large values which often
+  // cancel and thus cellCenter precision is lost if applied first.
+  geometry.position.xy += cellCenter;
 
   // calculate elevation, if 3d not enabled set to 0
   // cylindar geometry height are between -1.0 to 1.0, transform it to between 0, 1


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

Order of instructions in shader (combined with if branch statement) causes precision issues at high zooms

Before:


https://github.com/user-attachments/assets/badffa95-f0d4-41ef-bc54-80cc88e6fc97


After:


https://github.com/user-attachments/assets/105b6d20-61ff-4ce1-8373-4c7ade57be0b



<!-- For all the PRs -->
#### Change List
- Subtract large values from each other before applying small offset to preserve precision
