### PR TITLE
fix: updates pydeck pyproject.toml to include dynamic field

### DIFF
--- a/bindings/pydeck/pyproject.toml
+++ b/bindings/pydeck/pyproject.toml
@@ -2,6 +2,7 @@
 name = "pydeck"
 version = "0.9.1"
 requires-python = ">=3.8"
+dynamic = ["readme", "license", "authors", "keywords", "classifiers", "dependencies", "optional-dependencies", "description", "urls"]
 
 [build-system]
 requires = [


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #10047

<!-- For other PRs without open issue -->
#### Background

pydeck's pyproject.toml has a minimal [project] table (only name, version, requires-python) while all package metadata — description, readme, license, authors, keywords, classifiers, dependencies, optional-dependencies — is defined in setup.py. Modern setuptools requires that any field defined outside of pyproject.toml be explicitly declared in dynamic; without it, setuptools silently ignores those values.

The fatal error is specifically caused by readme not being listed as dynamic:
AttributeError: 'NoneType' object has no attribute 'get'

Because readme is not declared dynamic, setuptools passes None to its internal _long_description handler instead of the actual value from setup.py, which then crashes when it tries to call .get() on it.

After the updates, the wheel builds successfully:

```
pip wheel --no-build-isolation --no-deps ./bindings/pydeck
Processing ./bindings/pydeck
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: pydeck
  Building wheel for pydeck (pyproject.toml) ... done
  Created wheel for pydeck: filename=pydeck-0.9.1-py2.py3-none-any.whl size=11298026 sha256=64b5aba3cf88d686252ba2569c0a858f7a248d0ac8b4d4799a7c60c79cdcf6c8
  Stored in directory: /private/var/folders/gk/l1x3q77d4snf5jvdzc3p22gr0000gn/T/pip-ephem-wheel-cache-s1dq9z1m/wheels/6b/71/9d/da53b57ba8918522003c452495d63608573606f0ad1166f7c3
Successfully built pydeck
```

<!-- For all the PRs -->
#### Change List
- updates pydeck pyproject.toml to include dynamic field

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging-only change that affects how metadata is sourced during builds, with no runtime behavior impact.
> 
> **Overview**
> Ensures `pydeck` builds correctly with modern setuptools by adding a `dynamic` list to `bindings/pydeck/pyproject.toml`, allowing metadata (e.g., `readme`, `license`, `authors`, and dependency fields) to be populated from `setup.py` instead of being ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79816b75a8d8e7927552343666720719979ab4c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->