### PR TITLE
Fix orthographic scroll zoom transitions

### DIFF
--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -533,10 +533,14 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       scale = 1 / scale;
     }
 
+    const transitionProps = smooth
+      ? {...this._getTransitionProps({around: pos}), transitionDuration: 250}
+      : NO_TRANSITION_PROPS;
+
     const newControllerState = this.controllerState.zoom({pos, scale});
     this.updateViewport(
       newControllerState,
-      {...this._getTransitionProps({around: pos}), transitionDuration: smooth ? 250 : 1},
+      transitionProps,
       {
         isZooming: true,
         isPanning: true

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -10,6 +10,7 @@ import {
   FirstPersonView,
   _GlobeView as GlobeView
 } from '@deck.gl/core';
+import {Timeline} from '@luma.gl/engine';
 
 import testController from './test-controller';
 
@@ -91,6 +92,65 @@ test('OrthographicController#2d zoom', async t => {
     },
     // OrthographicView cannot be rotated
     ['pan#function key', 'multipan']
+  );
+
+  t.end();
+});
+
+test('OrthographicController scroll zoom responds without transition lag', t => {
+  const timeline = new Timeline();
+  const view = new OrthographicView({controller: true});
+  const baseProps = {
+    id: 'test-view',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    target: [0, 0, 0],
+    zoom: 0,
+    scrollZoom: true
+  };
+  const controllerProps = {...view.controller, ...baseProps};
+  const ControllerClass = controllerProps.type;
+
+  let currentProps = {...controllerProps};
+  let lastViewState = currentProps;
+
+  const controller = new ControllerClass({
+    timeline,
+    onViewStateChange: ({viewState}) => {
+      lastViewState = viewState;
+      currentProps = {...currentProps, ...viewState};
+      controller.setProps(currentProps);
+    },
+    onStateChange: () => {},
+    makeViewport: viewState =>
+      view.makeViewport({width: currentProps.width, height: currentProps.height, viewState})
+  });
+
+  controller.setProps(currentProps);
+
+  const wheelEvent = {
+    type: 'wheel',
+    offsetCenter: {x: 50, y: 50},
+    delta: -1,
+    srcEvent: {preventDefault() {}},
+    stopPropagation: () => {}
+  };
+
+  controller.handleEvent(wheelEvent as any);
+
+  const speed = 0.01;
+  const {delta} = wheelEvent;
+  let scale = 2 / (1 + Math.exp(-Math.abs(delta * speed)));
+  if (delta < 0 && scale !== 0) {
+    scale = 1 / scale;
+  }
+  const expectedZoom = baseProps.zoom + Math.log2(scale);
+
+  t.ok(
+    Math.abs((lastViewState.zoom as number) - expectedZoom) < 1e-6,
+    'zoom level updates immediately when scroll zoom is not smooth'
   );
 
   t.end();


### PR DESCRIPTION
## Summary
- setting `scrollZoom: {smooth: false}` did not completely disable transitions, which made it impossible to avoid transition related issues.
- avoid triggering zero-duration transitions when handling scroll zoom events to stop orthographic views from snapping back while rendering is slow
- add a regression test that ensures scroll wheel zoom immediately updates the orthographic view state when smooth scrolling is disabled

## Testing
- yarn test node test/modules/core/controllers/controllers.spec.ts

------
https://chatgpt.com/codex/tasks/task_i_68c031d9faf4832ca611a08cb85db61a