### PR TITLE
feat(widgets) InfoWidget: properly calculate popup position

### DIFF
--- a/docs/api-reference/widgets/info-widget.md
+++ b/docs/api-reference/widgets/info-widget.md
@@ -23,10 +23,10 @@ import {_InfoWidget as InfoWidget} from '@deck.gl/widgets';
 new Deck({
   widgets: [
     new InfoWidget({
-      visible: true,
-      position: [0.45, 51.47],
-      text: "Info",
-      style: {width: 200, boxShadow: 'rgba(0, 0, 0, 0.5) 2px 2px 5px'}
+      getTooltip: (info) => ({
+        text: 'Info'
+      }),
+      style: {width: '200px', boxShadow: 'rgba(0, 0, 0, 0.5) 2px 2px 5px'}
     })
   ]
 });
@@ -38,24 +38,6 @@ new Deck({
 
 The `InfoWidget` accepts the generic [`WidgetProps`](../core/widget.md#widgetprops) and:
 
-#### position ([number, number]) {#position}
-
-* Default: `[0, 0]`
-
-Position at which to place popup (e.g. [longitude, latitude]).
-
-#### text (string, optional) {#text}
-
-* Default: `''`
-
-Text to display within widget.
-
-#### visible (boolean, optional) {#visible}
-
-* Default: `false`
-
-Whether the widget is visible.
-
 #### mode (string, optional) {#mode}
 
 * Default: `'hover'`
@@ -63,7 +45,6 @@ Whether the widget is visible.
 Determines the interaction mode of the widget:
 * `'click'`: The widget is triggered by a user click.
 * `'hover'`: The widget is triggered when the user hovers over an element.
-* `'static'`: The widget remains visible at a fixed position.
 
 #### minOffset (number, optional) {#minoffset}
 
@@ -71,25 +52,43 @@ Determines the interaction mode of the widget:
 
 Minimum offset (in pixels) to keep the popup away from the canvas edges.
 
-#### getTooltip (Function, optional) {#gettooltip}
+#### getTooltip (Function) {#gettooltip}
 
 ```ts
-(info: PickingInfo, widget: InfoWidget) => InfoWidgetProps | null
+(info: PickingInfo, widget: InfoWidget) => TooltipContent | null
 ```
 
-* Default: `undefined`
+Function to generate the popup contents from the selected element. The returned object may contain the following fields:
 
-Function to generate the popup contents from the selected element.
+* `position` (`number[]`) - Anchor of the popup in world coordinates, e.g. [longitude, latitude]. If not supplied, default to the mouse position where the popup was triggered.
+* `text` (`string`) - Text content to display in the popup
+* `html` (`string`) - HTML content to display in the popup. If supplied, `text` is ignored.
+* `element` (`HTMLElement`) - HTML element to attach to the popup
+* `className` (`string`) - additional class name to add to the popup
+* `style` - CSS style overrides
 
-#### onClick (Function, optional) {#onclick}
+#### placement (string, optional) {#placement}
 
-```ts
-(widget: InfoWidget, info: PickingInfo) => boolean
-```
+Position content relative to the anchor.
+One of `bottom` | `left` | `right` | `top` | `bottom-start` | `bottom-end` | `left-start` | `left-end` | `right-start` | `right-end` | `top-start` | `top-end`
 
-* Default: `undefined`
+* Default: `'right'`
 
-Callback triggered when the widget is clicked.
+#### offset (number) {#offset}
+
+Pixel offset from the anchor
+
+* Default: `10`
+
+#### arrow (false | number | [number, number]) {#arrow}
+
+Show an arrow pointing at the anchor. Value can be one of the following:
+
+* `false` - do not display an arrow
+* `number` - pixel size of the arrow
+* `[width: number, height: number]` - pixel size of the arrow
+
+* Default: `10`
 
 ## Source
 

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -46,6 +46,7 @@
   },
   "peerDependencies": {
     "@deck.gl/core": "~9.2.0",
+    "@floating-ui/dom": "^1.7.5",
     "@luma.gl/core": "~9.2.6"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"

--- a/modules/widgets/src/info-widget.tsx
+++ b/modules/widgets/src/info-widget.tsx
@@ -5,43 +5,67 @@
 import {Widget} from '@deck.gl/core';
 import type {Deck, PickingInfo, Viewport, WidgetProps} from '@deck.gl/core';
 import {render, JSX} from 'preact';
+import {Popover, type PopoverProps} from './lib/components/popover';
+import {UserContent} from './lib/components/user-content';
+
+export type TooltipContent = {
+  /** Anchor of the popup in world coordinates, e.g. [longitude, latitude].
+   * If not supplied, default to the mouse position where the popup was triggered.
+   */
+  position?: number[];
+  /** Text content to display in the popup */
+  text?: string;
+  /** HTML content to display in the popup. If supplied, `text` is ignored. */
+  html?: string;
+  /** HTML element to attach inside the popup. */
+  element?: HTMLElement | null;
+  /** Custom class name to add to the popup */
+  className?: string;
+  /** CSS style overrides of the popup */
+  style?: Partial<CSSStyleDeclaration>;
+};
 
 export type InfoWidgetProps = WidgetProps & {
   /** View to attach to and interact with. Required when using multiple views */
   viewId?: string | null;
   /** Determines the interaction mode of the widget */
-  mode: 'click' | 'hover' | 'static';
+  mode: 'click' | 'hover';
   /** Function to generate the popup contents from the selected element */
-  getTooltip?: (info: PickingInfo, widget: InfoWidget) => InfoWidgetProps | null;
-  /** Position at which to place popup (clicked point: [longitude, latitude]) */
-  position: [number, number];
-  /** Text content of popup */
-  text?: string;
-  /** Visibility of info widget */
-  visible?: boolean;
-  /** Minimum offset (in pixels) to keep the popup away from the canvas edges. */
-  minOffset?: number;
-  /** Callback triggered when the widget is clicked. */
-  onClick?: (widget: InfoWidget, info: PickingInfo) => boolean;
+  getTooltip?: (
+    info: PickingInfo,
+    widget: InfoWidget
+  ) => TooltipContent | string | null | undefined;
+  /** Position popup relative to the anchor.
+   * @default 'right'
+   */
+  placement?: PopoverProps['placement'];
+  /** Pixel offset
+   * @default 10
+   */
+  offset?: PopoverProps['offset'];
+  /**
+   * Show an arrow pointing at the anchor. Optionally accepts a pixel size.
+   * @default 10
+   */
+  arrow?: PopoverProps['arrow'];
 };
 
 export class InfoWidget extends Widget<InfoWidgetProps> {
   static defaultProps: Required<InfoWidgetProps> = {
     ...Widget.defaultProps,
     id: 'info',
-    position: [0, 0],
-    text: '',
-    visible: false,
-    minOffset: 0,
     viewId: null,
     mode: 'hover',
     getTooltip: undefined!,
-    onClick: undefined!
+    placement: 'right',
+    offset: 10,
+    arrow: 10
   };
 
   className = 'deck-widget-info';
   placement = 'fill' as const;
   viewport?: Viewport;
+  tooltip: Required<TooltipContent> | null = null;
 
   constructor(props: InfoWidgetProps) {
     super(props);
@@ -53,11 +77,8 @@ export class InfoWidget extends Widget<InfoWidgetProps> {
     super.setProps(props);
   }
 
-  onCreateRootElement(): HTMLDivElement {
-    const element = super.onCreateRootElement();
-    const style = {margin: '0px', top: '0px', left: '0px', position: 'absolute'};
-    Object.entries(style).forEach(([key, value]) => element.style.setProperty(key, value));
-    return element;
+  onAdd({deck}: {deck: Deck<any>; viewId: string | null}) {
+    this.deck = deck;
   }
 
   onViewportChange(viewport) {
@@ -66,156 +87,77 @@ export class InfoWidget extends Widget<InfoWidgetProps> {
   }
 
   onHover(info: PickingInfo): void {
-    if (this.props.mode === 'hover' && this.props.getTooltip) {
-      const tooltip = this.props.getTooltip(info, this);
-      // hover tooltips should show over static and click infos
-      this.setProps({
-        visible: tooltip !== null,
-        ...tooltip,
-        style: {zIndex: '1', ...tooltip?.style}
-      });
+    if (this.props.mode === 'hover') {
+      this.tooltip = this._getTooltip(info);
     }
   }
 
-  onClick(info: PickingInfo): boolean {
-    if (this.props.mode === 'click' && this.props.getTooltip) {
-      const tooltip = this.props.getTooltip(info, this);
-      this.setProps({
-        visible: tooltip !== null,
-        ...tooltip
-      });
-      return tooltip !== null;
+  onClick(info: PickingInfo): void {
+    if (this.props.mode === 'click') {
+      this.tooltip = this._getTooltip(info);
     }
-
-    // Original behavior
-    return this.props.onClick?.(this, info) || false;
   }
 
-  onAdd({deck, viewId}: {deck: Deck<any>; viewId: string | null}) {
-    this.deck = deck;
-    if (!viewId) {
-      this.viewport = deck.getViewports()[0];
-    } else {
-      this.viewport = deck.getViewports().find(viewport => viewport.id === viewId);
-    }
+  protected _getTooltip(info: PickingInfo): Required<TooltipContent> | null {
+    if (!this.props.getTooltip) return null;
+
+    const content = this.props.getTooltip(info, this) ?? null;
+    if (content === null) return null;
+    const normalizedTooltip: TooltipContent =
+      typeof content === 'string' ? {text: content} : content;
+
+    const position = normalizedTooltip.position || info.coordinate;
+    if (!position) return null;
+
+    return {
+      position,
+      text: '',
+      html: '',
+      element: null,
+      className: '',
+      style: {},
+      ...normalizedTooltip
+    };
   }
 
   onRenderHTML(rootElement: HTMLElement): void {
-    if (!this.viewport) {
+    if (!this.viewport || this.tooltip === null) {
+      render(null, rootElement);
       return;
     }
-    const [longitude, latitude] = this.props.position;
+    const style: Partial<CSSStyleDeclaration> = {
+      ...this.props.style,
+      ...this.tooltip.style
+    };
     // Project the clicked geographic coordinate to canvas (x, y)
-    const [x, y] = this.viewport.project([longitude, latitude]);
-
-    const minOffset = this.props.minOffset || 0;
-    const gap = 10; // gap between clicked point and popup box
-    const arrowHeight = 8; // height of the triangle arrow
-    const arrowWidth = 16; // full width of the arrow
-
-    // Decide vertical orientation.
-    // If the clicked point is in the bottom half, place the popup above the point.
-    const isAbove = y > this.viewport.height / 2;
-    const background = (this.props.style && this.props.style.background) || 'rgba(255,255,255,0.9)';
+    const [x, y] = this.viewport.project(this.tooltip.position);
+    const background = style.backgroundColor || style.background || 'white';
 
     // Render the popup container with a content box and a placeholder for the arrow.
     // The container is positioned absolutely (initially at 0,0) and will be repositioned after measuring.
-    const ui = this.props.visible ? (
-      <div className="popup-container" style={{position: 'absolute', left: 0, top: 0}}>
-        <div
-          className="popup-content"
+    const ui = (
+      <Popover
+        x={x}
+        y={y}
+        placement={this.props.placement}
+        arrow={this.props.arrow}
+        arrowColor={background}
+        offset={this.props.offset}
+      >
+        <UserContent
+          className={`deck-widget-popup-content ${this.tooltip.className} ${this.props.className}`}
           style={{
             background,
             padding: '10px',
-            position: 'relative',
-            // Include any additional styles
-            ...(this.props.style as JSX.CSSProperties)
+            boxShadow: '2px 2px 8px rgba(0, 0, 0, 0.15)',
+            ...(style as JSX.CSSProperties)
           }}
-        >
-          {this.props.text}
-        </div>
-        <div className="popup-arrow" style={{position: 'absolute', width: '0px', height: '0px'}} />
-      </div>
-    ) : null;
+          html={this.tooltip.html}
+          text={this.tooltip.text}
+          element={this.tooltip.element}
+        />
+      </Popover>
+    );
     render(ui, rootElement);
-
-    // After rendering, measure the content and adjust positioning so that:
-    // - The popup (with its arrow) does not cover the clicked point.
-    // - The arrow's tip points to the clicked point.
-    // - The popup remains within the canvas bounds, with minOffset.
-    // eslint-disable-next-line max-statements, complexity
-    requestAnimationFrame(() => {
-      if (!this.props.visible || !rootElement.firstChild || !this.viewport) return;
-
-      const container = rootElement.firstChild as HTMLElement;
-      const contentEl = container.querySelector('.popup-content') as HTMLElement;
-      const arrowEl = container.querySelector('.popup-arrow') as HTMLElement;
-      if (!contentEl || !arrowEl) return;
-      const contentRect = contentEl.getBoundingClientRect();
-      const popupWidth = contentRect.width;
-      const popupHeight = contentRect.height;
-
-      // Compute ideal horizontal position: center the popup on the clicked x
-      let computedLeft = x - popupWidth / 2;
-      // Compute vertical position based on orientation:
-      // If the popup is above, position its bottom edge (minus arrow & gap) at the clicked y.
-      // Otherwise, position its top edge (plus arrow & gap) at the clicked y.
-      let computedTop;
-      if (isAbove) {
-        computedTop = y - gap - arrowHeight - popupHeight;
-      } else {
-        computedTop = y + gap + arrowHeight;
-      }
-
-      // Ensure the popup (content) stays within horizontal bounds of the canvas
-      if (computedLeft < minOffset) {
-        computedLeft = minOffset;
-      }
-      if (computedLeft + popupWidth > this.viewport.width - minOffset) {
-        computedLeft = this.viewport.width - minOffset - popupWidth;
-      }
-
-      // Ensure the vertical position (including the arrow) stays within canvas bounds.
-      if (isAbove) {
-        if (computedTop < minOffset) {
-          computedTop = minOffset;
-        }
-      } else if (computedTop + popupHeight + arrowHeight > this.viewport.height - minOffset) {
-        computedTop = this.viewport.height - minOffset - popupHeight - arrowHeight;
-      }
-
-      // Update container position (remove any transform and set left/top explicitly)
-      container.style.left = `${computedLeft}px`;
-      container.style.top = `${computedTop}px`;
-      container.style.transform = '';
-
-      // Compute arrow's horizontal offset relative to the container.
-      // We want the arrow's tip to align with the clicked point.
-      let arrowLeft = x - computedLeft - arrowWidth / 2;
-      // Optionally constrain arrowLeft so it stays within the popup's width.
-      arrowLeft = Math.max(arrowLeft, 0);
-      arrowLeft = Math.min(arrowLeft, popupWidth - arrowWidth);
-
-      // Update arrow element's style based on orientation.
-      if (isAbove) {
-        // Popup is above the clicked point so arrow appears at the bottom of the popup.
-        arrowEl.style.left = `${arrowLeft}px`;
-        arrowEl.style.bottom = `-${arrowHeight}px`;
-        arrowEl.style.top = '';
-        arrowEl.style.borderLeft = `${arrowWidth / 2}px solid transparent`;
-        arrowEl.style.borderRight = `${arrowWidth / 2}px solid transparent`;
-        arrowEl.style.borderTop = `${arrowHeight}px solid ${background}`;
-        arrowEl.style.borderBottom = '';
-      } else {
-        // Popup is below the clicked point so arrow appears at the top.
-        arrowEl.style.left = `${arrowLeft}px`;
-        arrowEl.style.top = `-${arrowHeight}px`;
-        arrowEl.style.bottom = '';
-        arrowEl.style.borderLeft = `${arrowWidth / 2}px solid transparent`;
-        arrowEl.style.borderRight = `${arrowWidth / 2}px solid transparent`;
-        arrowEl.style.borderBottom = `${arrowHeight}px solid ${background}`;
-        arrowEl.style.borderTop = '';
-      }
-    });
   }
 }

--- a/modules/widgets/src/lib/components/popover.tsx
+++ b/modules/widgets/src/lib/components/popover.tsx
@@ -1,0 +1,164 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+import type {JSX, ComponentChildren} from 'preact';
+import {useRef, useEffect, useMemo} from 'preact/hooks';
+import {createPortal} from 'preact/compat';
+import {
+  computePosition,
+  flip,
+  shift,
+  offset,
+  arrow,
+  type Placement,
+  type ComputePositionConfig
+} from '@floating-ui/dom';
+
+export type PopoverProps = {
+  /** Anchor x */
+  x: number;
+  /** Anchor y */
+  y: number;
+  /** Position content relative to the anchor.
+   * @default 'right'
+   */
+  placement?: Placement;
+  /** Pixel offset
+   * @default 0
+   */
+  offset?: number;
+  /**
+   * Show an arrow pointing at the anchor. Optionally accepts a pixel size.
+   * @default false
+   */
+  arrow?: false | number | [width: number, height: number];
+  /**
+   * CSS color of the arrow
+   * @default 'white'
+   */
+  arrowColor?: string;
+  /** Content of the popover */
+  children: ComponentChildren;
+};
+
+export const Popover = ({
+  x,
+  y,
+  placement = 'right',
+  offset: pixelOffset = 0,
+  arrow: arrowSize = false,
+  arrowColor = 'white',
+  children
+}: PopoverProps) => {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const arrowRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = () => {
+    if (!anchorRef.current || !contentRef.current) return;
+
+    const arrowWidth = Array.isArray(arrowSize) ? arrowSize[0] : arrowSize || 0;
+    const arrowHeight = Array.isArray(arrowSize) ? arrowSize[1] : arrowSize || 0;
+    const padding = pixelOffset + Math.max(arrowHeight, arrowWidth);
+
+    const middleware: ComputePositionConfig['middleware'] = placement.includes('-')
+      ? [offset(padding), flip(), shift()]
+      : [offset(padding), shift(), flip()];
+    if (arrowRef.current) middleware.push(arrow({element: arrowRef.current}));
+    computePosition(anchorRef.current, contentRef.current, {
+      placement,
+      strategy: 'fixed',
+      middleware
+    }).then(popoverPos => {
+      if (contentRef.current) {
+        Object.assign(contentRef.current.style, {
+          left: `${popoverPos.x}px`,
+          top: `${popoverPos.y}px`
+        });
+      }
+
+      const arrowData = popoverPos.middlewareData.arrow;
+      if (arrowData && arrowRef.current) {
+        const arrowStyle = createArrow(arrowWidth, arrowHeight, arrowColor, popoverPos.placement);
+        arrowStyle.transform = `translate(${arrowData.x || 0}px, ${arrowData.y || 0}px)`;
+        Object.assign(arrowRef.current.style, arrowStyle);
+      }
+    });
+  };
+
+  useMemo(() => {
+    updatePosition();
+  }, [x, y, placement, arrowSize, pixelOffset, children]);
+
+  useEffect(() => {
+    // initial mount
+    updatePosition();
+    if (contentRef.current) {
+      contentRef.current.style.visibility = 'visible';
+    }
+  }, []);
+
+  return (
+    <div style={{position: 'absolute', left: x, top: y}} ref={anchorRef}>
+      {createPortal(
+        <div
+          className="deck-widget deck-widget-popover"
+          style={{position: 'fixed', visibility: 'hidden', pointerEvents: 'none'}}
+          ref={contentRef}
+        >
+          {Boolean(arrowSize) && (
+            <div
+              className="deck-widget-popover-arrow"
+              style={{position: 'absolute'}}
+              ref={arrowRef}
+            />
+          )}
+          {children}
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+};
+
+function createArrow(
+  width: number,
+  height: number,
+  color: string,
+  placement: Placement
+): JSX.CSSProperties {
+  const result: JSX.CSSProperties = {
+    width: 0,
+    height: 0,
+    top: '',
+    bottom: '',
+    left: '',
+    right: ''
+  };
+  if (placement.startsWith('bottom')) {
+    result.borderLeft = `${width / 2}px solid transparent`;
+    result.borderRight = `${width / 2}px solid transparent`;
+    result.borderBottom = `${height}px solid ${color}`;
+    result.borderTop = '';
+    result.top = `${-height}px`;
+  } else if (placement.startsWith('top')) {
+    result.borderLeft = `${width / 2}px solid transparent`;
+    result.borderRight = `${width / 2}px solid transparent`;
+    result.borderTop = `${height}px solid ${color}`;
+    result.borderBottom = '';
+    result.bottom = `${-height}px`;
+  } else if (placement.startsWith('right')) {
+    result.borderTop = `${width / 2}px solid transparent`;
+    result.borderBottom = `${width / 2}px solid transparent`;
+    result.borderRight = `${height}px solid ${color}`;
+    result.borderLeft = '';
+    result.left = `${-height}px`;
+  } else if (placement.startsWith('left')) {
+    result.borderTop = `${width / 2}px solid transparent`;
+    result.borderBottom = `${width / 2}px solid transparent`;
+    result.borderLeft = `${height}px solid ${color}`;
+    result.borderRight = '';
+    result.right = `${-height}px`;
+  }
+  return result;
+}

--- a/modules/widgets/src/lib/components/user-content.tsx
+++ b/modules/widgets/src/lib/components/user-content.tsx
@@ -1,0 +1,30 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+import type {JSX, ComponentChildren} from 'preact';
+import {useEffect, useRef} from 'preact/hooks';
+
+export type UserContentProps = JSX.HTMLAttributes<HTMLDivElement> & {
+  text?: string;
+  html?: string;
+  element?: HTMLElement | null;
+};
+
+export const UserContent = ({text, html, element, ...props}: UserContentProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (containerRef.current && element) {
+      containerRef.current.append(element);
+    }
+    return () => {
+      element?.remove();
+    };
+  }, [element]);
+
+  return (
+    <div ref={containerRef} {...props} dangerouslySetInnerHTML={html ? {__html: html} : undefined}>
+      {text}
+    </div>
+  );
+};

--- a/modules/widgets/src/stylesheet.css
+++ b/modules/widgets/src/stylesheet.css
@@ -432,3 +432,8 @@
   background-color: var(--button-background, #fff);
   color: var(--button-text, rgb(24, 24, 26));
 }
+
+/* Popup styles */
+.deck-widget.deck-widget-popover {
+  margin: 0 !important;
+}

--- a/test/apps/widgets-9.2/app.ts
+++ b/test/apps/widgets-9.2/app.ts
@@ -89,6 +89,7 @@ function getLayers(filterRange = [2, 9]) {
 }
 
 const deck = new Deck({
+  parent: document.getElementById('app'),
   initialViewState: INITIAL_VIEW_STATE,
   controller: true,
   layers: getLayers(),
@@ -120,8 +121,8 @@ const deck = new Deck({
         );
       }
     }),
-    new _InfoWidget({mode: 'hover', getTooltip}),
-    new _InfoWidget({mode: 'click', getTooltip}),
+    new _InfoWidget({mode: 'hover', getTooltip, arrow: 10, offset: 10}),
+    new _InfoWidget({mode: 'click', getTooltip, arrow: 10, offset: 10}),
     new _TimelineWidget({
       placement: 'bottom-left',
       timeRange: [2, 9],
@@ -162,6 +163,6 @@ ${info.object.properties.featureclass} (${info.object.properties.location})
   return {
     position: info.object.geometry.coordinates,
     text,
-    style: {width: 200, boxShadow: 'rgba(0, 0, 0, 0.5) 2px 2px 5px'}
+    style: {minWidth: '200px'}
   };
 }

--- a/test/apps/widgets-9.2/index.html
+++ b/test/apps/widgets-9.2/index.html
@@ -4,9 +4,11 @@
     <meta charset="utf-8">
     <title>deck.gl Example</title>
     <style>
-      body {margin: 0; width: 100vw; height: 100vh; overflow: hidden;}
+      #app {position: fixed; top: 15vh; right: 0; width: 50vw; height: 70vh; overflow: hidden;}
     </style>
   </head>
-  <body></body>
+  <body>
+    <div id="app" ></div>
+  </body>
   <script type="module" src="app.ts"></script>
 </html>


### PR DESCRIPTION
Use [floating-ui](https://floating-ui.com/) (formerly popper) to calculate popup position.

- Allow Popup to escape from deck's clipping rectangle
- Smarter placement and more customizable options
- The new dependency is a small and very well tested module (>40M weekly downloads, already a nested dependency from arcgis)

Changes to InfoWidget (experimental export):

- Remove static mode (adding a new PopupWidget in a follow up PR, as discussed)
- Some props are dropped, mainly affecting static mode
- Avoid overwriting user props from a callback (flaky pattern)