### PR TITLE
feat(core): Orhtographic fitBounds()

### DIFF
--- a/modules/core/src/viewports/orthographic-viewport.ts
+++ b/modules/core/src/viewports/orthographic-viewport.ts
@@ -141,4 +141,51 @@ export default class OrthographicViewport extends Viewport {
 
     return {target: this.unprojectFlat(newCenter)};
   }
+
+  /**
+   * Compute center & zoom for an OrthographicViewport so that `bounds` fills the viewport.
+   * @param width  viewport width in px
+   * @param height viewport height in px
+   * @param bounds [[minX,minY],[maxX,maxY]] in the same world units you’re rendering
+   * @returns { target: [number, number], zoom: number }
+   *   target: center of the viewport in world units
+   *   zoom: deck.gl orthographic zoom level (log2(scale))
+   *   (deck.gl orthographic zoom is the log2 of the scale factor)
+   */
+  static fitBounds(options: {
+    bounds: Readonly<[[number, number], [number, number]]>;
+    width: number;
+    height: number;
+    zoomMode?: 'single' | 'per-axis';
+  }): {target: [number, number]; zoom: number | [number, number]} {
+    const {bounds, width, height, zoomMode = 'per-axis'} = options;
+    const [[minX, minY], [maxX, maxY]] = bounds;
+
+    // center of the box
+    const centerX = (minX + maxX) / 2;
+    const centerY = (minY + maxY) / 2;
+
+    // size of the box
+    const boxW = maxX - minX;
+    const boxH = maxY - minY;
+
+    // scale (world units → screen pixels)
+    const scaleX = width / boxW;
+    const scaleY = height / boxH;
+
+    // pick the smaller scale so the whole box fits
+    const scale = Math.min(scaleX, scaleY);
+
+    // deck.gl orthographic zoom is log2(scale)
+    const zoom = Math.log2(scale);
+
+    // 3) axis‐specific zooms (deck.gl’s orthographic zoom = log2(scale))
+    const zoomX = Math.log2(scaleX);
+    const zoomY = Math.log2(scaleY);
+
+    return {
+      target: [centerX, centerY],
+      zoom: zoomMode === 'single' ? zoom : [zoomX, zoomY]
+    };
+  }
 }

--- a/test/modules/core/viewports/index.ts
+++ b/test/modules/core/viewports/index.ts
@@ -6,3 +6,4 @@ import './viewport.spec';
 import './globe-viewport.spec';
 import './web-mercator-project-unproject.spec';
 import './web-mercator-viewport.spec';
+import './orthographic-viewport.spec';

--- a/test/modules/core/viewports/orthographic-viewport.spec.ts
+++ b/test/modules/core/viewports/orthographic-viewport.spec.ts
@@ -1,0 +1,92 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+
+import {OrthographicViewport} from '@deck.gl/core';
+
+const fitBounds = OrthographicViewport.fitBounds;
+
+test('OrthographicViewport#fitBounds - square bounds in square viewport (zoomMode=per-axis)', t => {
+  const result = fitBounds({
+    bounds: [
+      [0, 0],
+      [100, 100]
+    ],
+    width: 200,
+    height: 200
+  });
+
+  t.deepEqual(result.target, [50, 50], 'target is center of bounds');
+  t.deepEqual(result.zoom, [Math.log2(2), Math.log2(2)], 'zoom scales correctly');
+  t.end();
+});
+
+test('OrthographicViewport#fitBounds - wider viewport than bounds (zoomMode=single)', t => {
+  const result = fitBounds({
+    bounds: [
+      [0, 0],
+      [100, 100]
+    ],
+    width: 400,
+    height: 200,
+    zoomMode: 'single'
+  });
+
+  t.deepEqual(result.target, [50, 50], 'target is center');
+  const scale = Math.min(400 / 100, 200 / 100); // = 2
+  t.equal(result.zoom, Math.log2(scale), 'zoom uses smaller dimension to fit');
+  t.end();
+});
+
+test('OrthographicViewport#fitBounds - tall bounds, wide viewport', t => {
+  const result = fitBounds({
+    bounds: [
+      [0, 0],
+      [50, 200]
+    ],
+    width: 300,
+    height: 150
+  });
+
+  const scaleX = 300 / 50;
+  const scaleY = 150 / 200;
+  const zoomX = Math.log2(scaleX);
+  const zoomY = Math.log2(scaleY);
+
+  t.deepEqual(result.zoom, [zoomX, zoomY], 'per-axis zoom reflects size mismatch');
+  t.end();
+});
+
+test('OrthographicViewport#fitBounds - degenerate box (zero width)', t => {
+  const result = fitBounds({
+    bounds: [
+      [10, 10],
+      [10, 100]
+    ],
+    width: 200,
+    height: 200
+  });
+
+  t.ok(!Number.isFinite(result.zoom[0]), 'zoomX is infinite for zero width');
+  t.end();
+});
+
+test('OrthographicViewport#fitBounds - degenerate box (zero area)', t => {
+  const result = fitBounds({
+    bounds: [
+      [42, 42],
+      [42, 42]
+    ],
+    width: 500,
+    height: 500
+  });
+
+  t.deepEqual(result.target, [42, 42], 'target remains valid');
+  t.ok(
+    !Number.isFinite(result.zoom[0]) && !Number.isFinite(result.zoom[1]),
+    'zoom is infinite for zero area'
+  );
+  t.end();
+});


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

For discussion...

- We don't seem to have `fitBounds()` for our non-geospatial views, so I created on for Orthographic views.
- My first thought was to follow WebMercatorViewport and add a `OrthographicView.fitBounds()`, 
- but that would be rather awkward in use, since I need this function for updating **viewState** not **viewports**
- and viewports have a lot of "irrelevant" props that makes extracting viewState props from them feel hacky.

<!-- For all the PRs -->
#### Change List
-
