### PR TITLE
[feat]: SplitterWidget

### DIFF
--- a/examples/get-started/pure-js/widgets/app.ts
+++ b/examples/get-started/pure-js/widgets/app.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, MapView, PickingInfo} from '@deck.gl/core';
+import {Deck, MapView, MapViewProps, PickingInfo} from '@deck.gl/core';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {
   CompassWidget,
@@ -36,16 +36,25 @@ const INITIAL_VIEW_STATE = {
   pitch: 30
 };
 
+function getViewsForSplit(percentage: number) {
+  const x1 = '0%';
+  const width1 = `${percentage}%`;
+  const x2 = width1;
+  const width2 = `${100 - percentage}%`;
+
+  return [
+    new MapView({id: 'left-map', x: x1, width: width1, controller: true}),
+    new MapView({id: 'right-map', x: x2, width: width2, controller: true})
+  ];
+}
+
 const deck = new Deck({
   initialViewState: {
     'left-map': INITIAL_VIEW_STATE,
     'right-map': INITIAL_VIEW_STATE
   },
-  controller: true,
-  views: [
-    new MapView({id: 'left-map', width: "50%"}),
-    new MapView({id: 'right-map', width: "50%", x: "50%"})
-  ],
+  // controller: true,
+  views: getViewsForSplit(50),
   layers: [
     new GeoJsonLayer({
       id: 'base-map',
@@ -93,10 +102,15 @@ const deck = new Deck({
     new _ScaleWidget({placement: 'bottom-left'}),
     new _GeolocateWidget(),
     new _ThemeWidget(),
-    new _SplitterWidget({viewId1: 'view1', viewId2: 'view2', orientation: 'vertical'}),
     new _InfoWidget({mode: 'hover', getTooltip}),
-    new _InfoWidget({mode: 'click', getTooltip})
+    new _InfoWidget({mode: 'click', getTooltip}),
     // new _InfoWidget({mode: 'static', getTooltip})
+    new _SplitterWidget({
+      viewId1: 'left-map',
+      viewId2: 'right-map',
+      orientation: 'vertical',
+      onChange: ratio => deck.setProps({views: getViewsForSplit(ratio * 100)})
+    })
   ]
 });
 

--- a/examples/get-started/pure-js/widgets/app.ts
+++ b/examples/get-started/pure-js/widgets/app.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, PickingInfo} from '@deck.gl/core';
+import {Deck, MapView, PickingInfo} from '@deck.gl/core';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {
   CompassWidget,
@@ -16,6 +16,7 @@ import {
   _ThemeWidget,
   _InfoWidget,
   _InfoWidget,
+  _SplitterWidget,
   DarkGlassTheme,
   LightGlassTheme
 } from '@deck.gl/widgets';
@@ -36,8 +37,15 @@ const INITIAL_VIEW_STATE = {
 };
 
 const deck = new Deck({
-  initialViewState: INITIAL_VIEW_STATE,
+  initialViewState: {
+    'left-map': INITIAL_VIEW_STATE,
+    'right-map': INITIAL_VIEW_STATE
+  },
   controller: true,
+  views: [
+    new MapView({id: 'left-map', width: "50%"}),
+    new MapView({id: 'right-map', width: "50%", x: "50%"})
+  ],
   layers: [
     new GeoJsonLayer({
       id: 'base-map',
@@ -85,6 +93,7 @@ const deck = new Deck({
     new _ScaleWidget({placement: 'bottom-left'}),
     new _GeolocateWidget(),
     new _ThemeWidget(),
+    new _SplitterWidget({viewId1: 'view1', viewId2: 'view2', orientation: 'vertical'}),
     new _InfoWidget({mode: 'hover', getTooltip}),
     new _InfoWidget({mode: 'click', getTooltip})
     // new _InfoWidget({mode: 'static', getTooltip})

--- a/modules/widgets/src/components.tsx
+++ b/modules/widgets/src/components.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export const IconButton = props => {
+export type IconButtonProps = {
+  className: string;
+  label: string;
+  onClick: (event?) => void;
+}
+
+export const IconButton = (props: IconButtonProps) => {
   const {className, label, onClick} = props;
   return (
     <div className="deck-widget-button">

--- a/modules/widgets/src/components.tsx
+++ b/modules/widgets/src/components.tsx
@@ -5,8 +5,8 @@
 export type IconButtonProps = {
   className: string;
   label: string;
-  onClick: (event?) => void;
-}
+  onClick: (event?) => unknown;
+};
 
 export const IconButton = (props: IconButtonProps) => {
   const {className, label, onClick} = props;

--- a/modules/widgets/src/fullscreen-widget.tsx
+++ b/modules/widgets/src/fullscreen-widget.tsx
@@ -44,7 +44,7 @@ export type FullscreenWidgetProps = {
 
 export class FullscreenWidget implements Widget<FullscreenWidgetProps> {
   id = 'fullscreen';
-  props: FullscreenWidgetProps;
+  props: Required<FullscreenWidgetProps>;
   placement: WidgetPlacement = 'top-left';
 
   deck?: Deck<any>;
@@ -57,10 +57,14 @@ export class FullscreenWidget implements Widget<FullscreenWidgetProps> {
     this.placement = props.placement ?? this.placement;
 
     this.props = {
+      id: 'fullscreen',
+      placement: 'top-left',
+      enterLabel: 'Enter Fullscreen',
+      exitLabel: 'Exit Fullscreen',
+      container: undefined!,
+      className: '',
+      style: {},
       ...props,
-      enterLabel: props.enterLabel ?? 'Enter Fullscreen',
-      exitLabel: props.exitLabel ?? 'Exit Fullscreen',
-      style: props.style ?? {}
     };
   }
 

--- a/modules/widgets/src/fullscreen-widget.tsx
+++ b/modules/widgets/src/fullscreen-widget.tsx
@@ -64,7 +64,7 @@ export class FullscreenWidget implements Widget<FullscreenWidgetProps> {
       container: undefined!,
       className: '',
       style: {},
-      ...props,
+      ...props
     };
   }
 

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -17,6 +17,7 @@ export {ScreenshotWidget} from './screenshot-widget';
 export {LoadingWidget as _LoadingWidget} from './loading-widget';
 export {ThemeWidget as _ThemeWidget} from './theme-widget';
 export {InfoWidget as _InfoWidget} from './info-widget';
+export {SplitterWidget as _SplitterWidget} from './splitter-widget'
 
 export type {FullscreenWidgetProps} from './fullscreen-widget';
 export type {CompassWidgetProps} from './compass-widget';
@@ -28,6 +29,7 @@ export type {LoadingWidgetProps} from './loading-widget';
 export type {ScaleWidgetProps} from './scale-widget';
 export type {ThemeWidgetProps} from './theme-widget';
 export type {InfoWidgetProps} from './info-widget';
+export type {SplitterWidgetProps} from './splitter-widget'
 
 export {IconButton, ButtonGroup, GroupedIconButton} from './components';
 

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -17,7 +17,7 @@ export {ScreenshotWidget} from './screenshot-widget';
 export {LoadingWidget as _LoadingWidget} from './loading-widget';
 export {ThemeWidget as _ThemeWidget} from './theme-widget';
 export {InfoWidget as _InfoWidget} from './info-widget';
-export {SplitterWidget as _SplitterWidget} from './splitter-widget'
+export {SplitterWidget as _SplitterWidget} from './splitter-widget';
 
 export type {FullscreenWidgetProps} from './fullscreen-widget';
 export type {CompassWidgetProps} from './compass-widget';
@@ -29,7 +29,7 @@ export type {LoadingWidgetProps} from './loading-widget';
 export type {ScaleWidgetProps} from './scale-widget';
 export type {ThemeWidgetProps} from './theme-widget';
 export type {InfoWidgetProps} from './info-widget';
-export type {SplitterWidgetProps} from './splitter-widget'
+export type {SplitterWidgetProps} from './splitter-widget';
 
 export {IconButton, ButtonGroup, GroupedIconButton} from './components';
 

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -1,0 +1,177 @@
+// SplitterWidget.tsx
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import { h, render } from 'preact';
+import { useState, useRef } from 'preact/hooks';
+import { WidgetImpl, WidgetImplProps } from './widget-impl';
+
+/** Properties for the SplitterWidget */
+export type SplitterWidgetProps = WidgetImplProps & {
+  /** The view id for the first (resizable) view */
+  viewId1: string;
+  /** The view id for the second view */
+  viewId2: string;
+  /** Orientation of the splitter: vertical (default) or horizontal */
+  orientation?: 'vertical' | 'horizontal';
+  /** The initial split percentage (0 to 1) for the first view, default 0.5 */
+  initialSplit?: number;
+  /** Callback invoked when the splitter is dragged with the new split value */
+  onChange?: (newSplit: number) => void;
+  /** Callback invoked when dragging starts */
+  onDragStart?: () => void;
+  /** Callback invoked when dragging ends */
+  onDragEnd?: () => void;
+};
+
+/**
+ * A draggable splitter widget that appears as a vertical or horizontal line
+ * across the deck.gl canvas. It positions itself based on the split percentage
+ * of the first view and provides callbacks when dragged.
+ */
+export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
+  static defaultProps: Required<SplitterWidgetProps> = {
+    ...WidgetImpl.defaultProps,
+    id: 'splitter-widget',
+    viewId1: '',
+    viewId2: '',
+    orientation: 'vertical',
+    initialSplit: 0.5,
+    onChange: () => {},
+    onDragStart: () => {},
+    onDragEnd: () => {}
+  };
+
+  className = 'deck-widget-splitter';
+  placement = 'fill';
+
+  constructor(props: SplitterWidgetProps) {
+    // No placement prop is used.
+    super({ ...SplitterWidget.defaultProps, ...props });
+  }
+
+  setProps(props: Partial<SplitterWidgetProps>) {
+    super.setProps(props);
+  }
+
+  onRenderHTML() {
+    const element = this.element;
+    if (!element) return;
+    // Ensure the widget container fills the deck.gl canvas.
+    element.style.position = 'absolute';
+    element.style.top = '0';
+    element.style.left = '0';
+    element.style.width = '100%';
+    element.style.height = '100%';
+
+    render(
+      <Splitter
+        orientation={this.props.orientation!}
+        initialSplit={this.props.initialSplit!}
+        onChange={this.props.onChange}
+        onDragStart={this.props.onDragStart}
+        onDragEnd={this.props.onDragEnd}
+      />,
+      element
+    );
+  }
+}
+
+/**
+ * A functional component that renders a draggable splitter line.
+ * It computes its position based on the provided split percentage and
+ * updates it during mouse drag events.
+ */
+function Splitter({
+  orientation,
+  initialSplit,
+  onChange,
+  onDragStart,
+  onDragEnd
+}: {
+  orientation: 'vertical' | 'horizontal';
+  initialSplit: number;
+  onChange?: (newSplit: number) => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+}) {
+  const [split, setSplit] = useState(initialSplit);
+  const dragging = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleDragStart = (event: MouseEvent) => {
+    dragging.current = true;
+    onDragStart && onDragStart();
+    document.addEventListener('mousemove', handleDragging);
+    document.addEventListener('mouseup', handleDragEnd);
+    event.preventDefault();
+  };
+
+  const handleDragging = (event: MouseEvent) => {
+    if (!dragging.current || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    let newSplit: number;
+    if (orientation === 'vertical') {
+      newSplit = (event.clientX - rect.left) / rect.width;
+    } else {
+      newSplit = (event.clientY - rect.top) / rect.height;
+    }
+    // Clamp newSplit between 5% and 95%
+    newSplit = Math.min(Math.max(newSplit, 0.05), 0.95);
+    setSplit(newSplit);
+    onChange && onChange(newSplit);
+  };
+
+  const handleDragEnd = (event: MouseEvent) => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    onDragEnd && onDragEnd();
+    document.removeEventListener('mousemove', handleDragging);
+    document.removeEventListener('mouseup', handleDragEnd);
+  };
+
+  // The splitter line style based on orientation and the current split percentage.
+  const splitterStyle: h.JSX.CSSProperties =
+    orientation === 'vertical'
+      ? {
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: `${split * 100}%`,
+          width: '4px',
+          cursor: 'col-resize',
+          background: '#ccc',
+          zIndex: 10,
+          pointerEvents: 'auto'
+        }
+      : {
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: `${split * 100}%`,
+          height: '4px',
+          cursor: 'row-resize',
+          background: '#ccc',
+          zIndex: 10,
+          pointerEvents: 'auto'
+        };
+
+  // Container style to fill the entire deck.gl canvas.
+  const containerStyle: h.JSX.CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0
+  };
+
+  return (
+    <div ref={containerRef} style={containerStyle}>
+      <div
+        style={splitterStyle}
+        onMouseDown={handleDragStart as any} // Type cast to satisfy event typing.
+      />
+    </div>
+  );
+}

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -174,7 +174,7 @@ function Splitter({
     <div ref={containerRef} style={containerStyle}>
       <div
         style={splitterStyle}
-        onMouseDown={handleDragStart as h.JSX.MouseEventHandler} // Use the appropriate Preact event type.
+        onMouseDown={handleDragStart as h.JSX.MouseEventHandler<HTMLElement>} // Use the appropriate Preact event type.
       />
     </div>
   );

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import { h, render } from 'preact';
-import { useState, useRef } from 'preact/hooks';
-import { WidgetImpl, WidgetImplProps } from './widget-impl';
+import {h, render} from 'preact';
+import {useState, useRef} from 'preact/hooks';
+import {WidgetImpl, WidgetImplProps} from './widget-impl';
 
 /** Properties for the SplitterWidget */
 export type SplitterWidgetProps = WidgetImplProps & {
@@ -48,7 +48,7 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
 
   constructor(props: SplitterWidgetProps) {
     // No placement prop is used.
-    super({ ...SplitterWidget.defaultProps, ...props });
+    super({...SplitterWidget.defaultProps, ...props});
   }
 
   setProps(props: Partial<SplitterWidgetProps>) {
@@ -65,10 +65,12 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
     element.style.width = '100%';
     element.style.height = '100%';
 
+    element.style.margin = '0px';
+
     render(
       <Splitter
-        orientation={this.props.orientation!}
-        initialSplit={this.props.initialSplit!}
+        orientation={this.props.orientation}
+        initialSplit={this.props.initialSplit}
         onChange={this.props.onChange}
         onDragStart={this.props.onDragStart}
         onDragEnd={this.props.onDragEnd}
@@ -102,7 +104,7 @@ function Splitter({
 
   const handleDragStart = (event: MouseEvent) => {
     dragging.current = true;
-    onDragStart && onDragStart();
+    onDragStart?.();
     document.addEventListener('mousemove', handleDragging);
     document.addEventListener('mouseup', handleDragEnd);
     event.preventDefault();
@@ -120,13 +122,13 @@ function Splitter({
     // Clamp newSplit between 5% and 95%
     newSplit = Math.min(Math.max(newSplit, 0.05), 0.95);
     setSplit(newSplit);
-    onChange && onChange(newSplit);
+    onChange?.(newSplit);
   };
 
   const handleDragEnd = (event: MouseEvent) => {
     if (!dragging.current) return;
     dragging.current = false;
-    onDragEnd && onDragEnd();
+    onDragEnd?.();
     document.removeEventListener('mousemove', handleDragging);
     document.removeEventListener('mouseup', handleDragEnd);
   };
@@ -143,7 +145,8 @@ function Splitter({
           cursor: 'col-resize',
           background: '#ccc',
           zIndex: 10,
-          pointerEvents: 'auto'
+          pointerEvents: 'auto',
+          boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
         }
       : {
           position: 'absolute',
@@ -154,7 +157,8 @@ function Splitter({
           cursor: 'row-resize',
           background: '#ccc',
           zIndex: 10,
-          pointerEvents: 'auto'
+          pointerEvents: 'auto',
+          boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
         };
 
   // Container style to fill the entire deck.gl canvas.

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -174,7 +174,7 @@ function Splitter({
     <div ref={containerRef} style={containerStyle}>
       <div
         style={splitterStyle}
-        onMouseDown={handleDragStart as any} // Type cast to satisfy event typing.
+        onMouseDown={handleDragStart as h.JSX.MouseEventHandler} // Use the appropriate Preact event type.
       />
     </div>
   );


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

- I was thinking to myself, wouldn't it be nice to have a widget that lets users resize views?

![splitter-widget](https://github.com/user-attachments/assets/aebed466-b9d1-47ed-a03e-39f85ce6780b)

<!-- For all the PRs -->
#### Change List
- New experimental SplitterWidget

#### TODOs

- Cleanup of widget code
- Possibility to auto detect split from views?
- Possibility to include the view updates in the widget so the app doesn't have to.
- core: To make this work well in declarative setups, we might want to consider adding`DeckProps.initialViews`.
- core: Might be nice to have a `units: 'percent'` or `units: 'ratio'` type prop on views, so percentage views can be specified numerically without the need to generate strings such as "50%".
- 
