### PR TITLE
feat(widget): Add geocoder support to GeolocateWidget

### DIFF
--- a/test/apps/widgets-example-9.2/app.ts
+++ b/test/apps/widgets-example-9.2/app.ts
@@ -100,7 +100,7 @@ const deck = new Deck({
     new ResetViewWidget(),
     new _LoadingWidget(),
     new _ScaleWidget({placement: 'bottom-right'}),
-    new _GeolocateWidget(),
+    new _GeolocateWidget({viewId: 'left-map'}),
     new _ThemeWidget(),
     new _InfoWidget({mode: 'hover', getTooltip}),
     new _InfoWidget({mode: 'click', getTooltip}),


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

- The fact that we hadn't yet implemented geocoding in the GeolocateWidget was resulting in some confusion around the name.

<!-- For all the PRs -->
#### Change List

- Implement support for 3 geocoding services (all require apiKeys). coordinate support remains but now only as a fallback option until a proper geocoder and key are configured.
