### PR TITLE
fix: clamp transition progress

### DIFF
--- a/modules/core/src/controllers/transition-manager.ts
+++ b/modules/core/src/controllers/transition-manager.ts
@@ -8,6 +8,7 @@ import type {IViewState} from './view-state';
 
 import type {Timeline} from '@luma.gl/engine';
 import type {InteractionState} from './controller';
+import {clamp} from '@math.gl/core';
 
 const noop = () => {};
 
@@ -226,7 +227,7 @@ export default class TransitionManager<ControllerState extends IViewState<Contro
       time,
       settings: {interpolator, startProps, endProps, duration, easing}
     } = transition;
-    const t = easing(time / duration);
+    const t = easing(clamp(time / duration, 0, 1));
     const viewport = interpolator.interpolateProps(startProps, endProps, t);
 
     // This gurantees all props (e.g. bearing, longitude) are normalized

--- a/test/modules/core/lib/transition-manager.spec.ts
+++ b/test/modules/core/lib/transition-manager.spec.ts
@@ -260,3 +260,42 @@ test('TransitionManager#auto#duration', t => {
   );
   t.end();
 });
+
+test('TransitionManager clamps transition time', t => {
+  const timeline = new Timeline();
+  let viewState = null;
+
+  const initialProps = {
+    width: 100,
+    height: 100,
+    longitude: -122.45,
+    latitude: 37.78,
+    zoom: 0,
+    pitch: 0,
+    bearing: 0
+  };
+
+  const finalProps = {
+    ...initialProps,
+    zoom: 4,
+    transitionInterpolator: new LinearInterpolator(),
+    transitionDuration: 100
+  };
+
+  const transitionManager = new TransitionManager({
+    timeline,
+    getControllerState: props => new MapState(props),
+    onViewStateChange: ({viewState: vs}) => {
+      viewState = vs;
+    }
+  });
+
+  transitionManager.processViewStateChange(initialProps);
+  transitionManager.processViewStateChange(finalProps);
+
+  timeline.setTime(200);
+  transitionManager.updateTransition();
+
+  t.is(viewState.zoom, 4, 'transition ends at expected zoom');
+  t.end();
+});


### PR DESCRIPTION
## Summary
- prevent view state transitions from overshooting when frame time exceeds transition duration
- add unit test for clamping transition progress

## Testing
- `yarn test node` *(fails: SyntaxError: Unexpected identifier 'assert' in examples/layer-browser/src/data-samples.js)*

------
https://chatgpt.com/codex/tasks/task_i_68b081eeb30c832cacafa9aead2d20e4