### PR TITLE
[feat] Add hover support to InfoWidget

### DIFF
--- a/examples/get-started/pure-js/widgets/app.ts
+++ b/examples/get-started/pure-js/widgets/app.ts
@@ -86,22 +86,35 @@ const deck = new Deck({
     new _ScaleWidget({placement: 'bottom-left'}),
     new _GeolocateWidget(),
     new _ThemeWidget(),
-    new _InfoWidget({
-      onClick(widget: _InfoWidget, info: PickingInfo) {
-        if (info.object && info.layer?.id === 'airports') {
-          widget.setProps({
-            visible: true,
-            position: info.object.geometry.coordinates,
-            text: `${info.object.properties.name} (${info.object.properties.abbrev})`,
-            style: {width: 200, boxShadow: 'rgba(0, 0, 0, 0.5) 2px 2px 5px'}
-          });
-        } else {
-          widget.setProps({
-            visible: false
-          });
-        }
-        return true;
-      }
-    })
+    new _InfoWidget({mode: 'hover', getTooltip}),
+    new _InfoWidget({mode: 'click', getTooltip})
+    // new _InfoWidget({mode: 'static', getTooltip})
   ]
 });
+
+function getTooltip(info: PickingInfo, widget: _InfoWidget) {
+  if (!info.object || info.layer?.id !== 'airports') {
+    return null;
+  }
+
+  let text: string;
+  switch (widget.props.mode) {
+    case 'hover':
+      text = `${info.object.properties.name} (${info.object.properties.abbrev})`;
+      break;
+    case 'click':
+    case 'static':
+      text = `\
+${info.object.properties.name} (${info.object.properties.abbrev})
+${info.object.properties.type}
+${info.object.properties.featureclass} (${info.object.properties.location})
+`;
+      break;
+  }
+
+  return {
+    position: info.object.geometry.coordinates,
+    text,
+    style: {width: 200, boxShadow: 'rgba(0, 0, 0, 0.5) 2px 2px 5px'}
+  };
+}

--- a/examples/get-started/pure-js/widgets/app.ts
+++ b/examples/get-started/pure-js/widgets/app.ts
@@ -82,7 +82,6 @@ const deck = new Deck({
     new ScreenshotWidget(),
     new ResetViewWidget(),
     new _LoadingWidget(),
-    new _LoadingWidget(),
     new _ScaleWidget({placement: 'bottom-left'}),
     new _GeolocateWidget(),
     new _ThemeWidget(),

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -16,6 +16,10 @@ export type InfoWidgetProps = {
    * Additional CSS class.
    */
   className?: string;
+
+  mode: 'click' | 'hover' | 'static';
+
+  getTooltip?: (info: PickingInfo, widget: InfoWidget) => any;
   /**
    * Position at which to place popup (clicked point: [longitude, latitude]).
    */
@@ -62,7 +66,27 @@ export class InfoWidget implements Widget<InfoWidgetProps> {
     this.update();
   }
 
+  onHover(info: PickingInfo): void {
+    if (this.props.mode === 'hover' && this.props.getTooltip) {
+      const tooltip = this.props.getTooltip(info, this);
+      this.setProps({
+        visible: tooltip !== null,
+        ...tooltip
+      });
+    }
+  }
+
   onClick(info: PickingInfo): boolean {
+    if (this.props.mode === 'click' && this.props.getTooltip) {
+      const tooltip = this.props.getTooltip(info, this);
+      this.setProps({
+        visible: tooltip !== null,
+        ...tooltip
+      });
+      return tooltip != null;
+    }
+
+    // Original behavior
     return this.props.onClick?.(this, info) || false;
   }
 

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -69,9 +69,11 @@ export class InfoWidget implements Widget<InfoWidgetProps> {
   onHover(info: PickingInfo): void {
     if (this.props.mode === 'hover' && this.props.getTooltip) {
       const tooltip = this.props.getTooltip(info, this);
+      // hover tooltips should show over static and click infos
       this.setProps({
         visible: tooltip !== null,
-        ...tooltip
+        ...tooltip,
+        style: {zIndex: 1, ...tooltip?.style}, 
       });
     }
   }

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -73,7 +73,7 @@ export class InfoWidget implements Widget<InfoWidgetProps> {
       this.setProps({
         visible: tooltip !== null,
         ...tooltip,
-        style: {zIndex: 1, ...tooltip?.style}, 
+        style: {zIndex: 1, ...tooltip?.style}
       });
     }
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

- Three use cases for the `_InfoWidget`
- Hover to show info tooltip
- Click to show an anchored info box
- Static info (app could add multiple anchored info boxes) 

The static use case requires some row lookup which I didn't handle in this PR.

<!-- For all the PRs -->
#### Change List
- New mode prop
- Align the callback with getTooltip (we'll probably settle on a different name)
