### PR TITLE
Fix type hint of useDevicePixels to allow number input

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -93,7 +93,7 @@ export type DeckProps<ViewsT extends ViewOrViews = null> = {
   /** Controls the resolution of drawing buffer used for rendering.
    * @default `true` (use browser devicePixelRatio)
    */
-  useDevicePixels?: boolean;
+  useDevicePixels?: boolean | number;
   /** Extra pixels around the pointer to include while picking.
    * @default `0`
    */


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #

<!-- For other PRs without open issue -->
#### Background

The type hint of `useDevicePixels` currently only allows `boolean`, but the [docs say](https://deck.gl/docs/api-reference/core/deck#usedevicepixels) `number` is also allowed 

<img width="902" height="336" alt="image" src="https://github.com/user-attachments/assets/41d35776-2e86-4ab6-bb21-5a1991438473" />


<!-- For all the PRs -->
#### Change List
-
