### PR TITLE
feat(core, widgets): Allow widgets to modify views

### DIFF
--- a/examples/get-started/pure-js/widgets/app.ts
+++ b/examples/get-started/pure-js/widgets/app.ts
@@ -36,25 +36,16 @@ const INITIAL_VIEW_STATE = {
   pitch: 30
 };
 
-function getViewsForSplit(percentage: number) {
-  const x1 = '0%';
-  const width1 = `${percentage}%`;
-  const x2 = width1;
-  const width2 = `${100 - percentage}%`;
-
-  return [
-    new MapView({id: 'left-map', x: x1, width: width1, controller: true}),
-    new MapView({id: 'right-map', x: x2, width: width2, controller: true})
-  ];
-}
-
 const deck = new Deck({
   initialViewState: {
     'left-map': INITIAL_VIEW_STATE,
     'right-map': INITIAL_VIEW_STATE
   },
   // controller: true,
-  views: getViewsForSplit(50),
+  views: [
+    new MapView({id: 'left-map', controller: true}),
+    new MapView({id: 'right-map', controller: true})
+  ],
   layers: [
     new GeoJsonLayer({
       id: 'base-map',
@@ -105,12 +96,7 @@ const deck = new Deck({
     new _InfoWidget({mode: 'hover', getTooltip}),
     new _InfoWidget({mode: 'click', getTooltip}),
     // new _InfoWidget({mode: 'static', getTooltip})
-    new _SplitterWidget({
-      viewId1: 'left-map',
-      viewId2: 'right-map',
-      orientation: 'vertical',
-      onChange: ratio => deck.setProps({views: getViewsForSplit(ratio * 100)})
-    })
+    new _SplitterWidget({viewId1: 'left-map', viewId2: 'right-map', orientation: 'vertical'})
   ]
 });
 

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -572,7 +572,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
   /** Get a list of views that are currently rendered */
   getViews(): View[] {
     assert(this.viewManager);
-    const views = this.viewManager.views;
+    return this.viewManager.views;
   }
 
   /** Get a list of viewports that are currently rendered.
@@ -1087,10 +1087,10 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
   _applyWidgetUpdates() {
     if (this.widgetManager!.viewsNeedUpdate) {
-      let oldViews = this._getViews();
+      const oldViews = this._getViews();
       const views = this.widgetManager!.filterViews(oldViews);
       if (views) {
-        this.viewManager!.setProps({views})
+        this.viewManager!.setProps({views});
       }
       this.widgetManager!.viewsNeedUpdate = false;
     }

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -828,16 +828,12 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
   // Get the view descriptor list
   private _getViews(): View[] {
     const {views} = this.props;
-    let normalizedViews: View[] = Array.isArray(views)
+    const normalizedViews: View[] = Array.isArray(views)
       ? views
       : // If null, default to a full screen map view port
         views
         ? [views]
         : [new MapView({id: 'default-view'})];
-
-    if (this.widgetManager) {
-      normalizedViews = this.widgetManager.filterViews(normalizedViews) || normalizedViews;
-    }
 
     // Backward compatibility: support controller prop
     if (normalizedViews.length && this.props.controller) {

--- a/modules/core/src/lib/widget-manager.ts
+++ b/modules/core/src/lib/widget-manager.ts
@@ -138,7 +138,7 @@ export class WidgetManager {
 
   /** Widgets can modify or add/remove views */
   filterViews(views: View[]): View[] | undefined {
-    return this.widgets.reduce((views, widget) => widget.filterViews?.(views) || views, views as View[]);
+    return this.widgets.reduce((views, widget) => widget.filterViews?.(views) || views, views);
   }
 
   needsRedraw(opts: {clearRedrawFlags: boolean} = {clearRedrawFlags: false}): string | false {

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -39,9 +39,9 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
     viewId2: '',
     orientation: 'vertical',
     initialSplitRatio: 0.5,
-    onSplitRatioChange: () => { },
-    onDragStart: () => { },
-    onDragEnd: () => { }
+    onSplitRatioChange: () => {},
+    onDragStart: () => {},
+    onDragEnd: () => {}
   };
 
   className = 'deck-widget-splitter';
@@ -134,7 +134,10 @@ function cloneView(
  *                     Default is 'vertical'.
  * @returns partial view props for the two views.
  */
-function getViewPropsForSplitRatio(splitRatio: number, orientation: 'horizontal' | 'vertical' = 'vertical') {
+function getViewPropsForSplitRatio(
+  splitRatio: number,
+  orientation: 'horizontal' | 'vertical' = 'vertical'
+) {
   const percentage = splitRatio * 100;
   switch (orientation) {
     case 'horizontal':
@@ -224,29 +227,29 @@ function Splitter({
   const splitterStyle: h.JSX.CSSProperties =
     orientation === 'vertical'
       ? {
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
-        left: `${split * 100}%`,
-        width: '4px',
-        cursor: 'col-resize',
-        background: '#ccc',
-        zIndex: 10,
-        pointerEvents: 'auto',
-        boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
-      }
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: `${split * 100}%`,
+          width: '4px',
+          cursor: 'col-resize',
+          background: '#ccc',
+          zIndex: 10,
+          pointerEvents: 'auto',
+          boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
+        }
       : {
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: `${split * 100}%`,
-        height: '4px',
-        cursor: 'row-resize',
-        background: '#ccc',
-        zIndex: 10,
-        pointerEvents: 'auto',
-        boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
-      };
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: `${split * 100}%`,
+          height: '4px',
+          cursor: 'row-resize',
+          background: '#ccc',
+          zIndex: 10,
+          pointerEvents: 'auto',
+          boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
+        };
 
   // Container style to fill the entire deck.gl canvas.
   const containerStyle: h.JSX.CSSProperties = {

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -140,6 +140,7 @@ function getViewPropsForSplitRatio(splitRatio: number, orientation: 'horizontal'
     case 'horizontal':
       return getHorizontalSplit(percentage);
     case 'vertical':
+      default:
       return getVerticalSplit(percentage);
   }
 }

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -39,9 +39,9 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
     viewId2: '',
     orientation: 'vertical',
     initialSplitRatio: 0.5,
-    onSplitRatioChange: () => { },
-    onDragStart: () => { },
-    onDragEnd: () => { }
+    onSplitRatioChange: () => {},
+    onDragStart: () => {},
+    onDragEnd: () => {}
   };
 
   className = 'deck-widget-splitter';
@@ -57,7 +57,7 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
 
   onWidgetInitialized() {
     this._widgetManager!.viewsNeedUpdate = true;
-    this._widgetManager!.setNeedsRedraw('SplitterWidget')
+    this._widgetManager!.setNeedsRedraw('SplitterWidget');
   }
 
   setProps(props: Partial<SplitterWidgetProps>) {
@@ -92,8 +92,8 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
     this.props.onSplitRatioChange(splitRatio);
     this.splitRatio = splitRatio;
     this._widgetManager!.viewsNeedUpdate = true;
-    this._widgetManager!.setNeedsRedraw('SplitterWidget')
-  }
+    this._widgetManager!.setNeedsRedraw('SplitterWidget');
+  };
 
   filterViews(views: View[]): View[] {
     const view1Index = views.findIndex(view => view.id === this.props.viewId1);
@@ -108,16 +108,19 @@ export class SplitterWidget extends WidgetImpl<SplitterWidgetProps> {
   }
 }
 
-function cloneView(view: View, props: {
-  /** A relative (e.g. `'50%'`) or absolute position. Default `0`. */
-  x?: number | string;
-  /** A relative (e.g. `'50%'`) or absolute position. Default `0`. */
-  y?: number | string;
-  /** A relative (e.g. `'50%'`) or absolute extent. Default `'100%'`. */
-  width?: number | string;
-  /** A relative (e.g. `'50%'`) or absolute extent. Default `'100%'`. */
-  height?: number | string;
-}) {
+function cloneView(
+  view: View,
+  props: {
+    /** A relative (e.g. `'50%'`) or absolute position. Default `0`. */
+    x?: number | string;
+    /** A relative (e.g. `'50%'`) or absolute position. Default `0`. */
+    y?: number | string;
+    /** A relative (e.g. `'50%'`) or absolute extent. Default `'100%'`. */
+    width?: number | string;
+    /** A relative (e.g. `'50%'`) or absolute extent. Default `'100%'`. */
+    height?: number | string;
+  }
+) {
   const ViewType = view.constructor;
   return new ViewType({...view.props, ...props});
 }
@@ -191,29 +194,29 @@ function Splitter({
   const splitterStyle: h.JSX.CSSProperties =
     orientation === 'vertical'
       ? {
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
-        left: `${split * 100}%`,
-        width: '4px',
-        cursor: 'col-resize',
-        background: '#ccc',
-        zIndex: 10,
-        pointerEvents: 'auto',
-        boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
-      }
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: `${split * 100}%`,
+          width: '4px',
+          cursor: 'col-resize',
+          background: '#ccc',
+          zIndex: 10,
+          pointerEvents: 'auto',
+          boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
+        }
       : {
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: `${split * 100}%`,
-        height: '4px',
-        cursor: 'row-resize',
-        background: '#ccc',
-        zIndex: 10,
-        pointerEvents: 'auto',
-        boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
-      };
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: `${split * 100}%`,
+          height: '4px',
+          cursor: 'row-resize',
+          background: '#ccc',
+          zIndex: 10,
+          pointerEvents: 'auto',
+          boxShadow: 'inset -1px 0 0 white, inset 1px 0 0 white'
+        };
 
   // Container style to fill the entire deck.gl canvas.
   const containerStyle: h.JSX.CSSProperties = {

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -140,7 +140,7 @@ function getViewPropsForSplitRatio(splitRatio: number, orientation: 'horizontal'
     case 'horizontal':
       return getHorizontalSplit(percentage);
     case 'vertical':
-      default:
+    default:
       return getVerticalSplit(percentage);
   }
 }

--- a/modules/widgets/src/widget-impl.ts
+++ b/modules/widgets/src/widget-impl.ts
@@ -35,7 +35,7 @@ export abstract class WidgetImpl<PropsT extends WidgetImplProps> implements Widg
     this.props = props;
   }
 
-  abstract onWidgetInitialized(): void;
+  onWidgetInitialized(): void {};
   abstract onRenderHTML(): void;
 
   onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {

--- a/modules/widgets/src/widget-impl.ts
+++ b/modules/widgets/src/widget-impl.ts
@@ -33,6 +33,7 @@ export abstract class WidgetImpl<PropsT extends WidgetImplProps> implements Widg
     this.props = props;
   }
 
+  abstract onWidgetInitialized(): void
   abstract onRenderHTML(): void;
 
   onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {
@@ -45,6 +46,7 @@ export abstract class WidgetImpl<PropsT extends WidgetImplProps> implements Widg
     });
     this.element = el;
     this.onRenderHTML();
+    this.onWidgetInitialized?.();
     return this.element;
   }
 

--- a/modules/widgets/src/widget-impl.ts
+++ b/modules/widgets/src/widget-impl.ts
@@ -35,7 +35,7 @@ export abstract class WidgetImpl<PropsT extends WidgetImplProps> implements Widg
     this.props = props;
   }
 
-  onWidgetInitialized(): void {};
+  onWidgetInitialized(): void {}
   abstract onRenderHTML(): void;
 
   onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {

--- a/modules/widgets/src/widget-impl.ts
+++ b/modules/widgets/src/widget-impl.ts
@@ -5,6 +5,7 @@
 /* global document */
 import {_deepEqual, _applyStyles, _removeStyles} from '@deck.gl/core';
 import type {Deck, Widget} from '@deck.gl/core';
+import {WidgetManager} from 'modules/core/src/lib/widget-manager';
 
 export type WidgetImplProps = {
   id?: string;
@@ -19,6 +20,7 @@ export abstract class WidgetImpl<PropsT extends WidgetImplProps> implements Widg
 
   deck?: Deck<any>;
   element?: HTMLDivElement;
+  _widgetManager?: WidgetManager;
 
   static defaultProps: Required<WidgetImplProps> = {
     id: 'widget',
@@ -33,7 +35,7 @@ export abstract class WidgetImpl<PropsT extends WidgetImplProps> implements Widg
     this.props = props;
   }
 
-  abstract onWidgetInitialized(): void
+  abstract onWidgetInitialized(): void;
   abstract onRenderHTML(): void;
 
   onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

- Enable widgets to modify views
- Enables a fully declarative (pydeck, json, ...) SplitterWidget, and many more potential use cases.

<!-- For all the PRs -->
#### Change List

- Hook widgets into the deck.gl needsUpdate cycle
- Remove custom view updates in the widget demo app


![splitter-widget](https://github.com/user-attachments/assets/c6b6e1d1-1199-421d-afbe-2364f1c5e8c7)
