### PR TITLE
fix(mapbox-overlay) interleaved overlay using correct default parameters

### DIFF
--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -138,7 +138,7 @@ export default class MapboxOverlay implements IControl {
       deck: new Deck({
         ...this._props,
         gl,
-        parameters: {...getDefaultParameters(map, false), ...this._props.parameters},
+        parameters: {...getDefaultParameters(map, true), ...this._props.parameters},
         deviceProps: {
           createCanvasContext: {autoResize: true}
         }


### PR DESCRIPTION
## Summary
- initialize interleaved map overlays with interleaved default parameters so depth and blending align with expectations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4d47e67c8328b8035dca20e127ae)