### PR TITLE
feat(core): Add gpu-only memory option for layer attributes

### DIFF
--- a/docs/api-reference/core/layer.md
+++ b/docs/api-reference/core/layer.md
@@ -534,6 +534,32 @@ Layers may also include specialized loaders for their own use case, such as imag
 Find usage examples in the [data loading guide](../../developer-guide/loading-data.md).
 
 
+#### `memory` ('default' | 'gpu-only', optional) {#memory}
+
+- Default: `'default'`
+
+Controls how deck.gl stores generated attribute data in memory.
+
+- `'default'` retains CPU-side typed arrays alongside GPU buffers. This is the current behavior and enables CPU features such as bounds queries, attribute transitions, and partial updates using cached values.
+- `'gpu-only'` uploads generated attributes to GPU buffers and then releases CPU copies. This minimizes CPU memory usage and pooling, but disables features that depend on CPU-side attribute values (e.g. `layer.getBounds()`, attribute transitions, CPU validations) and forces partial updates to regenerate whole attributes or perform GPU-side copies.
+
+Use `'gpu-only'` when you are feeding data through GPU-heavy pipelines and do not rely on CPU-side attribute inspection. For example:
+
+```js
+import {ScatterplotLayer} from '@deck.gl/layers';
+
+const layer = new ScatterplotLayer({
+  id: 'points',
+  data,
+  memory: 'gpu-only',
+  getPosition: d => d.position,
+  getFillColor: [0, 128, 255]
+});
+```
+
+deck.gl will emit runtime warnings when a CPU-dependent feature is unavailable in this mode.
+
+
 #### `fetch` (Function, optional) {#fetch}
 
 Called to fetch and parse content from URLs.

