### PR TITLE
feat(core): Add `_container` to WidgetProps

### DIFF
--- a/docs/api-reference/core/widget.md
+++ b/docs/api-reference/core/widget.md
@@ -39,9 +39,9 @@ Additional inline CSS styles on the top HTML element of the widget. camelCase CS
 
 Additional CSS classnames on the top HTML element.
 
-#### `container` (string | HTMLDivElement, optional) {#container}
+#### `_container` (string | HTMLDivElement, optional) {#container}
 
-The container that this widget is being attached to. Default to `viewId`.
+Experimental. The container that this widget is being attached to. Default to `viewId`.
 - If set to `'root'`, the widget is placed relative to the whole deck.gl canvas.
 - If set to a valid view id, the widget is placed relative to that view.
 - If set to a HTMLElement, `placement` is ignored and the widget is appended into the given element.

--- a/modules/core/src/lib/widget-manager.ts
+++ b/modules/core/src/lib/widget-manager.ts
@@ -196,7 +196,7 @@ export class WidgetManager {
   /** Initialize new widget */
   private _addWidget(widget: Widget) {
     const {viewId = null, placement = DEFAULT_PLACEMENT} = widget;
-    const {container} = widget.props;
+    const container = widget.props._container ?? viewId;
 
     widget.widgetManager = this;
     widget.deck = this.deck;
@@ -204,7 +204,7 @@ export class WidgetManager {
     // Create an attach the HTML root element
     widget.rootElement = widget._onAdd({deck: this.deck, viewId});
     if (widget.rootElement) {
-      this._getContainer(container ?? viewId, placement).append(widget.rootElement);
+      this._getContainer(container, placement).append(widget.rootElement);
     }
 
     widget.updateHTML();

--- a/modules/core/src/lib/widget.ts
+++ b/modules/core/src/lib/widget.ts
@@ -24,7 +24,7 @@ export type WidgetProps = {
    * If set to a valid view id, the widget is placed relative to that view.
    * If set to a HTMLElement, `placement` is ignored and the widget is appended into the given element.
    */
-  container?: string | HTMLDivElement | null;
+  _container?: string | HTMLDivElement | null;
 };
 
 export abstract class Widget<
@@ -34,7 +34,7 @@ export abstract class Widget<
   static defaultProps: Required<WidgetProps> = {
     id: 'widget',
     style: {},
-    container: null,
+    _container: null,
     className: ''
   };
 

--- a/test/modules/core/lib/widget-manager.spec.ts
+++ b/test/modules/core/lib/widget-manager.spec.ts
@@ -342,7 +342,7 @@ test('WidgetManager#onRedraw#container', t => {
   const widgetManager = new WidgetManager({deck: mockDeckInstance, parentElement});
 
   const targetElement = document.createElement('div');
-  const widgetA = new TestWidget({id: 'A', container: targetElement});
+  const widgetA = new TestWidget({id: 'A', _container: targetElement});
   widgetManager.addDefault(widgetA);
 
   t.is(widgetA.rootElement?.parentNode, targetElement, 'widget is attached to external container');
@@ -352,7 +352,7 @@ test('WidgetManager#onRedraw#container', t => {
     'WidgetManager does not create default container'
   );
 
-  const widgetB = new TestWidget({id: 'B', placement: 'bottom-right', container: 'root'});
+  const widgetB = new TestWidget({id: 'B', placement: 'bottom-right', _container: 'root'});
   widgetManager.addDefault(widgetB);
 
   widgetManager.onRedraw({


### PR DESCRIPTION
#### Background

`widget.viewId` is currently overloaded with two purposes:
- Functionality - defines the view(port) that the widget interacts with. A widget does not receive viewport update events from unmatched views if viewId is specified.
- Layout - defines the bounding box that the widget is positioned relative to.

The above two are often the same, but not always. This PR proposes a new prop so that the user can specify the two separately. When not provided, `container` falls back to `viewId` which is consistent with the existing behavior.

#### Change List
- Add `_container` to WidgetProps
- Docs
