### PR TITLE
Update website development instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ PRs and bug reports are welcome, and we are actively looking for new maintainers
 The **master** branch is the active development branch.
 
 Building deck.gl locally from the source requires node.js `>=14`. Further limitations on the Node version may be imposed by [puppeteer](https://github.com/puppeteer/puppeteer#usage) and [headless-gl](https://github.com/stackgl/headless-gl#supported-platforms-and-nodejs-versions).
-We use [yarn](https://yarnpkg.com/en/docs/install) to manage the dependencies of deck.gl.
+We use [yarn](https://yarnpkg.com/en/docs/install) to manage the dependencies of deck.gl, and [volta](https://docs.volta.sh/guide/getting-started) to manage the Node and yarn version.
 
 ```bash
 git checkout master
@@ -19,6 +19,15 @@ yarn test
 ```
 
 See [additional instructions](#troubleshooting) for Windows, Linux and Apple M1.
+
+Run the website:
+
+```bash
+yarn build
+cd website
+yarn
+yarn start
+```
 
 Run the layer browser application:
 


### PR DESCRIPTION
Installed on a new computer and discovered since `yarn bootstrap` no longer builds, the website doesn't work until after running `yarn build`. Adding this to the docs for new contributors.