### PR TITLE
fix(carto): Fix tree-shaking of CartoRasterTileLoader

### DIFF
--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -17,6 +17,10 @@ import {injectAccessToken, TilejsonPropType} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 import {TileLayer, TileLayerProps} from '@deck.gl/geo-layers';
 import {copy, PostProcessModifier} from './post-process-utils';
+import {registerLoaders} from '@loaders.gl/core';
+import CartoRasterTileLoader from './schema/carto-raster-tile-loader';
+
+registerLoaders([CartoRasterTileLoader]);
 
 export const renderSubLayers = props => {
   const tileIndex = props.tile?.index?.q;

--- a/modules/carto/src/layers/spatial-index-tile-layer.ts
+++ b/modules/carto/src/layers/spatial-index-tile-layer.ts
@@ -4,9 +4,8 @@
 
 import {registerLoaders} from '@loaders.gl/core';
 import {DefaultProps, LayerProps} from '@deck.gl/core';
-import CartoRasterTileLoader from './schema/carto-raster-tile-loader';
 import CartoSpatialTileLoader from './schema/carto-spatial-tile-loader';
-registerLoaders([CartoRasterTileLoader, CartoSpatialTileLoader]);
+registerLoaders([CartoSpatialTileLoader]);
 
 import {PickingInfo} from '@deck.gl/core';
 import {TileLayer, _Tile2DHeader as Tile2DHeader, TileLayerProps} from '@deck.gl/geo-layers';


### PR DESCRIPTION
For an application to support the CARTO raster format, the loader must be [registered](https://loaders.gl/docs/modules/core/api-reference/register-loaders). For an application installing `@deck.gl/carto` from npm, that registration happens in the `node_modules/@deck.gl/carto/modules/carto/dist/layers/spatial-index-tile-layer.js` file. Certain builds — reproduced with Angular v18 production (not dev!) builds — may tree-shake this file, resulting in the loader never being registered.

The simplest fix is to move the loader registration into raster-tile-layer.js. If RasterTileLayer is tree-shaken, I think it's safe to assume that the loader is not needed? And I don't think SpatialIndexTileLayer needs the raster tile loader (https://github.com/visgl/deck.gl/commit/2eaabdd9fa46023544993359595e4171890d1b46).

Possible fixes:

- (a) Move `registerLoaders([CartoRasterTileLoader])` to `raster-tile-layer.ts`
- (b) Register all loaders unconditionally in `src/index.ts`
- (c) Set `package.json#sideEffects` to `true`
- (d) Move loader registration out of top-level module scope (shown below)

```javascript
class RasterTileLoader {
  constructor(...props) {
    super(...props);
    registerLoaders([CartoRasterTileLoader]);
  }
}
```

I've implemented (a) in this PR as it's the simplest fix, and consistent with what we're doing already. But (c) or (d) might be the 'correct' approaches here, otherwise we are technically depending on side effects while declaring that the package has none. See https://stackoverflow.com/a/49203452. Would be happy to switch the PR to either of the other options.