### PR TITLE
fix(carto): RasterTileLayer fix to support external loadOptions

### DIFF
--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -74,6 +74,7 @@ export default class RasterTileLayer<
 
     const {tiles: data, minzoom: minZoom, maxzoom: maxZoom, raster_metadata: metadata} = tileJSON;
     const SubLayerClass = this.getSubLayerClass('tile', PostProcessTileLayer);
+    const loadOptions = this.getLoadOptions();
     return new SubLayerClass(this.props, {
       id: `raster-tile-layer-${this.props.id}`,
       data,
@@ -83,8 +84,8 @@ export default class RasterTileLayer<
       minZoom,
       maxZoom,
       loadOptions: {
-        cartoRasterTile: {metadata},
-        ...this.getLoadOptions()
+        ...loadOptions,
+        cartoRasterTile: {...loadOptions?.cartoRasterTile, metadata}
       }
     });
   }


### PR DESCRIPTION
RasterTileLayer requires specific properties (metadata) passed to loader.
Passing custom `loadOptions` as props, overrides `loadOptions.cartoRasterTile.metadata` and layer loader always fail to parse tile.
 
 <!-- For all the PRs -->
#### Change List
- Carto: RasterTileLayer fix support  for external loadOptions
