### PR TITLE
chore(widgets) audit props and docs

### DIFF
--- a/docs/api-reference/core/widget.md
+++ b/docs/api-reference/core/widget.md
@@ -9,19 +9,43 @@ The `Widget` class is a base class used to define new widgets and should not be 
 
 ## Types 
 
-#### `WidgetProps` (object) {#widgetprops}
+### `WidgetProps` (object) {#widgetprops}
 
 Options for the widget, as passed into the constructor and can be updated with `setProps`.
 
-#### `id` (string) {#id}
+#### `id` (string, optional) {#id}
+
+* Default: the widget's name.
 
 The `id` string must be unique among all your widgets at a given time. While a default `id` is provided, it is recommended to set `id` explicitly if you have multiple widgets of the same type.
 
+Remarks:
+
+* `id` is used to match widgets between rendering calls. deck.gl requires each widget to have a unique `id`. A default `id` is assigned based on widget type, which means if you are using more than one widget of the same type (e.g. two `InfoWidget`s) you need to provide a custom `id` for at least one of them.
+
+#### `style` (object, optional) {#style}
+
+* Default: `{}`
+
+Additional inline CSS styles on the top HTML element of the widget. camelCase CSS properties (e.g. `backgroundColor`) and kabab-case CSS variables are accepted (e.g. `--button-size`).
+
+```ts
+  style?: Partial<CSSStyleDeclaration>;
+```
+
+#### `className` (string, optional) {#classname}
+
+* Default: `''`
+
+Additional CSS classnames on the top HTML element.
+
+### Additional `WidgetProps` on UI Widgets
+
 #### `viewId` (string | null) {#viewid}
 
-The `viewId` prop controls how a widget interacts with views. If `viewId` is defined, the widget is placed in that view and interacts exclusively with it; otherwise, it is placed in the root widget container and affects all views.
-
 * Default: `null`
+
+The `viewId` prop controls how a widget interacts with views. If `viewId` is defined, the widget is placed in that view and interacts exclusively with it; otherwise, it is placed in the root widget container and affects all views.
 
 When a widget instance is added to Deck, the user can optionally specify a `viewId` that it is attached to (default `null`). If assigned, this widget will only respond to events occurred inside the specific view that matches this id.
 
@@ -29,9 +53,9 @@ The id of the view that the widget is attached to. If `null`, the widget receive
 
 #### `placement` (string, optional) {#placement}
 
-Widget position within the view relative to the map container.
-
 * Default: `'top-left'`
+
+Widget position within the view relative to the map container.
 
 Widget positioning within the view. One of:
 
@@ -40,22 +64,6 @@ Widget positioning within the view. One of:
 - `'bottom-left'`
 - `'bottom-right'`
 - `'fill'`
-
-#### `style` (object, optional) {#style}
-
-Additional inline CSS styles on the top HTML element.
-
-```ts
-  style?: Partial<CSSStyleDeclaration>;
-```
-
-* Default: `{}`
-
-#### `className` (string, optional) {#classname}
-
-Additional CSS classnames on the top HTML element.
-  
-* Default: `''`
 
 ### Methods for Widget Writers
 

--- a/docs/api-reference/core/widget.md
+++ b/docs/api-reference/core/widget.md
@@ -27,7 +27,7 @@ Remarks:
 
 * Default: `{}`
 
-Additional inline CSS styles on the top HTML element of the widget. camelCase CSS properties (e.g. `backgroundColor`) and kabab-case CSS variables are accepted (e.g. `--button-size`).
+Additional inline CSS styles on the top HTML element of the widget. camelCase CSS properties (e.g. `backgroundColor`) and kebab-case CSS variables are accepted (e.g. `--button-size`).
 
 ```ts
   style?: Partial<CSSStyleDeclaration>;

--- a/docs/api-reference/widgets/compass-widget.md
+++ b/docs/api-reference/widgets/compass-widget.md
@@ -3,15 +3,19 @@ import {CompassWidget} from '@deck.gl/widgets';
 
 # CompassWidget
 
+<img src="https://img.shields.io/badge/from-v9.0-green.svg?style=flat-square" alt="from v9.0" />
+
 This widget visualizes bearing and pitch. Click it once to reset bearing to 0, click it a second time to reset pitch to 0. Supports Map and Globe view.
+
+## Usage
 
 <WidgetPreview cls={CompassWidget}/>
 
 ```ts
