### PR TITLE
Split widgets infovis demo with orthographic view

### DIFF
--- a/test/apps/widgets-infovis/app.ts
+++ b/test/apps/widgets-infovis/app.ts
@@ -70,10 +70,11 @@ new Deck({
     })
   ],
   widgets: [
-    new ZoomWidget(),
-    new GimbalWidget(),
     new FullscreenWidget(),
-    new ResetViewWidget(),
+    new GimbalWidget(),
+    new ResetViewWidget({id: 'reset-orbit', viewId: 'orbit-view', placement: 'top-right'}),
+    new ResetViewWidget({id: 'reset-ortho', viewId: 'ortho-view', placement: 'top-right'}),
+    new ZoomWidget({viewId: 'ortho-view'}),
     new ThemeWidget({
       // darkModeTheme: DarkTheme,
       // lightModeTheme: LightTheme,

--- a/test/apps/widgets-infovis/app.ts
+++ b/test/apps/widgets-infovis/app.ts
@@ -73,6 +73,15 @@ new Deck({
     new FullscreenWidget(),
     new GimbalWidget(),
     new ResetViewWidget({id: 'reset-orbit', viewId: 'orbit-view', placement: 'top-right'}),
+    new ScrollbarWidget({
+      id: 'scroll-orbit',
+      viewId: 'orbit-view',
+      orientation: 'horizontal',
+      contentBounds: [
+        [-50, -50],
+        [50, 50]
+      ]
+    }),
     new ResetViewWidget({id: 'reset-ortho', viewId: 'ortho-view', placement: 'top-right'}),
     new ZoomWidget({viewId: 'ortho-view'}),
     new ThemeWidget({


### PR DESCRIPTION
## Summary
- split the widgets infovis demo canvas into orbit and orthographic views
- add an orthographic scatterplot layer and dedicated view state

## Testing
- git commit -m "Add orthographic split view to widgets infovis demo"

------
https://chatgpt.com/codex/tasks/task_i_68f7ac0a1d28832ca5289fc22272f25f