### PR TITLE
CARTO: Do not mutate passed in loadOptions objects

### DIFF
--- a/modules/carto/src/layers/cluster-tile-layer.ts
+++ b/modules/carto/src/layers/cluster-tile-layer.ts
@@ -38,7 +38,7 @@ import {DEFAULT_TILE_SIZE} from '../constants';
 import QuadbinTileset2D from './quadbin-tileset-2d';
 import {getQuadbinPolygon} from './quadbin-utils';
 import CartoSpatialTileLoader from './schema/carto-spatial-tile-loader';
-import {injectAccessToken, TilejsonPropType} from './utils';
+import {TilejsonPropType, mergeLoadOptions} from './utils';
 import type {TilejsonResult} from '@carto/api-client';
 
 registerLoaders([CartoSpatialTileLoader]);
@@ -216,13 +216,15 @@ export default class ClusterTileLayer<
   static defaultProps = defaultProps;
 
   getLoadOptions(): any {
-    const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    return {
-      ...loadOptions,
-      ...injectAccessToken(loadOptions, tileJSON.accessToken),
-      cartoSpatialTile: {...loadOptions.cartoSpatialTile, scheme: 'quadbin'}
-    };
+    return mergeLoadOptions(super.getLoadOptions(), {
+      fetch: {
+        headers: {
+          Authorization: `Bearer ${tileJSON.accessToken}`
+        }
+      },
+      cartoSpatialTile: {scheme: 'quadbin'}
+    });
   }
 
   renderLayers(): Layer | null | LayersList {

--- a/modules/carto/src/layers/cluster-tile-layer.ts
+++ b/modules/carto/src/layers/cluster-tile-layer.ts
@@ -218,9 +218,11 @@ export default class ClusterTileLayer<
   getLoadOptions(): any {
     const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    injectAccessToken(loadOptions, tileJSON.accessToken);
-    loadOptions.cartoSpatialTile = {...loadOptions.cartoSpatialTile, scheme: 'quadbin'};
-    return loadOptions;
+    return {
+      ...loadOptions,
+      ...injectAccessToken(loadOptions, tileJSON.accessToken),
+      cartoSpatialTile: {...loadOptions.cartoSpatialTile, scheme: 'quadbin'}
+    };
   }
 
   renderLayers(): Layer | null | LayersList {

--- a/modules/carto/src/layers/cluster-tile-layer.ts
+++ b/modules/carto/src/layers/cluster-tile-layer.ts
@@ -218,11 +218,7 @@ export default class ClusterTileLayer<
   getLoadOptions(): any {
     const tileJSON = this.props.data as TilejsonResult;
     return mergeLoadOptions(super.getLoadOptions(), {
-      fetch: {
-        headers: {
-          Authorization: `Bearer ${tileJSON.accessToken}`
-        }
-      },
+      fetch: {headers: {Authorization: `Bearer ${tileJSON.accessToken}`}},
       cartoSpatialTile: {scheme: 'quadbin'}
     });
   }

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -49,11 +49,7 @@ export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> exten
   getLoadOptions(): any {
     const tileJSON = this.props.data as TilejsonResult;
     return mergeLoadOptions(super.getLoadOptions(), {
-      fetch: {
-        headers: {
-          Authorization: `Bearer ${tileJSON.accessToken}`
-        }
-      },
+      fetch: {headers: {Authorization: `Bearer ${tileJSON.accessToken}`}},
       cartoSpatialTile: {scheme: 'h3'}
     });
   }

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -7,7 +7,7 @@ import {H3HexagonLayer, H3HexagonLayerProps} from '@deck.gl/geo-layers';
 import H3Tileset2D, {getHexagonResolution} from './h3-tileset-2d';
 import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import type {TilejsonResult} from '@carto/api-client';
-import {injectAccessToken, TilejsonPropType} from './utils';
+import {TilejsonPropType, mergeLoadOptions, mergeBoundaryData} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 
 export const renderSubLayers = props => {
@@ -47,13 +47,15 @@ export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> exten
   }
 
   getLoadOptions(): any {
-    const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    return {
-      ...loadOptions,
-      ...injectAccessToken(loadOptions, tileJSON.accessToken),
-      cartoSpatialTile: {...loadOptions.cartoSpatialTile, scheme: 'h3'}
-    };
+    return mergeLoadOptions(super.getLoadOptions(), {
+      fetch: {
+        headers: {
+          Authorization: `Bearer ${tileJSON.accessToken}`
+        }
+      },
+      cartoSpatialTile: {scheme: 'h3'}
+    });
   }
 
   renderLayers(): SpatialIndexTileLayer | null {

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {CompositeLayer, CompositeLayerProps, Layer, LayersList, DefaultProps} from '@deck.gl/core';
+import {CompositeLayer, CompositeLayerProps, DefaultProps} from '@deck.gl/core';
 import {H3HexagonLayer, H3HexagonLayerProps} from '@deck.gl/geo-layers';
 import H3Tileset2D, {getHexagonResolution} from './h3-tileset-2d';
 import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import type {TilejsonResult} from '@carto/api-client';
-import {TilejsonPropType, mergeLoadOptions, mergeBoundaryData} from './utils';
+import {TilejsonPropType, mergeLoadOptions} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 
 export const renderSubLayers = props => {

--- a/modules/carto/src/layers/h3-tile-layer.ts
+++ b/modules/carto/src/layers/h3-tile-layer.ts
@@ -49,9 +49,11 @@ export default class H3TileLayer<DataT = any, ExtraPropsT extends {} = {}> exten
   getLoadOptions(): any {
     const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    injectAccessToken(loadOptions, tileJSON.accessToken);
-    loadOptions.cartoSpatialTile = {...loadOptions.cartoSpatialTile, scheme: 'h3'};
-    return loadOptions;
+    return {
+      ...loadOptions,
+      ...injectAccessToken(loadOptions, tileJSON.accessToken),
+      cartoSpatialTile: {...loadOptions.cartoSpatialTile, scheme: 'h3'}
+    };
   }
 
   renderLayers(): SpatialIndexTileLayer | null {

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -8,7 +8,7 @@ import QuadbinTileset2D from './quadbin-tileset-2d';
 import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import {hexToBigInt} from 'quadbin';
 import type {TilejsonResult} from '@carto/api-client';
-import {injectAccessToken, TilejsonPropType} from './utils';
+import {TilejsonPropType, mergeLoadOptions, mergeBoundaryData} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 
 export const renderSubLayers = props => {
@@ -43,13 +43,15 @@ export default class QuadbinTileLayer<
   static defaultProps = defaultProps;
 
   getLoadOptions(): any {
-    const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    return {
-      ...loadOptions,
-      ...injectAccessToken(loadOptions, tileJSON.accessToken),
-      cartoSpatialTile: {...loadOptions.cartoSpatialTile, scheme: 'quadbin'}
-    };
+    return mergeLoadOptions(super.getLoadOptions(), {
+      fetch: {
+        headers: {
+          Authorization: `Bearer ${tileJSON.accessToken}`
+        }
+      },
+      cartoSpatialTile: {scheme: 'quadbin'}
+    });
   }
 
   renderLayers(): SpatialIndexTileLayer | null {

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -45,9 +45,11 @@ export default class QuadbinTileLayer<
   getLoadOptions(): any {
     const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    injectAccessToken(loadOptions, tileJSON.accessToken);
-    loadOptions.cartoSpatialTile = {...loadOptions.cartoSpatialTile, scheme: 'quadbin'};
-    return loadOptions;
+    return {
+      ...loadOptions,
+      ...injectAccessToken(loadOptions, tileJSON.accessToken),
+      cartoSpatialTile: {...loadOptions.cartoSpatialTile, scheme: 'quadbin'}
+    };
   }
 
   renderLayers(): SpatialIndexTileLayer | null {

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -45,11 +45,7 @@ export default class QuadbinTileLayer<
   getLoadOptions(): any {
     const tileJSON = this.props.data as TilejsonResult;
     return mergeLoadOptions(super.getLoadOptions(), {
-      fetch: {
-        headers: {
-          Authorization: `Bearer ${tileJSON.accessToken}`
-        }
-      },
+      fetch: {headers: {Authorization: `Bearer ${tileJSON.accessToken}`}},
       cartoSpatialTile: {scheme: 'quadbin'}
     });
   }

--- a/modules/carto/src/layers/quadbin-tile-layer.ts
+++ b/modules/carto/src/layers/quadbin-tile-layer.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {CompositeLayer, CompositeLayerProps, Layer, LayersList, DefaultProps} from '@deck.gl/core';
+import {CompositeLayer, CompositeLayerProps, DefaultProps} from '@deck.gl/core';
 import QuadbinLayer, {QuadbinLayerProps} from './quadbin-layer';
 import QuadbinTileset2D from './quadbin-tileset-2d';
 import SpatialIndexTileLayer, {SpatialIndexTileLayerProps} from './spatial-index-tile-layer';
 import {hexToBigInt} from 'quadbin';
 import type {TilejsonResult} from '@carto/api-client';
-import {TilejsonPropType, mergeLoadOptions, mergeBoundaryData} from './utils';
+import {TilejsonPropType, mergeLoadOptions} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 
 export const renderSubLayers = props => {

--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -64,11 +64,7 @@ export default class RasterTileLayer<
   getLoadOptions(): any {
     const tileJSON = this.props.data as TilejsonResult;
     return mergeLoadOptions(super.getLoadOptions(), {
-      fetch: {
-        headers: {
-          Authorization: `Bearer ${tileJSON.accessToken}`
-        }
-      }
+      fetch: {headers: {Authorization: `Bearer ${tileJSON.accessToken}`}}
     });
   }
 

--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -64,8 +64,10 @@ export default class RasterTileLayer<
   getLoadOptions(): any {
     const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    injectAccessToken(loadOptions, tileJSON.accessToken);
-    return loadOptions;
+    return {
+      ...loadOptions,
+      ...injectAccessToken(loadOptions, tileJSON.accessToken)
+    };
   }
 
   renderLayers(): Layer | null | LayersList {

--- a/modules/carto/src/layers/raster-tile-layer.ts
+++ b/modules/carto/src/layers/raster-tile-layer.ts
@@ -13,7 +13,7 @@ import {
 import RasterLayer, {RasterLayerProps} from './raster-layer';
 import QuadbinTileset2D from './quadbin-tileset-2d';
 import type {TilejsonResult} from '@carto/api-client';
-import {injectAccessToken, TilejsonPropType} from './utils';
+import {TilejsonPropType, mergeLoadOptions} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 import {TileLayer, TileLayerProps} from '@deck.gl/geo-layers';
 import {copy, PostProcessModifier} from './post-process-utils';
@@ -62,12 +62,14 @@ export default class RasterTileLayer<
   static defaultProps = defaultProps;
 
   getLoadOptions(): any {
-    const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    return {
-      ...loadOptions,
-      ...injectAccessToken(loadOptions, tileJSON.accessToken)
-    };
+    return mergeLoadOptions(super.getLoadOptions(), {
+      fetch: {
+        headers: {
+          Authorization: `Bearer ${tileJSON.accessToken}`
+        }
+      }
+    });
   }
 
   renderLayers(): Layer | null | LayersList {

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -9,19 +9,29 @@ import {_deepEqual as deepEqual} from '@deck.gl/core';
 import type {TilejsonResult} from '@carto/api-client';
 
 /**
- * Adds access token to Authorization header in loadOptions
+ * Merges load options with additional options, creating a new object without mutating the input.
+ * Handles nested objects through recursive deep merge.
  */
-export function injectAccessToken(loadOptions: any, accessToken: string): any {
-  if (!loadOptions?.fetch?.headers?.Authorization) {
-    return {
-      ...loadOptions,
-      fetch: {
-        ...loadOptions.fetch,
-        headers: {...loadOptions.fetch?.headers, Authorization: `Bearer ${accessToken}`}
-      }
-    };
+export function mergeLoadOptions(loadOptions: any, additionalOptions: any): any {
+  if (!loadOptions) {
+    return additionalOptions;
   }
-  return loadOptions;
+  if (!additionalOptions) {
+    return loadOptions;
+  }
+
+  const result = {...loadOptions};
+
+  for (const key in additionalOptions) {
+    const value = additionalOptions[key];
+    if (typeof value === 'object' && value !== null) {
+      result[key] = mergeLoadOptions(loadOptions[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
 }
 
 export function mergeBoundaryData(geometry: VectorTile, properties: PropertiesTile): VectorTile {

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -11,13 +11,17 @@ import type {TilejsonResult} from '@carto/api-client';
 /**
  * Adds access token to Authorization header in loadOptions
  */
-export function injectAccessToken(loadOptions: any, accessToken: string): void {
+export function injectAccessToken(loadOptions: any, accessToken: string): any {
   if (!loadOptions?.fetch?.headers?.Authorization) {
-    loadOptions.fetch = {
-      ...loadOptions.fetch,
-      headers: {...loadOptions.fetch?.headers, Authorization: `Bearer ${accessToken}`}
+    return {
+      ...loadOptions,
+      fetch: {
+        ...loadOptions.fetch,
+        headers: {...loadOptions.fetch?.headers, Authorization: `Bearer ${accessToken}`}
+      }
     };
   }
+  return loadOptions;
 }
 
 export function mergeBoundaryData(geometry: VectorTile, properties: PropertiesTile): VectorTile {

--- a/modules/carto/src/layers/utils.ts
+++ b/modules/carto/src/layers/utils.ts
@@ -10,9 +10,9 @@ import type {TilejsonResult} from '@carto/api-client';
 
 /**
  * Merges load options with additional options, creating a new object without mutating the input.
- * Handles nested objects through recursive deep merge.
+ * Handles nested objects through recursive deep merge with protection against circular references.
  */
-export function mergeLoadOptions(loadOptions: any, additionalOptions: any): any {
+export function mergeLoadOptions(loadOptions: any, additionalOptions: any, depth = 0): any {
   if (!loadOptions) {
     return additionalOptions;
   }
@@ -20,12 +20,21 @@ export function mergeLoadOptions(loadOptions: any, additionalOptions: any): any 
     return loadOptions;
   }
 
+  // Safety check against deep recursion
+  if (depth > 10) {
+    return additionalOptions;
+  }
+
   const result = {...loadOptions};
 
   for (const key in additionalOptions) {
     const value = additionalOptions[key];
+    // Skip circular references
+    if (value === loadOptions || value === additionalOptions) {
+      continue;
+    }
     if (typeof value === 'object' && value !== null) {
-      result[key] = mergeLoadOptions(loadOptions[key], value);
+      result[key] = mergeLoadOptions(loadOptions[key], value, depth + 1);
     } else {
       result[key] = value;
     }

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -77,9 +77,11 @@ export default class VectorTileLayer<
   getLoadOptions(): any {
     const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    injectAccessToken(loadOptions, tileJSON.accessToken);
-    loadOptions.gis = {format: 'binary'}; // Use binary for MVT loading
-    return loadOptions;
+    return {
+      ...loadOptions,
+      ...injectAccessToken(loadOptions, tileJSON.accessToken),
+      gis: {format: 'binary'} // Use binary for MVT loading
+    };
   }
 
   /* eslint-disable camelcase */

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -77,11 +77,7 @@ export default class VectorTileLayer<
   getLoadOptions(): any {
     const tileJSON = this.props.data as TilejsonResult;
     return mergeLoadOptions(super.getLoadOptions(), {
-      fetch: {
-        headers: {
-          Authorization: `Bearer ${tileJSON.accessToken}`
-        }
-      },
+      fetch: {headers: {Authorization: `Bearer ${tileJSON.accessToken}`}},
       gis: {format: 'binary'} // Use binary for MVT loading
     });
   }

--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -20,7 +20,7 @@ import {
 import {GeoJsonLayer} from '@deck.gl/layers';
 
 import type {TilejsonResult} from '@carto/api-client';
-import {TilejsonPropType, injectAccessToken, mergeBoundaryData} from './utils';
+import {TilejsonPropType, mergeLoadOptions, mergeBoundaryData} from './utils';
 import {DEFAULT_TILE_SIZE} from '../constants';
 import PointLabelLayer from './point-label-layer';
 
@@ -75,13 +75,15 @@ export default class VectorTileLayer<
   }
 
   getLoadOptions(): any {
-    const loadOptions = super.getLoadOptions() || {};
     const tileJSON = this.props.data as TilejsonResult;
-    return {
-      ...loadOptions,
-      ...injectAccessToken(loadOptions, tileJSON.accessToken),
+    return mergeLoadOptions(super.getLoadOptions(), {
+      fetch: {
+        headers: {
+          Authorization: `Bearer ${tileJSON.accessToken}`
+        }
+      },
       gis: {format: 'binary'} // Use binary for MVT loading
-    };
+    });
   }
 
   /* eslint-disable camelcase */

--- a/modules/carto/test/layers/utils.spec.ts
+++ b/modules/carto/test/layers/utils.spec.ts
@@ -3,78 +3,80 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {injectAccessToken} from '../../src/layers/utils';
+import {mergeLoadOptions} from '../../src/layers/utils';
 
-test('utils#injectAccessToken', t => {
-  t.test('should add Authorization header when not present', t => {
-    const loadOptions = {
-      fetch: {
-        headers: {}
+test('utils#mergeLoadOptions', t => {
+  const accessToken = 'test-token';
+  const loadOptions = {
+    fetch: {
+      headers: {
+        'Content-Type': 'application/json'
       }
-    };
-    const accessToken = 'test-token';
-    const result = injectAccessToken(loadOptions, accessToken);
+    }
+  };
 
-    t.deepEqual(result, {
-      fetch: {
-        headers: {
-          Authorization: 'Bearer test-token'
-        }
+  const result = mergeLoadOptions(loadOptions, {
+    fetch: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
       }
-    }, 'should return new object with Authorization header');
-    t.deepEqual(loadOptions.fetch.headers, {}, 'should not mutate original object');
-    t.end();
+    }
   });
 
-  t.test('should not modify existing Authorization header', t => {
-    const loadOptions = {
-      fetch: {
-        headers: {
-          Authorization: 'Bearer existing-token'
-        }
+  t.deepEqual(result, {
+    fetch: {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`
       }
-    };
-    const accessToken = 'test-token';
-    const result = injectAccessToken(loadOptions, accessToken);
-
-    t.deepEqual(result, loadOptions, 'should return original object');
-    t.equal(result.fetch.headers.Authorization, 'Bearer existing-token', 'should preserve existing token');
-    t.end();
+    }
   });
 
-  t.test('should handle missing fetch object', t => {
-    const loadOptions = {};
-    const accessToken = 'test-token';
-    const result = injectAccessToken(loadOptions, accessToken);
+  // Test with no existing headers
+  const loadOptions2 = {
+    fetch: {}
+  };
 
-    t.deepEqual(result, {
-      fetch: {
-        headers: {
-          Authorization: 'Bearer test-token'
-        }
+  const result2 = mergeLoadOptions(loadOptions2, {
+    fetch: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
       }
-    }, 'should create fetch object with Authorization header');
-    t.deepEqual(loadOptions, {}, 'should not mutate original object');
-    t.end();
+    }
   });
 
-  t.test('should handle missing headers object', t => {
-    const loadOptions = {
-      fetch: {}
-    };
-    const accessToken = 'test-token';
-    const result = injectAccessToken(loadOptions, accessToken);
-
-    t.deepEqual(result, {
-      fetch: {
-        headers: {
-          Authorization: 'Bearer test-token'
-        }
+  t.deepEqual(result2, {
+    fetch: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
       }
-    }, 'should create headers object with Authorization header');
-    t.deepEqual(loadOptions.fetch, {}, 'should not mutate original object');
-    t.end();
+    }
   });
 
-  t.end();
+  // Test with no existing fetch
+  const loadOptions3 = {};
+
+  const result3 = mergeLoadOptions(loadOptions3, {
+    fetch: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    }
+  });
+
+  t.deepEqual(result3, {
+    fetch: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    }
+  });
+
+  // Test with no additional options
+  const result4 = mergeLoadOptions(loadOptions, null);
+  t.deepEqual(result4, loadOptions);
+
+  // Test with no load options
+  const result5 = mergeLoadOptions(null, loadOptions);
+  t.deepEqual(result5, loadOptions);
 }); 

--- a/modules/carto/test/layers/utils.spec.ts
+++ b/modules/carto/test/layers/utils.spec.ts
@@ -79,4 +79,4 @@ test('utils#mergeLoadOptions', t => {
   // Test with no load options
   const result5 = mergeLoadOptions(null, loadOptions);
   t.deepEqual(result5, loadOptions);
-}); 
+});

--- a/modules/carto/test/layers/utils.spec.ts
+++ b/modules/carto/test/layers/utils.spec.ts
@@ -1,0 +1,80 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {injectAccessToken} from '../../src/layers/utils';
+
+test('utils#injectAccessToken', t => {
+  t.test('should add Authorization header when not present', t => {
+    const loadOptions = {
+      fetch: {
+        headers: {}
+      }
+    };
+    const accessToken = 'test-token';
+    const result = injectAccessToken(loadOptions, accessToken);
+
+    t.deepEqual(result, {
+      fetch: {
+        headers: {
+          Authorization: 'Bearer test-token'
+        }
+      }
+    }, 'should return new object with Authorization header');
+    t.deepEqual(loadOptions.fetch.headers, {}, 'should not mutate original object');
+    t.end();
+  });
+
+  t.test('should not modify existing Authorization header', t => {
+    const loadOptions = {
+      fetch: {
+        headers: {
+          Authorization: 'Bearer existing-token'
+        }
+      }
+    };
+    const accessToken = 'test-token';
+    const result = injectAccessToken(loadOptions, accessToken);
+
+    t.deepEqual(result, loadOptions, 'should return original object');
+    t.equal(result.fetch.headers.Authorization, 'Bearer existing-token', 'should preserve existing token');
+    t.end();
+  });
+
+  t.test('should handle missing fetch object', t => {
+    const loadOptions = {};
+    const accessToken = 'test-token';
+    const result = injectAccessToken(loadOptions, accessToken);
+
+    t.deepEqual(result, {
+      fetch: {
+        headers: {
+          Authorization: 'Bearer test-token'
+        }
+      }
+    }, 'should create fetch object with Authorization header');
+    t.deepEqual(loadOptions, {}, 'should not mutate original object');
+    t.end();
+  });
+
+  t.test('should handle missing headers object', t => {
+    const loadOptions = {
+      fetch: {}
+    };
+    const accessToken = 'test-token';
+    const result = injectAccessToken(loadOptions, accessToken);
+
+    t.deepEqual(result, {
+      fetch: {
+        headers: {
+          Authorization: 'Bearer test-token'
+        }
+      }
+    }, 'should create headers object with Authorization header');
+    t.deepEqual(loadOptions.fetch, {}, 'should not mutate original object');
+    t.end();
+  });
+
+  t.end();
+}); 


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

In a number of places the `loadOptions` prop was mutated, which could lead to bugs when multiple `Layer` instances shared a `loadOptions` object

<!-- For all the PRs -->
#### Change List
- Replace `injectAccessToken` with more generic `mergeLoadOptions`
- Update Layers to use new helper
- Tests