-import {CompassWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {CompassWidget} from '@deck.gl/widgets';
 
-const deck = new Deck({
+new Deck({
   widgets: [new CompassWidget()]
 });
 ```

--- a/docs/api-reference/widgets/compass-widget.md
+++ b/docs/api-reference/widgets/compass-widget.md
@@ -28,13 +28,13 @@ The `CompassWidget` accepts the generic [`WidgetProps`](../core/widget.md#widget
 
 #### `label` (string, optional) {#label}
 
-Tooltip message displayed while hovering a mouse over the widget.
+* Default: `'Compass'`
 
-Default: `'Compass'`
+Tooltip message displayed while hovering a mouse over the widget.
 
 #### `transitionDuration` (number, optional) {#transitionduration}
 
-Default: `200`
+* Default: `200`
 
 Bearing and pitch reset transition duration in milliseconds.
 

--- a/docs/api-reference/widgets/compass-widget.md
+++ b/docs/api-reference/widgets/compass-widget.md
@@ -20,13 +20,7 @@ const deck = new Deck({
 
 ### `CompassWidgetProps` {#compasswidgetprops}
 
-The `CompassWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'compass'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `CompassWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `label` (string, optional) {#label}
 

--- a/docs/api-reference/widgets/context-menu-widget.md
+++ b/docs/api-reference/widgets/context-menu-widget.md
@@ -56,3 +56,7 @@ Menu item definition:
 - Menu items are dynamically generated based on what was clicked
 - Click elsewhere to hide the menu
 - Menu automatically positions itself at the cursor location
+
+## Source
+
+[modules/widgets/src/context-menu-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/context-menu-widget.tsx)

--- a/docs/api-reference/widgets/context-menu-widget.md
+++ b/docs/api-reference/widgets/context-menu-widget.md
@@ -39,7 +39,6 @@ const deck = new Deck({
 
 The `ContextMenuWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
-- `id` (string, default: `'context'`) - **Required.** Unique id for this widget
 - `getMenuItems` (function) - **Required.** Function that returns menu items based on the picked object. Receives `PickingInfo` and returns an array of `ContextWidgetMenuItem` objects or `null`.
 - `onMenuItemSelected` (function, optional) - Callback invoked when a menu item is selected. Receives the selected item key and `PickingInfo`.
 - `visible` (boolean, default `false`) - Controls visibility of the context menu.

--- a/docs/api-reference/widgets/context-menu-widget.md
+++ b/docs/api-reference/widgets/context-menu-widget.md
@@ -14,19 +14,17 @@ import {_ContextMenuWidget as ContextMenuWidget} from '@deck.gl/widgets';
 const deck = new Deck({
   widgets: [
     new ContextMenuWidget({
-      getMenuItems: (info, widget) => {
+      getMenuItems: (info) => {
         if (info.object) {
-        const name = info.object.properties.name;
           return [
-            {key: 'name', label: name},
-            {key: 'delete', label: 'Delete'}
+            {label: 'Show Info', key: 'info'},
+            {label: 'Delete', key: 'delete'}
           ];
         }
         return [{label: 'Add Point', key: 'add'}];
       },
       onMenuItemSelected: (key, pickInfo) => {
-        if (key === 'add') addPoint(pickInfo);  
-        if (key === 'delete') deletePoint(pickInfo);  
+        console.log('Selected:', key, pickInfo?.object);
       }
     })
   ]
@@ -37,7 +35,7 @@ const deck = new Deck({
 
 ### `ContextMenuWidgetProps` {#contextmenuwidgetprops}
 
-The `ContextMenuWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
+The `ContextMenuWidget` accepts the generic [`WidgetProps`](../core/widget.md#props) and:
 
 - `getMenuItems` (function) - **Required.** Function that returns menu items based on the picked object. Receives `PickingInfo` and returns an array of `ContextWidgetMenuItem` objects or `null`.
 - `onMenuItemSelected` (function, optional) - Callback invoked when a menu item is selected. Receives the selected item key and `PickingInfo`.

--- a/docs/api-reference/widgets/context-menu-widget.md
+++ b/docs/api-reference/widgets/context-menu-widget.md
@@ -14,17 +14,19 @@ import {_ContextMenuWidget as ContextMenuWidget} from '@deck.gl/widgets';
 const deck = new Deck({
   widgets: [
     new ContextMenuWidget({
-      getMenuItems: (info) => {
+      getMenuItems: (info, widget) => {
         if (info.object) {
+          const name = info.object.properties.name;
           return [
-            {label: 'Show Info', key: 'info'},
-            {label: 'Delete', key: 'delete'}
+            {key: 'name', label: name},
+            {key: 'delete', label: 'Delete'}
           ];
         }
         return [{label: 'Add Point', key: 'add'}];
       },
       onMenuItemSelected: (key, pickInfo) => {
-        console.log('Selected:', key, pickInfo?.object);
+        if (key === 'add') addPoint(pickInfo);
+        if (key === 'delete') deletePoint(pickInfo);
       }
     })
   ]
@@ -35,7 +37,7 @@ const deck = new Deck({
 
 ### `ContextMenuWidgetProps` {#contextmenuwidgetprops}
 
-The `ContextMenuWidget` accepts the generic [`WidgetProps`](../core/widget.md#props) and:
+The `ContextMenuWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 - `getMenuItems` (function) - **Required.** Function that returns menu items based on the picked object. Receives `PickingInfo` and returns an array of `ContextWidgetMenuItem` objects or `null`.
 - `onMenuItemSelected` (function, optional) - Callback invoked when a menu item is selected. Receives the selected item key and `PickingInfo`.

--- a/docs/api-reference/widgets/fps-widget.md
+++ b/docs/api-reference/widgets/fps-widget.md
@@ -19,10 +19,5 @@ new Deck({
 
 ### `FpsWidgetProps` {#fpswidgetprops}
 
-The `FpsWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
+The `FpsWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops).
 
-- `id` (default `'fps'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.

--- a/docs/api-reference/widgets/fps-widget.md
+++ b/docs/api-reference/widgets/fps-widget.md
@@ -26,3 +26,6 @@ new Deck({
 
 The `FpsWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops).
 
+## Source
+
+[modules/widgets/src/fps-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/fps-widget.tsx)

--- a/docs/api-reference/widgets/fps-widget.md
+++ b/docs/api-reference/widgets/fps-widget.md
@@ -1,15 +1,20 @@
-# FpsWidget
+import {WidgetPreview} from '@site/src/doc-demos/widgets';
+import {_FpsWidget as FpsWidget} from '@deck.gl/widgets';
 
-Displays the measured frames per second (FPS) as reported by the attached
-`Deck` instance.
+# FpsWidget (Experimental)
 
-```ts
-import {FpsWidget} from '@deck.gl/widgets';
-```
+<img src="https://img.shields.io/badge/from-v9.2-green.svg?style=flat-square" alt="from v9.2" />
+
+Displays the measured frames per second (FPS) as reported by the attached `Deck` instance.
 
 ## Usage
 
+<WidgetPreview cls={FpsWidget}/>
+
 ```ts
+import {Deck} from '@deck.gl/core';
+import {_FpsWidget as FpsWidget} from '@deck.gl/widgets';
+
 new Deck({
   widgets: [new FpsWidget({placement: 'top-right'})]
 });

--- a/docs/api-reference/widgets/fullscreen-widget.md
+++ b/docs/api-reference/widgets/fullscreen-widget.md
@@ -28,22 +28,21 @@ The `FullscreenWidget` accepts the generic [`WidgetProps`](../core/widget.md#wid
 
 #### `container` (HTMLElement, optional) {#container}
 
-Default: `undefined`
+* Default: `undefined`
 
 A [compatible DOM element](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Compatible_elements) which should be made full screen. By default, the map container element will be made full screen.
 
 #### `enterLabel` (string, optional) {#enterlabel}
 
-Tooltip message displayed while hovering a mouse over the widget when out of fullscreen.
+* Default: `'Enter Fullscreen'`
 
-Default: `'Enter Fullscreen'`
+Tooltip message displayed while hovering a mouse over the widget when out of fullscreen.
 
 #### `exitLabel` (string, optional) {#exitlabel}
 
+* Default: `'Exit Fullscreen'`
+
 Tooltip message displayed while hovering a mouse over the widget when fullscreen.
-
-Default: `'Exit Fullscreen'`
-
 
 ## Styles
 

--- a/docs/api-reference/widgets/fullscreen-widget.md
+++ b/docs/api-reference/widgets/fullscreen-widget.md
@@ -3,15 +3,19 @@ import {FullscreenWidget} from '@deck.gl/widgets';
 
 # FullscreenWidget
 
+<img src="https://img.shields.io/badge/from-v9.0-green.svg?style=flat-square" alt="from v9.0" />
+
 This widget enlarges deck.gl to fill the full screen. Click the widget to enter or exit full screen.
+
+## Usage
 
 <WidgetPreview cls={FullscreenWidget}/>
 
 ```ts
-import {FullscreenWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {FullscreenWidget} from '@deck.gl/widgets';
 
-const deck = new Deck({
+new Deck({
   widgets: [new FullscreenWidget()]
 });
 ```

--- a/docs/api-reference/widgets/fullscreen-widget.md
+++ b/docs/api-reference/widgets/fullscreen-widget.md
@@ -20,13 +20,7 @@ const deck = new Deck({
 
 ### `FullscreenWidgetProps` {#fullscreenwidgetprops}
 
-The `FullscreenWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'fullscreen'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `FullscreenWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `container` (HTMLElement, optional) {#container}
 
@@ -46,17 +40,6 @@ Tooltip message displayed while hovering a mouse over the widget when fullscreen
 
 Default: `'Exit Fullscreen'`
 
-#### `style` (object, optional) {#style}
-
-Default: `{}`
-
-Additional CSS styles for the widget. camelCase CSS properties (e.g. `backgroundColor`) and kabab-case CSS variables are accepted (e.g. `--button-size`).
-
-#### `className` (string, optional) {#classname}
-
-Default: `undefined`
-
-Class name to attach to the widget element. The element has the default class name of `deck-widget deck-fullscreen-widget`.
 
 ## Styles
 

--- a/docs/api-reference/widgets/geocoder-widget.md
+++ b/docs/api-reference/widgets/geocoder-widget.md
@@ -3,6 +3,8 @@ import {_GeocoderWidget} from '@deck.gl/widgets';
 
 # GeocoderWidget (Experimental)
 
+<img src="https://img.shields.io/badge/from-v9.2-green.svg?style=flat-square" alt="from v9.2" />
+
 The GeocoderWidget helps the user find positions on the map.
 
 This widget provides an input box for entering an address or a pair of coordinates.
@@ -14,8 +16,8 @@ Addresses that return a valid location are stored in browser local storage (up t
 <WidgetPreview cls={_GeocoderWidget}/>
 
 ```ts
-import {_GeocoderWidget as GeocoderWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {_GeocoderWidget as GeocoderWidget} from '@deck.gl/widgets';
 
 new Deck({
   widgets: [new GeocoderWidget()]

--- a/docs/api-reference/widgets/geocoder-widget.md
+++ b/docs/api-reference/widgets/geocoder-widget.md
@@ -64,3 +64,6 @@ In addition to addresses / coordinates, one position of obvious interest is the 
 
 If `props._geolocation` **Current position** from the drop-down uses `navigator.geolocation` to center the map. The option is hidden if the browser does not provide the Geolocation API or the user denies access.
 
+## Source
+
+[modules/widgets/src/geocoder-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/geocoder-widget.tsx)

--- a/docs/api-reference/widgets/geocoder-widget.md
+++ b/docs/api-reference/widgets/geocoder-widget.md
@@ -26,13 +26,7 @@ new Deck({
 
 ### `GeocoderWidgetProps` {#geocoderwidgetprops}
 
-The `GeocoderWidgetProps` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'geocoder'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `GeocoderWidgetProps` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `label` (string, optional) {#label}
 

--- a/docs/api-reference/widgets/geocoder-widget.md
+++ b/docs/api-reference/widgets/geocoder-widget.md
@@ -32,29 +32,31 @@ The `GeocoderWidgetProps` accepts the generic [`WidgetProps`](../core/widget.md#
 
 #### `label` (string, optional) {#label}
 
+* Default: `'Geocoder'`
+
 Tooltip message displayed while hovering a mouse over the widget.
 
-Default: `'Geocoder'`
+#### `transitionDuration` (number, optional) {#transitionduration}
+
+* Default: `200`
+
+View state transition duration in milliseconds.
 
 #### `geocoder` (string, optional) {#geocoder}
 
-Default: `'coordinates'`
+* Default: `'coordinates'`
 
 Which geocoding service to use. Supported values are `'coordinates'`, `'google'`, `'mapbox'`, `'opencage'`, or `'custom'`.
 
 #### `apiKey` (string, optional) {#apikey}
+
+* Default: `''`
 
 Required if `geocoder` is set to a third party provider. For quick testing, applications can use the  `coordinates` geocode does not require an api key.
 
 #### `customGeocoder` (optional) {#customgeocoder}
 
 Only used when `geocoder` is `'custom'`. A function that receives the entered text and an API key, and resolves to a `{longitude, latitude}` object when successful.
-
-#### `transitionDuration` (number, optional) {#transitionduration}
-
-Default: `200`
-
-View state transition duration in milliseconds.
 
 #### `_geolocation` (optional) {#_geolocation}
 

--- a/docs/api-reference/widgets/gimbal-widget.md
+++ b/docs/api-reference/widgets/gimbal-widget.md
@@ -3,15 +3,19 @@ import {GimbalWidget} from '@deck.gl/widgets';
 
 # GimbalWidget
 
+<img src="https://img.shields.io/badge/from-v9.2-green.svg?style=flat-square" alt="from v9.2" />
+
 Visualizes the orientation of an `OrbitView` using nested circles. Clicking resets `rotationOrbit` and `rotationX` to `0`.
+
+## Usage
 
 <WidgetPreview cls={GimbalWidget}/>
 
 ```ts
-import {GimbalWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {GimbalWidget} from '@deck.gl/widgets';
 
-const deck = new Deck({
+new Deck({
   widgets: [new GimbalWidget()]
 });
 ```

--- a/docs/api-reference/widgets/gimbal-widget.md
+++ b/docs/api-reference/widgets/gimbal-widget.md
@@ -32,3 +32,6 @@ new Deck({
 | `--icon-gimbal-outer-color` | `rgb(68, 92, 204)` |
 | `--icon-gimbal-inner-color` | `rgb(240, 92, 68)` |
 
+## Source
+
+[modules/widgets/src/gimbal-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/gimbal-widget.tsx)

--- a/docs/api-reference/widgets/gimbal-widget.md
+++ b/docs/api-reference/widgets/gimbal-widget.md
@@ -20,10 +20,29 @@ new Deck({
 });
 ```
 
-## Props
+## Types
 
-- `label`: `'Gimbal'`
-- `transitionDuration`: `200`
+### `GimbalWidgetProps` {#gimbalwidgetprops}
+
+The `GimbalWidgetProps` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
+
+#### `label` (string, optional) {#label}
+
+* Default: `'Gimbal'`
+
+Tooltip message displayed while hovering a mouse over the widget.
+
+#### `strokeWidth` (number, optional) {#strokewidth}
+
+* Default: `1.5`
+
+Width of gimbal lines.
+
+#### `transitionDuration` (number, optional) {#transitionduration}
+
+* Default: `200`
+
+View state transition duration in milliseconds.
 
 ## Styles
 

--- a/docs/api-reference/widgets/gimbal-widget.md
+++ b/docs/api-reference/widgets/gimbal-widget.md
@@ -18,7 +18,6 @@ const deck = new Deck({
 
 ## Props
 
-- `id`: `'gimbal'`
 - `label`: `'Gimbal'`
 - `transitionDuration`: `200`
 

--- a/docs/api-reference/widgets/info-widget.md
+++ b/docs/api-reference/widgets/info-widget.md
@@ -40,19 +40,26 @@ The `InfoWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetpro
 
 #### position ([number, number]) {#position}
 
+* Default: `[0, 0]`
+
 Position at which to place popup (e.g. [longitude, latitude]).
 
 #### text (string, optional) {#text}
+
+* Default: `''`
 
 Text to display within widget.
 
 #### visible (boolean, optional) {#visible}
 
+* Default: `false`
+
 Whether the widget is visible.
 
-Default: `false`
 
 #### minOffset (number, optional) {#minoffset}
+
+* Default: `0`
 
 Minimum offset (in pixels) to keep the popup away from the canvas edges.
 

--- a/docs/api-reference/widgets/info-widget.md
+++ b/docs/api-reference/widgets/info-widget.md
@@ -34,13 +34,7 @@ const deck = new Deck({
 
 ### `InfoWidgetProps` {#infowidgetprops}
 
-The `InfoWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'info'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `InfoWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### position ([number, number]) {#position}
 

--- a/docs/api-reference/widgets/info-widget.md
+++ b/docs/api-reference/widgets/info-widget.md
@@ -56,6 +56,14 @@ Text to display within widget.
 
 Whether the widget is visible.
 
+#### mode (string, optional) {#mode}
+
+* Default: `'hover'`
+
+Determines the interaction mode of the widget:
+* `'click'`: The widget is triggered by a user click.
+* `'hover'`: The widget is triggered when the user hovers over an element.
+* `'static'`: The widget remains visible at a fixed position.
 
 #### minOffset (number, optional) {#minoffset}
 
@@ -63,9 +71,25 @@ Whether the widget is visible.
 
 Minimum offset (in pixels) to keep the popup away from the canvas edges.
 
+#### getTooltip (Function, optional) {#gettooltip}
+
+```ts
+(info: PickingInfo, widget: InfoWidget) => InfoWidgetProps | null
+```
+
+* Default: `undefined`
+
+Function to generate the popup contents from the selected element.
+
 #### onClick (Function, optional) {#onclick}
 
-`(widget: _InfoWidget, info: PickingInfo) => boolean`
+```ts
+(widget: InfoWidget, info: PickingInfo) => boolean
+```
+
+* Default: `undefined`
+
+Callback triggered when the widget is clicked.
 
 ## Source
 

--- a/docs/api-reference/widgets/info-widget.md
+++ b/docs/api-reference/widgets/info-widget.md
@@ -5,7 +5,9 @@ import {_InfoWidget} from '@deck.gl/widgets';
 
 <img src="https://img.shields.io/badge/from-v9.2-green.svg?style=flat-square" alt="from v9.2" />
 
-The InfoWidget shows a popup when an item in a layer has been clicked.
+This widget shows a popup at a fixed position, or when an item in a deck.gl layer has been clicked or hovered.
+
+## Usage
 
 <WidgetPreview cls={_InfoWidget} props={{
   visible: true,
@@ -15,10 +17,10 @@ The InfoWidget shows a popup when an item in a layer has been clicked.
 }}/>
 
 ```ts
-import {_InfoWidget as InfoWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {_InfoWidget as InfoWidget} from '@deck.gl/widgets';
 
-const deck = new Deck({
+new Deck({
   widgets: [
     new InfoWidget({
       visible: true,

--- a/docs/api-reference/widgets/loading-widget.md
+++ b/docs/api-reference/widgets/loading-widget.md
@@ -28,9 +28,9 @@ The `InfoWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetpro
 
 #### `label` (string, optional) {#label}
 
-Tooltip message displayed while hovering a mouse over the widget.
+* Default: `'Loading data'`
 
-Default: `'Loading data'`
+Tooltip message displayed while hovering a mouse over the widget.
 
 ## Source
 

--- a/docs/api-reference/widgets/loading-widget.md
+++ b/docs/api-reference/widgets/loading-widget.md
@@ -22,29 +22,7 @@ const deck = new Deck({
 
 ### `LoadingWidgetProps` {#loadingwidgetprops}
 
-The `LoadingWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'loading'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
-
-## Props
-
-#### `id` (string, optional) {#id}
-
-Default: `'loading'`
-
-The `id` must be unique among all your widgets at a given time. 
-
-Note: It is necessary to set `id` explicitly if you have more than once instance of the same widget.
-
-#### `placement` (string, optional) {#placement}
-
-Default: `'top-left'`
-
-Widget position within the view relative to the map container. Valid options are `top-left`, `top-right`, `bottom-left`, `bottom-right`, or `fill`.
+The `InfoWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `label` (string, optional) {#label}
 

--- a/docs/api-reference/widgets/loading-widget.md
+++ b/docs/api-reference/widgets/loading-widget.md
@@ -7,13 +7,15 @@ import {_LoadingWidget} from '@deck.gl/widgets';
 
 This widget shows a spinning indicator while any deck.gl layers are loading data.
 
+## Usage
+
 <WidgetPreview cls={_LoadingWidget}/>
 
 ```ts
-import {_LoadingWidget as LoadingWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {_LoadingWidget as LoadingWidget} from '@deck.gl/widgets';
 
-const deck = new Deck({
+new Deck({
   widgets: [new LoadingWidget()]
 });
 ```

--- a/docs/api-reference/widgets/overview.md
+++ b/docs/api-reference/widgets/overview.md
@@ -6,15 +6,15 @@ This module contains the following widgets:
 
 ### Navigation Widgets
 
-- [ZoomWidget](./zoom-widget.md)
-- [ResetViewWidget](./reset-view-widget.md)
 - [GimbalWidget](./gimbal-widget.md)
+- [ResetViewWidget](./reset-view-widget.md)
+- [ZoomWidget](./zoom-widget.md)
 
 ### Geospatial Widgets
 
 - [CompassWidget](./compass-widget.md)
-- [ScaleWidget](./scale-widget.md)
 - [GeocoderWidget](./geocoder-widget.md)
+- [ScaleWidget](./scale-widget.md)
 
 ### View Widgets
 
@@ -24,8 +24,8 @@ This module contains the following widgets:
 
 ### Information Widgets
 
-- [InfoWidget](./info-widget.md)
 - [ContextMenuWidget](./context-menu-widget.md)
+- [InfoWidget](./info-widget.md)
 
 ### Control Widgets
 
@@ -33,11 +33,11 @@ This module contains the following widgets:
 
 ### Utility Widgets
 
-- [ScreenshotWidget](./screenshot-widget.md)
-- [ThemeWidget](./theme-widget.md)
-- [LoadingWidget](./loading-widget.md)
 - [FpsWidget](./fps-widget.md)
+- [LoadingWidget](./loading-widget.md)
+- [ScreenshotWidget](./screenshot-widget.md)
 - [StatsWidget](./stats-widget.md)
+- [ThemeWidget](./theme-widget.md)
 
 ## Installation
 

--- a/docs/api-reference/widgets/overview.md
+++ b/docs/api-reference/widgets/overview.md
@@ -8,23 +8,36 @@ This module contains the following widgets:
 
 - [ZoomWidget](./zoom-widget.md)
 - [ResetViewWidget](./reset-view-widget.md)
-<!-- - [GimbalWidget](./gimbal-widget.md) -->
+- [GimbalWidget](./gimbal-widget.md)
 
 ### Geospatial Widgets
 
 - [CompassWidget](./compass-widget.md)
-<!-- - [ScaleWidget](./scale-widget.md) -->
-<!-- - [GeocoderWidget](./geocoder-widget.md) -->
+- [ScaleWidget](./scale-widget.md)
+- [GeocoderWidget](./geocoder-widget.md)
+
+### View Widgets
+
+- [FullscreenWidget](./fullscreen-widget.md)
+- [SplitterWidget](./splitter-widget.md)
+- [ViewSelectorWidget](./view-selector-widget.md)
+
+### Information Widgets
+
+- [InfoWidget](./info-widget.md)
+- [ContextMenuWidget](./context-menu-widget.md)
+
+### Control Widgets
+
+- [TimelineWidget](./timeline-widget.md)
 
 ### Utility Widgets
 
-- [FullscreenWidget](./fullscreen-widget.md)
 - [ScreenshotWidget](./screenshot-widget.md)
-- [LoadingWidget](./loading-widget.md)
 - [ThemeWidget](./theme-widget.md)
-- [InfoWidget](./info-widget.md)
-- [SplitterWidget](./splitter-widget.md)
-- [TimelineWidget](./timeline-widget.md)
+- [LoadingWidget](./loading-widget.md)
+- [FpsWidget](./fps-widget.md)
+- [StatsWidget](./stats-widget.md)
 
 ## Installation
 

--- a/docs/api-reference/widgets/reset-view-widget.md
+++ b/docs/api-reference/widgets/reset-view-widget.md
@@ -7,11 +7,13 @@ import {ResetViewWidget} from '@deck.gl/widgets';
 
 This widget resets the view state of a deck.gl viewport to its initial state. The user clicks the widget to return to the initial view.
 
+## Usage
+
 <WidgetPreview cls={ResetViewWidget}/>
 
 ```ts
-import {ResetViewWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {ResetViewWidget} from '@deck.gl/widgets';
 
 const deck = new Deck({
   widgets: [new ResetViewWidget()]

--- a/docs/api-reference/widgets/reset-view-widget.md
+++ b/docs/api-reference/widgets/reset-view-widget.md
@@ -22,13 +22,7 @@ const deck = new Deck({
 
 ### `ResetViewWidgetProps` {#resetviewwidgetprops}
 
-The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'reset-view'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `label` (string, optional) {#label}
 

--- a/docs/api-reference/widgets/reset-view-widget.md
+++ b/docs/api-reference/widgets/reset-view-widget.md
@@ -28,9 +28,10 @@ The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widg
 
 #### `label` (string, optional) {#label}
 
+* Default: `'Reset View'`
+
 Tooltip message displayed while hovering a mouse over the widget.
 
-Default: `'Reset View'`
 
 ## Styles
 

--- a/docs/api-reference/widgets/reset-view-widget.md
+++ b/docs/api-reference/widgets/reset-view-widget.md
@@ -32,6 +32,11 @@ The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widg
 
 Tooltip message displayed while hovering a mouse over the widget.
 
+#### `initialViewState` (ViewState, optional) {#initialviewstate}
+
+* Default: `deck.props.initialViewState`
+
+The initial view state to reset the view to.
 
 ## Styles
 

--- a/docs/api-reference/widgets/scale-widget.md
+++ b/docs/api-reference/widgets/scale-widget.md
@@ -7,6 +7,8 @@ import {_ScaleWidget} from '@deck.gl/widgets';
 
 This widget displays a dynamic cartographic scale bar that updates as the map view changes. It shows a horizontal line with end tick marks and a distance label, reflecting the current map scale based on zoom level and latitude.
 
+## Usage
+
 <WidgetPreview cls={_ScaleWidget}/>
 
 ```ts

--- a/docs/api-reference/widgets/scale-widget.md
+++ b/docs/api-reference/widgets/scale-widget.md
@@ -28,7 +28,7 @@ The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widg
 
 #### `label` (string, optional) {#label}
 
-Default: `'Scale'`
+* Default: `'Scale'`
 
 Tooltip label for the widget.
 

--- a/docs/api-reference/widgets/scale-widget.md
+++ b/docs/api-reference/widgets/scale-widget.md
@@ -22,13 +22,7 @@ const deck = new Deck({
 
 ### `ResetViewWidgetProps` {#resetviewwidgetprops}
 
-The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'scale'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `ResetViewWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `label` (string, optional) {#label}
 

--- a/docs/api-reference/widgets/screenshot-widget.md
+++ b/docs/api-reference/widgets/screenshot-widget.md
@@ -12,13 +12,15 @@ Only the deck.gl canvas is captured, not other HTML DOM element underneath or on
 It is possible to use `props.onCapture` to integrate with more advanced screen capture modules such as [html2canvas](https://html2canvas.hertzen.com/)
 :::
 
+## Usage
+
 <WidgetPreview cls={ScreenshotWidget}/>
 
 ```ts
 import {ScreenshotWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
 
-const deck = new Deck({
+new Deck({
   widgets: [new ScreenshotWidget()]
 });
 ```

--- a/docs/api-reference/widgets/screenshot-widget.md
+++ b/docs/api-reference/widgets/screenshot-widget.md
@@ -31,21 +31,24 @@ The `ScreenshotWidget` accepts the generic [`WidgetProps`](../core/widget.md#wid
 
 #### `label` (string, optional) {#label}
 
+* Default: `'Screenshot'`
+
 Tooltip message displayed while hovering a mouse over the widget.
 
-Default: `'Screenshot'`
 
 #### `imageFormat` (string, optional) {#imageformat}
 
-Format of the downloaded image. Browser dependent, may support `image/jpeg`, `image/webp`, `image/avif`
+* Default: `'image/png'`
 
-Default: `'image/png'`
+Format of the downloaded image. Browser dependent, may support `image/jpeg`, `image/webp`, `image/avif`
 
 #### `onCapture` (function, optional) {#oncapture}
 
 ```ts
-onCapture(widget: ScreenshotWidget): void
+(widget: ScreenshotWidget) => void
 ```
+
+* Default: `undefined`
 
 Allows the application to define its own capture logic, perhaps to integrate a more advanced screen capture module such as [html2canvas](https://html2canvas.hertzen.com/).
 

--- a/docs/api-reference/widgets/screenshot-widget.md
+++ b/docs/api-reference/widgets/screenshot-widget.md
@@ -25,13 +25,7 @@ const deck = new Deck({
 
 ### `ScreenshotWidgetProps` {#screenshotwidgetprops}
 
-The `ScreenshotWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'screenshot'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `ScreenshotWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `label` (string, optional) {#label}
 

--- a/docs/api-reference/widgets/screenshot-widget.md
+++ b/docs/api-reference/widgets/screenshot-widget.md
@@ -35,6 +35,11 @@ The `ScreenshotWidget` accepts the generic [`WidgetProps`](../core/widget.md#wid
 
 Tooltip message displayed while hovering a mouse over the widget.
 
+#### `filename` (string, optional) {filename}
+
+* Default: `'screenshot.png'`
+
+Filename for captured screenshot.
 
 #### `imageFormat` (string, optional) {#imageformat}
 

--- a/docs/api-reference/widgets/screenshot-widget.md
+++ b/docs/api-reference/widgets/screenshot-widget.md
@@ -35,7 +35,7 @@ The `ScreenshotWidget` accepts the generic [`WidgetProps`](../core/widget.md#wid
 
 Tooltip message displayed while hovering a mouse over the widget.
 
-#### `filename` (string, optional) {filename}
+#### `filename` (string, optional) {#filename}
 
 * Default: `'screenshot.png'`
 

--- a/docs/api-reference/widgets/splitter-widget.md
+++ b/docs/api-reference/widgets/splitter-widget.md
@@ -7,6 +7,8 @@ import {_SplitterWidget} from '@deck.gl/widgets';
 
 This widget renders a draggable splitter line across the deck.gl canvas to divide two views. It supports both vertical and horizontal orientations, allowing users to compare two views (e.g., two map or globe views) by dragging the splitter handle.
 
+## Usage
+
 <WidgetPreview cls={_SplitterWidget} props={{
   orientation: 'vertical',
   initialSplit: 0.5

--- a/docs/api-reference/widgets/splitter-widget.md
+++ b/docs/api-reference/widgets/splitter-widget.md
@@ -47,39 +47,55 @@ The `SplitterWidget` accepts the generic [`WidgetProps`](../core/widget.md#widge
 
 #### `viewId1` (string, required) {#viewid1}
 
+* Default: `''`
+
 The `id` of the first (resizable) view.
 
 #### `viewId2` (string, required) {#viewid2}
+
+* Default: `''`
 
 The `id` of the second view to compare against.
 
 #### `orientation` ('vertical' | 'horizontal', optional) {#orientation}
 
-Default: `'vertical'`
+* Default: `'vertical'`
 
 Orientation of the splitter line. Use `vertical` for side-by-side comparison or `horizontal` for top-bottom.
 
 #### `initialSplit` (number, optional) {#initialsplit}
 
-Default: `0.5`
+* Default: `0.5`
 
 Initial split ratio (between 0 and 1) for the first view.
 
 #### `onChange` (Function, optional) {#onchange}
 
-`(newSplit: number) => void`
+```ts
+(newSplit: number) => void
+```
+
+* Default: `() => {}`
 
 Callback invoked during dragging with the updated split ratio.
 
 #### `onDragStart` (Function, optional) {#ondragstart}
 
-`() => void`
+```ts
+() => void
+```
+
+* Default: `() => {}`
 
 Callback invoked when the user begins dragging the splitter.
 
 #### `onDragEnd` (Function, optional) {#ondragend}
 
-`() => void`
+```ts
+() => void
+```
+
+* Default: `() => {}`
 
 Callback invoked when the user releases the splitter.
 

--- a/docs/api-reference/widgets/splitter-widget.md
+++ b/docs/api-reference/widgets/splitter-widget.md
@@ -41,13 +41,7 @@ const deck = new Deck({
 
 ### `SplitterWidgetProps` {#splitterwidgetprops}
 
-The `SplitterWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'splitter'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `SplitterWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `viewId1` (string, required) {#viewid1}
 

--- a/docs/api-reference/widgets/stats-widget.md
+++ b/docs/api-reference/widgets/stats-widget.md
@@ -3,6 +3,8 @@ import {_StatsWidget as StatsWidget} from '@deck.gl/widgets';
 
 # StatsWidget (Experimental)
 
+<img src="https://img.shields.io/badge/from-v9.2-green.svg?style=flat-square" alt="from v9.2" />
+
 Displays performance and debugging statistics from deck.gl, luma.gl, or custom probe.gl stats objects in a collapsible widget.
 
 ## Usage

--- a/docs/api-reference/widgets/stats-widget.md
+++ b/docs/api-reference/widgets/stats-widget.md
@@ -56,3 +56,7 @@ The `StatsWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetpr
   - `'luma'`: luma.gl WebGL statistics
   - `'device'`: GPU device statistics
   - `'custom'`: User-provided stats object
+
+## Source
+
+[modules/widgets/src/stats-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/stats-widget.tsx)

--- a/docs/api-reference/widgets/stats-widget.md
+++ b/docs/api-reference/widgets/stats-widget.md
@@ -31,7 +31,6 @@ const deck = new Deck({
 
 The `StatsWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
-- `id` (string, default: `'stats'`) - **Required.** Unique id for this widget
 - `type` (string, default `'deck'`) - Type of stats to display: `'deck'`, `'luma'`, `'device'`, or `'custom'`
 - `stats` (Stats, optional) - Custom stats object when using `type: 'custom'`
 - `title` (string, default `'Stats'`) - Title shown in the widget header

--- a/docs/api-reference/widgets/theme-widget.md
+++ b/docs/api-reference/widgets/theme-widget.md
@@ -26,13 +26,7 @@ const deck = new Deck({
 
 ### `ThemeWidgetProps` {#themewidgetprops}
 
-The `ThemeWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'theme'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `ThemeWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `lightModeTheme` (object, optional) {#lightmodetheme}
 

--- a/docs/api-reference/widgets/theme-widget.md
+++ b/docs/api-reference/widgets/theme-widget.md
@@ -42,11 +42,11 @@ Styles for light mode theme.
 
 Styles for dark mode theme.
 
-#### `initialTheme` (`'auto' | 'light' | 'dark' | 'none'`) {#initialtheme}
+#### `initialTheme` (`'auto' | 'light' | 'dark'`) {#initialtheme}
 
-Set the initial theme. 'auto' inspects `window.matchMedia('(prefers-color-scheme: dark)')`, and `none` prevents the widget from changing the theme on-mount.
 * Default: `'auto'`
 
+Set the initial theme. `'auto'` inspects `window.matchMedia('(prefers-color-scheme: dark)')`.
 
 #### `lightModeLabel` (string, optional) {#lightmodelabel}
 

--- a/docs/api-reference/widgets/theme-widget.md
+++ b/docs/api-reference/widgets/theme-widget.md
@@ -11,7 +11,9 @@ This widget changes the theme of deck.gl between light mode and dark mode. Click
 :::info
 
 - The `ThemeWidget` is mainly intended for minimal applications and to help developers test theme changes. More advanced applications that already support theming in their non-Deck UI will likely want to control change of deck themes using the same mechanism that is used for the remainder of their UI.
-  :::
+:::
+
+## Usage
 
 <BrowserOnly>{() => <WidgetPreview cls={_ThemeWidget}/>}</BrowserOnly>
 
@@ -19,7 +21,7 @@ This widget changes the theme of deck.gl between light mode and dark mode. Click
 import {_ThemeWidget as ThemeWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
 
-const deck = new Deck({
+new Deck({
   widgets: [new ThemeWidget()]
 });
 ```

--- a/docs/api-reference/widgets/theme-widget.md
+++ b/docs/api-reference/widgets/theme-widget.md
@@ -32,33 +32,33 @@ The `ThemeWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetpr
 
 #### `lightModeTheme` (object, optional) {#lightmodetheme}
 
-Styles for light mode theme.
+* Default: Light Glass Theme
 
-Default: Light Glass Theme
+Styles for light mode theme.
 
 #### `darkModeTheme` (object, optional) {#darkmodetheme}
 
-Styles for dark mode theme.
+* Default: Dark Glass Theme
 
-Default: Dark Glass Theme
+Styles for dark mode theme.
 
 #### `initialTheme` (`'auto' | 'light' | 'dark' | 'none'`) {#initialtheme}
 
 Set the initial theme. 'auto' inspects `window.matchMedia('(prefers-color-scheme: dark)')`, and `none` prevents the widget from changing the theme on-mount.
+* Default: `'auto'`
 
-Default: `'auto'`
 
 #### `lightModeLabel` (string, optional) {#lightmodelabel}
 
-Tooltip message displayed while hovering a mouse over the widget when out of fullscreen.
+* Default: `'Light Theme'`
 
-Default: `'Light Theme'`
+Tooltip message displayed while hovering a mouse over the widget when out of fullscreen.
 
 #### `darkModeLabel` (string, optional) {#darkmodelabel}
 
-Tooltip message displayed while hovering a mouse over the widget when fullscreen.
+* Default: `'Dark Theme'`
 
-Default: `'Dark Theme'`
+Tooltip message displayed while hovering a mouse over the widget when fullscreen.
 
 ## Styles
 

--- a/docs/api-reference/widgets/timeline-widget.md
+++ b/docs/api-reference/widgets/timeline-widget.md
@@ -30,31 +30,35 @@ The `TimelineWidget` accepts the generic [`WidgetProps`](../core/widget.md#widge
 
 #### `timeRange` ([number, number], optional) {#timerange}
 
-Default: `[0, 100]`
+* Default: `[0, 100]`
 
 Minimum and maximum values for the time slider.
 
 #### `step` (number, optional) {#step}
 
-Default: `1`
+* Default: `1`
 
 Increment step for the slider and play animation.
 
 #### `initialTime` (number, optional) {#initialtime}
 
-Default: `timeRange[0]`
+* Default: `timeRange[0]`
 
 Starting value of the slider.
 
 #### `onTimeChange` (Function, optional) {#ontimechange}
 
-`(value: number) => void`
+```ts
+(value: number) => void
+```
+
+* Default: `() => {}`
 
 Callback invoked when the time value changes (drag or play).
 
 #### `playInterval` (number, optional) {#playinterval}
 
-Default: `1000`
+* Default: `1000`
 
 Interval in milliseconds between automatic time increments when playing.
 

--- a/docs/api-reference/widgets/timeline-widget.md
+++ b/docs/api-reference/widgets/timeline-widget.md
@@ -7,13 +7,15 @@ import {_TimelineWidget} from '@deck.gl/widgets';
 
 This widget provides a time slider with play/pause controls. Configure a time range, step interval, and play speed to animate data over time.
 
+## Usage
+
 <WidgetPreview cls={_TimelineWidget}/>
 
 ```ts
-import {_TimelineWidget as TimelineWidget} from '@deck.gl/widgets';
 import {Deck} from '@deck.gl/core';
+import {_TimelineWidget as TimelineWidget} from '@deck.gl/widgets';
 
-const deck = new Deck({
+new Deck({
   widgets: [
     new TimelineWidget({
       timeRange: [0, 24],

--- a/docs/api-reference/widgets/timeline-widget.md
+++ b/docs/api-reference/widgets/timeline-widget.md
@@ -26,27 +26,7 @@ const deck = new Deck({
 
 ### `TimelineProps` {#timelineprops}
 
-The `TimelineWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'timeline'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
-
-## Props
-
-#### `id` (string, optional) {#id}
-
-Default: `'timeline'`
-
-Unique identifier for the widget.
-
-#### `placement` (string, optional) {#placement}
-
-Default: `'bottom-left'`
-
-Widget position within the view. Valid options: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `fill`.
+The `TimelineWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `timeRange` ([number, number], optional) {#timerange}
 

--- a/docs/api-reference/widgets/view-selector-widget.md
+++ b/docs/api-reference/widgets/view-selector-widget.md
@@ -3,6 +3,8 @@ import {_ViewSelectorWidget as ViewSelectorWidget} from '@deck.gl/widgets';
 
 # ViewSelectorWidget (Experimental)
 
+<img src="https://img.shields.io/badge/from-v9.2-green.svg?style=flat-square" alt="from v9.2" />
+
 Provides a dropdown menu for selecting different view modes including single view and split view configurations.
 
 ## Usage

--- a/docs/api-reference/widgets/view-selector-widget.md
+++ b/docs/api-reference/widgets/view-selector-widget.md
@@ -32,7 +32,6 @@ const deck = new Deck({
 
 The `ViewSelectorWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
-- `id` (string, default: `'view-selector'`) - **Required.** Unique id for this widget
 - `initialViewMode` (ViewMode, default `'single'`) - Initial view mode selection
 - `onViewModeChange` (function, optional) - Callback invoked when view mode changes. Receives the new `ViewMode`.
 - `label` (string, default `'Split View'`) - Tooltip label for the widget

--- a/docs/api-reference/widgets/view-selector-widget.md
+++ b/docs/api-reference/widgets/view-selector-widget.md
@@ -58,3 +58,6 @@ Available view modes:
 ## Integration
 
 This widget provides the UI for view mode selection but does not currently trigger callbacks or modify deck.gl view configuration automatically. Applications need to implement custom logic to detect view mode changes and update view configurations accordingly.
+## Source
+
+[modules/widgets/src/view-selector-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/view-selector-widget.tsx)

--- a/docs/api-reference/widgets/view-selector-widget.md
+++ b/docs/api-reference/widgets/view-selector-widget.md
@@ -53,11 +53,10 @@ Available view modes:
 - Selection updates the current view mode internally
 - The widget button displays an icon matching the currently selected mode
 
-**Note:** The `onViewModeChange` callback is currently not invoked in the implementation, so this widget primarily serves as a visual selector without automatic view switching functionality.
-
 ## Integration
 
 This widget provides the UI for view mode selection but does not currently trigger callbacks or modify deck.gl view configuration automatically. Applications need to implement custom logic to detect view mode changes and update view configurations accordingly.
+
 ## Source
 
 [modules/widgets/src/view-selector-widget.tsx](https://github.com/visgl/deck.gl/tree/master/modules/widgets/src/view-selector-widget.tsx)

--- a/docs/api-reference/widgets/zoom-widget.md
+++ b/docs/api-reference/widgets/zoom-widget.md
@@ -3,7 +3,11 @@ import {ZoomWidget} from '@deck.gl/widgets';
 
 # ZoomWidget
 
+<img src="https://img.shields.io/badge/from-v9.0-green.svg?style=flat-square" alt="from v9.0" />
+
 This widget controls the zoom level of a deck.gl view. Click '+' to zoom in by 1, click '-' to zoom out by 1. Supports controlling Map and Globe views.
+
+## Usage
 
 <WidgetPreview cls={ZoomWidget} props={{orientation: 'horizontal'}}/>
 

--- a/docs/api-reference/widgets/zoom-widget.md
+++ b/docs/api-reference/widgets/zoom-widget.md
@@ -18,13 +18,7 @@ const deck = new Deck({
 
 ### `ZoomProps` {#zoomprops}
 
-The `Zoomidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops):
-
-- `id` (default `'zoom'`) -  Unique id for this widget
-- `placement` (default `'top-left'`) - Widget position within the view relative to the map container
-- `viewId` (default `null`) - The `viewId` prop controls how a widget interacts with views. 
-- `style` (default `{}`) - Additional inline styles on the top HTML element.
-- `className` (default `''`) - Additional classnames on the top HTML element.
+The `Zoomidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
 #### `orientation` (string, optional) {#orientation}
 

--- a/docs/api-reference/widgets/zoom-widget.md
+++ b/docs/api-reference/widgets/zoom-widget.md
@@ -26,25 +26,25 @@ The `Zoomidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprop
 
 #### `orientation` (string, optional) {#orientation}
 
-Default: `'vertical'`
+* Default: `'vertical'`
 
 Widget button orientation. Valid options are `vertical` or `horizontal`.
 
 #### `zoomInLabel` (string, optional) {#zoominlabel}
 
-Tooltip message displayed while hovering a mouse over the zoom in button.
+* Default: `'Zoom In'`
 
-Default: `'Zoom In'`
+Tooltip message displayed while hovering a mouse over the zoom in button.
 
 #### `zoomOutLabel` (string, optional) {#zoomoutlabel}
 
-Tooltip message displayed while hovering a mouse over the zoom out button.
+* Default: `'Zoom Out'`
 
-Default: `'Zoom Out'`
+Tooltip message displayed while hovering a mouse over the zoom out button.
 
 #### `transitionDuration` (number, optional) {#transitionduration}
 
-Default: `200`
+* Default: `200`
 
 Zoom transition duration in milliseconds.
 

--- a/modules/widgets/src/compass-widget.tsx
+++ b/modules/widgets/src/compass-widget.tsx
@@ -7,6 +7,7 @@ import type {Viewport, WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
 
 export type CompassWidgetProps = WidgetProps & {
+  /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
   /** View to attach to and interact with. Required when using multiple views. */
   viewId?: string | null;
@@ -28,7 +29,6 @@ export class CompassWidget extends Widget<CompassWidgetProps> {
 
   className = 'deck-widget-compass';
   placement: WidgetPlacement = 'top-left';
-  viewId?: string | null = null;
   viewports: {[id: string]: Viewport} = {};
 
   constructor(props: CompassWidgetProps = {}) {

--- a/modules/widgets/src/context-menu-widget.tsx
+++ b/modules/widgets/src/context-menu-widget.tsx
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 /* global document */
-import {Widget, WidgetProps} from '@deck.gl/core';
-import type {Deck, PickingInfo} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
+import type {Deck, PickingInfo, WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
 import {SimpleMenu} from './lib/components/simple-menu';
 

--- a/modules/widgets/src/context-menu-widget.tsx
+++ b/modules/widgets/src/context-menu-widget.tsx
@@ -1,3 +1,7 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* global document */
 import {Widget, WidgetProps} from '@deck.gl/core';
 import type {Deck, PickingInfo} from '@deck.gl/core';
@@ -50,7 +54,7 @@ export class ContextMenuWidget extends Widget<ContextMenuWidgetProps> {
   constructor(props: ContextMenuWidgetProps) {
     super(props, ContextMenuWidget.defaultProps);
     this.pickInfo = null;
-    this.setProps(props);
+    this.setProps(this.props);
   }
 
   onAdd({deck}: {deck: Deck<any>}): HTMLDivElement {

--- a/modules/widgets/src/fps-widget.tsx
+++ b/modules/widgets/src/fps-widget.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Widget, WidgetProps} from '@deck.gl/core';
-import type {WidgetPlacement, Deck} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
+import type {WidgetPlacement, Deck, WidgetProps} from '@deck.gl/core';
 
 /** Properties for the FpsWidget. */
 export type FpsWidgetProps = WidgetProps & {

--- a/modules/widgets/src/fps-widget.tsx
+++ b/modules/widgets/src/fps-widget.tsx
@@ -9,6 +9,8 @@ import type {WidgetPlacement, Deck} from '@deck.gl/core';
 export type FpsWidgetProps = WidgetProps & {
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
 };
 
 /**
@@ -18,7 +20,8 @@ export class FpsWidget extends Widget<FpsWidgetProps> {
   static defaultProps: Required<FpsWidgetProps> = {
     ...Widget.defaultProps,
     id: 'fps',
-    placement: 'top-left'
+    placement: 'top-left',
+    viewId: null
   };
 
   className = 'deck-widget-fps';
@@ -28,13 +31,12 @@ export class FpsWidget extends Widget<FpsWidgetProps> {
 
   constructor(props: FpsWidgetProps = {}) {
     super(props, FpsWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<FpsWidgetProps>): void {
-    if (props.placement) {
-      this.placement = props.placement;
-    }
+    this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/fullscreen-widget.tsx
+++ b/modules/widgets/src/fullscreen-widget.tsx
@@ -13,6 +13,8 @@ export type FullscreenWidgetProps = WidgetProps & {
   id?: string;
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
   /** Tooltip message when out of fullscreen. */
   enterLabel?: string;
   /** Tooltip message when fullscreen. */
@@ -29,6 +31,7 @@ export class FullscreenWidget extends Widget<FullscreenWidgetProps> {
     ...Widget.defaultProps,
     id: 'fullscreen',
     placement: 'top-left',
+    viewId: null,
     enterLabel: 'Enter Fullscreen',
     exitLabel: 'Exit Fullscreen',
     container: undefined!
@@ -40,7 +43,7 @@ export class FullscreenWidget extends Widget<FullscreenWidgetProps> {
 
   constructor(props: FullscreenWidgetProps = {}) {
     super(props, FullscreenWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   onAdd(): void {
@@ -64,6 +67,7 @@ export class FullscreenWidget extends Widget<FullscreenWidgetProps> {
 
   setProps(props: Partial<FullscreenWidgetProps>) {
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/geocoder-widget.tsx
+++ b/modules/widgets/src/geocoder-widget.tsx
@@ -24,11 +24,12 @@ const CURRENT_LOCATION = 'current';
 
 /** Properties for the GeocoderWidget */
 export type GeocoderWidgetProps = WidgetProps & {
-  viewId?: string;
+  viewId?: string | null;
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
   /** Tooltip message */
   label?: string;
+  /** View state reset transition duration in ms. 0 disables the transition */
   transitionDuration?: number;
   /** Geocoding service selector, for declarative usage */
   geocoder?: 'google' | 'mapbox' | 'opencage' | 'coordinates' | 'custom';
@@ -49,7 +50,7 @@ export class GeocoderWidget extends Widget<GeocoderWidgetProps> {
   static defaultProps: Required<GeocoderWidgetProps> = {
     ...Widget.defaultProps,
     id: 'geocoder',
-    viewId: undefined!,
+    viewId: null,
     placement: 'top-left',
     label: 'Geocoder',
     transitionDuration: 200,
@@ -68,18 +69,17 @@ export class GeocoderWidget extends Widget<GeocoderWidgetProps> {
 
   constructor(props: GeocoderWidgetProps = {}) {
     super(props, GeocoderWidget.defaultProps);
-    this.placement = this.props.placement ?? this.placement;
     this.setProps(this.props);
-    this.geocoder = getGeocoder(this.props);
   }
 
   setProps(props: Partial<GeocoderWidgetProps>): void {
-    super.setProps(props);
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     this.geocoder = getGeocoder(this.props);
     if (this.geocoder.requiresApiKey && !this.props.apiKey) {
       throw new Error(`API key is required for the ${this.geocoder.name} geocoder`);
     }
+    super.setProps(props);
   }
 
   onRenderHTML(rootElement: HTMLElement): void {

--- a/modules/widgets/src/geocoder-widget.tsx
+++ b/modules/widgets/src/geocoder-widget.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Widget, WidgetProps} from '@deck.gl/core';
-import type {WidgetPlacement, Viewport} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
+import type {WidgetPlacement, Viewport, WidgetProps} from '@deck.gl/core';
 import {FlyToInterpolator, LinearInterpolator} from '@deck.gl/core';
 import {render} from 'preact';
 import {DropdownMenu} from './lib/components/dropdown-menu';

--- a/modules/widgets/src/gimbal-widget.tsx
+++ b/modules/widgets/src/gimbal-widget.tsx
@@ -12,7 +12,7 @@ export type GimbalWidgetProps = WidgetProps & {
   viewId?: string | null;
   /** Tooltip message. */
   label?: string;
-  /** Width of gimbal lines */
+  /** Width of gimbal lines. */
   strokeWidth?: number;
   /** Transition duration in ms when resetting rotation. */
   transitionDuration?: number;
@@ -23,7 +23,7 @@ export class GimbalWidget extends Widget<GimbalWidgetProps> {
     ...Widget.defaultProps,
     id: 'gimbal',
     placement: 'top-left',
-    viewId: undefined!,
+    viewId: null,
     label: 'Gimbal',
     strokeWidth: 1.5,
     transitionDuration: 200
@@ -31,7 +31,6 @@ export class GimbalWidget extends Widget<GimbalWidgetProps> {
 
   className = 'deck-widget-gimbal';
   placement: WidgetPlacement = 'top-left';
-  viewId?: string | null = null;
 
   constructor(props: GimbalWidgetProps = {}) {
     super(props, GimbalWidget.defaultProps);

--- a/modules/widgets/src/index.ts
+++ b/modules/widgets/src/index.ts
@@ -5,25 +5,31 @@
 // Navigation widgets
 export {ZoomWidget} from './zoom-widget';
 export {ResetViewWidget} from './reset-view-widget';
+export {GimbalWidget} from './gimbal-widget';
 
 // Geospatial widgets
 export {CompassWidget} from './compass-widget';
-export {GimbalWidget} from './gimbal-widget';
 export {ScaleWidget as _ScaleWidget} from './scale-widget';
 export {GeocoderWidget as _GeocoderWidget} from './geocoder-widget';
 
-// Utility widgets
+// View widgets
 export {FullscreenWidget} from './fullscreen-widget';
+export {SplitterWidget as _SplitterWidget} from './splitter-widget';
+export {ViewSelectorWidget as _ViewSelectorWidget} from './view-selector-widget';
+
+// Information widgets
+export {InfoWidget as _InfoWidget} from './info-widget';
+export {ContextMenuWidget as _ContextMenuWidget} from './context-menu-widget';
+
+// Control widgets
+export {TimelineWidget as _TimelineWidget} from './timeline-widget';
+
+// Utility widgets
 export {ScreenshotWidget} from './screenshot-widget';
+export {ThemeWidget as _ThemeWidget} from './theme-widget';
 export {LoadingWidget as _LoadingWidget} from './loading-widget';
 export {FpsWidget as _FpsWidget} from './fps-widget';
-export {ThemeWidget as _ThemeWidget} from './theme-widget';
-export {InfoWidget as _InfoWidget} from './info-widget';
 export {StatsWidget as _StatsWidget} from './stats-widget';
-export {ContextMenuWidget as _ContextMenuWidget} from './context-menu-widget';
-export {SplitterWidget as _SplitterWidget} from './splitter-widget';
-export {TimelineWidget as _TimelineWidget} from './timeline-widget';
-export {ViewSelectorWidget as _ViewSelectorWidget} from './view-selector-widget';
 
 export type {FullscreenWidgetProps} from './fullscreen-widget';
 export type {CompassWidgetProps} from './compass-widget';
@@ -46,8 +52,7 @@ export type {GimbalWidgetProps} from './gimbal-widget';
 export {LightTheme, DarkTheme, LightGlassTheme, DarkGlassTheme} from './themes';
 export type {DeckWidgetTheme} from './themes';
 
-// Experimental exports
-
+// Experimental preact components
 export {ButtonGroup as _ButtonGroup, type ButtonGroupProps} from './lib/components/button-group';
 export {IconButton as _IconButton, type IconButtonProps} from './lib/components/icon-button';
 export {

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -1,33 +1,38 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* global document */
 import {Widget, WidgetProps} from '@deck.gl/core';
 import type {Deck, PickingInfo, Viewport} from '@deck.gl/core';
 import {render, JSX} from 'preact';
 
 export type InfoWidgetProps = WidgetProps & {
-  /** View to attach to and interact with. Required when using multiple views. */
+  /** View to attach to and interact with. Required when using multiple views */
   viewId?: string | null;
-  /** InfoWidget mode */
+  /** Determines the interaction mode of the widget */
   mode: 'click' | 'hover' | 'static';
-  /** Get the popup contents from the selected element */
-  getTooltip?: (info: PickingInfo, widget: InfoWidget) => any;
-  /** Position at which to place popup (clicked point: [longitude, latitude]). */
+  /** Function to generate the popup contents from the selected element */
+  getTooltip?: (info: PickingInfo, widget: InfoWidget) => InfoWidgetProps | null;
+  /** Position at which to place popup (clicked point: [longitude, latitude]) */
   position: [number, number];
-  /** Text of popup */
+  /** Text content of popup */
   text?: string;
   /** Visibility of info widget */
   visible?: boolean;
   /** Minimum offset (in pixels) to keep the popup away from the canvas edges. */
   minOffset?: number;
+  /** Callback triggered when the widget is clicked. */
   onClick?: (widget: InfoWidget, info: PickingInfo) => boolean;
 };
 
 export class InfoWidget extends Widget<InfoWidgetProps> {
   static defaultProps: Required<InfoWidgetProps> = {
     ...Widget.defaultProps,
+    id: 'info',
     position: [0, 0],
     text: '',
     visible: false,
-    // Set default minOffset if not provided
     minOffset: 0,
     viewId: null,
     mode: 'hover',
@@ -37,19 +42,15 @@ export class InfoWidget extends Widget<InfoWidgetProps> {
 
   className = 'deck-widget-info';
   placement = 'fill' as const;
-  viewId?: string | null = null;
   viewport?: Viewport;
 
   constructor(props: InfoWidgetProps) {
     super(props, InfoWidget.defaultProps);
-    props.position = props.position || [0, 0];
-    props.text = props.text || '';
-    props.visible = props.visible || false;
-    // Set default minOffset if not provided
-    props.minOffset = props.minOffset ?? 0;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<InfoWidgetProps>) {
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 /* global document */
-import {Widget, WidgetProps} from '@deck.gl/core';
-import type {Deck, PickingInfo, Viewport} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
+import type {Deck, PickingInfo, Viewport, WidgetProps} from '@deck.gl/core';
 import {render, JSX} from 'preact';
 
 export type InfoWidgetProps = WidgetProps & {

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -73,7 +73,7 @@ export class InfoWidget extends Widget<InfoWidgetProps> {
       this.setProps({
         visible: tooltip !== null,
         ...tooltip,
-        style: {zIndex: 1, ...tooltip?.style}
+        style: {zIndex: '1', ...tooltip?.style}
       });
     }
   }

--- a/modules/widgets/src/loading-widget.tsx
+++ b/modules/widgets/src/loading-widget.tsx
@@ -11,6 +11,8 @@ import {IconButton} from './lib/components/icon-button';
 export type LoadingWidgetProps = WidgetProps & {
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views */
+  viewId?: string | null;
   /** Tooltip message when loading */
   label?: string;
 };
@@ -23,6 +25,7 @@ export class LoadingWidget extends Widget<LoadingWidgetProps> {
     ...Widget.defaultProps,
     id: 'loading',
     placement: 'top-left',
+    viewId: null,
     label: 'Loading layer data'
   };
 
@@ -32,11 +35,12 @@ export class LoadingWidget extends Widget<LoadingWidgetProps> {
 
   constructor(props: LoadingWidgetProps = {}) {
     super(props, LoadingWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<LoadingWidgetProps>) {
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/loading-widget.tsx
+++ b/modules/widgets/src/loading-widget.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WidgetPlacement, Layer} from '@deck.gl/core';
+import type {WidgetPlacement, Layer, WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
-import {Widget, WidgetProps} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
 import {IconButton} from './lib/components/icon-button';
 
 /** Properties for the LoadingWidget */

--- a/modules/widgets/src/reset-view-widget.tsx
+++ b/modules/widgets/src/reset-view-widget.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WidgetPlacement} from '@deck.gl/core';
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
-import {Widget, WidgetProps} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
 import {IconButton} from './lib/components/icon-button';
 
 /** @todo - is the the best we can do? */

--- a/modules/widgets/src/reset-view-widget.tsx
+++ b/modules/widgets/src/reset-view-widget.tsx
@@ -32,7 +32,7 @@ export class ResetViewWidget extends Widget<ResetViewWidgetProps> {
     placement: 'top-left',
     label: 'Reset View',
     initialViewState: undefined!,
-    viewId: undefined!
+    viewId: null
   };
 
   className = 'deck-widget-reset-view';
@@ -40,11 +40,12 @@ export class ResetViewWidget extends Widget<ResetViewWidgetProps> {
 
   constructor(props: ResetViewWidgetProps = {}) {
     super(props, ResetViewWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<ResetViewWidgetProps>) {
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/scale-widget.tsx
+++ b/modules/widgets/src/scale-widget.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WidgetPlacement, Viewport} from '@deck.gl/core';
+import type {WidgetPlacement, Viewport, WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
-import {Widget, WidgetProps} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
 
 export type ScaleWidgetProps = WidgetProps & {
   /** Widget positioning within the view. Default 'bottom-left'. */

--- a/modules/widgets/src/scale-widget.tsx
+++ b/modules/widgets/src/scale-widget.tsx
@@ -7,9 +7,12 @@ import {render} from 'preact';
 import {Widget, WidgetProps} from '@deck.gl/core';
 
 export type ScaleWidgetProps = WidgetProps & {
+  /** Widget positioning within the view. Default 'bottom-left'. */
   placement?: WidgetPlacement;
+  /** Label for the scale widget */
   label?: string;
-  onCapture?: (widget: ScaleWidget) => void;
+  /** View to attach to and interact with. Required when using multiple views */
+  viewId?: string | null;
 };
 
 /**
@@ -25,7 +28,7 @@ export class ScaleWidget extends Widget<ScaleWidgetProps> {
     id: 'scale',
     placement: 'bottom-left',
     label: 'Scale',
-    onCapture: undefined!
+    viewId: null
   };
 
   className = 'deck-widget-scale';
@@ -40,11 +43,12 @@ export class ScaleWidget extends Widget<ScaleWidgetProps> {
 
   constructor(props: ScaleWidgetProps = {}) {
     super(props, ScaleWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<ScaleWidgetProps>): void {
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/screenshot-widget.tsx
+++ b/modules/widgets/src/screenshot-widget.tsx
@@ -3,9 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 /* global document */
-import type {WidgetPlacement} from '@deck.gl/core';
+import type {WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
-import {Widget, WidgetProps} from '@deck.gl/core';
+import {Widget} from '@deck.gl/core';
 import {IconButton} from './lib/components/icon-button';
 
 /** Properties for the ScreenshotWidget */

--- a/modules/widgets/src/screenshot-widget.tsx
+++ b/modules/widgets/src/screenshot-widget.tsx
@@ -12,6 +12,8 @@ import {IconButton} from './lib/components/icon-button';
 export type ScreenshotWidgetProps = WidgetProps & {
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
   /** Tooltip message */
   label?: string;
   /** Filename to save to */
@@ -31,6 +33,7 @@ export class ScreenshotWidget extends Widget<ScreenshotWidgetProps> {
     ...Widget.defaultProps,
     id: 'screenshot',
     placement: 'top-left',
+    viewId: null,
     label: 'Screenshot',
     filename: 'screenshot.png',
     imageFormat: 'image/png',
@@ -42,11 +45,12 @@ export class ScreenshotWidget extends Widget<ScreenshotWidgetProps> {
 
   constructor(props: ScreenshotWidgetProps = {}) {
     super(props, ScreenshotWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<ScreenshotWidgetProps>) {
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -4,7 +4,7 @@
 
 import {h, render} from 'preact';
 import {useState, useRef} from 'preact/hooks';
-import {Widget, WidgetProps} from '@deck.gl/core';
+import {Widget, type WidgetProps} from '@deck.gl/core';
 
 /** Properties for the SplitterWidget */
 export type SplitterWidgetProps = WidgetProps & {

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -1,4 +1,3 @@
-// SplitterWidget.tsx
 // deck.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
@@ -47,7 +46,6 @@ export class SplitterWidget extends Widget<SplitterWidgetProps> {
   placement = 'fill' as const;
 
   constructor(props: SplitterWidgetProps) {
-    // No placement prop is used.
     super(props, SplitterWidget.defaultProps);
   }
 

--- a/modules/widgets/src/stats-widget.tsx
+++ b/modules/widgets/src/stats-widget.tsx
@@ -1,3 +1,7 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {Widget, WidgetPlacement, WidgetProps} from '@deck.gl/core';
 import {luma} from '@luma.gl/core';
 import {render} from 'preact';

--- a/modules/widgets/src/stats-widget.tsx
+++ b/modules/widgets/src/stats-widget.tsx
@@ -30,6 +30,11 @@ export const DEFAULT_FORMATTERS: Record<string, (stat: Stat) => string> = {
 };
 
 export type StatsWidgetProps = WidgetProps & {
+  /** Widget positioning within the view. Default 'top-left'. */
+  placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
+  /** Type of stats to display. */
   type?: 'deck' | 'luma' | 'device' | 'custom';
   /** Stats object to visualize. */
   stats?: Stats;
@@ -48,6 +53,8 @@ export class StatsWidget extends Widget<StatsWidgetProps> {
   static defaultProps: Required<StatsWidgetProps> = {
     ...Widget.defaultProps,
     type: 'deck',
+    placement: 'top-left',
+    viewId: null,
     stats: undefined!,
     title: 'Stats',
     framesPerUpdate: 1,
@@ -68,13 +75,14 @@ export class StatsWidget extends Widget<StatsWidgetProps> {
   constructor(props: StatsWidgetProps = {}) {
     super(props, StatsWidget.defaultProps);
     this._formatters = {...DEFAULT_FORMATTERS};
-    this.setProps(props);
     this._resetOnUpdate = {...this.props.resetOnUpdate};
     this._stats = this.props.stats;
+    this.setProps(props);
   }
 
   setProps(props: Partial<StatsWidgetProps>): void {
-    super.setProps(props);
+    this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     this._stats = this._getStats();
     if (props.formatters) {
       for (const name in props.formatters) {
@@ -86,6 +94,7 @@ export class StatsWidget extends Widget<StatsWidgetProps> {
     if (props.resetOnUpdate) {
       this._resetOnUpdate = {...props.resetOnUpdate};
     }
+    super.setProps(props);
   }
 
   onAdd(): void {

--- a/modules/widgets/src/stats-widget.tsx
+++ b/modules/widgets/src/stats-widget.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Widget, WidgetPlacement, WidgetProps} from '@deck.gl/core';
+import {Widget, type WidgetPlacement, type WidgetProps} from '@deck.gl/core';
 import {luma} from '@luma.gl/core';
 import {render} from 'preact';
 import type {Stats, Stat} from '@probe.gl/stats';

--- a/modules/widgets/src/theme-widget.tsx
+++ b/modules/widgets/src/theme-widget.tsx
@@ -13,6 +13,8 @@ import {LightGlassTheme, DarkGlassTheme} from './themes';
 export type ThemeWidgetProps = WidgetProps & {
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
   /** Tooltip message when dark mode is selected. */
   lightModeLabel?: string;
   /** Styles for light mode theme */
@@ -30,6 +32,7 @@ export class ThemeWidget extends Widget<ThemeWidgetProps> {
     ...Widget.defaultProps,
     id: 'theme',
     placement: 'top-left',
+    viewId: null,
     lightModeLabel: 'Light Mode',
     lightModeTheme: LightGlassTheme,
     darkModeLabel: 'Dark Mode',
@@ -43,14 +46,15 @@ export class ThemeWidget extends Widget<ThemeWidgetProps> {
 
   constructor(props: ThemeWidgetProps = {}) {
     super(props, ThemeWidget.defaultProps);
-    this.placement = props.placement ?? this.placement;
     this.themeMode = this._getInitialThemeMode();
+    this.setProps(this.props);
   }
 
   // eslint-disable-next-line complexity
   setProps(props: Partial<ThemeWidgetProps>) {
     const {lightModeTheme, darkModeTheme} = this.props;
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
 
     // Update if current theme definition changed

--- a/modules/widgets/src/theme-widget.tsx
+++ b/modules/widgets/src/theme-widget.tsx
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {log, _deepEqual as deepEqual, _applyStyles as applyStyles} from '@deck.gl/core';
-import {Widget, WidgetProps, WidgetPlacement} from '@deck.gl/core';
+import {Widget, type WidgetProps, type WidgetPlacement} from '@deck.gl/core';
 import {render} from 'preact';
 // import {useCallback} from 'preact/hooks';
 import {IconButton} from './lib/components/icon-button';

--- a/modules/widgets/src/timeline-widget.tsx
+++ b/modules/widgets/src/timeline-widget.tsx
@@ -2,45 +2,23 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Widget, type WidgetPlacement} from '@deck.gl/core';
+import {Widget, type WidgetPlacement, type WidgetProps} from '@deck.gl/core';
 import {render} from 'preact';
 
-export type TimelineWidgetProps = {
-  /**
-   * Widget id
-   */
-  id?: string;
-  /**
-   * CSS inline style overrides.
-   */
-  style?: Partial<CSSStyleDeclaration>;
-  /**
-   * Additional CSS class.
-   */
-  className?: string;
-  /**
-   * Widget placement.
-   */
+export type TimelineWidgetProps = WidgetProps & {
+  /** Widget positioning within the view. Default 'bottom-left'. */
   placement?: WidgetPlacement;
-  /**
-   * Slider timeRange [min, max].
-   */
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
+  /** Slider timeRange [min, max]. */
   timeRange?: [number, number];
-  /**
-   * Slider step.
-   */
+  /** Slider step. */
   step?: number;
-  /**
-   * Initial slider value.
-   */
+  /** Initial slider value. */
   initialTime?: number;
-  /**
-   * Callback when value changes.
-   */
+  /** Callback when value changes. */
   onTimeChange?: (value: number) => void;
-  /**
-   * Play interval in milliseconds.
-   */
+  /** Play interval in milliseconds. */
   playInterval?: number;
 };
 
@@ -56,7 +34,8 @@ export class TimelineWidget extends Widget<TimelineWidgetProps> {
   static defaultProps: Required<TimelineWidgetProps> = {
     ...Widget.defaultProps,
     id: 'timeline',
-    placement: 'bottom-left' as const,
+    placement: 'bottom-left',
+    viewId: null,
     timeRange: [0, 100],
     step: 1,
     initialTime: undefined!,
@@ -67,10 +46,12 @@ export class TimelineWidget extends Widget<TimelineWidgetProps> {
   constructor(props: TimelineWidgetProps = {}) {
     super(props, TimelineWidget.defaultProps);
     this.currentTime = this.props.initialTime ?? this.props.timeRange[0];
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<TimelineWidgetProps>): void {
-    this.placement = props.placement || this.placement;
+    this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
     super.setProps(props);
   }
 

--- a/modules/widgets/src/view-selector-widget.tsx
+++ b/modules/widgets/src/view-selector-widget.tsx
@@ -39,10 +39,7 @@ export class ViewSelectorWidget extends Widget<ViewSelectorWidgetProps> {
     viewId: null,
     label: 'Split View',
     initialViewMode: 'single',
-    onViewModeChange: (viewMode: string) => {
-      // eslint-disable-next-line no-console
-      console.log(viewMode);
-    }
+    onViewModeChange: () => {}
   };
 
   className = 'deck-widget-view-selector';
@@ -76,6 +73,7 @@ export class ViewSelectorWidget extends Widget<ViewSelectorWidgetProps> {
   handleSelectMode = (viewMode: ViewMode) => {
     this.viewMode = viewMode;
     this.updateHTML();
+    this.props.onViewModeChange(viewMode);
   };
 }
 

--- a/modules/widgets/src/view-selector-widget.tsx
+++ b/modules/widgets/src/view-selector-widget.tsx
@@ -1,4 +1,3 @@
-// ViewSelectorWidget.tsx
 // deck.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
@@ -14,6 +13,8 @@ export type ViewMode = 'single' | 'split-horizontal' | 'split-vertical';
 export type ViewSelectorWidgetProps = WidgetProps & {
   /** Widget positioning within the view. Default 'top-left'. */
   placement?: WidgetPlacement;
+  /** View to attach to and interact with. Required when using multiple views. */
+  viewId?: string | null;
   /** Tooltip label */
   label?: string;
   /** The initial view mode. Defaults to 'single'. */
@@ -35,6 +36,7 @@ export class ViewSelectorWidget extends Widget<ViewSelectorWidgetProps> {
     ...Widget.defaultProps,
     id: 'view-selector',
     placement: 'top-left',
+    viewId: null,
     label: 'Split View',
     initialViewMode: 'single',
     onViewModeChange: (viewMode: string) => {
@@ -49,13 +51,14 @@ export class ViewSelectorWidget extends Widget<ViewSelectorWidgetProps> {
 
   constructor(props: ViewSelectorWidgetProps = {}) {
     super(props, ViewSelectorWidget.defaultProps);
-    this.placement = this.props.placement;
     this.viewMode = this.props.initialViewMode;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<ViewSelectorWidgetProps>) {
-    super.setProps(props);
     this.placement = props.placement ?? this.placement;
+    this.viewId = props.viewId ?? this.viewId;
+    super.setProps(props);
   }
 
   onRenderHTML(rootElement: HTMLElement) {

--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Widget, FlyToInterpolator, LinearInterpolator} from '@deck.gl/core';
-import {Viewport, WidgetProps, WidgetPlacement} from '@deck.gl/core';
+import type {Viewport, WidgetProps, WidgetPlacement} from '@deck.gl/core';
 import {render} from 'preact';
 import {ButtonGroup} from './lib/components/button-group';
 import {GroupedIconButton} from './lib/components/grouped-icon-button';

--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -32,18 +32,16 @@ export class ZoomWidget extends Widget<ZoomWidgetProps> {
     transitionDuration: 200,
     zoomInLabel: 'Zoom In',
     zoomOutLabel: 'Zoom Out',
-    viewId: undefined!
+    viewId: null
   };
 
   className = 'deck-widget-zoom';
   placement: WidgetPlacement = 'top-left';
-  viewId?: string | null = null;
   viewports: {[id: string]: Viewport} = {};
 
   constructor(props: ZoomWidgetProps = {}) {
     super(props, ZoomWidget.defaultProps);
-    this.viewId = props.viewId ?? this.viewId;
-    this.placement = props.placement ?? this.placement;
+    this.setProps(this.props);
   }
 
   setProps(props: Partial<ZoomWidgetProps>) {


### PR DESCRIPTION
For #9490 

<!-- For all the PRs -->
#### Change List
- chore: [Add `viewId` prop to all widgets for multi-view support](https://github.com/visgl/deck.gl/commit/39c4ee67b3cbce225712411ce07fad455d7a9891) so widgets with UI can be placed in any view.
- fix: [Invoke onViewModeChange callback on mode select](https://github.com/visgl/deck.gl/commit/94acf9d786cbea584b5aa51e65eab5cc579a024c)
- chore: [Refactor widget imports for type-only usage](https://github.com/visgl/deck.gl/pull/9796/commits/90d1733cd888d526d2c7fdbd697428e8f803c3d4)
- docs: [Refactor widget exports and update overview documentation](https://github.com/visgl/deck.gl/commit/154c8820d618198a60f67dd0a5f63eb8078c60b6)
- docs: [Refactor widget docs to centralize WidgetProps](https://github.com/visgl/deck.gl/commit/3b169cf1bd90159992410147ff99914a03633786)
- docs: [Add usage sections and version badges to widget docs](https://github.com/visgl/deck.gl/commit/953b0b414ad8c44b2a6687130992385cf806a55a)
- docs: [Document default prop values for widget API](https://github.com/visgl/deck.gl/commit/f2009cd4130e95e68493c2dd14a7fdb2f33e3a22)
- docs: [Add source links to widget API docs](https://github.com/visgl/deck.gl/commit/55bd766474baca1752622966a81b2f4b54649738)
- docs: [Audit widget docs for missing props](https://github.com/visgl/deck.gl/commit/6b9eb64e9851a6283d5169130db7b2658046b236) for GimbalWidget, InfoWidget, ResetViewWidget, and ScreenshotWidget
- docs: [Remove 'none' option from initialTheme prop docs](https://github.com/visgl/deck.gl/commit/86588bc8c8cbea8ae0d9bd6ef6448efd7bf73583)

