### PR TITLE
fix(core) Append `.js` to WebGPU shaders for script builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,12 +55,12 @@
       },
       {
         "transform": "@vis.gl/ts-plugins/ts-transform-append-extension",
-        "extensions": [".js", ".glsl.js"],
+        "extensions": [".js", ".glsl.js", ".wgsl.js"],
         "after": true
       },
       {
         "transform": "@vis.gl/ts-plugins/ts-transform-append-extension",
-        "extensions": [".js", ".glsl.js"],
+        "extensions": [".js", ".glsl.js", ".wgsl.js"],
         "afterDeclarations": true
       }
     ]


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

As of 9.1.6, `docusaurus` is throwing an error related to the WebGPU shaders recently introduced in 9.1. This attempts to fix the issue by appending a js extension to our compiled JS files, we did with glsl shaders.

```
ERROR in ./node_modules/@deck.gl/core/dist/shaderlib/project/project.js 7:0-45
Module not found: Error: Can't resolve './project.wgsl' in '/Users/chris.gervang/code/hubble.gl/website/node_modules/@deck.gl/core/dist/shaderlib/project'
Did you mean 'project.wgsl.js'?
BREAKING CHANGE: The request './project.wgsl' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

I've confirmed 9.1.5 and earlier does not throw an error. 9.1.6 was the first release with `.wgsl` shaders in the distribution.

<!-- For all the PRs -->
#### Change List
- Append `.js` to WebGPU shaders for script builds
