### PR TITLE
chore(yarn): Add package.json#packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.19"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/website/package.json
+++ b/website/package.json
@@ -60,5 +60,6 @@
   "volta": {
     "node": "18.19.0",
     "yarn": "1.22.19"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Once Yarn v2+ has been installed locally in a development environment, it comes with Corepack as the [preferred way to install package managers](https://yarnpkg.com/corepack). However, Volta (if installed) silently and globally disables Corepack...

- https://github.com/nodejs/corepack/issues/507#issuecomment-2625366567
- https://github.com/volta-cli/volta/issues/987

... which has caused some confusing bugs when the wrong version of Yarn is used, installing a different dependency chain locally vs. CI, and then we get different behaviors in each. To avoid that, I have to disable Volta when working in projects that use Corepack, and to re-enable Volta when working in deck.gl or luma.gl.

Would others be OK with including the `package.json#packageManager` field here, and (if so) in other vis.gl projects? The advantage would be that we get the right version of Yarn whether we're using Volta or Corepack, as long as we keep both entries pinned to the same version.

Or' if this isn't an issue for anyone else, I can keep enabling/disabling Volta as needed, not the end of the world. :) 