### PR TITLE
Revert "Simplify Widget class constructor"

### DIFF
--- a/modules/core/src/lib/tooltip-widget.ts
+++ b/modules/core/src/lib/tooltip-widget.ts
@@ -45,7 +45,7 @@ export class TooltipWidget extends Widget<TooltipWidgetProps> {
   lastViewport?: Viewport;
 
   constructor(props: TooltipWidgetProps = {}) {
-    super(props);
+    super(props, TooltipWidget.defaultProps);
     this.setProps(props);
   }
 

--- a/modules/core/src/lib/widget.ts
+++ b/modules/core/src/lib/widget.ts
@@ -50,12 +50,8 @@ export abstract class Widget<
   deck?: Deck<ViewsT>;
   rootElement?: HTMLDivElement | null;
 
-  constructor(props: PropsT) {
-    this.props = {
-      // @ts-expect-error `defaultProps` may not exist on constructor
-      ...(this.constructor.defaultProps as Required<PropsT>),
-      ...props
-    };
+  constructor(props: PropsT, defaultProps: Required<PropsT>) {
+    this.props = {...defaultProps, ...props};
     // @ts-expect-error TODO(ib) - why is id considered optional even though we use Required<>
     this.id = this.props.id;
   }

--- a/modules/widgets/src/compass-widget.tsx
+++ b/modules/widgets/src/compass-widget.tsx
@@ -32,7 +32,7 @@ export class CompassWidget extends Widget<CompassWidgetProps> {
   viewports: {[id: string]: Viewport} = {};
 
   constructor(props: CompassWidgetProps = {}) {
-    super(props);
+    super(props, CompassWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/context-menu-widget.tsx
+++ b/modules/widgets/src/context-menu-widget.tsx
@@ -52,7 +52,7 @@ export class ContextMenuWidget extends Widget<ContextMenuWidgetProps> {
   pickInfo: PickingInfo | null = null;
 
   constructor(props: ContextMenuWidgetProps) {
-    super(props);
+    super(props, ContextMenuWidget.defaultProps);
     this.pickInfo = null;
     this.setProps(this.props);
   }

--- a/modules/widgets/src/fps-widget.tsx
+++ b/modules/widgets/src/fps-widget.tsx
@@ -32,7 +32,7 @@ export class FpsWidget extends Widget<FpsWidgetProps> {
   private _lastFps: number = -1;
 
   constructor(props: FpsWidgetProps = {}) {
-    super(props);
+    super(props, FpsWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/fullscreen-widget.tsx
+++ b/modules/widgets/src/fullscreen-widget.tsx
@@ -42,7 +42,7 @@ export class FullscreenWidget extends Widget<FullscreenWidgetProps> {
   fullscreen: boolean = false;
 
   constructor(props: FullscreenWidgetProps = {}) {
-    super(props);
+    super(props, FullscreenWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/geocoder-widget.tsx
+++ b/modules/widgets/src/geocoder-widget.tsx
@@ -68,7 +68,7 @@ export class GeocoderWidget extends Widget<GeocoderWidgetProps> {
   geocoder: Geocoder = CoordinatesGeocoder;
 
   constructor(props: GeocoderWidgetProps = {}) {
-    super(props);
+    super(props, GeocoderWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/gimbal-widget.tsx
+++ b/modules/widgets/src/gimbal-widget.tsx
@@ -34,7 +34,7 @@ export class GimbalWidget extends Widget<GimbalWidgetProps> {
   viewports: {[id: string]: Viewport} = {};
 
   constructor(props: GimbalWidgetProps = {}) {
-    super(props);
+    super(props, GimbalWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -44,7 +44,7 @@ export class InfoWidget extends Widget<InfoWidgetProps> {
   viewport?: Viewport;
 
   constructor(props: InfoWidgetProps) {
-    super(props);
+    super(props, InfoWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/loading-widget.tsx
+++ b/modules/widgets/src/loading-widget.tsx
@@ -34,7 +34,7 @@ export class LoadingWidget extends Widget<LoadingWidgetProps> {
   loading = true;
 
   constructor(props: LoadingWidgetProps = {}) {
-    super(props);
+    super(props, LoadingWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/reset-view-widget.tsx
+++ b/modules/widgets/src/reset-view-widget.tsx
@@ -40,7 +40,7 @@ export class ResetViewWidget<ViewsT extends ViewOrViews = null> extends Widget<
   placement: WidgetPlacement = 'top-left';
 
   constructor(props: ResetViewWidgetProps<ViewsT> = {}) {
-    super(props);
+    super(props, ResetViewWidget.defaultProps as Required<ResetViewWidgetProps<ViewsT>>);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/scale-widget.tsx
+++ b/modules/widgets/src/scale-widget.tsx
@@ -42,7 +42,7 @@ export class ScaleWidget extends Widget<ScaleWidgetProps> {
   scaleText: string = '';
 
   constructor(props: ScaleWidgetProps = {}) {
-    super(props);
+    super(props, ScaleWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/screenshot-widget.tsx
+++ b/modules/widgets/src/screenshot-widget.tsx
@@ -44,7 +44,7 @@ export class ScreenshotWidget extends Widget<ScreenshotWidgetProps> {
   placement: WidgetPlacement = 'top-left';
 
   constructor(props: ScreenshotWidgetProps = {}) {
-    super(props);
+    super(props, ScreenshotWidget.defaultProps);
     this.setProps(this.props);
   }
 

--- a/modules/widgets/src/splitter-widget.tsx
+++ b/modules/widgets/src/splitter-widget.tsx
@@ -46,7 +46,7 @@ export class SplitterWidget extends Widget<SplitterWidgetProps> {
   placement = 'fill' as const;
 
   constructor(props: SplitterWidgetProps) {
-    super(props);
+    super(props, SplitterWidget.defaultProps);
   }
 
   setProps(props: Partial<SplitterWidgetProps>) {

--- a/modules/widgets/src/stats-widget.tsx
+++ b/modules/widgets/src/stats-widget.tsx
@@ -73,7 +73,7 @@ export class StatsWidget extends Widget<StatsWidgetProps> {
   _stats: Stats;
 
   constructor(props: StatsWidgetProps = {}) {
-    super(props);
+    super(props, StatsWidget.defaultProps);
     this._formatters = {...DEFAULT_FORMATTERS};
     this._resetOnUpdate = {...this.props.resetOnUpdate};
     this._stats = this.props.stats;

--- a/modules/widgets/src/theme-widget.tsx
+++ b/modules/widgets/src/theme-widget.tsx
@@ -45,7 +45,7 @@ export class ThemeWidget extends Widget<ThemeWidgetProps> {
   themeMode: 'light' | 'dark' = 'dark';
 
   constructor(props: ThemeWidgetProps = {}) {
-    super(props);
+    super(props, ThemeWidget.defaultProps);
     this.themeMode = this._getInitialThemeMode();
     this.setProps(this.props);
   }

--- a/modules/widgets/src/timeline-widget.tsx
+++ b/modules/widgets/src/timeline-widget.tsx
@@ -45,7 +45,7 @@ export class TimelineWidget extends Widget<TimelineWidgetProps> {
   };
 
   constructor(props: TimelineWidgetProps = {}) {
-    super(props);
+    super(props, TimelineWidget.defaultProps);
     this.currentTime = this.props.initialTime ?? this.props.timeRange[0];
     this.setProps(this.props);
   }

--- a/modules/widgets/src/view-selector-widget.tsx
+++ b/modules/widgets/src/view-selector-widget.tsx
@@ -47,7 +47,7 @@ export class ViewSelectorWidget extends Widget<ViewSelectorWidgetProps> {
   viewMode: ViewMode;
 
   constructor(props: ViewSelectorWidgetProps = {}) {
-    super(props);
+    super(props, ViewSelectorWidget.defaultProps);
     this.viewMode = this.props.initialViewMode;
     this.setProps(this.props);
   }

--- a/modules/widgets/src/zoom-widget.tsx
+++ b/modules/widgets/src/zoom-widget.tsx
@@ -40,7 +40,7 @@ export class ZoomWidget extends Widget<ZoomWidgetProps> {
   viewports: {[id: string]: Viewport} = {};
 
   constructor(props: ZoomWidgetProps = {}) {
-    super(props);
+    super(props, ZoomWidget.defaultProps);
     this.setProps(this.props);
   }
 


### PR DESCRIPTION
Reverts visgl/deck.gl#9815

After additional thought, I am not comfortable with making "negative changes" to our API based on how one current LLM model performs on it.

Basically, having an API that implicitly expects a static member be defined for subclassing to work is what I consider surprising to end users and such "magic" is not something I would like to find in any API I am using.

I expect that we will need to follow up with discussion in slack. Perhaps someone actually prefers this design and then that is of course a different discussion.