### PR TITLE
RFC: Migrate from tape to vitest

### DIFF
--- a/dev-docs/RFCs/proposals/vitest-migration-rfc.md
+++ b/dev-docs/RFCs/proposals/vitest-migration-rfc.md
@@ -271,16 +271,19 @@ async function getDefaultSpyFactory() {
 
 #### Peer Dependencies
 
-Only `@probe.gl/test-utils` remains as an optional peer dependency (for backward compat):
+`@probe.gl/test-utils` is a **required** peer dependency because the default entry point (`@deck.gl/test-utils`) has a static import from `tape.ts`. Only `vitest` is optional (for the `./vitest` sub-entry):
 
 ```json
 "peerDependencies": {
-  "@probe.gl/test-utils": "^4.1.0"
+  "@probe.gl/test-utils": "^4.1.1",
+  "vitest": "^4.0.18"
 },
 "peerDependenciesMeta": {
-  "@probe.gl/test-utils": { "optional": true }
+  "vitest": { "optional": true }
 }
 ```
+
+**Note:** Users who only use `@deck.gl/test-utils/vitest` don't technically need `@probe.gl/test-utils`, but it remains required for backward compatibility with existing 9.x users.
 
 #### User Experience Matrix
 


### PR DESCRIPTION
#### Background

This RFC proposes modernizing deck.gl's test infrastructure by replacing tape (assertion framework) + ocular-test (runner) with vitest. The migration would consolidate tooling, improve developer experience, and maintain CLI compatibility.

I'd like to learn about features/workflows maintainers used that I can test against vitest. I primarily used CI tests, which includes node, browser, and render tests.

#### Change List
- Add RFC document at `dev-docs/RFCs/proposals/vitest-migration-rfc.md`
- Proposes phased migration of ~185 test files
- Details assertion mapping from tape to vitest
- Covers @deck.gl/test-utils updates needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds documentation (an RFC) and does not change runtime code, build outputs, or CI behavior.
> 
> **Overview**
> Adds a new draft RFC (`dev-docs/RFCs/proposals/vitest-migration-rfc.md`) proposing a phased migration from `tape` + `ocular-test` to `vitest`, including a Vitest workspace setup (node smoke tests + headless/headed browser runs) and a new/updated `yarn` command matrix.
> 
> The RFC also outlines planned API changes for test files (tape assertions → `expect()`), a Playwright-based replacement for Puppeteer/`BrowserTestDriver` in browser/render/interaction tests, and a proposed `@deck.gl/test-utils` update to use an injectable `createSpy` with a deprecation timeline for the implicit probe.gl fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc15d7cbd0c160a6a145a8982ce723cee4dbd580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->