### PR TITLE
fix: filter layers in mapbox overlay, interleaved mode

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -174,8 +174,9 @@ export function drawLayer(
 
   deck._drawLayers('mapbox-repaint', {
     viewports: [currentViewport],
-    layerFilter: ({layer: deckLayer}) =>
-      layer.id === deckLayer.id || deckLayer.props.operation.includes('terrain'),
+    layerFilter: params =>
+      (!deck.props.layerFilter || deck.props.layerFilter(params)) &&
+      (layer.id === params.layer.id || params.layer.props.operation.includes('terrain')),
     clearStack,
     clearCanvas: false
   });


### PR DESCRIPTION
Hey all, this is my first PR! I tried my best to follow the existing style/conventions, and I also added a regression test for this fix (could probably use some guidance on this; I'm not super sure this is the best approach).

Overall a pretty simple fix. The gist is that in `MapboxOverlay` we should also use the provided `layerFilter` prop (if it exists) when rendering the "mapbox layers", because in the interleaved case, these layers will also include user-provided layers.
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #9300 

<!-- For all the PRs -->
#### Change List
- Makes sure `layerFilter` is called when rendering `MapboxOverlay` in interleaved mode
