### PR TITLE
fix: restore useDevicePixels: number type

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -93,7 +93,7 @@ export type DeckProps<ViewsT extends ViewOrViews = null> = {
   /** Controls the resolution of drawing buffer used for rendering.
    * @default `true` (use browser devicePixelRatio)
    */
-  useDevicePixels?: boolean;
+  useDevicePixels?: boolean | number;
   /** Extra pixels around the pointer to include while picking.
    * @default `0`
    */


### PR DESCRIPTION
Closes #9823

<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
- Restore useDevicePixels: number type
