### PR TITLE
Fix shader NaN compatibility for Firefox + NVIDIA

### DIFF
--- a/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregation-transform.ts
+++ b/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregation-transform.ts
@@ -146,7 +146,7 @@ flat out vec2 values;
 flat out vec3 values;
 #endif
 
-const float NAN = intBitsToFloat(-1);
+const float NAN = 0.0 / 0.0;
 
 void main() {
   int row = gl_VertexID / SAMPLER_WIDTH;


### PR DESCRIPTION
## Summary
- Fixes compilation error in GPU aggregation shaders on Firefox with certain NVIDIA drivers
- Replaces `intBitsToFloat(-1)` with `0.0/0.0` for NaN creation

## Problem
The hexagon and contour layer examples fail to render on Firefox + NVIDIA driver combinations with this error:
```
error C7532: global function uintBitsToFloat requires "#version 330" or later
```

The `intBitsToFloat` function isn't reliably supported across all browser/driver combinations, even though the shader targets GLSL ES 3.00.

## Solution
Use `0.0/0.0` to create NaN, which is the standard, portable method in GLSL that works consistently across all browsers and drivers. The fragment shader already uses `isnan()` to check for NaN values, so this integrates correctly with the existing pipeline.

## Testing
- Ran full test suite - all GPU aggregation layer tests pass (grid, hexagon, heatmap)
- Changed code in: `modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregation-transform.ts:149`

Fixes #9869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace NaN creation from intBitsToFloat(-1) to 0.0/0.0 in `webgl-aggregation-transform.ts` vertex shader to improve cross-browser/driver compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4660bd5aa31d71402cfa802b4e7ce46dbcbb3b35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->