### PR TITLE
chore(widgets): Encapsulate the hacky / complex setViewState()

### DIFF
--- a/modules/widgets/src/geolocate-widget.tsx
+++ b/modules/widgets/src/geolocate-widget.tsx
@@ -4,11 +4,7 @@
 
 import {Widget, WidgetProps} from '@deck.gl/core';
 import type {WidgetPlacement, Viewport} from '@deck.gl/core';
-import {FlyToInterpolator, LinearInterpolator} from '@deck.gl/core';
 import {render} from 'preact';
-
-/** @todo - is the the best we can do? */
-type ViewState = Record<string, unknown>;
 
 /** Properties for the GeolocateWidget */
 export type GeolocateWidgetProps = WidgetProps & {
@@ -17,7 +13,8 @@ export type GeolocateWidgetProps = WidgetProps & {
   placement?: WidgetPlacement;
   /** Tooltip message */
   label?: string;
-  transitionDuration?: number;
+  /** Animated transition duration. Set to 0 to disable transitions */
+  transitionDurationMs?: number;
 };
 
 /**
@@ -32,7 +29,7 @@ export class GeolocateWidget extends Widget<GeolocateWidgetProps> {
     viewId: undefined!,
     placement: 'top-left',
     label: 'Geolocate',
-    transitionDuration: 200
+    transitionDurationMs: 200
   };
 
   className = 'deck-widget-geolocate';
@@ -95,31 +92,6 @@ export class GeolocateWidget extends Widget<GeolocateWidgetProps> {
   handleCoordinates = coordinates => {
     this.setViewState(coordinates);
   };
-
-  // TODO - MOVE TO WIDGETIMPL?
-
-  setViewState(viewState: ViewState) {
-    const viewId = this.props.viewId || (viewState?.id as string) || 'default-view';
-    const viewport = this.viewports[viewId] || {};
-    const nextViewState: ViewState = {
-      ...viewport,
-      ...viewState
-    };
-    if (this.props.transitionDuration > 0) {
-      nextViewState.transitionDuration = this.props.transitionDuration;
-      nextViewState.transitionInterpolator =
-        'latitude' in nextViewState ? new FlyToInterpolator() : new LinearInterpolator();
-    }
-
-    // @ts-ignore Using private method temporary until there's a public one
-    this.deck._onViewStateChange({viewId, viewState: nextViewState, interactionState: {}});
-  }
-
-  onViewportChange(viewport: Viewport) {
-    this.viewports[viewport.id] = viewport;
-  }
-
-  viewports: Record<string, Viewport> = {};
 }
 
 /**

--- a/modules/widgets/src/reset-view-widget.tsx
+++ b/modules/widgets/src/reset-view-widget.tsx
@@ -19,7 +19,9 @@ export type ResetViewWidgetProps = WidgetProps & {
   /** The initial view state to reset the view to. Defaults to deck.props.initialViewState */
   initialViewState?: ViewState;
   /** View to interact with. Required when using multiple views. */
-  viewId?: string | null;
+  viewId?: string;
+  /** Set to 0 to disable transitions */
+  transitionDurationMs?: number;
 };
 
 /**
@@ -32,7 +34,8 @@ export class ResetViewWidget extends Widget<ResetViewWidgetProps> {
     placement: 'top-left',
     label: 'Reset View',
     initialViewState: undefined!,
-    viewId: undefined!
+    viewId: undefined!,
+    transitionDurationMs: 200,
   };
 
   className = 'deck-widget-reset-view';
@@ -61,18 +64,10 @@ export class ResetViewWidget extends Widget<ResetViewWidgetProps> {
 
   handleClick() {
     const initialViewState = this.props.initialViewState || this.deck?.props.initialViewState;
-    this.setViewState(initialViewState);
-  }
-
-  setViewState(viewState: ViewState) {
-    const viewId = this.props.viewId || viewState?.id || 'default-view';
-    const nextViewState = {
-      ...viewState
-      // only works for geospatial?
-      // transitionDuration: this.props.transitionDuration,
-      // transitionInterpolator: new FlyToInterpolator()
-    };
-    // @ts-ignore Using private method temporary until there's a public one
-    this.deck._onViewStateChange({viewId, viewState: nextViewState, interactionState: {}});
+    this.setViewState({
+      viewState: initialViewState, 
+      viewId: this.props.viewId, 
+      transitionDurationMs: this.props.transitionDurationMs
+    });
   }
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

For discussion
- Right now several widgets control the view state, which is possible with some hacky and convoluted code.
- Instead of duplicating this in each widgets, suggest we move it up to Widget or WidgetManager.

<!-- For all the PRs -->
#### Change List
-
