### PR TITLE
feat(widgets): New GimbalWidget

### DIFF
--- a/docs/api-reference/widgets/gimbal-widget.md
+++ b/docs/api-reference/widgets/gimbal-widget.md
@@ -1,0 +1,31 @@
+import {WidgetPreview} from '@site/src/doc-demos/widgets';
+import {GimbalWidget} from '@deck.gl/widgets';
+
+# GimbalWidget
+
+Visualizes the orientation of an `OrbitView` using nested circles. Clicking resets `rotationOrbit` and `rotationX` to `0`.
+
+<WidgetPreview cls={GimbalWidget}/>
+
+```ts
+import {GimbalWidget} from '@deck.gl/widgets';
+import {Deck} from '@deck.gl/core';
+
+const deck = new Deck({
+  widgets: [new GimbalWidget()]
+});
+```
+
+## Props
+
+- `id`: `'gimbal'`
+- `label`: `'Gimbal'`
+- `transitionDuration`: `200`
+
+## Styles
+
+| Name | Default |
+| ---- | ------- |
+| `--icon-gimbal-outer-color` | `rgb(68, 92, 204)` |
+| `--icon-gimbal-inner-color` | `rgb(240, 92, 68)` |
+

--- a/docs/api-reference/widgets/overview.md
+++ b/docs/api-reference/widgets/overview.md
@@ -10,6 +10,7 @@ This module contains the following widgets:
 
 ### Geospatial Widgets
 - [CompassWidget](./compass-widget.md)
+- [GimbalWidget](./gimbal-widget.md)
 <!-- - [ScaleWidget](./scale-widget.md) -->
 <!-- - [GeolocateWidget](./geolocate-widget.md) -->
 

