### PR TITLE
feat(webgpu): Enable transparency for WebGPU and ported example layers

### DIFF
--- a/examples/website/point-cloud/app.tsx
+++ b/examples/website/point-cloud/app.tsx
@@ -67,16 +67,6 @@ export default function App({
       f64Pos[i] = pos.value[i];
     }
     (data as LASMesh).attributes.POSITION.value = f64Pos;
-    // TODO: (kaapp) lack of transparency support for webgpu requires us to recolour the points
-    // for now. We can remove this once we can create transparent webgpu canvas
-    const color = (data as LASMesh).attributes.COLOR_0;
-    for (let i = 0; i < color.value.length / 4; i++) {
-      const index = i * 4;
-      color.value[index] = 0xff; // r
-      color.value[index + 1] = 0x00; // g
-      color.value[index + 2] = 0x00; // b
-      color.value[index + 3] = 0xff; // a
-    }
     if (header.boundingBox) {
       const [mins, maxs] = header.boundingBox;
       // File contains bounding box info

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -46,6 +46,7 @@ export {default as FirstPersonViewport} from './viewports/first-person-viewport'
 
 // Shader modules
 export {
+  color,
   picking,
   project,
   project32,

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -21,7 +21,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {Timeline} from '@luma.gl/engine';
 import {AnimationLoop} from '@luma.gl/engine';
 import {GL} from '@luma.gl/constants';
-import type {Device, DeviceProps, Framebuffer, Parameters} from '@luma.gl/core';
+import type {CanvasContextProps, Device, DeviceProps, Framebuffer, Parameters} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
 import {Stats} from '@probe.gl/stats';
@@ -374,34 +374,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
     // Create a new device
     if (!deviceOrPromise) {
-      const canvasContextUserProps = this.props.deviceProps?.createCanvasContext;
-      const canvasContextProps =
-        typeof canvasContextUserProps === 'object' ? canvasContextUserProps : undefined;
-
-      // In deck.gl v9, Deck always bundles and adds a webgl2Adapter.
-      // This behavior is expected to change in deck.gl v10 to support WebGPU only builds.
-      const deviceProps = {adapters: [], ...props.deviceProps};
-      if (!deviceProps.adapters.includes(webgl2Adapter)) {
-        deviceProps.adapters.push(webgl2Adapter);
-      }
-
-      // Create the "best" device supported from the registered adapters
-      deviceOrPromise = luma.createDevice({
-        // luma by default throws if a device is already attached
-        // asynchronous device creation could happen after finalize() is called
-        // TODO - createDevice should support AbortController?
-        _reuseDevices: true,
-        // tests can't handle WebGPU devices yet so we force WebGL2 unless overridden
-        type: 'webgl',
-        ...deviceProps,
-        // In deck.gl v10 we may emphasize multi canvas support and unwind this prop wrapping
-        createCanvasContext: {
-          ...canvasContextProps,
-          canvas: this._createCanvas(props),
-          useDevicePixels: this.props.useDevicePixels,
-          autoResize: true
-        }
-      });
+      deviceOrPromise = this._createDevice(props);
     }
 
     this.animationLoop = this._createAnimationLoop(deviceOrPromise, props);
@@ -871,6 +844,44 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
       // onBeforeRender,
       // onAfterRender,
+    });
+  }
+
+  // Create a device from the deviceProps, assigning required defaults
+  private _createDevice(props: DeckProps<ViewsT>): Promise<Device> {
+    const canvasContextUserProps = this.props.deviceProps?.createCanvasContext;
+    const canvasContextProps =
+      typeof canvasContextUserProps === 'object' ? canvasContextUserProps : undefined;
+
+    // In deck.gl v9, Deck always bundles and adds a webgl2Adapter.
+    // This behavior is expected to change in deck.gl v10 to support WebGPU only builds.
+    const deviceProps = {adapters: [], ...props.deviceProps};
+    if (!deviceProps.adapters.includes(webgl2Adapter)) {
+      deviceProps.adapters.push(webgl2Adapter);
+    }
+
+    const defaultCanvasProps: CanvasContextProps = {
+      // we must use 'premultiplied' canvas for webgpu to enable transparency and match shaders
+      alphaMode: this.props.deviceProps?.type === 'webgpu' ? 'premultiplied' : undefined
+    };
+
+    // Create the "best" device supported from the registered adapters
+    return luma.createDevice({
+      // luma by default throws if a device is already attached
+      // asynchronous device creation could happen after finalize() is called
+      // TODO - createDevice should support AbortController?
+      _reuseDevices: true,
+      // tests can't handle WebGPU devices yet so we force WebGL2 unless overridden
+      type: 'webgl',
+      ...deviceProps,
+      // In deck.gl v10 we may emphasize multi canvas support and unwind this prop wrapping
+      createCanvasContext: {
+        ...defaultCanvasProps,
+        ...canvasContextProps,
+        canvas: this._createCanvas(props),
+        useDevicePixels: this.props.useDevicePixels,
+        autoResize: true
+      }
     });
   }
 

