### PR TITLE
fix Improperly Controlled Modification of Dynamically-Determined Object Attributes (Prototype-polluting assignment)

### DIFF
--- a/modules/core/src/lib/resource/resource-manager.ts
+++ b/modules/core/src/lib/resource/resource-manager.ts
@@ -144,6 +144,9 @@ export default class ResourceManager {
     onChange: (data: any) => void
   ) {
     const consumers = this._consumers;
+    if (consumerId === '__proto__' || consumerId === 'constructor' || consumerId === 'prototype') {
+      throw new Error('Invalid consumerId');
+    }
     const consumer = (consumers[consumerId] = consumers[consumerId] || {});
     let request = consumer[requestId];
 


### PR DESCRIPTION
https://github.com/visgl/deck.gl/blob/f7fe3d5544f8aebd22ae25d5e77609f2c51a4f95/modules/core/src/lib/resource/resource-manager.ts#L165-L165

fix the prototype pollution vulnerability, ensure that the `consumerId` does not contain any special property names like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a validation check before using `consumerId` to index into the `this._consumers` object. The best way to fix this problem without changing existing functionality is to add a check to ensure that `consumerId` does not match any of the special property names. If it does, we can either throw an error or handle it appropriately.


Most JavaScript objects inherit the properties of the built-in `Object.prototype` object. Prototype pollution is a type of vulnerability in which an attacker is able to modify `Object.prototype`. Since most objects inherit from the compromised `Object.prototype` object, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting. One way to cause prototype pollution is by modifying an object obtained via a user-controlled property name. Most objects have a special `__proto__` property that refers to `Object.prototype`. An attacker can abuse this special property to trick the application into performing unintended modifications of `Object.prototype`.



## POC
In the below, the untrusted value `req.params.id` is used as the property name `req.session.todos[id]`. If a malicious user passes in the ID value `__proto__`, the variable `items` will then refer to `Object.prototype`. Finally, the modification of `items` then allows the attacker to inject arbitrary properties onto `Object.prototype`.
```ts
let express = require('express');
let app = express()

app.put('/todos/:id', (req, res) => {
    let id = req.params.id;
    let items = req.session.todos[id];
    if (!items) {
        items = req.session.todos[id] = {};
    }
    items[req.query.name] = req.query.text;
    res.end(200);
});
```
One way to fix this is to use [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) objects to associate key/value pairs instead of regular objects, as shown below:
```ts
let express = require('express');
let app = express()

app.put('/todos/:id', (req, res) => {
    let id = req.params.id;
    let items = req.session.todos.get(id);
    if (!items) {
        items = new Map();
        req.sessions.todos.set(id, items);
    }
    items.set(req.query.name, req.query.text);
    res.end(200);
});
```
Another way to fix it is to prevent the `__proto__` property from being used as a key, as shown below:
```ts
let express = require('express');
let app = express()

app.put('/todos/:id', (req, res) => {
    let id = req.params.id;
    if (id === '__proto__' || id === 'constructor' || id === 'prototype') {
        res.end(403);
        return;
    }
    let items = req.session.todos[id];
    if (!items) {
        items = req.session.todos[id] = {};
    }
    items[req.query.name] = req.query.text;
    res.end(200);
});
```

## References
[Object.prototype.proto](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)


