### PR TITLE
fix: do not touch stencil in _renderPass()

### DIFF
--- a/modules/core/src/passes/screen-pass.ts
+++ b/modules/core/src/passes/screen-pass.ts
@@ -67,7 +67,8 @@ export default class ScreenPass extends Pass {
       framebuffer: outputBuffer,
       parameters: {viewport: [0, 0, ...texSize]},
       clearColor: clearCanvas ? [0, 0, 0, 0] : false,
-      clearDepth: 1
+      clearDepth: 1,
+      clearStencil: false
     });
 
     this.model.draw(renderPass);


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

When using `RasterTileLayer` with `MapboxOverlay` interleaved rendering, the rendering of the mapbox layers above the deck.gl layer is broken (some of the mapbox tiles render, while others do not). Preventing the stencil from being cleared fixes the issue

<!-- For all the PRs -->
#### Change List
- Use `clearStencil: false` in `ScreenPass._renderPass()`