--- a/modules/core/src/shaderlib/color/color.ts
+++ b/modules/core/src/shaderlib/color/color.ts
@@ -1,0 +1,51 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {ShaderModule} from '@luma.gl/shadertools';
+import {LayerProps} from '../../types/layer-props';
+
+const colorWGSL = /* WGSL */ `
+
+struct ColorUniforms {
+  opacity: f32,
+};
+
+var<private> color: ColorUniforms = ColorUniforms(1.0);
+// TODO (kaapp) avoiding binding index collisions to handle layer opacity 
+// requires some thought.
+// @group(0) @binding(0) var<uniform> color: ColorUniforms;
+
+@must_use
+fn deckgl_premultiplied_alpha(fragColor: vec4<f32>) -> vec4<f32> {
+    return vec4(fragColor.rgb * fragColor.a, fragColor.a); 
+};
+`;
+
+export type ColorProps = {
+  /**
+   * Opacity of the layer, between 0 and 1. Default 1.
+   */
+  opacity?: number;
+};
+
+export type ColorUniforms = {
+  opacity?: number;
+};
+
+export default {
+  name: 'color',
+  dependencies: [],
+  source: colorWGSL,
+  getUniforms: (_props: Partial<ColorProps>) => {
+    // TODO (kaapp) Handle layer opacity
+    // apply gamma to opacity to make it visually "linear"
+    // TODO - v10: use raw opacity?
+    // opacity: Math.pow(props.opacity!, 1 / 2.2)
+    return {};
+  },
+  uniformTypes: {
+    opacity: 'f32'
+  }
+  // @ts-ignore TODO v9.1
+} as const satisfies ShaderModule<LayerProps, ColorUniforms, {}>;

--- a/modules/core/src/shaderlib/index.ts
+++ b/modules/core/src/shaderlib/index.ts
@@ -6,6 +6,7 @@ import {ShaderAssembler} from '@luma.gl/shadertools';
 
 import {gouraudMaterial, phongMaterial} from '@luma.gl/shadertools';
 import {layerUniforms} from './misc/layer-uniforms';
+import color from './color/color';
 import geometry from './misc/geometry';
 import project from './project/project';
 import project32 from './project32/project32';
@@ -47,7 +48,7 @@ export function getShaderAssembler(language: 'glsl' | 'wgsl'): ShaderAssembler {
   return shaderAssembler;
 }
 
-export {layerUniforms, picking, project, project32, gouraudMaterial, phongMaterial, shadow};
+export {layerUniforms, color, picking, project, project32, gouraudMaterial, phongMaterial, shadow};
 
 // Useful for custom shader modules
 export type {ProjectProps, ProjectUniforms} from './project/viewport-uniforms';

--- a/modules/layers/src/line-layer/line-layer.ts
+++ b/modules/layers/src/line-layer/line-layer.ts
@@ -5,6 +5,7 @@
 import {
   Layer,
   project32,
+  color,
   picking,
   UNIT,
   LayerProps,
@@ -114,7 +115,7 @@ export default class LineLayer<DataT = any, ExtraProps extends {} = {}> extends 
   }
 
   getShaders() {
-    return super.getShaders({vs, fs, source, modules: [project32, picking, lineUniforms]});
+    return super.getShaders({vs, fs, source, modules: [project32, color, picking, lineUniforms]});
   }
 
   // This layer has its own wrapLongitude logic

