### PR TITLE
fix(widgets): ResetViewWidget default viewId

### DIFF
--- a/modules/widgets/src/reset-view-widget.tsx
+++ b/modules/widgets/src/reset-view-widget.tsx
@@ -70,14 +70,16 @@ export class ResetViewWidget<ViewsT extends ViewOrViews = null> extends Widget<
   }
 
   setViewState(viewState?: ViewStateMap<ViewsT>) {
-    const viewId = (this.props.viewId || 'default-view') as unknown as string;
-    const nextViewState = {
-      ...(viewId !== 'default-view' ? viewState?.[viewId] : viewState)
-      // only works for geospatial?
-      // transitionDuration: this.props.transitionDuration,
-      // transitionInterpolator: new FlyToInterpolator()
-    };
-    // @ts-ignore Using private method temporary until there's a public one
-    this.deck._onViewStateChange({viewId, viewState: nextViewState, interactionState: {}});
+    const viewIds = this.viewId ? [this.viewId] : (this.deck?.getViews().map(v => v.id) ?? []);
+    for (const viewId of viewIds) {
+      const nextViewState = {
+        ...(viewState?.[viewId] ?? viewState)
+        // only works for geospatial?
+        // transitionDuration: this.props.transitionDuration,
+        // transitionInterpolator: new FlyToInterpolator()
+      };
+      // @ts-ignore Using private method temporary until there's a public one
+      this.deck._onViewStateChange({viewId, viewState: nextViewState, interactionState: {}});
+    }
   }
 }

--- a/test/apps/widgets-9.2/app.ts
+++ b/test/apps/widgets-9.2/app.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, PickingInfo} from '@deck.gl/core';
+import {Deck, MapView, PickingInfo} from '@deck.gl/core';
 import {DataFilterExtension} from '@deck.gl/extensions';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {_WMSLayer as WMSLayer} from '@deck.gl/geo-layers';
@@ -91,6 +91,7 @@ function getLayers(filterRange = [2, 9]) {
 
 const deck = new Deck({
   parent: document.getElementById('app'),
+  views: new MapView({repeat: true}),
   initialViewState: INITIAL_VIEW_STATE,
   controller: true,
   layers: getLayers(),


### PR DESCRIPTION
Currently, if no `viewId` is explicitly passed to `ResetViewWidget`, it does not do anything unless there is a view named `default-view`.

This PR makes the widget reset all views if `viewId` is not specified. This is probably different from the intended behavior, but more consistent with how `viewId` is [documented](https://deck.gl/docs/api-reference/core/widget#viewid).

#### Change List
- ResetViewWidget viewId fallback
