### PR TITLE
feat(core) Add getWorldBounds() method

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -47,6 +47,7 @@
     "@luma.gl/engine": "^9.2.4",
     "@luma.gl/shadertools": "^9.2.4",
     "@luma.gl/webgl": "^9.2.4",
+    "@math.gl/culling": "^4.1.0",
     "@math.gl/core": "^4.1.0",
     "@math.gl/sun": "^4.1.0",
     "@math.gl/types": "^4.1.0",

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -35,6 +35,7 @@ export {default as AttributeManager} from './lib/attribute/attribute-manager';
 export {default as Layer} from './lib/layer';
 export {default as CompositeLayer} from './lib/composite-layer';
 export {default as DeckRenderer} from './lib/deck-renderer';
+export {transformBoundsToWorld} from './lib/world-bounds';
 
 // Viewports
 export {default as Viewport} from './viewports/viewport';

--- a/modules/core/src/lib/world-bounds.ts
+++ b/modules/core/src/lib/world-bounds.ts
@@ -1,0 +1,54 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {projectPosition} from '../shaderlib/project/project-functions';
+import {makeOrientedBoundingBoxFromPoints, OrientedBoundingBox} from '@math.gl/culling';
+
+import type Viewport from '../viewports/viewport';
+import type {CoordinateSystem} from './constants';
+import type {NumericArray} from '../types/types';
+
+export type WorldBoundsTransformOptions = {
+  bounds: [number[], number[]];
+  viewport: Viewport;
+  coordinateSystem: CoordinateSystem;
+  coordinateOrigin: [number, number, number];
+  modelMatrix?: NumericArray | null;
+  /** Additional props that affect bounds transformation and caching */
+  worldBoundsCacheKey?: unknown;
+};
+
+export function transformBoundsToWorld(options: WorldBoundsTransformOptions): OrientedBoundingBox {
+  const {bounds, viewport, coordinateOrigin, coordinateSystem, modelMatrix} = options;
+  const corners = getBoundingBoxCorners(bounds);
+
+  const worldPositions = corners.map(position =>
+    projectPosition(position, {
+      viewport,
+      coordinateSystem,
+      coordinateOrigin,
+      modelMatrix
+    })
+  );
+
+  return makeOrientedBoundingBoxFromPoints(worldPositions);
+}
+
+function getBoundingBoxCorners(bounds: [number[], number[]]): number[][] {
+  const [min, max] = bounds;
+  const dimension = Math.max(min.length, max.length, 3);
+  const corners: number[][] = [];
+
+  for (let i = 0; i < 8; i++) {
+    const corner: number[] = [];
+    for (let axis = 0; axis < 3; axis++) {
+      const minValue = axis < dimension ? (min[axis] ?? 0) : 0;
+      const maxValue = axis < dimension ? (max[axis] ?? minValue) : minValue;
+      corner[axis] = i & (1 << axis) ? maxValue : minValue;
+    }
+    corners.push(corner);
+  }
+
+  return corners;
+}

--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -76,6 +76,7 @@ export {
   fp64LowPart,
   createIterable,
   getShaderAssembler,
+  transformBoundsToWorld,
   // Widgets
   Widget
 } from '@deck.gl/core';

--- a/test/modules/core/lib/index.ts
+++ b/test/modules/core/lib/index.ts
@@ -18,3 +18,4 @@ import './pick-layers.spec';
 import './picking.spec';
 import './view-manager.spec';
 import './widget-manager.spec';
+import './world-bounds.spec';

