### PR TITLE
feat(layers) Tighten layer prop types

### DIFF
--- a/modules/aggregation-layers/src/contour-layer/contour-layer.ts
+++ b/modules/aggregation-layers/src/contour-layer/contour-layer.ts
@@ -64,7 +64,7 @@ type _ContourLayerProps<DataT> = {
    * The grid origin
    * @default [0, 0]
    */
-  gridOrigin?: [number, number];
+  gridOrigin?: Readonly<[number, number]>;
 
   /**
    * When set to true, aggregation is performed on GPU, provided other conditions are met.

--- a/modules/aggregation-layers/src/grid-layer/grid-cell-layer.ts
+++ b/modules/aggregation-layers/src/grid-layer/grid-cell-layer.ts
@@ -13,15 +13,15 @@ import type {ScaleType} from '../common/types';
 
 /** Proprties added by GridCellLayer. */
 type GridCellLayerProps = {
-  cellSizeCommon: [number, number];
-  cellOriginCommon: [number, number];
-  colorDomain: [number, number];
-  colorCutoff: [number, number] | null;
+  cellSizeCommon: Readonly<[number, number]>;
+  cellOriginCommon: Readonly<[number, number]>;
+  colorDomain: Readonly<[number, number]>;
+  colorCutoff: Readonly<[number, number]> | null;
   colorRange: Color[];
   colorScaleType: ScaleType;
-  elevationDomain: [number, number];
-  elevationCutoff: [number, number] | null;
-  elevationRange: [number, number];
+  elevationDomain: Readonly<[number, number]>;
+  elevationCutoff: Readonly<[number, number]> | null;
+  elevationRange: Readonly<[number, number]>;
 };
 
 export class GridCellLayer<ExtraPropsT extends {} = {}> extends ColumnLayer<

--- a/modules/aggregation-layers/src/grid-layer/grid-layer-uniforms.ts
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer-uniforms.ts
@@ -16,12 +16,12 @@ uniform gridUniforms {
 `;
 
 export type GridProps = {
-  colorDomain: [number, number, number, number];
+  colorDomain: Readonly<[number, number, number, number]>;
   colorRange: Texture;
-  elevationDomain: [number, number, number, number];
-  elevationRange: [number, number];
-  originCommon: [number, number];
-  sizeCommon: [number, number];
+  elevationDomain: Readonly<[number, number, number, number]>;
+  elevationRange: Readonly<[number, number]>;
+  originCommon: Readonly<[number, number]>;
+  sizeCommon: Readonly<[number, number]>;
 };
 
 export const gridUniforms = {

--- a/modules/aggregation-layers/src/grid-layer/grid-layer.ts
+++ b/modules/aggregation-layers/src/grid-layer/grid-layer.ts
@@ -90,7 +90,7 @@ type _GridLayerProps<DataT> = {
    * Color scale domain, default is set to the extent of aggregated weights in each cell.
    * @default [min(colorWeight), max(colorWeight)]
    */
-  colorDomain?: [number, number] | null;
+  colorDomain?: Readonly<[number, number]> | null;
 
   /**
    * Default: [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`
@@ -107,13 +107,13 @@ type _GridLayerProps<DataT> = {
    * Elevation scale input domain, default is set to between 0 and the max of aggregated weights in each cell.
    * @default [0, max(elevationWeight)]
    */
-  elevationDomain?: [number, number] | null;
+  elevationDomain?: Readonly<[number, number]> | null;
 
   /**
    * Elevation scale output range.
    * @default [0, 1000]
    */
-  elevationRange?: [number, number];
+  elevationRange?: Readonly<[number, number]>;
 
   /**
    * Cell elevation multiplier.

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -55,7 +55,7 @@ const TEXTURE_PROPS: TextureProps = {
     addressModeV: 'clamp-to-edge'
   }
 };
-const DEFAULT_COLOR_DOMAIN = [0, 0];
+const DEFAULT_COLOR_DOMAIN = [0, 0] as const;
 const AGGREGATION_MODE = {
   SUM: 0,
   MEAN: 1
@@ -126,7 +126,7 @@ type _HeatmapLayerProps<DataT> = {
    *
    * @default null
    */
-  colorDomain?: [number, number] | null;
+  colorDomain?: Readonly<[number, number]> | null;
 
   /**
    * Defines the type of aggregation operation
@@ -174,7 +174,7 @@ export default class HeatmapLayer<
   static defaultProps = defaultProps;
 
   state!: AggregationLayer<DataT>['state'] & {
-    colorDomain?: number[];
+    colorDomain?: Readonly<[number, number]>;
     isWeightMapDirty?: boolean;
     weightsTexture?: Texture;
     maxWeightsTexture?: Texture;
@@ -594,7 +594,10 @@ export default class HeatmapLayer<
       const metersPerPixel =
         (viewport.distanceScales.metersPerUnit[2] * (commonBounds[2] - commonBounds[0])) /
         textureSize;
-      this.state.colorDomain = colorDomain.map(x => x * metersPerPixel * weightsScale);
+      this.state.colorDomain = [
+        colorDomain[0] * metersPerPixel * weightsScale,
+        colorDomain[1] * metersPerPixel * weightsScale
+      ];
     } else {
       this.state.colorDomain = colorDomain || DEFAULT_COLOR_DOMAIN;
     }

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-uniforms.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-uniforms.ts
@@ -16,7 +16,7 @@ uniform triangleUniforms {
 
 export type TriangleProps = {
   aggregationMode: number;
-  colorDomain: [number, number];
+  colorDomain: Readonly<[number, number]>;
   intensity: number;
   threshold: number;
   colorTexture: Texture;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -11,7 +11,7 @@ import {TriangleProps, triangleUniforms} from './triangle-layer-uniforms';
 
 type _TriangleLayerProps = {
   data: {attributes: {positions: Buffer; texCoords: Buffer}};
-  colorDomain: [number, number];
+  colorDomain: Readonly<[number, number]>;
   aggregationMode: number;
   threshold: number;
   intensity: number;

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-cell-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-cell-layer.ts
@@ -12,14 +12,14 @@ import type {ScaleType} from '../common/types';
 
 /** Proprties added by HexagonCellLayer. */
 export type _HexagonCellLayerProps = {
-  hexOriginCommon: [number, number];
-  colorDomain: [number, number];
-  colorCutoff: [number, number] | null;
+  hexOriginCommon: Readonly<[number, number]>;
+  colorDomain: Readonly<[number, number]>;
+  colorCutoff: Readonly<[number, number]> | null;
   colorRange: Color[];
   colorScaleType: ScaleType;
-  elevationDomain: [number, number];
-  elevationCutoff: [number, number] | null;
-  elevationRange: [number, number];
+  elevationDomain: Readonly<[number, number]>;
+  elevationCutoff: Readonly<[number, number]> | null;
+  elevationRange: Readonly<[number, number]>;
 };
 
 export default class HexagonCellLayer<ExtraPropsT extends {} = {}> extends ColumnLayer<

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer-uniforms.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer-uniforms.ts
@@ -15,11 +15,11 @@ uniform hexagonUniforms {
 `;
 
 export type HexagonProps = {
-  colorDomain: [number, number, number, number];
+  colorDomain: Readonly<[number, number, number, number]>;
   colorRange: Texture;
-  elevationDomain: [number, number, number, number];
-  elevationRange: [number, number];
-  originCommon: [number, number];
+  elevationDomain: Readonly<[number, number, number, number]>;
+  elevationRange: Readonly<[number, number]>;
+  originCommon: Readonly<[number, number]>;
 };
 
 export const hexagonUniforms = {

--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.ts
@@ -92,7 +92,7 @@ type _HexagonLayerProps<DataT> = {
    * Color scale domain, default is set to the extent of aggregated weights in each cell.
    * @default [min(colorWeight), max(colorWeight)]
    */
-  colorDomain?: [number, number] | null;
+  colorDomain?: Readonly<[number, number]> | null;
 
   /**
    * Default: [colorbrewer](http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6) `6-class YlOrRd`
@@ -109,13 +109,13 @@ type _HexagonLayerProps<DataT> = {
    * Elevation scale input domain, default is set to between 0 and the max of aggregated weights in each cell.
    * @default [0, max(elevationWeight)]
    */
-  elevationDomain?: [number, number] | null;
+  elevationDomain?: Readonly<[number, number]> | null;
 
   /**
    * Elevation scale output range.
    * @default [0, 1000]
    */
-  elevationRange?: [number, number];
+  elevationRange?: Readonly<[number, number]>;
 
   /**
    * Cell elevation multiplier.

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer.ts
@@ -55,7 +55,7 @@ export type _ScreenGridLayerProps<DataT> = {
    * Color scale input domain. The color scale maps continues numeric domain into discrete color range.
    * @default [1, max(weight)]
    */
-  colorDomain?: [number, number] | null;
+  colorDomain?: Readonly<[number, number]> | null;
 
   /**
    * Specified as an array of colors [color1, color2, ...].

--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -102,7 +102,7 @@ export type DataColumnOptions<Options> = Options &
     /** Internal API, use `type` instead */
     logicalType?: LogicalDataType;
     isIndexed?: boolean;
-    defaultValue?: number | number[];
+    defaultValue?: number | Readonly<number[]>;
   };
 
 export type DataColumnSettings<Options> = DataColumnOptions<Options> & {

--- a/modules/core/src/types/layer-props.ts
+++ b/modules/core/src/types/layer-props.ts
@@ -53,14 +53,18 @@ export type Accessor<In, Out> = Out | AccessorFunction<In, Out>;
 /** A position in the format of `[lng, lat, alt?]` or `[x, y, z?]` depending on the coordinate system.
  * See https://deck.gl/docs/developer-guide/coordinate-systems#positions
  */
-export type Position = [number, number] | [number, number, number] | Float32Array | Float64Array;
+export type Position =
+  | Readonly<[number, number]>
+  | Readonly<[number, number, number]>
+  | Readonly<Float32Array>
+  | Readonly<Float64Array>;
 
 /** A color in the format of `[r, g, b, a?]` */
 export type Color =
-  | [number, number, number]
-  | [number, number, number, number]
-  | Uint8Array
-  | Uint8ClampedArray;
+  | Readonly<[number, number, number]>
+  | Readonly<[number, number, number, number]>
+  | Readonly<Uint8Array>
+  | Readonly<Uint8ClampedArray>;
 
 export type Material = LightingModuleSettings['material'];
 

--- a/modules/extensions/src/brushing/brushing-extension.ts
+++ b/modules/extensions/src/brushing/brushing-extension.ts
@@ -20,7 +20,7 @@ export type BrushingExtensionProps<DataT = any> = {
    * Called to retrieve an arbitrary position for each object that it will be filtered by.
    * Only effective if `brushingTarget` is set to `custom`.
    */
-  getBrushingTarget?: Accessor<DataT, [number, number]>;
+  getBrushingTarget?: Accessor<DataT, Readonly<[number, number]>>;
   /**
    * Enable/disable brushing. If brushing is disabled, all objects are rendered.
    * @default true

--- a/modules/extensions/src/clip/clip-extension.ts
+++ b/modules/extensions/src/clip/clip-extension.ts
@@ -16,7 +16,7 @@ export type ClipExtensionProps = {
   /** Rectangular bounds to be used for clipping the rendered region, in `[left, bottom, right, top]`.
    * @default [0, 0, 1, 1]
    */
-  clipBounds?: [number, number, number, number];
+  clipBounds?: Readonly<[number, number, number, number]>;
   /**
    * Controls whether an object is clipped by its anchor (e.g. icon, point) or by its geometry (e.g. path, polygon).
    * If not specified, it is automatically deduced from the layer.
@@ -35,7 +35,7 @@ bool clip_isInBounds(vec2 position) {
 `;
 
 export type ClipModuleProps = {
-  bounds: [number, number, number, number];
+  bounds: Readonly<[number, number, number, number]>;
 };
 
 /*

--- a/modules/extensions/src/data-filter/data-filter-extension.ts
+++ b/modules/extensions/src/data-filter/data-filter-extension.ts
@@ -52,13 +52,13 @@ export type DataFilterExtensionProps<DataT = any> = {
    * If an object's filtered value is within the bounds, the object will be rendered; otherwise it will be hidden.
    * @default [-1, 1]
    */
-  filterRange?: [number, number] | [number, number][];
+  filterRange?: Readonly<[number, number]> | Readonly<[number, number]>[];
   /**
    * If specified, objects will be faded in/out instead of abruptly shown/hidden.
    * When the filtered value is outside of the bounds defined by `filterSoftRange` but still within the bounds defined by `filterRange`, the object will be rendered as "faded."
    * @default null
    */
-  filterSoftRange?: [number, number] | [number, number][] | null;
+  filterSoftRange?: Readonly<[number, number]> | Readonly<[number, number]>[] | null;
   /**
    * When an object is "faded", manipulate its size so that it appears smaller or thinner. Only works if `filterSoftRange` is specified.
    * @default true

--- a/modules/extensions/src/fill-style/fill-style-extension.ts
+++ b/modules/extensions/src/fill-style/fill-style-extension.ts
@@ -70,7 +70,7 @@ export type FillStyleExtensionProps<DataT = any> = {
    * Accessor for the offset of the pattern, relative to the original size. Offset `[0.5, 0.5]` shifts the pattern alignment by half.
    * @default [0, 0]
    */
-  getFillPatternOffset?: Accessor<DataT, [number, number]>;
+  getFillPatternOffset?: Accessor<DataT, Readonly<[number, number]>>;
 };
 
 export type FillStyleExtensionOptions = {

--- a/modules/extensions/src/path-style/path-style-extension.ts
+++ b/modules/extensions/src/path-style/path-style-extension.ts
@@ -26,7 +26,7 @@ export type PathStyleExtensionProps<DataT = any> = {
    * Accessor for the dash array to draw each path with: `[dashSize, gapSize]` relative to the width of the path.
    * Requires the `dash` option to be on.
    */
-  getDashArray?: Accessor<DataT, [number, number]>;
+  getDashArray?: Accessor<DataT, Readonly<[number, number]>>;
   /**
    * Accessor for the offset to draw each path with, relative to the width of the path.
    * Negative offset is to the left hand side, and positive offset is to the right hand side.

--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -24,7 +24,7 @@ import {arcUniforms, ArcProps} from './arc-layer-uniforms';
 import vs from './arc-layer-vertex.glsl';
 import fs from './arc-layer-fragment.glsl';
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<ArcLayerProps> = {
   getSourcePosition: {type: 'accessor', value: (x: any) => x.sourcePosition},

--- a/modules/layers/src/column-layer/column-layer-uniforms.ts
+++ b/modules/layers/src/column-layer/column-layer-uniforms.ts
@@ -26,7 +26,7 @@ uniform columnUniforms {
 export type ColumnProps = {
   radius: number;
   angle: number;
-  offset: [number, number];
+  offset: Readonly<[number, number]>;
   extruded: boolean;
   stroked: boolean;
   isStroke: boolean;

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -26,7 +26,7 @@ import {columnUniforms, ColumnProps} from './column-layer-uniforms';
 import vs from './column-layer-vertex.glsl';
 import fs from './column-layer-fragment.glsl';
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<ColumnLayerProps> = {
   diskResolution: {type: 'number', min: 4, value: 20},
@@ -91,7 +91,7 @@ type _ColumnLayerProps<DataT> = {
    * Disk offset from the position, relative to the radius.
    * @default [0,0]
    */
-  offset?: [number, number];
+  offset?: Readonly<[number, number]>;
 
   /**
    * Radius multiplier, between 0 - 1

--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -91,7 +91,7 @@ type _IconLayerProps<DataT> = {
    * Icon offsest accessor, in pixels.
    * @default [0, 0]
    */
-  getPixelOffset?: Accessor<DataT, [number, number]>;
+  getPixelOffset?: Accessor<DataT, Readonly<[number, number]>>;
   /**
    * Callback called if the attempt to fetch an icon returned by `getIcon` fails.
    */
@@ -103,7 +103,7 @@ type _IconLayerProps<DataT> = {
 
 export type IconLayerProps<DataT = unknown> = _IconLayerProps<DataT> & LayerProps;
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<IconLayerProps> = {
   iconAtlas: {type: 'image', value: null, async: true},

--- a/modules/layers/src/line-layer/line-layer.ts
+++ b/modules/layers/src/line-layer/line-layer.ts
@@ -25,7 +25,7 @@ import {shaderWGSL as source} from './line-layer.wgsl';
 import vs from './line-layer-vertex.glsl';
 import fs from './line-layer-fragment.glsl';
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<LineLayerProps> = {
   getSourcePosition: {type: 'accessor', value: (x: any) => x.sourcePosition},

--- a/modules/layers/src/path-layer/path-layer.ts
+++ b/modules/layers/src/path-layer/path-layer.ts
@@ -95,7 +95,7 @@ type _PathLayerProps<DataT> = {
 
 export type PathLayerProps<DataT = unknown> = _PathLayerProps<DataT> & LayerProps;
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<PathLayerProps> = {
   widthUnits: 'meters',

--- a/modules/layers/src/path-layer/path-tesselator.ts
+++ b/modules/layers/src/path-layer/path-tesselator.ts
@@ -56,11 +56,11 @@ export default class PathTesselator extends Tesselator<
   }
 
   /* Implement base Tesselator interface */
-  protected normalizeGeometry(path: PathGeometry): number[][] | PathGeometry {
+  protected normalizeGeometry(path: PathGeometry): NormalizedPathGeometry {
     if (this.normalize) {
       return normalizePath(path, this.positionSize, this.opts.resolution, this.opts.wrapLongitude);
     }
-    return path;
+    return path as NormalizedPathGeometry;
   }
 
   /* Implement base Tesselator interface */

--- a/modules/layers/src/path-layer/path.ts
+++ b/modules/layers/src/path-layer/path.ts
@@ -22,7 +22,7 @@ export function normalizePath(
   size: number,
   gridResolution?: number,
   wrapLongitude?: boolean
-): number[][] | NumericArray {
+): NormalizedPathGeometry {
   let flatPath: NumericArray;
   if (Array.isArray(path[0])) {
     const length = path.length * size;
@@ -36,10 +36,12 @@ export function normalizePath(
     flatPath = path as NumericArray;
   }
   if (gridResolution) {
-    return cutPolylineByGrid(flatPath, {size, gridResolution});
+    return cutPolylineByGrid(flatPath, {size, gridResolution}) as
+      | FlatPathGeometry
+      | FlatPathGeometry[];
   }
   if (wrapLongitude) {
-    return cutPolylineByMercatorBounds(flatPath, {size});
+    return cutPolylineByMercatorBounds(flatPath, {size}) as FlatPathGeometry[];
   }
   return flatPath;
 }

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -28,8 +28,8 @@ import vs from './point-cloud-layer-vertex.glsl';
 import fs from './point-cloud-layer-fragment.glsl';
 import source from './point-cloud-layer.wgsl';
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
-const DEFAULT_NORMAL: [number, number, number] = [0, 0, 1];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
+const DEFAULT_NORMAL = [0, 0, 1] as const;
 
 const defaultProps: DefaultProps<PointCloudLayerProps> = {
   sizeUnits: 'pixels',
@@ -107,7 +107,7 @@ type _PointCloudLayerProps<DataT> = {
    * The normal of each object, in `[nx, ny, nz]`.
    * @default [0, 0, 1]
    */
-  getNormal?: Accessor<DataT, [number, number, number]>;
+  getNormal?: Accessor<DataT, Readonly<[number, number, number]>>;
 
   /**
    * The rgba color is in the format of `[r, g, b, [a]]`

--- a/modules/layers/src/polygon-layer/polygon-layer.ts
+++ b/modules/layers/src/polygon-layer/polygon-layer.ts
@@ -198,8 +198,8 @@ type _PolygonLayerProps<DataT = unknown> = {
   material?: Material;
 };
 
-const defaultLineColor: [number, number, number, number] = [0, 0, 0, 255];
-const defaultFillColor: [number, number, number, number] = [0, 0, 0, 255];
+const defaultLineColor = [0, 0, 0, 255] as const;
+const defaultFillColor = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<PolygonLayerProps> = {
   stroked: true,

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -22,7 +22,7 @@ import type {
 } from '@deck.gl/core';
 import {Parameters} from '@luma.gl/core';
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 /** All props supported by the ScatterplotLayer */
 export type ScatterplotLayerProps<DataT = unknown> = _ScatterplotLayerProps<DataT> & LayerProps;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -92,7 +92,7 @@ type _SolidPolygonLayerProps<DataT> = {
 /** Render filled and/or extruded polygons. */
 export type SolidPolygonLayerProps<DataT = unknown> = _SolidPolygonLayerProps<DataT> & LayerProps;
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const defaultProps: DefaultProps<SolidPolygonLayerProps> = {
   filled: true,

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -75,7 +75,7 @@ export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends 
   updateState(params: UpdateParameters<this>) {
     super.updateState(params);
     const {props, oldProps, changeFlags} = params;
-    let {outlineColor} = props;
+    const {outlineColor} = props;
 
     if (
       changeFlags.updateTriggersChanged &&
@@ -85,11 +85,15 @@ export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends 
       this.getAttributeManager()!.invalidate('instanceIconDefs');
     }
     if (outlineColor !== oldProps.outlineColor) {
-      outlineColor = outlineColor.map(x => x / 255) as Color;
-      outlineColor[3] = Number.isFinite(outlineColor[3]) ? outlineColor[3] : 1;
+      const normalizedOutlineColor = [
+        outlineColor[0] / 255,
+        outlineColor[1] / 255,
+        outlineColor[2] / 255,
+        (outlineColor[3] ?? 255) / 255
+      ];
 
       this.setState({
-        outlineColor
+        outlineColor: normalizedOutlineColor
       });
     }
     if (!props.sdf && props.outlineWidth) {

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-uniforms.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-uniforms.ts
@@ -22,8 +22,8 @@ export type TextBackgroundProps = {
   sizeScale: number;
   sizeMinPixels: number;
   sizeMaxPixels: number;
-  borderRadius: [number, number, number, number];
-  padding: [number, number, number, number];
+  borderRadius: Readonly<[number, number, number, number]>;
+  padding: Readonly<[number, number, number, number]>;
   sizeUnits: number;
   stroked: boolean;
 };

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer.ts
@@ -29,14 +29,14 @@ type _TextBackgroundLayerProps<DataT> = {
   sizeMinPixels?: number;
   sizeMaxPixels?: number;
 
-  borderRadius?: number | [number, number, number, number];
-  padding?: [number, number] | [number, number, number, number];
+  borderRadius?: number | Readonly<[number, number, number, number]>;
+  padding?: Readonly<[number, number]> | Readonly<[number, number, number, number]>;
 
   getPosition?: Accessor<DataT, Position>;
   getSize?: Accessor<DataT, number>;
   getAngle?: Accessor<DataT, number>;
-  getPixelOffset?: Accessor<DataT, [number, number]>;
-  getBoundingRect?: Accessor<DataT, [number, number, number, number]>;
+  getPixelOffset?: Accessor<DataT, Readonly<[number, number]>>;
+  getBoundingRect?: Accessor<DataT, Readonly<[number, number, number, number]>>;
   getFillColor?: Accessor<DataT, Color>;
   getLineColor?: Accessor<DataT, Color>;
   getLineWidth?: Accessor<DataT, number>;
@@ -151,14 +151,19 @@ export default class TextBackgroundLayer<DataT = any, ExtraPropsT extends {} = {
     }
 
     if (!Array.isArray(borderRadius)) {
-      borderRadius = [borderRadius, borderRadius, borderRadius, borderRadius];
+      borderRadius = [
+        borderRadius as number,
+        borderRadius as number,
+        borderRadius as number,
+        borderRadius as number
+      ];
     }
 
     const model = this.state.model!;
     const textBackgroundProps: TextBackgroundProps = {
       billboard,
       stroked: Boolean(getLineWidth),
-      borderRadius,
+      borderRadius: borderRadius as [number, number, number, number],
       padding: padding as [number, number, number, number],
       sizeUnits: UNIT[sizeUnits],
       sizeScale,

--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -40,7 +40,7 @@ const ALIGNMENT_BASELINE = {
   bottom: -1
 } as const;
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 const DEFAULT_LINE_HEIGHT = 1.0;
 
@@ -92,14 +92,14 @@ type _TextLayerProps<DataT> = {
    * If an array of 4 is supplied, it is interpreted as `[bottom_right_corner, top_right_corner, bottom_left_corner, top_left_corner]` border radius in pixel.
    * @default 0
    */
-  backgroundBorderRadius?: number | [number, number, number, number];
+  backgroundBorderRadius?: number | Readonly<[number, number, number, number]>;
   /**
    * The padding of the background..
    * If an array of 2 is supplied, it is interpreted as `[padding_x, padding_y]` in pixels.
    * If an array of 4 is supplied, it is interpreted as `[padding_left, padding_top, padding_right, padding_bottom]` in pixels.
    * @default [0, 0, 0, 0]
    */
-  backgroundPadding?: [number, number] | [number, number, number, number];
+  backgroundPadding?: Readonly<[number, number]> | Readonly<[number, number, number, number]>;
   /**
    * Specifies a list of characters to include in the font. If set to 'auto', will be automatically generated from the data set.
    * @default (ASCII characters 32-128)
@@ -180,7 +180,7 @@ type _TextLayerProps<DataT> = {
    * Label offset from the anchor position, [x, y] in pixels
    * @default [0, 0]
    */
-  getPixelOffset?: Accessor<DataT, [number, number]>;
+  getPixelOffset?: Accessor<DataT, Readonly<[number, number]>>;
   /**
    * @deprecated Use `background` and `getBackgroundColor` instead
    */

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -29,7 +29,7 @@ import {
 
 type GLTFInstantiatorOptions = Parameters<typeof createScenegraphsFromGLTF>[2];
 
-const DEFAULT_COLOR: [number, number, number, number] = [255, 255, 255, 255];
+const DEFAULT_COLOR = [255, 255, 255, 255] as const;
 
 export type ScenegraphLayerProps<DataT = unknown> = _ScenegraphLayerProps<DataT> & LayerProps;
 
@@ -90,17 +90,17 @@ type _ScenegraphLayerProps<DataT> = {
    * @see https://en.wikipedia.org/wiki/Euler_angles
    * @default [0, 0, 0]
    */
-  getOrientation?: Accessor<DataT, [number, number, number]>;
+  getOrientation?: Accessor<DataT, Readonly<[number, number, number]>>;
   /**
    * Scaling factor of the model along each axis.
    * @default [1, 1, 1]
    */
-  getScale?: Accessor<DataT, [number, number, number]>;
+  getScale?: Accessor<DataT, Readonly<[number, number, number]>>;
   /**
    * Translation from the anchor point, [x, y, z] in meters.
    * @default [0, 0, 0]
    */
-  getTranslation?: Accessor<DataT, [number, number, number]>;
+  getTranslation?: Accessor<DataT, Readonly<[number, number, number]>>;
   /**
    * TransformMatrix. If specified, `getOrientation`, `getScale` and `getTranslation` are ignored.
    */

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -80,7 +80,7 @@ function getGeometry(data: Mesh): Geometry {
   }
 }
 
-const DEFAULT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
+const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 
 type Mesh =
   | GeometryType
@@ -112,17 +112,17 @@ type _SimpleMeshLayerProps<DataT> = {
    * @see https://en.wikipedia.org/wiki/Euler_angles
    * @default [0, 0, 0]
    */
-  getOrientation?: Accessor<DataT, [number, number, number]>;
+  getOrientation?: Accessor<DataT, Readonly<[number, number, number]>>;
   /**
    * Scaling factor of the model along each axis.
    * @default [1, 1, 1]
    */
-  getScale?: Accessor<DataT, [number, number, number]>;
+  getScale?: Accessor<DataT, Readonly<[number, number, number]>>;
   /**
    * Translation from the anchor point, [x, y, z] in meters.
    * @default [0, 0, 0]
    */
-  getTranslation?: Accessor<DataT, [number, number, number]>;
+  getTranslation?: Accessor<DataT, Readonly<[number, number, number]>>;
   /**
    * TransformMatrix. If specified, `getOrientation`, `getScale` and `getTranslation` are ignored.
    */


### PR DESCRIPTION
#### Background

In the current release, when supplying a constant array to a layer prop such as `*Color`, you get the following type error:

```
The type 'readonly [255, 0, 0, 255]' is 'readonly' and cannot be assigned to the mutable type '[number, number, number, number]'.
```

In reality, our layers do not mutate user-supplied data. This PR marks all layer props that expect array values as `readonly`. It will continue to work with dynamically constructed values, but also accept constants.

<img width="485" height="498" alt="image" src="https://github.com/user-attachments/assets/618c9ba7-dfe4-4f35-84e8-7afee7be31b6" />


#### Change list

- Make `Color` and `Position` types `readonly`
- Make other prop values that are array or array accessors `readonly`, e.g. normals, scales, domains
- Type changes necessary to pass type check
- fix: MultiIconLayer was mutating the incoming `outlineColor`