### PR TITLE
Revert #9483 using 6 coordinates in glViewport

### DIFF
--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -474,11 +474,8 @@ function getGLViewport(
     dimensions.x * pixelRatio,
     height - (dimensions.y + dimensions.height) * pixelRatio,
     dimensions.width * pixelRatio,
-    dimensions.height * pixelRatio,
-    // TODO(ibgreen): WebGPU requires 6 coordinates. luma should probably autofill 0 and 1 if omitted.
-    0,
-    1
-  ] as unknown as [number, number, number, number];
+    dimensions.height * pixelRatio
+  ];
 }
 
 function mergeModuleParameters(


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes https://github.com/visgl/deck.gl/issues/9536

<!-- For other PRs without open issue -->
#### Background

Caused by https://github.com/visgl/deck.gl/pull/9483/files#diff-e6bb172fd86c7d509a8ed078b42f5f10eb56d84a5873e7407178bc03beab5923R477-R481

As per comment, luma should backfill these for WebGPU

I've tested by rebuilding the website locally and the Maplibre globe example now works as expected

<!-- For all the PRs -->
#### Change List
- Revert to only passing 4 values for glViewport