--- a/modules/widgets/src/gimbal-widget.tsx
+++ b/modules/widgets/src/gimbal-widget.tsx
@@ -1,0 +1,189 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Widget, LinearInterpolator} from '@deck.gl/core';
+import type {Viewport, WidgetPlacement, WidgetProps} from '@deck.gl/core';
+import {render} from 'preact';
+
+export type GimbalWidgetProps = WidgetProps & {
+  placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
+  /** Tooltip message. */
+  label?: string;
+  /** Width of gimbal lines */
+  strokeWidth?: number;
+  /** Transition duration in ms when resetting rotation. */
+  transitionDuration?: number;
+};
+
+export class GimbalWidget extends Widget<GimbalWidgetProps> {
+  static defaultProps: Required<GimbalWidgetProps> = {
+    ...Widget.defaultProps,
+    id: 'gimbal',
+    placement: 'top-left',
+    viewId: undefined!,
+    label: 'Gimbal',
+    strokeWidth: 1.5,
+    transitionDuration: 200
+  };
+
+  className = 'deck-widget-gimbal';
+  placement: WidgetPlacement = 'top-left';
+  viewId?: string | null = null;
+
+  constructor(props: GimbalWidgetProps = {}) {
+    super(props, GimbalWidget.defaultProps);
+    this.setProps(this.props);
+  }
+
+  setProps(props: Partial<GimbalWidgetProps>) {
+    this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
+    super.setProps(props);
+  }
+
+  onRenderHTML(rootElement: HTMLElement): void {
+    const {rotationOrbit, rotationX} = this.getNormalizedRotation();
+    // Note - we use CSS 3D transforms instead of SVG 2D transforms
+    const ui = (
+      <div className="deck-widget-button" style={{perspective: 100, pointerEvents: 'auto'}}>
+        <button
+          type="button"
+          onClick={() => {
+            this.resetOrbitView();
+          }}
+          title={this.props.label}
+          style={{position: 'relative', width: 26, height: 26}}
+        >
+          {/* Outer ring */}
+          <svg
+            className="gimbal-outer-ring"
+            width="100%"
+            height="100%"
+            viewBox="0 0 26 26"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              transform: `rotateY(${rotationOrbit}deg)`
+            }}
+          >
+            <circle
+              cx="13"
+              cy="13"
+              r="10"
+              stroke="var(--icon-gimbal-outer-color, rgb(68, 92, 204))"
+              strokeWidth={this.props.strokeWidth}
+              fill="none"
+            />
+          </svg>
+
+          {/* Inner ring */}
+          <svg
+            className="gimbal-inner-ring"
+            width="100%"
+            height="100%"
+            viewBox="0 0 26 26"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              transform: `rotateX(${rotationX}deg)`
+            }}
+          >
+            <circle
+              cx="13"
+              cy="13"
+              r="7"
+              stroke="var(--icon-gimbal-inner-color, rgb(240, 92, 68))"
+              strokeWidth={this.props.strokeWidth}
+              fill="none"
+            />
+          </svg>
+        </button>
+      </div>
+    );
+
+    render(ui, rootElement);
+  }
+
+  onViewportChange(viewport: Viewport) {
+    this.updateHTML();
+  }
+
+  resetOrbitView() {
+    const viewId = this.getViewId();
+    const viewState = this.getViewState(viewId);
+    if ('rotationOrbit' in viewState || 'rotationX' in viewState) {
+      const nextViewState = {
+        ...viewState,
+        rotationOrbit: 0,
+        rotationX: 0,
+        transitionDuration: this.props.transitionDuration,
+        transitionInterpolator: new LinearInterpolator({
+          transitionProps: ['rotationOrbit', 'rotationX']
+        })
+      };
+      // @ts-ignore Using private method temporary until there's a public one
+      this.deck._onViewStateChange({viewId, viewState: nextViewState, interactionState: {}});
+    }
+  }
+
+  getNormalizedRotation() {
+    const viewState = this.getViewState(this.getViewId());
+    const [rz, rx] = this.getRotation(viewState);
+    const rotationOrbit = normalizeAndClampAngle(rz);
+    const rotationX = normalizeAndClampAngle(rx);
+    console.log('GimbalWidget', {rotationOrbit, rotationX}, {rz, rx});
+    return {rotationOrbit, rotationX};
+  }
+
+  getRotation(viewState?: any): [number, number] {
+    if (viewState && ('rotationOrbit' in viewState || 'rotationX' in viewState)) {
+      return [-(viewState.rotationOrbit || 0), viewState.rotationX || 0];
+    }
+    return [0, 0];
+  }
+
+  // Move to Widget/WidgetManager?
+
+  getViewId() {
+    const viewId = this.viewId || 'OrbitView';
+    return viewId;
+  }
+
+  getViewState(viewId: string) {
+    const viewManager = this.getViewManager();
+    const viewState = (viewId && viewManager.getViewState(viewId)) || viewManager.viewState;
+    return viewState;
+  }
+
+  getViewManager() {
+    // @ts-expect-error protected
+    const viewManager = this.deck?.viewManager;
+    if (!viewManager) {
+      throw new Error('wigdet must be added to a deck instance');
+    }
+    return viewManager;
+  }
+}
+
+function normalizeAndClampAngle(angle: number): number {
+  // Bring angle into [-180, 180]
+  let normalized = ((((angle + 180) % 360) + 360) % 360) - 180;
+
+  // Avoid rotating the gimbal rings to close to 90 degrees as they will visually disappear
+  const AVOID_ANGLE_DELTA = 10;
+  const distanceFrom90 = normalized - 90;
+  if (Math.abs(distanceFrom90) < AVOID_ANGLE_DELTA) {
+    if (distanceFrom90 < AVOID_ANGLE_DELTA) {
+      normalized = 90 + AVOID_ANGLE_DELTA;
+    } else if (distanceFrom90 > -AVOID_ANGLE_DELTA) {
+      normalized = 90 - AVOID_ANGLE_DELTA;
+    }
+  }
+  // Clamp to [-80, 80]
+  return normalized; // Math.max(-80, Math.min(80, normalized));
+}

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -8,6 +8,7 @@ export {ResetViewWidget} from './reset-view-widget';
 
 // Geospatial widgets
 export {CompassWidget} from './compass-widget';
