### PR TITLE
fix(CARTO): H3 tile bounding box includes edge children

### DIFF
--- a/test/modules/carto/layers/h3-tileset-2d.spec.ts
+++ b/test/modules/carto/layers/h3-tileset-2d.spec.ts
@@ -36,10 +36,10 @@ test('H3Tileset2D', async t => {
   t.equal(tileset.getTileId({i: '82754ffffffffff'}), '82754ffffffffff', 'tile id');
   const {bbox} = tileset.getTileMetadata({i: '82754ffffffffff'});
   const expectedBbox = {
-    west: -0.8199508788179312,
-    south: -1.855492618547643,
-    east: 1.9211969045935835,
-    north: 0.9361637645983679
+    west: -1.0122479382442804,
+    south: -2.0477834895958438,
+    east: 2.113493964019933,
+    north: 1.1284546356465657
   };
   t.ok(
     Object.keys(bbox).every(name => equals(bbox[name], expectedBbox[name])),


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

The child cells of a H3 tile do not exactly fit into the bounds of the tile.

<img width="420" alt="Screenshot 2025-07-02 at 12 04 15" src="https://github.com/user-attachments/assets/94adcebe-1eb2-4bc9-83b1-fa6b14ce9de1" />

This leads to picking being broken on the edges of H3 tiles as the picking system culls a tile before it can be rendering for picking

<!-- For all the PRs -->
#### Change List
- Pad H3 tiles by appropriate amount
- Test update
