### PR TITLE
fix(release) CHANGELOG now always contains `v` prefix

### DIFF
--- a/scripts/github-release.js
+++ b/scripts/github-release.js
@@ -40,7 +40,7 @@ function getGitTag() {
 
 function getReleaseNotes(version) {
   let changelog = readFileSync('CHANGELOG.md', 'utf-8');
-  const header = changelog.match(new RegExp(`^###.*\\b${version.replace('v', '')}\\b.*$`, 'm'));
+  const header = changelog.match(new RegExp(`^###.*\\b${version}\\b.*$`, 'm'));
   if (!header) {
     return null;
   }


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

I found a bug in the github release script while using it in hubble. This script is currently disabled in deck's release action, but if we choose to re-enable it, the script would currently fail.

<!-- For all the PRs -->
#### Change List
- remove broken regex