--- a/test/modules/core/lib/world-bounds.spec.ts
+++ b/test/modules/core/lib/world-bounds.spec.ts
@@ -1,0 +1,106 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-catch';
+import {Layer, COORDINATE_SYSTEM, transformBoundsToWorld, Viewport} from '@deck.gl/core';
+import {Matrix4} from '@math.gl/core';
+import LayerState from '../../../../modules/core/src/lib/layer-state';
+
+class WorldBoundsLayer extends Layer<{customKey?: number}> {
+  initializeState() {}
+
+  override getBounds() {
+    return [
+      [-1, 0, 0],
+      [1, 0, 0]
+    ];
+  }
+
+  protected override getWorldBoundsOptions() {
+    const options = super.getWorldBoundsOptions();
+    if (!options) {
+      return null;
+    }
+    return {...options, worldBoundsCacheKey: this.props.customKey};
+  }
+}
+
+WorldBoundsLayer.defaultProps = {
+  customKey: 0
+};
+
+const VIEWPORT = new Viewport({
+  id: 'identity',
+  width: 1,
+  height: 1,
+  position: [0, 0, 0],
+  viewMatrix: new Matrix4().identity(),
+  projectionMatrix: new Matrix4().identity()
+});
+
+test('transformBoundsToWorld#modelMatrix applied to corners', t => {
+  const modelMatrix = new Matrix4().rotateZ(Math.PI / 2);
+  const bounds = [
+    [-1, 0, 0],
+    [1, 0, 0]
+  ] as [number[], number[]];
+
+  const obb = transformBoundsToWorld({
+    bounds,
+    coordinateOrigin: [0, 0, 0],
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+    modelMatrix,
+    viewport: VIEWPORT
+  });
+
+  const halfAxes = obb.halfAxes;
+  t.ok(Math.abs(halfAxes[0]) < 1e-6, 'x component is rotated to zero');
+  t.ok(Math.abs(halfAxes[1] - 1) < 1e-6, 'y component reflects rotation');
+  t.deepEqual([...obb.center], [0, 0, 0], 'center is preserved');
+  t.end();
+});
+
+test('Layer#getWorldBounds#cache invalidation and key', t => {
+  const layer = new WorldBoundsLayer({
+    id: 'world-bounds-layer',
+    data: [],
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+    customKey: 0
+  });
+
+  layer.context = {viewport: VIEWPORT} as any;
+  layer.internalState = new LayerState({attributeManager: null, layer});
+  layer.internalState.viewport = VIEWPORT;
+
+  const first = layer.getWorldBounds();
+  const second = layer.getWorldBounds();
+  t.equal(first, second, 'bounds are cached when inputs are unchanged');
+
+  layer.updateState({
+    props: layer.props,
+    oldProps: layer.props,
+    context: layer.context,
+    changeFlags: {
+      dataChanged: false,
+      propsChanged: false,
+      updateTriggersChanged: false,
+      extensionsChanged: false,
+      viewportChanged: true,
+      stateChanged: false,
+      propsOrDataChanged: false,
+      somethingChanged: true
+    }
+  });
+
+  const afterViewportChange = layer.getWorldBounds();
+  t.notEqual(afterViewportChange, first, 'cache invalidates when viewport changes');
+
+  const cachedAgain = layer.getWorldBounds();
+  t.equal(afterViewportChange, cachedAgain, 'bounds cache is reused after recompute');
+
+  layer.props = {...layer.props, customKey: 1};
+  const afterKeyChange = layer.getWorldBounds();
+  t.notEqual(afterKeyChange, cachedAgain, 'cache key forces recomputation');
+  t.end();
+});


### PR DESCRIPTION
## Summary

deck.gl really needs the ability to exclude layers from being drawn based on bounds checks. And the existing getBounds function is not sufficient. As a first step, this PR adds a Layer.getWorldBounds() that returns a math.gl OrientedBoundingBox that applies modelMatrix coordinateSystem etc.

- add a world-bounds utility that transforms layer bounds into oriented bounding boxes
- introduce Layer.getWorldBounds with caching and configurable cache invalidation
- add world-bounds unit tests and export the helper through the main deck.gl entry

## Testing
- npx eslint modules/core/src/lib/layer.ts modules/core/src/lib/world-bounds.ts
- npx prettier --check modules/core/src/lib/layer.ts modules/core/src/lib/world-bounds.ts
- node_modules/.bin/ts-node test/modules/core/lib/world-bounds.spec.ts (fails: ts-node ESM loader not configured)
- git commit (runs lint/prettier/test-fast)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414aed409483289f96e0c2cf208294)