### PR TITLE
chore(layers): Change warning to debug message

### DIFF
--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -252,7 +252,7 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
 
     // Breaking change in v8.9
     if (this.props.maxWidth > 0) {
-      log.warn('v8.9 breaking change: TextLayer maxWidth is now relative to text size')();
+      log.once(1, 'v8.9 breaking change: TextLayer maxWidth is now relative to text size')();
     }
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

- The TextLayer warning generates noise on our logs. 
- Since it is a "log.warn()" it generates a full stack trace.
- Proposal: keep it but as a debug message.
- This was a v8.9 change message, so seems reasonable to make the change in 9.2

<!-- For all the PRs -->
#### Change List
- `log.warn(...)()` => `log.once(1, ...)()`
