### PR TITLE
fix: picking on non-geospatial tile layer with modelMatrix

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -26,6 +26,7 @@ import {
   Tileset2DProps
 } from '../tileset-2d/index';
 import {urlType, URLTemplate, getURLFromTemplate} from '../tileset-2d/index';
+import {Matrix4} from '@math.gl/core';
 
 const defaultProps: DefaultProps<TileLayerProps> = {
   TilesetClass: Tileset2D,
@@ -401,6 +402,11 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
 
   filterSubLayer({layer, cullRect}: FilterContext) {
     const {tile} = (layer as Layer<{tile: Tile2DHeader}>).props;
-    return this.state.tileset!.isTileVisible(tile, cullRect);
+    const {modelMatrix} = this.props;
+    return this.state.tileset!.isTileVisible(
+      tile,
+      cullRect,
+      modelMatrix ? new Matrix4(modelMatrix) : null
+    );
   }
 }

--- a/modules/geo-layers/src/tileset-2d/utils.ts
+++ b/modules/geo-layers/src/tileset-2d/utils.ts
@@ -39,7 +39,7 @@ export const urlType = {
   }
 };
 
-function transformBox(bbox: Bounds, modelMatrix: Matrix4): Bounds {
+export function transformBox(bbox: Bounds, modelMatrix: Matrix4): Bounds {
   const transformedCoords = [
     // top-left
     modelMatrix.transformAsPoint([bbox[0], bbox[1]]),


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #9702

These are the changes that fixed my issue with non-geospatial data but unsure if there's some place else in the codebase that could be a more efficient fix or that could include geospatial data. happy to look into it if you think that's the case

<!-- For all the PRs -->
#### Change List
- pass tile's `modelMatrix` to tileset's `isTileVisible`
- export utils' `transformBox` to use in `isTileVisible`