+export {GimbalWidget} from './gimbal-widget';
 export {ScaleWidget as _ScaleWidget} from './scale-widget';
 export {GeolocateWidget as _GeolocateWidget} from './geolocate-widget';
 
@@ -36,6 +37,7 @@ export type {InfoWidgetProps} from './info-widget';
 export type {SplitterWidgetProps} from './splitter-widget';
 export type {TimelineWidgetProps} from './timeline-widget';
 export type {ViewSelectorWidgetProps} from './view-selector-widget';
+export type {GimbalWidgetProps} from './gimbal-widget';
 
 export {IconButton, ButtonGroup, GroupedIconButton} from './lib/components';
 

--- a/test/apps/widgets-infovis/app.ts
+++ b/test/apps/widgets-infovis/app.ts
@@ -2,23 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, OrbitView} from '@deck.gl/core';
+import {Deck, OrbitView, OrbitViewState} from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
-import {
-  CompassWidget,
-  ZoomWidget,
-  FullscreenWidget,
-  DarkGlassTheme,
-  LightGlassTheme
-} from '@deck.gl/widgets';
+import {GimbalWidget, ZoomWidget, FullscreenWidget} from '@deck.gl/widgets';
 import '@deck.gl/widgets/stylesheet.css';
 
-/* global window */
-const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-const widgetTheme = prefersDarkScheme.matches ? DarkGlassTheme : LightGlassTheme;
-
 function generateData(count) {
-  const result = [];
+  const result: {position: number[]; color: number[]}[] = [];
   for (let i = 0; i < count; i++) {
     result.push({
       position: [Math.random() * 100 - 50, Math.random() * 100 - 50, Math.random() * 100 - 50],
@@ -33,7 +23,7 @@ const INITIAL_VIEW_STATE = {
   rotationX: 45,
   rotationOrbit: 0,
   zoom: 0
-};
+} as const satisfies OrbitViewState;
 
 new Deck({
   views: new OrbitView(),
@@ -47,12 +37,9 @@ new Deck({
       getFillColor: d => d.color,
       getRadius: 3,
       pickable: true,
-      autoHighlight: true
+      autoHighlight: true,
+      billboard: true
     })
   ],
-  widgets: [
-    new ZoomWidget({style: widgetTheme}),
-    new CompassWidget({style: widgetTheme}),
-    new FullscreenWidget({style: widgetTheme})
-  ]
+  widgets: [new ZoomWidget(), new GimbalWidget(), new FullscreenWidget({})]
 });

--- a/test/apps/widgets-infovis/index.html
+++ b/test/apps/widgets-infovis/index.html
@@ -6,6 +6,6 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width" />
   </head>
   <body>
-    <script type="module" src="./app.js"></script>
+    <script type="module" src="./app.ts"></script>
   </body>
 </html>

--- a/test/apps/widgets-infovis/package.json
+++ b/test/apps/widgets-infovis/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "vite --open",
-    "start-local": "vite --config ../../../vite.config.local.mjs",
+    "start-local": "vite --config ../vite.config.local.mjs",
     "build": "vite build"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #
![gimbal](https://github.com/user-attachments/assets/b684e71f-23ae-4e73-989c-cf5485faab35)


<!-- For other PRs without open issue -->
#### Background

- Starting to focus on non-geospatial widgets which is my primary motivation for 9.2.

<!-- For all the PRs -->
#### Change List

- I am trying to different approach to handling view updates in widgets.
- The approach currently in use in other widgets is based on scraping the viewports and trying to extract some view state information from them to then be used to update view states.
- Working with directly with view states seems more natural / less hacky.

#### Open Issues

- The documentation references the widget example to illustrate the widgets. However, this won't work at the moment for non-geospatial widgets.
- There is currently a test app that could be move to examples
- Alternatively we could make the existing example more complex with a switcher between geospatial and non-geospatial.
- Another possible option is to have two official examples for widgets, one pure-js and one react and have them focus on non-geo / geo respectively. That way we would cover a bigger matrix of options
