### PR TITLE
fix(widgets): FullscreenWidget widget default container

### DIFF
--- a/modules/widgets/src/fullscreen-widget.tsx
+++ b/modules/widgets/src/fullscreen-widget.tsx
@@ -74,7 +74,7 @@ export class FullscreenWidget extends Widget<FullscreenWidgetProps> {
   }
 
   getContainer() {
-    return this.props.container || this.deck?.getCanvas()?.parentElement;
+    return this.props.container || this.deck?.props.parent || this.deck?.getCanvas()?.parentElement;
   }
 
   onFullscreenChange() {


### PR DESCRIPTION
Fallout from #8893 root container is no longer the direct parent of deck canvas

#### Change List
- Update default container of FullscreenWidget
