### PR TITLE
feat(extensions): add ColumnShapeExtension for per-instance bevel shapes

### DIFF
--- a/docs/api-reference/extensions/column-shape-extension.md
+++ b/docs/api-reference/extensions/column-shape-extension.md
@@ -1,0 +1,93 @@
+
+# ColumnShapeExtension
+
+The `ColumnShapeExtension` adds per-instance bevel shapes (dome, cone, flat) and radius scaling to the `ColumnLayer`. This enables visualizations such as tree canopies, architectural columns with domed or pointed caps, and 3D bar charts with styled tops.
+
+```js
+import {ColumnLayer} from '@deck.gl/layers';
+import {ColumnShapeExtension} from '@deck.gl/extensions';
+
+const layer = new ColumnLayer({
+  data: TREES_DATA,
+  extruded: true,
+  diskResolution: 20,
+  getPosition: d => d.position,
+  getElevation: d => d.height,
+  getFillColor: d => d.color,
+
+  // ColumnShapeExtension props
+  extensions: [new ColumnShapeExtension()],
+  getBevel: d => ({segs: 8, height: d.canopyHeight, bulge: 0.2}),
+  getRadius: d => d.canopyRadius / d.trunkRadius,
+});
+```
+
+## Installation
+
+To install the dependencies from NPM:
+
+```bash
+npm install deck.gl
+# or
+npm install @deck.gl/core @deck.gl/layers @deck.gl/extensions
+```
+
+```js
+import {ColumnShapeExtension} from '@deck.gl/extensions';
+new ColumnShapeExtension();
+```
+
+## Constructor
+
+```js
+new ColumnShapeExtension();
+```
+
+## Layer Properties
+
+When added to a layer via the `extensions` prop, the `ColumnShapeExtension` adds the following properties to the layer:
+
+### `getBevel` (Accessor&lt;BevelProp&gt;, optional) {#getbevel}
+
+* Default: `'flat'`
+
+The bevel shape for the top cap of each column instance.
+
+Supported values:
+- `'flat'`: No bevel (default flat top)
+- `'dome'`: Rounded dome with 8 segments and smooth normals
+- `'cone'`: Pointed cone shape (2 segments)
+- `{segs, height, bulge}`: Full control over shape parameters
+  - `segs` (number): Number of bevel segments. 0-1 = flat, 2 = cone, 3+ = dome
+  - `height` (number): Bevel height in world units
+  - `bulge` (number): Curve factor. 0 = standard dome, negative = concave, positive = convex
+
+### `getRadius` (Accessor&lt;number&gt;, optional) {#getradius}
+
+* Default: `1`
+
+Per-instance radius multiplier. The final rendered radius is `radiusScale * getRadius(d)`.
+
+## BevelProp Type
+
+```typescript
+type BevelProp =
+  | 'flat'       // No bevel
+  | 'dome'       // Dome with default segments
+  | 'cone'       // Cone shape
+  | {
+      segs?: number;   // Bevel segments (0-1=flat, 2=cone, 3+=dome)
+      height?: number; // Bevel height in world units
+      bulge?: number;  // Curve factor (-1 to 1+)
+    };
+```
+
+## Limitations
+
+- Only works with `ColumnLayer` (and its subclasses like `GridCellLayer`).
+- Requires `extruded: true` on the parent layer for bevel shapes to render.
+- Custom `vertices` prop on ColumnLayer bypasses dome geometry generation.
+
+## Source
+
+[modules/extensions/src/column-shape](https://github.com/visgl/deck.gl/tree/master/modules/extensions/src/column-shape)

--- a/docs/api-reference/extensions/overview.md
+++ b/docs/api-reference/extensions/overview.md
@@ -11,6 +11,7 @@ This module contains the following extensions:
 - [BrushingExtension](./brushing-extension.md)
 - [ClipExtension](./clip-extension.md)
 - [CollisionFilterExtension](./collision-filter-extension.md)
+- [ColumnShapeExtension](./column-shape-extension.md)
 - [DataFilterExtension](./data-filter-extension.md)
 - [FillStyleExtension](./fill-style-extension.md)
 - [Fp64Extension](./fp64-extension.md)

--- a/modules/extensions/src/column-shape/column-shape-extension.ts
+++ b/modules/extensions/src/column-shape/column-shape-extension.ts
@@ -1,0 +1,204 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * ColumnShapeExtension - Adds per-instance bevel shapes and radius scaling to ColumnLayer.
+ *
+ * This extension enables per-instance dome, cone, and custom bevel shapes on top of
+ * ColumnLayer columns, with per-instance radius multipliers. Useful for tree canopy
+ * visualizations, 3D bar charts with styled caps, and architectural column rendering.
+ *
+ * Originally inspired by:
+ * - https://github.com/visgl/deck.gl-community/pull/470 (ExperimentalColumnLayer)
+ * - https://github.com/visgl/deck.gl/pull/9933 (getBevel & getRadius proposal)
+ */
+
+import {LayerExtension} from '@deck.gl/core';
+import {columnShapeShaders, ColumnShapeModuleProps} from './shader-module';
+import {createDomeColumnAttributes} from './dome-column-geometry';
+
+import type {Layer, LayerContext, DefaultProps, Accessor, UpdateParameters} from '@deck.gl/core';
+
+/** Bevel shape type - can be a string shortcut or a custom configuration object */
+export type BevelProp =
+  | 'flat'
+  | 'dome'
+  | 'cone'
+  | {
+      /** Number of bevel segments: 0-1 = flat, 2 = cone, 3+ = dome */
+      segs?: number;
+      /** Bevel height in world units */
+      height?: number;
+      /** Curve factor: 0 = standard, negative = concave, positive = convex */
+      bulge?: number;
+    };
+
+/** Parsed bevel parameters for shader consumption */
+type BevelParams = {
+  segs: number;
+  height: number;
+  bulge: number;
+};
+
+const defaultProps: DefaultProps<ColumnShapeExtensionProps> = {
+  getBevel: {type: 'accessor', value: 'flat'},
+  getRadius: {type: 'accessor', value: 1}
+};
+
+export type ColumnShapeExtensionProps<DataT = any> = {
+  /**
+   * Bevel shape for the top cap of each column.
+   *
+   * Supported values:
+   * - `'flat'`: No bevel (default flat top)
+   * - `'dome'`: Rounded dome with smooth normals
+   * - `'cone'`: Pointed cone shape
+   * - `{segs, height, bulge}`: Full control over shape parameters
+   *   - `segs`: Number of bevel segments (0-1 = flat, 2 = cone, 3+ = dome)
+   *   - `height`: Bevel height in world units
+   *   - `bulge`: Curve factor (-1 to 1+), 0 = standard dome
+   *
+   * @default 'flat'
+   */
+  getBevel?: Accessor<DataT, BevelProp>;
+  /**
+   * Per-instance radius multiplier.
+   * The final radius = radiusScale * getRadius(d)
+   *
+   * @default 1
+   */
+  getRadius?: Accessor<DataT, number>;
+};
+
+/** Parses a BevelProp value into shader-compatible parameters */
+function parseBevelProp(bevel: BevelProp): BevelParams {
+  if (typeof bevel === 'string') {
+    switch (bevel) {
+      case 'dome':
+        return {segs: 8, height: 1, bulge: 0};
+      case 'cone':
+        return {segs: 2, height: 1, bulge: 0};
+      case 'flat':
+      default:
+        return {segs: 0, height: 0, bulge: 0};
+    }
+  }
+  return {
+    segs: bevel.segs ?? 0,
+    height: bevel.height ?? 0,
+    bulge: bevel.bulge ?? 0
+  };
+}
+
+export default class ColumnShapeExtension extends LayerExtension {
+  static defaultProps = defaultProps;
+  static extensionName = 'ColumnShapeExtension';
+
+  isEnabled(layer: Layer<ColumnShapeExtensionProps>): boolean {
+    return layer.getAttributeManager() !== null;
+  }
+
+  getShaders(this: Layer<ColumnShapeExtensionProps>, extension: this): any {
+    if (!extension.isEnabled(this)) {
+      return null;
+    }
+    return {
+      modules: [columnShapeShaders]
+    };
+  }
+
+  initializeState(
+    this: Layer<ColumnShapeExtensionProps>,
+    _context: LayerContext,
+    extension: this
+  ): void {
+    if (!extension.isEnabled(this)) {
+      return;
+    }
+
+    const attributeManager = this.getAttributeManager()!;
+
+    attributeManager.addInstanced({
+      instanceBevelSegs: {
+        size: 1,
+        accessor: 'getBevel',
+        transform: (bevel: BevelProp) => parseBevelProp(bevel).segs,
+        defaultValue: 0
+      },
+      instanceBevelHeights: {
+        size: 1,
+        accessor: 'getBevel',
+        transform: (bevel: BevelProp) => parseBevelProp(bevel).height,
+        defaultValue: 0
+      },
+      instanceBevelBulge: {
+        size: 1,
+        accessor: 'getBevel',
+        transform: (bevel: BevelProp) => parseBevelProp(bevel).bulge,
+        defaultValue: 0
+      },
+      instanceRadii: {
+        size: 1,
+        accessor: 'getRadius',
+        defaultValue: 1
+      }
+    });
+
+    // Monkey-patch getGeometry to return dome geometry instead of flat-cap geometry.
+    // ColumnLayer calls getGeometry during _updateGeometry; our patched version
+    // returns geometry with concentric bevel rings for dome/cone shapes.
+    const layer = this as any;
+    const originalGetGeometry = layer.getGeometry.bind(layer);
+
+    layer.getGeometry = (
+      diskResolution: number,
+      vertices: number[] | undefined,
+      hasThickness: boolean
+    ) => {
+      // Use original geometry for non-extruded, custom vertices, or flat cases
+      if (!hasThickness || vertices) {
+        return originalGetGeometry(diskResolution, vertices, hasThickness);
+      }
+
+      // Get a real Geometry instance from the original method, then replace
+      // its attribute buffers with our dome data.
+      const geometry = originalGetGeometry(diskResolution, undefined, true);
+
+      const bevelSegments = Math.max(3, Math.floor(diskResolution / 4));
+      const {positions, normals} = createDomeColumnAttributes({
+        radius: 1,
+        height: 2,
+        nradial: diskResolution,
+        bevelSegments,
+        bevelHeight: 1
+      });
+
+      // Replace geometry attribute buffers with dome data
+      geometry.attributes.POSITION = {size: 3, value: positions};
+      geometry.attributes.NORMAL = {size: 3, value: normals};
+      geometry.vertexCount = positions.length / 3;
+
+      return geometry;
+    };
+  }
+
+  updateState(
+    this: Layer<ColumnShapeExtensionProps>,
+    _params: UpdateParameters<Layer<ColumnShapeExtensionProps>>,
+    extension: this
+  ): void {
+    if (!extension.isEnabled(this)) {
+      return;
+    }
+
+    const props = this.props;
+    const bevelEnabled = props.getBevel !== undefined && props.getBevel !== 'flat';
+
+    const columnShapeProps: ColumnShapeModuleProps = {
+      bevelEnabled,
+      bevelTopZ: 0
+    };
+    this.setShaderModuleProps({columnShape: columnShapeProps});
+  }
+}

--- a/modules/extensions/src/column-shape/dome-column-geometry.ts
+++ b/modules/extensions/src/column-shape/dome-column-geometry.ts
@@ -1,0 +1,135 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Dome-enabled column geometry attributes for ColumnShapeExtension.
+ *
+ * Generates triangle-strip vertex data with:
+ * - Cylinder sides: z from -1 to sidesTopZ (= 0 for bevelHeight=1, height=2)
+ * - Bevel rings: concentric ring pairs using spherical coords
+ * - Apex vertex at (0, 0, 1)
+ * - Smooth dome normals
+ *
+ * Returns raw Float32Arrays - the caller wraps them in a Geometry instance
+ * obtained from the original ColumnLayer.getGeometry.
+ */
+
+export type DomeColumnGeometryProps = {
+  radius?: number;
+  height?: number;
+  nradial?: number;
+  bevelSegments?: number;
+  bevelHeight?: number;
+};
+
+export function createDomeColumnAttributes(props: DomeColumnGeometryProps): {
+  positions: Float32Array;
+  normals: Float32Array;
+} {
+  const {radius = 1, height = 2, nradial = 10, bevelSegments = 4, bevelHeight = 1} = props;
+
+  const isExtruded = height > 0;
+  const vertsAroundEdge = nradial + 1; // +1 to close the strip
+  const stepAngle = (Math.PI * 2) / nradial;
+  const bevelDepth = bevelSegments >= 2 ? bevelHeight * radius : 0;
+  const sidesTopZ = height / 2 - bevelDepth; // 0 when bevelHeight=1, height=2
+  const bevelLevels = bevelSegments >= 2 ? bevelSegments - 1 : 0;
+
+  // Vertex count: sides (2 per edge vertex) + degenerate (1) + bevel rings (2 per edge per level) + apex (1)
+  const numVertices = !isExtruded
+    ? nradial
+    : bevelSegments >= 2
+      ? vertsAroundEdge * 2 + 1 + bevelLevels * vertsAroundEdge * 2 + 1
+      : vertsAroundEdge * 3 + 1; // flat cap fallback
+
+  const positions = new Float32Array(numVertices * 3);
+  const normals = new Float32Array(numVertices * 3);
+
+  let i = 0;
+  const setVertex = (pos: [number, number, number], norm: [number, number, number]) => {
+    positions[i] = pos[0];
+    positions[i + 1] = pos[1];
+    positions[i + 2] = pos[2];
+    normals[i] = norm[0];
+    normals[i + 1] = norm[1];
+    normals[i + 2] = norm[2];
+    i += 3;
+  };
+
+  const getXY = (j: number, scale = 1): [number, number] => {
+    return [Math.cos(j * stepAngle) * radius * scale, Math.sin(j * stepAngle) * radius * scale];
+  };
+
+  const getNormal = (j: number): [number, number] => {
+    return [Math.cos(j * stepAngle), Math.sin(j * stepAngle)];
+  };
+
+  if (!isExtruded) {
+    // Flat disk - no bevel needed
+    for (let j = 0; j < nradial; j++) {
+      const [x, y] = getXY(j);
+      setVertex([x, y, 0], [0, 0, 1]);
+    }
+  } else {
+    // === Cylinder sides ===
+    for (let j = 0; j < vertsAroundEdge; j++) {
+      const [x, y] = getXY(j);
+      const [nx, ny] = getNormal(j);
+      setVertex([x, y, sidesTopZ], [nx, ny, 0]); // top of cylinder
+      setVertex([x, y, -height / 2], [nx, ny, 0]); // bottom of cylinder
+    }
+
+    if (bevelSegments >= 2) {
+      // === Degenerate triangle to transition from cylinder strip to bevel strip ===
+      const [fx, fy] = getXY(0);
+      const phi0 = Math.PI / 2 / bevelLevels;
+      const dz0 = Math.sin(phi0) * bevelDepth;
+      const dr0 = Math.cos(phi0) * radius - radius;
+      const len0 = Math.sqrt(dz0 * dz0 + dr0 * dr0);
+      setVertex([fx, fy, sidesTopZ], [dz0 / len0, 0, -dr0 / len0]);
+
+      // === Bevel rings ===
+      for (let level = 0; level < bevelLevels; level++) {
+        const phi1 = (level / bevelLevels) * (Math.PI / 2);
+        const phi2 = ((level + 1) / bevelLevels) * (Math.PI / 2);
+        const r1 = Math.cos(phi1);
+        const r2 = Math.cos(phi2);
+        const z1 = sidesTopZ + Math.sin(phi1) * bevelDepth;
+        const z2 = sidesTopZ + Math.sin(phi2) * bevelDepth;
+
+        for (let j = 0; j < vertsAroundEdge; j++) {
+          const angle = (j % nradial) * stepAngle;
+          const cos = Math.cos(angle);
+          const sin = Math.sin(angle);
+          const [x1, y1] = getXY(j, r1);
+          const [x2, y2] = getXY(j, r2);
+          // Smooth normals: spherical normal direction
+          setVertex(
+            [x1, y1, z1],
+            [cos * Math.cos(phi1), sin * Math.cos(phi1), Math.sin(phi1)]
+          );
+          setVertex(
+            [x2, y2, z2],
+            [cos * Math.cos(phi2), sin * Math.cos(phi2), Math.sin(phi2)]
+          );
+        }
+      }
+
+      // === Apex vertex ===
+      setVertex([0, 0, height / 2], [0, 0, 1]);
+    } else {
+      // Flat cap (zigzag triangle strip) - same as standard ColumnGeometry
+      for (let j = 0; j < vertsAroundEdge; j++) {
+        const v = Math.floor(j / 2) * Math.sign(0.5 - (j % 2));
+        const [x, y] = getXY((v + nradial) % nradial);
+        setVertex([x, y, height / 2], [0, 0, 1]);
+      }
+    }
+  }
+
+  return {
+    positions: positions.subarray(0, i),
+    normals: normals.subarray(0, i)
+  };
+}

--- a/modules/extensions/src/column-shape/shader-module.ts
+++ b/modules/extensions/src/column-shape/shader-module.ts
@@ -1,0 +1,154 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule} from '@luma.gl/shadertools';
+
+const uniformBlock = /* glsl */ `\
+uniform columnShapeUniforms {
+  bool bevelEnabled;
+  float bevelTopZ;
+} columnShape;
+`;
+
+const vs = /* glsl */ `
+${uniformBlock}
+
+in float instanceBevelSegs;
+in float instanceBevelHeights;
+in float instanceBevelBulge;
+in float instanceRadii;
+`;
+
+const fs = `
+${uniformBlock}
+`;
+
+const inject = {
+  // DECKGL_FILTER_SIZE receives `inout vec3 size` (the offset vector passed as `pos` in main).
+  // Instance attributes declared in `vs` are in scope here.
+  'vs:DECKGL_FILTER_SIZE': /* glsl */ `
+    if (columnShape.bevelEnabled) {
+      size.xy *= instanceRadii;
+    }
+  `,
+
+  // vs:#main-end is injected at the end of main() where all vertex/instance
+  // attributes (positions, instanceElevations, etc.) are in scope.
+  // We recompute ALL vertex positions when bevel is enabled because the standard
+  // elevation formula (positions.z * fullElevation) is wrong for truncated cylinder + dome.
+  'vs:#main-end': /* glsl */ `
+    if (columnShape.bevelEnabled && column.extruded) {
+      float bevelSegs = instanceBevelSegs;
+      float bevelHeight = instanceBevelHeights;
+      float bevelBulge = instanceBevelBulge;
+
+      float fullElevation = instanceElevations * column.elevationScale;
+
+      // Per-instance bevel flags
+      bool isFlat = bevelHeight < 0.001 || bevelSegs < 1.5;
+      bool isCone = bevelSegs > 1.5 && bevelSegs < 2.5;
+      bool isBevelVertex = positions.z > columnShape.bevelTopZ;
+
+      // Bevel size clamped to full elevation
+      float bevelSize = isFlat ? 0.0 : min(bevelHeight, fullElevation);
+
+      float elevation = 0.0;
+      vec2 adjustedXY = positions.xy;
+      vec3 adjustedNormal = normals;
+
+      if (isBevelVertex) {
+        // Dome/bevel vertex: z encodes the spherical phi angle via asin
+        float phi = asin(clamp(positions.z, 0.0, 1.0));
+        float t = phi / 1.5708; // normalize to [0, 1] (pi/2)
+
+        if (isFlat) {
+          // Flat instance: collapse dome to flat top
+          elevation = fullElevation;
+          adjustedXY = length(positions.xy) > 0.001 ? normalize(positions.xy) : vec2(1.0, 0.0);
+          adjustedNormal = vec3(0.0, 0.0, 1.0);
+        } else if (isCone) {
+          // Cone: linear interpolation
+          elevation = fullElevation - bevelSize + t * bevelSize;
+          adjustedXY = (length(positions.xy) > 0.001 ? normalize(positions.xy) : vec2(1.0, 0.0)) * (1.0 - t);
+          adjustedNormal = vec3(normalize(positions.xy) * 0.7071, 0.7071);
+        } else {
+          // Dome: use z directly for elevation (smooth curve from geometry)
+          elevation = fullElevation - bevelSize + positions.z * bevelSize;
+          float r = length(positions.xy);
+          vec2 xyDir = r > 0.001 ? positions.xy / r : vec2(1.0, 0.0);
+          // Bulge effect: radial distortion along the dome surface
+          float bulgeEffect = bevelBulge * sin(t * 3.14159) * (1.0 - t * t);
+          adjustedXY = xyDir * max(r + bulgeEffect, 0.0);
+          // Use geometry's smooth normals (already correct from dome-column-geometry)
+        }
+      } else {
+        // Cylinder vertex: z in [-1, bevelTopZ]
+        // Map z from [-1, bevelTopZ] to [0, 1] range for cylinder height
+        float cylinderT = (positions.z + 1.0) / (columnShape.bevelTopZ + 1.0);
+        elevation = cylinderT * (isFlat ? fullElevation : (fullElevation - bevelSize));
+      }
+
+      // Recompute position with corrected elevation
+      float shouldRender = float(instanceFillColors.a > 0.0 && instanceElevations >= 0.0);
+      float dotRadius = column.radius * instanceRadii * column.coverage * shouldRender;
+
+      vec3 centroidPosition = vec3(instancePositions.xy, instancePositions.z + elevation);
+      mat2 rm = mat2(cos(column.angle), sin(column.angle), -sin(column.angle), cos(column.angle));
+      vec2 ofs = (rm * adjustedXY + column.offset) * dotRadius;
+      if (column.radiusUnits == UNIT_METERS) {
+        ofs = project_size(ofs);
+      }
+      vec3 bevelPos = vec3(ofs, 0.0);
+
+      gl_Position = project_position_to_clipspace(centroidPosition, instancePositions64Low, bevelPos, geometry.position);
+
+      // Recompute normal
+      geometry.normal = project_normal(vec3(rm * adjustedNormal.xy, adjustedNormal.z));
+
+      // Recompute Gouraud lighting
+      if (!column.isStroke) {
+        #ifndef FLAT_SHADING
+        vec3 lightColor = lighting_getLightColor(vColor.rgb / max(layer.opacity, 0.001), project.cameraPosition, geometry.position.xyz, geometry.normal);
+        vColor = vec4(lightColor, vColor.a);
+        #endif
+      }
+    }
+  `
+};
+
+export type ColumnShapeModuleProps = {
+  bevelEnabled?: boolean;
+  bevelTopZ?: number;
+};
+
+type ColumnShapeModuleUniforms = {
+  bevelEnabled?: boolean;
+  bevelTopZ?: number;
+};
+
+function getUniforms(opts?: ColumnShapeModuleProps | {}): ColumnShapeModuleUniforms {
+  if (!opts) {
+    return {};
+  }
+  const uniforms: ColumnShapeModuleUniforms = {};
+  if ('bevelEnabled' in opts) {
+    uniforms.bevelEnabled = opts.bevelEnabled;
+  }
+  if ('bevelTopZ' in opts) {
+    uniforms.bevelTopZ = opts.bevelTopZ;
+  }
+  return uniforms;
+}
+
+export const columnShapeShaders = {
+  name: 'columnShape',
+  vs,
+  fs,
+  inject,
+  getUniforms,
+  uniformTypes: {
+    bevelEnabled: 'i32',
+    bevelTopZ: 'f32'
+  }
+} as const satisfies ShaderModule<ColumnShapeModuleProps, ColumnShapeModuleUniforms>;

