### PR TITLE
Avoid 9.2 breaking change in Widget base class

### DIFF
--- a/modules/core/src/lib/widget-manager.ts
+++ b/modules/core/src/lib/widget-manager.ts
@@ -201,12 +201,11 @@ export class WidgetManager {
     widget.deck = this.deck;
 
     // Create an attach the HTML root element
-    widget.rootElement = widget.onCreateRootElement();
+    widget.rootElement = widget._onAdd({deck: this.deck, viewId});
     if (widget.rootElement) {
       this._getContainer(viewId, placement).append(widget.rootElement);
     }
 
-    widget.onAdd?.({deck: this.deck, viewId});
     widget.updateHTML();
   }
 

--- a/modules/core/src/lib/widget.ts
+++ b/modules/core/src/lib/widget.ts
@@ -86,16 +86,14 @@ export abstract class Widget<
     }
   }
 
-  // WIDGET LIFECYCLE
-
   // @note empty method calls have an overhead in V8 but it is very low, ~1ns
 
   /**
-   * Called to create the root DOM element for this widget
+   * Common utility to create the root DOM element for this widget
    * Configures the top-level styles and adds basic class names for theming
-   * @returns an optional UI element that should be appended to the Deck container
+   * @returns an UI element that should be appended to the Deck container
    */
-  onCreateRootElement(): HTMLDivElement {
+  protected onCreateRootElement(): HTMLDivElement {
     const CLASS_NAMES = [
       // Add class names for theming
       'deck-widget',
@@ -112,16 +110,25 @@ export abstract class Widget<
     return element;
   }
 
+  // WIDGET LIFECYCLE
+
   /** Called to render HTML into the root element */
   abstract onRenderHTML(rootElement: HTMLElement): void;
 
-  /** Called after the widget is added to a Deck instance and the DOM rootElement has been created */
+  /** Internal API called by Deck when the widget is first added to a Deck instance */
+  _onAdd(params: {deck: Deck<any>; viewId: string | null}): HTMLDivElement {
+    return this.onAdd(params) ?? this.onCreateRootElement();
+  }
+
+  /** Overridable by subclass - called when the widget is first added to a Deck instance
+   * @returns an optional UI element that should be appended to the Deck container
+   */
   onAdd(params: {
     /** The Deck instance that the widget is attached to */
     deck: Deck<any>;
     /** The id of the view that the widget is attached to */
     viewId: string | null;
-  }) {}
+  }): HTMLDivElement | void {}
 
   /** Called when the widget is removed */
   onRemove(): void {}


### PR DESCRIPTION
#### Background

From v9.1 to v9.2, `Widget` changed from a TypeScript interface to an abstract class. A breaking change is introduced that if a widget implementation returns a HTML element from `onAdd`, it is now ignored. The `ContextMenuWidget` on master is broken because of this. I also think it's unnecessary to break existing custom widgets from 9.1.

This PR reverts the breaking change by only calling the new `onCreateRootElement` method if `onAdd` does not return anything (as in most classes in the widgets module). A quick audit shows no existing `onAdd` methods expect `rootElement` to exist. Tested the change with `test/apps/widgets-9.2`.

#### Change List
- Change `onCreateRootElement` from public API to protected utility
- If Widget subclass returns an element from `onAdd`, use the element as `widget.rootElement` (v9.1 compatibility)