--- a/docs/developer-guide/tips-and-tricks.md
+++ b/docs/developer-guide/tips-and-tricks.md
@@ -75,3 +75,16 @@ new Deck({
   _typedArrayManagerProps: isMobile ? {overAlloc: 1, poolSize: 0} : null
 })
 ```
+
+### GPU-only layer attributes
+
+Layers can opt into storing generated attributes only on the GPU by setting [`memory: 'gpu-only'`](../api-reference/core/layer.md#memory). In this mode, CPU-side typed arrays are released after upload, reducing application memory pressure and avoiding typed array pooling overhead.
+
+Because CPU copies are not retained, features that depend on CPU-side attribute values are disabled or downgraded:
+
+- Bounds calculations (`layer.getBounds()` and any culling logic that relies on it) return `null`.
+- Attribute transitions are skipped.
+- Partial attribute updates regenerate whole attributes or fall back to GPU-side copies, so update ranges are ignored.
+- CPU-side validations or transformations that require staging arrays will emit runtime warnings.
+
+Use this mode when your rendering pipeline is GPU-driven and you do not need CPU inspection of attribute data. Switch back to the default memory behavior if you rely on the features above.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,10 @@
 
 This page contains highlights of each deck.gl release. Also check our [vis.gl blog](https://medium.com/vis-gl) for news about new releases and features in deck.gl.
 
+## deck.gl v9.3 (upcoming)
+
+- Layers now accept a `memory: 'gpu-only'` prop to keep generated attributes on the GPU, reducing CPU memory at the cost of CPU-bound features such as bounds queries and attribute transitions.
+
 ## deck.gl v9.2
 
 Target release date: September, 2025

--- a/modules/aggregation-layers/src/common/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/common/aggregation-layer.ts
@@ -101,7 +101,8 @@ export default abstract class AggregationLayer<
   _getAttributeManager() {
     return new AttributeManager(this.context.device, {
       id: this.props.id,
-      stats: this.context.stats
+      stats: this.context.stats,
+      memory: this.props.memory
     });
   }
 }

--- a/modules/aggregation-layers/src/heatmap-layer/aggregation-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/aggregation-layer.ts
@@ -159,7 +159,8 @@ export default abstract class AggregationLayer<
   _getAttributeManager() {
     return new AttributeManager(this.context.device, {
       id: this.props.id,
-      stats: this.context.stats
+      stats: this.context.stats,
+      memory: this.props.memory
     });
   }
 }

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -329,7 +329,8 @@ export default class HeatmapLayer<
   _getAttributeManager() {
     return new AttributeManager(this.context.device, {
       id: this.props.id,
-      stats: this.context.stats
+      stats: this.context.stats,
+      memory: this.props.memory
     });
   }
 

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -120,7 +120,8 @@ export type {
   Position,
   Color,
   TextureSource,
-  Material
+  Material,
+  MemoryUsage
 } from './types/layer-props';
 export type {DrawLayerParameters, FilterContext} from './passes/layers-pass';
 export type {PickingInfo, GetPickingInfoParams} from './lib/picking/pick-info';

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -144,6 +144,7 @@ const defaultProps: DefaultProps<LayerProps> = {
 
   parameters: {type: 'object', value: {}, optional: true, compare: 2},
   loadOptions: {type: 'object', value: null, optional: true, ignore: true},
+  memory: 'default',
   transitions: null,
   extensions: [],
   loaders: {type: 'array', value: [], optional: true, ignore: true},
@@ -1246,7 +1247,8 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
     return new AttributeManager(context.device, {
       id: this.props.id,
       stats: context.stats,
-      timeline: context.timeline
+      timeline: context.timeline,
+      memory: this.props.memory
     });
   }
 

--- a/modules/core/src/transitions/gpu-interpolation-transition.ts
+++ b/modules/core/src/transitions/gpu-interpolation-transition.ts
@@ -16,6 +16,7 @@ import {
   getFloat32VertexFormat
 } from './gpu-transition-utils';
 import {GPUTransitionBase} from './gpu-transition';
+import log from '../utils/log';
 
 import type {InterpolationTransitionSettings} from '../lib/attribute/transition-settings';
 import type {TypedArray} from '../types/types';
@@ -80,6 +81,12 @@ export default class GPUInterpolationTransition extends GPUTransitionBase<Interp
     }
     model.setVertexCount(vertexCount);
     if (attribute.isConstant) {
+      if (!attribute.value) {
+        log.warn(
+          `${attribute.id}: transition skipped because constant attribute has no CPU value available.`
+        )();
+        return;
+      }
       model.setAttributes({aFrom: buffers[0]});
       model.setConstantAttributes({aTo: attribute.value as TypedArray});
     } else {

--- a/modules/core/src/transitions/gpu-spring-transition.ts
+++ b/modules/core/src/transitions/gpu-spring-transition.ts
@@ -14,6 +14,7 @@ import {
 } from './gpu-transition-utils';
 import Attribute from '../lib/attribute/attribute';
 import {GPUTransitionBase} from './gpu-transition';
+import log from '../utils/log';
 
 import type {SpringTransitionSettings} from '../lib/attribute/transition-settings';
 import type {TypedArray} from '../types/types';
@@ -69,6 +70,12 @@ export default class GPUSpringTransition extends GPUTransitionBase<SpringTransit
     const {model} = this.transform;
     model.setVertexCount(Math.floor(this.currentLength / attribute.size));
     if (attribute.isConstant) {
+      if (!attribute.value) {
+        log.warn(
+          `${attribute.id}: spring transition skipped because constant attribute has no CPU value available.`
+        )();
+        return;
+      }
       model.setConstantAttributes({aTo: attribute.value as TypedArray});
     } else {
       model.setAttributes({aTo: attribute.getBuffer()!});

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -9,6 +9,7 @@ import type {BinaryAttribute} from '../lib/attribute/attribute';
 import type {ConstructorOf, NumericArray, TypedArray} from './types';
 import type {PickingInfo} from '../lib/picking/pick-info';
 import type {MjolnirEvent} from 'mjolnir.js';
+export type MemoryUsage = 'default' | 'gpu-only';
 
 import type {Texture, TextureProps} from '@luma.gl/core';
 import type {Buffer, Parameters} from '@luma.gl/core';
@@ -207,6 +208,10 @@ export type LayerProps = {
    * Options to customize the behavior of loaders
    */
   loadOptions?: any;
+  /**
+   * Control whether CPU copies of generated attributes are retained after they are uploaded to GPU buffers.
+   */
+  memory?: MemoryUsage;
   /**
    * Callback to calculate the polygonOffset WebGL parameter.
    */


### PR DESCRIPTION
## Summary

deck.gl keeps CPU side arrays for all attributes which effectively doubles memory usage. This PR adds a new flag that drops the CPU side array after GPU upload

- inline the memory usage type and remove the extra helper file to reduce surface area
- move release note mention to whats-new.md per feedback and keep changelog unchanged
- keep gpu-only memory documentation intact across API references and developer tips

Notes:
The new memory prop controls whether deck.gl retains CPU-side attribute arrays after upload ('default') or drops them ('gpu-only'). It affects all attributes managed by AttributeManager and DataColumn lifecycle: in 'gpu-only' mode typed array pooling is avoided, partial update ranges are ignored (full regeneration or GPU copy), CPU-bound features like transitions and bounds queries are disabled/warned, and values may be null after upload.

The existing noAlloc prop is an attribute-level flag indicating that the layer supplies buffers externally, so Attribute.allocate skips creating/owning a CPU typed array. It does not change post-upload retention or global behavior; the layer is still responsible for managing CPU data if needed. In contrast, memory: 'gpu-only' is a layer prop that globally changes how deck.gl manages CPU copies for auto-generated attributes.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941461404148328885fc07576f0d8ff)