### PR TITLE
Update Seattle Summit 2025 agenda and speaker details

### DIFF
--- a/website/static/events/seattle-summit-2025/index.html
+++ b/website/static/events/seattle-summit-2025/index.html
@@ -401,6 +401,29 @@
                                     <div class="u-flex u-flex-column">
                                         <h4 class="title-gl f32 f24--tablet u-mb20">11:00 - 11:25</h4>
                                         <div class="u-flex u-justify-center u-mb20">
+                                            <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/speakers/chrisk.jpg" alt="Chris Kapp" class="author u-mr10" />
+                                        </div>
+                                        <h3 class="f18 u-mb20 f20--desktop-l" style="font-weight: 500">
+                                            Tessera: Geometric Error for Harmonised 3D Tiles Visualisation
+                                        </h3>
+        
+                                        <p class="u-mb8 f18--desktop-l">
+                                            Chris Kapp
+                                            <span class="f16 author-title">Senior Software Engineer</span>
+                                        </p>
+                                    </div>
+                                    <div class="u-mt32">
+                                        <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/logos/sensat.svg" style="height:12px;opacity:0.6" alt="Sensat" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div
+                                class="grid-cell grid-cell--col4 grid-cell--col6--desktop-s grid-cell--col12--mobile u-mb56 card-agenda">
+                                <div class="card-bg u-flex u-flex-column u-justify-space">
+                                    <div class="u-flex u-flex-column">
+                                        <h4 class="title-gl f32 f24--tablet u-mb20">11:30 - 11:55</h4>
+                                        <div class="u-flex u-justify-center u-mb20">
                                             <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/speakers/chris.jpg" alt="Chris Gervang"
                                                 class="author u-mr10" />
                                             <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/speakers/adam.png" alt="Adam Krebs"
@@ -417,29 +440,6 @@
                                     </div>
                                     <div class="u-mt32">
                                         <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/logos/joby.png" height="18" alt="Joby Aviation" />
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div
-                                class="grid-cell grid-cell--col4 grid-cell--col6--desktop-s grid-cell--col12--mobile u-mb56 card-agenda">
-                                <div class="card-bg u-flex u-flex-column u-justify-space">
-                                    <div class="u-flex u-flex-column">
-                                        <h4 class="title-gl f32 f24--tablet u-mb20">11:30 - 11:55</h4>
-                                        <div class="u-flex u-justify-center u-mb20">
-                                            <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/speakers/chrisk.jpg" alt="Chris Kapp" class="author u-mr10" />
-                                        </div>
-                                        <h3 class="f18 u-mb20 f20--desktop-l" style="font-weight: 500">
-                                            Tessera: Geometric Error for Harmonised 3D Tiles Visualisation
-                                        </h3>
-        
-                                        <p class="u-mb8 f18--desktop-l">
-                                            Chris Kapp
-                                            <span class="f16 author-title">Senior Software Engineer</span>
-                                        </p>
-                                    </div>
-                                    <div class="u-mt32">
-                                        <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/logos/sensat.svg" style="height:12px;opacity:0.6" alt="Sensat" />
                                     </div>
                                 </div>
                             </div>
@@ -493,11 +493,15 @@
                                 </div>
                             </div>
 
+                            <div class="divider-agenda u-mb56">
+                                <p>14:00 Break & Networking</p>
+                            </div>
+
                             <div
                                 class="grid-cell grid-cell--col4 grid-cell--col6--desktop-s grid-cell--col12--mobile u-mb56 card-agenda">
                                 <div class="card-bg u-flex u-flex-column u-justify-space">
                                     <div class="u-flex u-flex-column">
-                                        <h4 class="title-gl f32 f24--tablet u-mb20">14:00 - 14:25</h4>
+                                        <h4 class="title-gl f32 f24--tablet u-mb20">14:30 - 14:55</h4>
                                         <div class="u-flex u-justify-center u-mb20">
                                             <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/speakers/michael.jpg" alt="Michael Zager" class="author u-mr10" />
                                         </div>
@@ -519,7 +523,7 @@
                                 class="grid-cell grid-cell--col4 grid-cell--col6--desktop-s grid-cell--col12--mobile u-mb56 card-agenda">
                                 <div class="card-bg u-flex u-flex-column u-justify-space">
                                     <div class="u-flex u-flex-column">
-                                        <h4 class="title-gl f32 f24--tablet u-mb20">14:30 - 14:55</h4>
+                                        <h4 class="title-gl f32 f24--tablet u-mb20">15:00 - 15:25</h4>
                                         <div class="u-flex u-justify-center u-mb20">
                                             <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/seattle-summit-2025/speakers/tim.png" alt="Tim Sylvester" class="author u-mr10" />
                                         </div>


### PR DESCRIPTION
Swapped session times and details for Chris Kapp and Chris Gervang/Adam Krebs, updated speaker images, titles, and company logos. Added a break & networking divider at 14:00 and adjusted subsequent session times to reflect the new schedule.
