### PR TITLE
fix(carto): Assign default aggregationExp in fetchMap()

### DIFF
--- a/modules/carto/src/api/fetch-map.ts
+++ b/modules/carto/src/api/fetch-map.ts
@@ -46,6 +46,9 @@ type Dataset = {
   queryParameters: QueryParameters;
 };
 
+const DEFAULT_AGGREGATION_EXP_ALIAS = '__aggregationValue';
+const DEFAULT_AGGREGATION_EXP = `1 AS ${DEFAULT_AGGREGATION_EXP_ALIAS}`;
+
 /* global clearInterval, setInterval, URL */
 /* eslint-disable complexity, max-statements, max-params */
 async function _fetchMapDataset(dataset: Dataset, context: _FetchMapContext) {
@@ -88,14 +91,24 @@ async function _fetchMapDataset(dataset: Dataset, context: _FetchMapContext) {
         });
       }
     } else if (spatialDataType === 'h3') {
-      const options = {...globalOptions, aggregationExp, aggregationResLevel, spatialDataColumn};
+      const options = {
+        ...globalOptions,
+        aggregationExp: aggregationExp || DEFAULT_AGGREGATION_EXP,
+        aggregationResLevel,
+        spatialDataColumn
+      };
       if (type === 'table') {
         dataset.data = await h3TableSource({...options, tableName: source});
       } else if (type === 'query') {
         dataset.data = await h3QuerySource({...options, sqlQuery: source, queryParameters});
       }
     } else if (spatialDataType === 'quadbin') {
-      const options = {...globalOptions, aggregationExp, aggregationResLevel, spatialDataColumn};
+      const options = {
+        ...globalOptions,
+        aggregationExp: aggregationExp || DEFAULT_AGGREGATION_EXP,
+        aggregationResLevel,
+        spatialDataColumn
+      };
       if (type === 'table') {
         dataset.data = await quadbinTableSource({...options, tableName: source});
       } else if (type === 'query') {

--- a/modules/carto/src/api/fetch-map.ts
+++ b/modules/carto/src/api/fetch-map.ts
@@ -30,6 +30,7 @@ import {ParseMapResult, parseMap} from './parse-map';
 import {assert} from '../utils';
 import type {Basemap} from './types';
 import {fetchBasemapProps} from './basemap';
+import {DEFAULT_AGGREGATION_EXP} from '../constants';
 
 type Dataset = {
   id: string;
@@ -45,9 +46,6 @@ type Dataset = {
   aggregationResLevel: number;
   queryParameters: QueryParameters;
 };
-
-const DEFAULT_AGGREGATION_EXP_ALIAS = '__aggregationValue';
-const DEFAULT_AGGREGATION_EXP = `1 AS ${DEFAULT_AGGREGATION_EXP_ALIAS}`;
 
 /* global clearInterval, setInterval, URL */
 /* eslint-disable complexity, max-statements, max-params */

--- a/modules/carto/src/constants.ts
+++ b/modules/carto/src/constants.ts
@@ -3,3 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 export const DEFAULT_TILE_SIZE = 512;
+
+export const DEFAULT_AGGREGATION_EXP_ALIAS = '__aggregationValue';
+export const DEFAULT_AGGREGATION_EXP = `1 AS ${DEFAULT_AGGREGATION_EXP_ALIAS}`;


### PR DESCRIPTION
#### Background

In v9.1, `@deck.gl/carto` fetchMap() fails to load layers depending on a default value of the `aggregationExp` property, required for H3 and Quadbin table or query sources. The issue does not occur on `master` branch, or in the v9.2 alpha, but I'm currently seeing another issue (link: TBD) in the v9.2 alpha and would like to backport the fix for v9.1 in the meantime.

<!-- For all the PRs -->
#### Change List
- carto: fetchMap() should apply default aggregationExp




#### PR Dependency Tree


  * **PR #9668** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)