### PR TITLE
fix(mapbox): Fix view selection logic in getViewport

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -300,7 +300,11 @@ type MaplibreRenderParameters = {
 
 function getViewport(deck: Deck, map: Map, renderParameters?: unknown): Viewport {
   const viewState = getViewState(map);
-  const view = getDefaultView(map);
+  const {
+    props: {views}
+  } = deck;
+  const view =
+    (views && flatten(views).filter((v: {id: string}) => v.id === 'mapbox')) || getDefaultView(map);
 
   if (renderParameters) {
     // Called from MapboxLayer.render


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #9664

<!-- For all the PRs -->
#### Change List
- Updates getViewport to select the 'mapbox' view from deck.props.views if available, falling back to getDefaultView.
