### PR TITLE
CARTO: Fallback to hidden tiles for maxDensity

### DIFF
--- a/modules/carto/src/layers/heatmap-tile-layer.ts
+++ b/modules/carto/src/layers/heatmap-tile-layer.ts
@@ -235,7 +235,13 @@ class HeatmapTileLayer<DataT = any, ExtraProps extends {} = {}> extends Composit
 
     let tileZ = 0;
     let maxDensity = 0;
-    const tiles = [...this.state.tiles].filter(t => t.isVisible && t.content);
+    const loadedTiles = [...this.state.tiles].filter(t => t.content);
+    const visibleTiles = loadedTiles.filter(t => t.isVisible);
+
+    // As deck.gl initially marks tiles as hidden, use hidden tiles as fallback for calculation.
+    // This avoids an ugly flash/glitch at startup when layer is first rendered
+    const tiles = visibleTiles.length ? visibleTiles : loadedTiles;
+
     for (const tile of tiles) {
       const cell = tile.content[0];
       const unitDensity = unitDensityForCell(cell.id);


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

On first load, the max density is incorrect

<!-- For all the PRs -->
#### Change List
- Use the loaded, but invisible tiles to get a value for `maxDensity` before the layer is made visible and rendered