--- a/modules/extensions/src/index.ts
+++ b/modules/extensions/src/index.ts
@@ -11,6 +11,7 @@ export {default as ClipExtension} from './clip/clip-extension';
 export {default as CollisionFilterExtension} from './collision-filter/collision-filter-extension';
 export {default as MaskExtension} from './mask/mask-extension';
 export {default as _TerrainExtension} from './terrain/terrain-extension';
+export {default as ColumnShapeExtension} from './column-shape/column-shape-extension';
 
 // Shader module
 export {default as project64} from './fp64/project64';
@@ -34,3 +35,7 @@ export type {CollisionFilterExtensionProps} from './collision-filter/collision-f
 export type {MaskExtensionProps} from './mask/mask-extension';
 export type {TerrainExtensionProps} from './terrain/terrain-extension';
 export type {TerrainModuleProps} from './terrain/shader-module';
+export type {
+  ColumnShapeExtensionProps,
+  BevelProp
+} from './column-shape/column-shape-extension';

--- a/test/modules/extensions/column-shape.spec.ts
+++ b/test/modules/extensions/column-shape.spec.ts
@@ -1,0 +1,89 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {ColumnShapeExtension} from '@deck.gl/extensions';
+import {ColumnLayer} from '@deck.gl/layers';
+import {testLayer} from '@deck.gl/test-utils';
+
+const SAMPLE_DATA = [
+  {position: [0, 0], elevation: 100},
+  {position: [1, 1], elevation: 200},
+  {position: [2, 2], elevation: 300}
+];
+
+test('ColumnShapeExtension#flat bevel', t => {
+  const testCases = [
+    {
+      props: {
+        id: 'column-shape-flat',
+        data: SAMPLE_DATA,
+        extruded: true,
+        getPosition: d => d.position,
+        getElevation: d => d.elevation,
+        extensions: [new ColumnShapeExtension()],
+        getBevel: 'flat',
+        getRadius: 1
+      },
+      onAfterUpdate: ({layer}) => {
+        const attributes = layer.getAttributeManager().getAttributes();
+        t.ok(attributes.instanceBevelSegs, 'instanceBevelSegs attribute exists');
+        t.ok(attributes.instanceBevelHeights, 'instanceBevelHeights attribute exists');
+        t.ok(attributes.instanceBevelBulge, 'instanceBevelBulge attribute exists');
+        t.ok(attributes.instanceRadii, 'instanceRadii attribute exists');
+      }
+    }
+  ];
+
+  testLayer({Layer: ColumnLayer, testCases, onError: t.notOk});
+  t.end();
+});
+
+test('ColumnShapeExtension#dome bevel', t => {
+  const testCases = [
+    {
+      props: {
+        id: 'column-shape-dome',
+        data: SAMPLE_DATA,
+        extruded: true,
+        getPosition: d => d.position,
+        getElevation: d => d.elevation,
+        extensions: [new ColumnShapeExtension()],
+        getBevel: 'dome',
+        getRadius: d => 1.5
+      },
+      onAfterUpdate: ({layer}) => {
+        const attributes = layer.getAttributeManager().getAttributes();
+        t.ok(attributes.instanceRadii, 'instanceRadii attribute exists for dome');
+      }
+    }
+  ];
+
+  testLayer({Layer: ColumnLayer, testCases, onError: t.notOk});
+  t.end();
+});
+
+test('ColumnShapeExtension#custom bevel object', t => {
+  const testCases = [
+    {
+      props: {
+        id: 'column-shape-custom',
+        data: SAMPLE_DATA,
+        extruded: true,
+        getPosition: d => d.position,
+        getElevation: d => d.elevation,
+        extensions: [new ColumnShapeExtension()],
+        getBevel: {segs: 6, height: 0.8, bulge: 0.3},
+        getRadius: d => d.elevation / 100
+      },
+      onAfterUpdate: ({layer}) => {
+        const attributes = layer.getAttributeManager().getAttributes();
+        t.ok(attributes.instanceBevelSegs, 'instanceBevelSegs attribute exists for custom bevel');
+      }
+    }
+  ];
+
+  testLayer({Layer: ColumnLayer, testCases, onError: t.notOk});
+  t.end();
+});