--- a/modules/layers/src/line-layer/line-layer.wgsl.ts
+++ b/modules/layers/src/line-layer/line-layer.wgsl.ts
@@ -3,13 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 export const shaderWGSL = /* wgsl */ `\
-// TODO(ibgreen): Hack for Layer uniforms (move to new "color" module?)
-struct LayerUniforms {
-  opacity: f32,
-};
-var<private> layer: LayerUniforms = LayerUniforms(1.0);
-// @group(0) @binding(1) var<uniform> layer: LayerUniforms;
-
 // ---------- Helper Structures & Functions ----------
 
 // Placeholder filter functions.
@@ -43,17 +36,17 @@ fn splitLine(a: vec3<f32>, b: vec3<f32>, x: f32) -> vec3<f32> {
 
 // ---------- Uniforms & Global Structures ----------
 
-// Uniforms for line, layer, and project are assumed to be defined elsewhere.
+// Uniforms for line, color, and project are assumed to be defined elsewhere.
 // For example:
 //
 // @group(0) @binding(0)
 // var<uniform> line: LineUniform;
 //
-// struct LayerUniform {
+// struct ColorUniform {
 //   opacity: f32,
 // };
 // @group(0) @binding(1)
-// var<uniform> layer: LayerUniform;
+// var<uniform> color: ColorUniform;
 //
 // struct ProjectUniform {
 //   viewportSize: vec2<f32>,
@@ -150,7 +143,7 @@ fn vertexMain(
   let finalPosition: vec4<f32> = filteredP + vec4<f32>(clipOffset, 0.0, 0.0);
 
   // Compute color.
-  var vColor: vec4<f32> = vec4<f32>(instanceColors.rgb, instanceColors.a * layer.opacity);
+  var vColor: vec4<f32> = vec4<f32>(instanceColors.rgb, instanceColors.a * color.opacity);
   // vColor = deckgl_filter_color(vColor, geometry);
 
   var output: Varyings;
@@ -174,6 +167,9 @@ fn fragmentMain(
 
   // Apply the deck.gl filter to the color.
   fragColor = deckgl_filter_color(fragColor, geometry);
+
+  // Apply premultiplied alpha as required by transparent canvas
+  fragColor = deckgl_premultiplied_alpha(fragColor);
 
   return fragColor;
 }

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -4,6 +4,7 @@
 
 import {
   Layer,
+  color,
   project32,
   picking,
   UNIT,
@@ -131,7 +132,7 @@ export default class PointCloudLayer<DataT = any, ExtraPropsT extends {} = {}> e
       vs,
       fs,
       source,
-      modules: [project32, gouraudMaterial, picking, pointCloudUniforms]
+      modules: [project32, color, gouraudMaterial, picking, pointCloudUniforms]
     });
   }
 

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.wgsl.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.wgsl.ts
@@ -3,16 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 export default /* wgsl */ `\
-// TODO(ibgreen): Hack for Layer uniforms (move to new "color" module?)
-
-struct LayerUniforms {
-  opacity: f32,
-};
-
-var<private> layer: LayerUniforms = LayerUniforms(1.0);
-// @group(0) @binding(1) var<uniform> layer: LayerUniforms;
-
-// Main shaders
 struct ConstantAttributes {
   instanceNormals: vec3<f32>,
   instanceColors: vec4<f32>,
@@ -73,7 +63,7 @@ fn vertexMain(attributes: Attributes) -> Varyings {
   let lightColor = lighting_getLightColor2(attributes.instanceColors.rgb, project.cameraPosition, geometry.position.xyz, geometry.normal);
 
   // Apply opacity to instance color, or return instance picking color
-  varyings.vColor = vec4(lightColor, attributes.instanceColors.a * layer.opacity);
+  varyings.vColor = vec4(lightColor, attributes.instanceColors.a * color.opacity);
   // DECKGL_FILTER_COLOR(vColor, geometry);
 
   return varyings;
@@ -93,6 +83,9 @@ fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
 
   fragColor = varyings.vColor;
   // DECKGL_FILTER_COLOR(fragColor, geometry);
+
+  // Apply premultiplied alpha as required by transparent canvas
+  fragColor = deckgl_premultiplied_alpha(fragColor);
 
   return fragColor;
 }

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Layer, project32, picking, UNIT} from '@deck.gl/core';
+import {Layer, color, project32, picking, UNIT} from '@deck.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
 
 import {scatterplotUniforms, ScatterplotProps} from './scatterplot-layer-uniforms';
@@ -175,7 +175,7 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT extends {} = {}> 
       vs,
       fs,
       source,
-      modules: [project32, picking, scatterplotUniforms]
+      modules: [project32, color, picking, scatterplotUniforms]
     });
   }
 

--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -44,6 +44,7 @@ export {
   Attribute,
   AttributeManager,
   // Shader modules
+  color,
   picking,
   project,
   project32,

--- a/website/src/store/device-store.jsx
+++ b/website/src/store/device-store.jsx
@@ -18,6 +18,7 @@ export async function createDevice(type) {
       type,
       createCanvasContext: {
         container: 'deckgl-wrapper',
+        alphaMode: 'premultiplied',
         useDevicePixels: true,
         autoResize: true,
         width: undefined,


### PR DESCRIPTION
Enable transparency for WebGPU tracker

#### Change List
- Moved opacity to a new `color` module, but uniform is not yet supplied to avoid making the PR too wide-reaching and no example provides an opacity slider.
- Moved device creation in deck constructor to a separate function due to complexity limits in linter.
- Create device with `premultiplied` alpha by default if creating a WebGPU device from `deviceProps`
- Create device with `premultiplied` alpha from `DeviceTabs` for examples.
- Use new `color` module to premultiply alpha for all ported WGSL shaders
- Remove the workaround in the pointcloud example that recoloured all points to red now that we can have a transparent canvas in WebGPU.

**Scatterplot example**
**WebGL**
<img width="1512" height="904" alt="image" src="https://github.com/user-attachments/assets/68e25d19-e7c1-46f8-b430-035095a1fcd3" />
**WebGPU**
<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/95dfdcb8-fd16-4e52-8f3c-f43274c96614" />



There are some differences between webgl and webgpu when zooming far out in the scatterplot layer - but I think this is probably blending related and something that can be addressed later if it's a problem.
**WebGL**
<img width="1512" height="904" alt="image" src="https://github.com/user-attachments/assets/59216494-477a-4a10-93ab-f4c551a48b1d" />
**WebGPU**
<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/031ae2cd-de64-4ddc-ac7a-d64c2f468d4a" />


Other examples working nicely
<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/f68dd8cd-eb6c-4f90-ac8f-7452ef79560c" />
<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/800b79fa-d618-43f5-a7fd-67bc2a837877" />

