### PR TITLE
fix(google): Do not force canvas resize

### DIFF
--- a/modules/google-maps/src/google-maps-overlay.ts
+++ b/modules/google-maps/src/google-maps-overlay.ts
@@ -267,10 +267,6 @@ export default class GoogleMapsOverlay {
         deck.setProps({_framebuffer});
       }
 
-      // With external gl context, animation loop doesn't resize webgl-canvas and thus fails to
-      // calculate corrext pixel ratio. Force this manually.
-      device.getDefaultCanvasContext().resize();
-
       // Camera changed, will trigger a map repaint right after this
       // Clear any change flag triggered by setting viewState so that deck does not request
       // a second repaint


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Changing the device pixel ratio while using `interleaved` `GoogleMapsOverlay` breaks the camera syncing - fixed only by a page refresh. Repro on https://deck.gl/examples/google-maps by changing page zoom a watching trucks go out of sync with basemap

https://github.com/user-attachments/assets/ef0be9d1-bc36-490b-b44d-f5fede45f69f

The problematic code is the forced resizing, which doesn't seem to do anything (apart from causing this bug). 

<!-- For all the PRs -->
#### Change List
- Do not force resize