--- a/test/modules/extensions/index.ts
+++ b/test/modules/extensions/index.ts
@@ -6,6 +6,7 @@ import './brushing.spec';
 import './data-filter.spec';
 import './collision-filter';
 import './clip.spec';
+import './column-shape.spec';
 import './fp64.spec';
 import './path.spec';
 import './fill-style.spec';


### PR DESCRIPTION
## Summary

Closes #9942 

Adds a new `ColumnShapeExtension` to `@deck.gl/extensions` that enables per-instance dome, cone, and custom bevel shapes on `ColumnLayer`, with per-instance radius multipliers.

This is a non-invasive **LayerExtension** approach — it does not modify ColumnLayer internals. Instead it:
- Injects shader hooks (`DECKGL_FILTER_SIZE`, `#main-end`) for GPU-side vertex transformation
- Monkey-patches `getGeometry` to swap in dome-enabled geometry with concentric bevel rings and smooth normals
- Adds 4 instanced attributes (`instanceBevelSegs`, `instanceBevelHeights`, `instanceBevelBulge`, `instanceRadii`)

### Features

- **`getBevel` accessor**: `'flat'` | `'dome'` | `'cone'` | `{segs, height, bulge}` per instance
- **`getRadius` accessor**: per-instance radius multiplier
- Dome geometry with smooth spherical normals
- Bulge effect for convex/concave dome surfaces
- Correct Gouraud lighting recomputation for shaped caps

### Use cases

- Tree canopy visualization (dome caps sized by canopy area)
- Architectural column rendering with styled tops
- 3D bar charts with per-bar cap styles

### Example

```js
import {ColumnLayer} from '@deck.gl/layers';
import {ColumnShapeExtension} from '@deck.gl/extensions';

new ColumnLayer({
  data: TREES,
  extruded: true,
  extensions: [new ColumnShapeExtension()],
  getBevel: d => ({segs: 8, height: d.canopyHeight, bulge: 0.2}),
  getRadius: d => d.canopyRadius,
});
```

<img width="836" height="703" alt="image" src="https://github.com/user-attachments/assets/9f2f98bc-0656-4186-bb1d-e1d81a92424d" />

### Prior art

- visgl/deck.gl-community#470 (ExperimentalColumnLayer)
- visgl/deck.gl#9933 (getBevel & getRadius proposal)

## Test plan

- [x] Unit tests added (`test/modules/extensions/column-shape.spec.ts`)
- [x] API documentation added (`docs/api-reference/extensions/column-shape-extension.md`)
- [x] Extension registered in `@deck.gl/extensions` index with type exports
- [ ] Visual regression tests (render test cases)
- [x] Manual testing with tree canopy dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)