### PR TITLE
fix(carto): PointLabelLayer used with formatTiles=mvt

### DIFF
--- a/modules/carto/src/layers/vector-tile-layer.ts
+++ b/modules/carto/src/layers/vector-tile-layer.ts
@@ -161,7 +161,14 @@ export default class VectorTileLayer<
     };
 
     if (this.state.mvt) {
-      subLayers.push(super.renderSubLayers(props) as GeoJsonLayer);
+      const subLayerProps = {
+        ...props,
+        _subLayerProps: {
+          ...props._subLayerProps,
+          ...defaultToPointLabelLayer
+        }
+      };
+      subLayers.push(super.renderSubLayers(subLayerProps) as GeoJsonLayer);
     } else {
       const {west, south, east, north} = tileBbox;
 


### PR DESCRIPTION
Followup to https://github.com/visgl/deck.gl/pull/9900

Match behavior with binary rendering path to enable collision avoidance for MVT based data sources

<!-- For all the PRs -->
#### Change List
- Default to `PointLabelLayer` for `'points-text'` subLayer in `MVTLayer`