### PR TITLE
website: Enable WebGPU for line layer example

### DIFF
--- a/website/src/examples/line-layer.js
+++ b/website/src/examples/line-layer.js
@@ -24,6 +24,8 @@ class LineDemo extends Component {
 
   static code = `${GITHUB_TREE}/examples/website/line`;
 
+  static hasDeviceTabs = true;
+
   static parameters = {
     width: {
       displayName: 'Width',
@@ -62,6 +64,8 @@ class LineDemo extends Component {
     return (
       <App
         {...otherProps}
+        key={this.props.device?.type} 
+        device={this.props.device}
         flightPaths={data && data[0]}
         airports={data && data[1]}
         lineWidth={params.width.value}


### PR DESCRIPTION
Enable WebGPU for the line layer example in the website. 

We had issues with this before as I remember seeing the lines jumping around but seems that has been fixed. I think that was potentially fixed by the vertex buffer layout changes I made to luma where we could previously assign buffers to the wrong locations. Lack of transparency support does still make things not ideal when lines are overlapping, think I will try to understand what's required to get that working next as it'll make these examples a lot nicer with the basemap too.

I've also added the WebGPU-specific workaround here to the tracker.

#### Change List
- Enable device tabs
- WebGPU compatibility change to use a function so we get a buffer for `instanceWidths` as WebGPU can't support constant attributes


https://github.com/user-attachments/assets/3b19cfa6-1eb2-4d88-8abf-989239e06d4c

