### PR TITLE
Ensure zoomOffset is correctly part of the round/ceil Z calculation

### DIFF
--- a/modules/geo-layers/src/tileset-2d/utils.ts
+++ b/modules/geo-layers/src/tileset-2d/utils.ts
@@ -294,10 +294,7 @@ export function getTileIndices({
     ? Math.round(viewport.zoom + Math.log2(TILE_SIZE / tileSize) + zoomOffset)
     : Math.ceil(viewport.zoom + zoomOffset);
 
-  // This check doesn't round/ceil and doesn't use the offset. This ensures that tiles are not rendered if the
-  // viewport.zoom is less than minZoom. eg. at viewport.zoom = 9.5 with minZoom = 10 we should not fetch tiles
-  // at z = 10 until viewport.zoom is 10 or greater.
-  if (typeof minZoom === 'number' && Number.isFinite(minZoom) && viewport.zoom < minZoom) {
+  if (typeof minZoom === 'number' && Number.isFinite(minZoom) && z < minZoom) {
     if (!extent) {
       return [];
     }

--- a/test/modules/geo-layers/tileset-2d/utils.spec.ts
+++ b/test/modules/geo-layers/tileset-2d/utils.spec.ts
@@ -102,14 +102,6 @@ const TEST_CASES = [
     output: []
   },
   {
-    title: 'ignore round and offset on minZoom check',
-    viewport: new WebMercatorViewport({longitude: -90, latitude: 45, zoom: 3.5}),
-    zoomOffset: 1,
-    minZoom: 4,
-    maxZoom: undefined,
-    output: []
-  },
-  {
     title: 'over zoom',
     viewport: new WebMercatorViewport({
       width: 800,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
This fixes an issue where minZoom isn't actually minZoom because we round or ceil the current zoom.  So you get scenarios like this:
|Extent Set?|minZoom|currentZoom|display?|
|---|---|---|---|
|yes|10|9.000001|yes|
|no|10|9.499999|no|
|no|10|9.5|yes|

After this PR:
|Extent Set?|minZoom|currentZoom|display?|
|---|---|---|---|
|yes|10|9.000001|no|
|yes|10|10|yes|
|no|10|9.499999|no|
|no|10|9.5|no|
|no|10|10|yes|
<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #9806

<!-- For all the PRs -->
#### Change List
- Changes getTileIndices to use Math.floor instead of Math.round or Math.ceil 
