### PR TITLE
fix(mapbox-overlay) Handle map resize redraw

### DIFF
--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -246,6 +246,8 @@ export default class MapboxOverlay implements IControl {
         height: `${clientHeight}px`
       });
     }
+
+    this._updateViewState();
   };
 
   private _updateViewState = () => {

--- a/test/modules/mapbox/mapbox-overlay.spec.ts
+++ b/test/modules/mapbox/mapbox-overlay.spec.ts
@@ -158,6 +158,36 @@ test('MapboxOverlay#overlaidNoIntitalLayers', t => {
   });
 });
 
+test('MapboxOverlay#overlaid handles resize', t => {
+  let redrawCount = 0;
+  const onRedrawLayer = () => {
+    redrawCount++;
+  };
+
+  const map = new MockMapboxMap({
+    center: {lng: -122.45, lat: 37.78},
+    zoom: 14
+  });
+  const overlay = new MapboxOverlay({
+    layers: [new TestScatterplotLayer({onAfterRedraw: onRedrawLayer})]
+  });
+
+  map.addControl(overlay);
+  map.triggerRepaint();
+
+  map.once('render', async () => {
+    const initialRedrawCount = redrawCount;
+
+    map.fire('resize');
+    await sleep(0);
+
+    t.ok(redrawCount > initialRedrawCount, 'Overlay redraws immediately after resize');
+
+    map.removeControl(overlay);
+    t.end();
+  });
+});
+
 test('MapboxOverlay#interleaved', t => {
   let drawLog = [];
   const onRedrawLayer = ({viewport, layer}) => {


### PR DESCRIPTION
## Summary
- trigger view state update and redraw when the Mapbox map fires a resize event
- add coverage to ensure overlaid overlays redraw immediately after resize

## Testing
- yarn test node test/modules/mapbox/mapbox-overlay.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4d45e5cc8328af30c56f12f65bd6)