### PR TITLE
fix(core): correct opacity in interleaved mode

### DIFF
--- a/examples/layer-browser/src/app.tsx
+++ b/examples/layer-browser/src/app.tsx
@@ -88,6 +88,7 @@ export default class App extends PureComponent {
         useDevicePixels: true,
         pickingRadius: 0,
         drawPickingColors: false,
+        interleaved: true,
 
         // Model matrix manipulation
         separation: 0,

--- a/modules/carto/src/layers/raster-layer.ts
+++ b/modules/carto/src/layers/raster-layer.ts
@@ -145,18 +145,7 @@ export default class RasterLayer<DataT = any, ExtraProps = {}> extends Composite
         offset,
         lineWidthScale, // Re-use widthScale prop to pass cell scale,
         highlightedObjectIndex,
-        highlightColor,
-
-        // RTT requires blending otherwise opacity < 1 blends with black
-        // render target
-        parameters: {
-          blendColorSrcFactor: 'one',
-          blendAlphaSrcFactor: 'one',
-          blendColorDstFactor: 'zero',
-          blendAlphaDstFactor: 'zero',
-          blendColorOperation: 'add',
-          blendAlphaOperation: 'add'
-        }
+        highlightColor
       }
     );
   }

--- a/modules/core/src/lib/deck-renderer.ts
+++ b/modules/core/src/lib/deck-renderer.ts
@@ -85,7 +85,8 @@ export default class DeckRenderer {
     const outputBuffer = this.lastPostProcessEffect ? this.renderBuffers[0] : renderOpts.target;
     if (this.lastPostProcessEffect) {
       renderOpts.clearColor = [0, 0, 0, 0];
-      renderOpts.clearCanvas = true;
+      // Interleaved basemap rendering requires clearCanvas to be false
+      renderOpts.clearCanvas = opts.clearCanvas === undefined ? true : opts.clearCanvas;
     }
     const renderStats = layerPass.render({...renderOpts, target: outputBuffer});
 

--- a/modules/core/src/passes/screen-pass.ts
+++ b/modules/core/src/passes/screen-pass.ts
@@ -31,7 +31,18 @@ export default class ScreenPass extends Pass {
   constructor(device: Device, props: ScreenPassProps) {
     super(device, props);
     const {module, fs, id} = props;
-    const parameters = {depthWriteEnabled: false, depthCompare: 'always' as const};
+    const parameters: any = {
+      depthWriteEnabled: false,
+      depthCompare: 'always' as const,
+      depthBias: 0,
+      blend: true,
+      blendColorSrcFactor: 'one',
+      blendColorDstFactor: 'one-minus-src-alpha',
+      blendAlphaSrcFactor: 'one',
+      blendAlphaDstFactor: 'one-minus-src-alpha',
+      blendColorOperation: 'add',
+      blendAlphaOperation: 'add'
+    };
     this.model = new ClipSpace(device, {id, fs, modules: [module, screenUniforms], parameters});
   }
 


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

When using `PostProcessEffect` with `interleaved: true`, due to [clearing of the canvas](https://github.com/visgl/deck.gl/blob/master/modules/core/src/lib/deck-renderer.ts#L88) the result is the basemap is completely cleared with a solid grey color:

<img width="621" alt="Screenshot 2025-05-22 at 09 40 00" src="https://github.com/user-attachments/assets/4ea115ba-b924-420c-b035-72ae00c77213" />

With this change, the clearing is applied only when needed, and the blending in `ScreenPass` is fixed to give correct results. Here is a layer, drawn with opacity with a `ink` postprocess applied, in interleaved mode.

https://github.com/user-attachments/assets/18a06a92-3100-41f4-ab52-1d47eb2b3a7e

In order to test, the layer browser has been enhanced to include a toggle for interleaved rendering

<!-- For all the PRs -->
#### Change List
- Do not clear canvas in `deck-renderer` when `clearCanvas` is explicitly set to `false`
- Correct blending in `ScreenPass` (only used in `PostProcessEffect`)
- Tidy up `RasterLayer`
- Enhance layer browser to support interleaved
