### PR TITLE
feat(core): Add async DeckPicker methods

### DIFF
--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -91,7 +91,10 @@ export default class DeckPicker {
     }
   }
 
-  /** Pick the closest info at given coordinate @returns Promise that resolves with picking info */
+  /**
+   * Pick the closest info at given coordinate
+   * @returns Promise that resolves with picking info
+   */
   pickObjectAsync(opts: PickByPointOptions & PickOperationContext): Promise<{
     result: PickingInfo[];
     emptyInfo: PickingInfo;
@@ -99,17 +102,28 @@ export default class DeckPicker {
     return this._pickClosestObjectAsync(opts);
   }
 
-  /** Get all unique infos within a bounding box */
+  /**
+   * Picks a list of unique infos within a bounding box
+   * @returns Promise that resolves to all unique infos within a bounding box
+   */
   pickObjectsAsync(opts: PickByRectOptions & PickOperationContext): Promise<PickingInfo[]> {
     return this._pickVisibleObjectsAsync(opts);
   }
 
-  /** Pick the closest info at given coordinate @deprecated WebGL only */
+  /**
+   * Pick the closest info at given coordinate
+   * @returns picking info
+   * @deprecated WebGL only - use pickObjectAsync instead
+   */
   pickObject(opts: PickByPointOptions & PickOperationContext) {
     return this._pickClosestObject(opts);
   }
 
-  /** Get all unique infos within a bounding box */
+  /**
+   * Get all unique infos within a bounding box
+   * @returns all unique infos within a bounding box
+   * @deprecated WebGL only - use pickObjectAsync instead
+   */
   pickObjects(opts: PickByRectOptions & PickOperationContext) {
     return this._pickVisibleObjects(opts);
   }
@@ -499,7 +513,6 @@ export default class DeckPicker {
 
   /**
    * Pick all objects within the given bounding box
-   * @deprecated WebGL only
    */
   // eslint-disable-next-line max-statements
   async _pickVisibleObjectsAsync({
@@ -744,6 +757,7 @@ export default class DeckPicker {
     decodePickingColor: null;
   }>;
 
+  // Note: Implementation of the overloaded signatures above, TSDoc is on the signatures
   async _drawAndSampleAsync(
     {
       layers,
@@ -848,6 +862,7 @@ export default class DeckPicker {
     decodePickingColor: null;
   };
 
+  // Note: Implementation of the overloaded signatures above, TSDoc is on the signatures
   _drawAndSample(
     {
       layers,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

Add new `pick...Async()` methods to the deck picker.

- in WebGPU, all readback is asynchronous.
- this means that we won't be ble to support the current sync picking methods in the Deck API.
- To avoid breaking existing apps, we keep the old sync picking functions and simply mark them as `@deprecated` in TSDoc

This PR doesn't actually implement async picking. It just introduces the async picking API and path. This allows the rest of deck code base to start preparing, and will make future picking diffs cleaner.

<!-- For all the PRs -->
#### Change List

- Add new `pick...Async()` methods to the deck picker.

