### PR TITLE
Include `@loaders.gl/schema` dependency

### DIFF
--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@loaders.gl/gltf": "^4.2.0",
+    "@loaders.gl/schema": "^4.2.0",
     "@luma.gl/gltf": "^9.1.9",
     "@luma.gl/shadertools": "^9.1.9"
   },


### PR DESCRIPTION
`@deck.gl/mesh-layers` has a dependency on `@loaders.gl/schema` but it is not included in the `package.json` dependencies.

TODO update lock file

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
-
