### PR TITLE
feat(core): add explicit WebGPU buffer groups

### DIFF
--- a/modules/core/src/lib/attribute/attribute-buffer-groups.ts
+++ b/modules/core/src/lib/attribute/attribute-buffer-groups.ts
@@ -1,0 +1,313 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import Attribute from './attribute';
+import {getStride} from './gl-utils';
+
+import {Buffer} from '@luma.gl/core';
+import type {BufferAttributeLayout, BufferLayout, Device} from '@luma.gl/core';
+
+type ModelInfo = {
+  isInstanced?: boolean;
+};
+
+type PackedGroup = {
+  id: string;
+  attributes: Attribute[];
+  layout: BufferLayout;
+  byteStride: number;
+  byteOffsets: Record<string, number>;
+  rowCount: number;
+};
+
+type PackedGroupState = {
+  buffer: Buffer;
+  layoutKey: string;
+};
+
+/** Internal bindings produced for explicitly grouped WebGPU attributes. */
+export type AttributeBufferGroupBindings = {
+  /** Layouts for the current model, including ungrouped fallback attributes. */
+  bufferLayouts: BufferLayout[];
+  /** Shared vertex buffers keyed by group id. */
+  buffers: Record<string, Buffer>;
+  /** Source attribute ids consumed by shared buffers. */
+  groupedAttributeIds: Set<string>;
+};
+
+/**
+ * Packs explicitly grouped CPU-backed attributes into additional WebGPU vertex buffers.
+ *
+ * This intentionally does not replace Attribute-owned buffers. Keeping the legacy upload path
+ * intact makes unsupported states safe to fall back to and keeps this 9.4 compatibility path
+ * isolated from existing WebGL behavior.
+ */
+export default class AttributeBufferGroups {
+  private device: Device;
+  private id: string;
+  private isTransitionAttribute: (attributeName: string) => boolean;
+  private packedBuffers: Record<string, PackedGroupState> = {};
+
+  constructor(
+    device: Device,
+    {
+      id,
+      isTransitionAttribute
+    }: {
+      id: string;
+      isTransitionAttribute: (attributeName: string) => boolean;
+    }
+  ) {
+    this.device = device;
+    this.id = id;
+    this.isTransitionAttribute = isTransitionAttribute;
+  }
+
+  /** Returns whether any attributes explicitly request WebGPU grouping. */
+  hasGroups(attributes: Record<string, Attribute>): boolean {
+    return (
+      this.device.type === 'webgpu' &&
+      Object.values(attributes).some(attribute => Boolean(attribute.settings.bufferGroup))
+    );
+  }
+
+  /** Deletes shared buffers created by this helper. */
+  finalize(): void {
+    for (const state of Object.values(this.packedBuffers)) {
+      state.buffer.delete();
+    }
+    this.packedBuffers = {};
+  }
+
+  /**
+   * Returns constructor-time layouts. Values may not exist yet, so runtime-only fallbacks are
+   * resolved by {@link getBindings} before the first draw.
+   */
+  getBufferLayouts(attributes: Record<string, Attribute>, modelInfo?: ModelInfo): BufferLayout[] {
+    const groups = this._getPackedGroups(attributes, modelInfo, {
+      requireValues: false,
+      excludeAttributes: {}
+    });
+    return this._getBufferLayouts(attributes, groups, modelInfo);
+  }
+
+  /** Returns runtime layouts and shared buffers for a grouped WebGPU model update. */
+  getBindings(
+    attributes: Record<string, Attribute>,
+    changedAttributes: Record<string, Attribute>,
+    modelInfo: ModelInfo | undefined,
+    excludeAttributes: Record<string, boolean>
+  ): AttributeBufferGroupBindings {
+    const groups = this._getPackedGroups(attributes, modelInfo, {
+      requireValues: true,
+      excludeAttributes
+    });
+    const buffers: Record<string, Buffer> = {};
+    const groupedAttributeIds = new Set<string>();
+
+    for (const group of groups.values()) {
+      const needsUpload =
+        !this.packedBuffers[group.id] ||
+        group.attributes.some(attribute => Boolean(changedAttributes[attribute.id]));
+      buffers[group.id] = this._getPackedBuffer(group, needsUpload);
+      for (const attribute of group.attributes) {
+        groupedAttributeIds.add(attribute.id);
+      }
+    }
+
+    return {
+      bufferLayouts: this._getBufferLayouts(attributes, groups, modelInfo),
+      buffers,
+      groupedAttributeIds
+    };
+  }
+
+  private _getPackedGroups(
+    attributes: Record<string, Attribute>,
+    modelInfo: ModelInfo | undefined,
+    {
+      requireValues,
+      excludeAttributes
+    }: {
+      requireValues: boolean;
+      excludeAttributes: Record<string, boolean>;
+    }
+  ): Map<string, PackedGroup> {
+    const groupedAttributes = new Map<string, Attribute[]>();
+
+    for (const attribute of Object.values(attributes)) {
+      const groupId = attribute.settings.bufferGroup;
+      if (!groupId) {
+        continue;
+      }
+      const group = groupedAttributes.get(groupId) || [];
+      group.push(attribute);
+      groupedAttributes.set(groupId, group);
+    }
+
+    const packedGroups = new Map<string, PackedGroup>();
+    for (const [groupId, groupAttributes] of groupedAttributes) {
+      const group = this._getPackedGroup(
+        groupId,
+        groupAttributes,
+        modelInfo,
+        requireValues,
+        excludeAttributes
+      );
+      if (group) {
+        packedGroups.set(groupId, group);
+      }
+    }
+    return packedGroups;
+  }
+
+  // eslint-disable-next-line complexity
+  private _getPackedGroup(
+    id: string,
+    attributes: Attribute[],
+    modelInfo: ModelInfo | undefined,
+    requireValues: boolean,
+    excludeAttributes: Record<string, boolean>
+  ): PackedGroup | null {
+    if (attributes.length < 2) {
+      return null;
+    }
+
+    const layouts = attributes.map(attribute => attribute.getBufferLayout(modelInfo));
+    const stepMode = layouts[0].stepMode;
+    const rowCount = Math.max(1, attributes[0].numInstances);
+
+    for (let index = 0; index < attributes.length; index++) {
+      const attribute = attributes[index];
+      const accessor = attribute.getAccessor();
+      const naturalStride = attribute.size * accessor.bytesPerElement;
+
+      if (
+        excludeAttributes[attribute.id] ||
+        attribute.settings.isIndexed ||
+        attribute.settings.noAlloc ||
+        attribute.doublePrecision ||
+        this.isTransitionAttribute(attribute.id) ||
+        layouts[index].stepMode !== stepMode ||
+        attribute.numInstances !== attributes[0].numInstances ||
+        (accessor.offset || 0) !== 0 ||
+        (accessor.vertexOffset || 0) !== 0 ||
+        getStride(accessor) !== naturalStride ||
+        (requireValues &&
+          (!ArrayBuffer.isView(attribute.value) ||
+            attribute.value.byteLength < rowCount * naturalStride))
+      ) {
+        return null;
+      }
+    }
+
+    const byteOffsets: Record<string, number> = {};
+    const layoutAttributes: BufferAttributeLayout[] = [];
+    let byteStride = 0;
+
+    for (let index = 0; index < attributes.length; index++) {
+      const attribute = attributes[index];
+      byteStride = alignTo4(byteStride);
+      byteOffsets[attribute.id] = byteStride;
+      for (const layoutAttribute of layouts[index].attributes || []) {
+        layoutAttributes.push({
+          ...layoutAttribute,
+          byteOffset: byteStride + (layoutAttribute.byteOffset || 0)
+        });
+      }
+      byteStride += getStride(attribute.getAccessor());
+    }
+
+    byteStride = alignTo4(byteStride);
+    return {
+      id,
+      attributes,
+      byteStride,
+      byteOffsets,
+      rowCount,
+      layout: {
+        name: id,
+        byteStride,
+        stepMode,
+        attributes: layoutAttributes
+      }
+    };
+  }
+
+  private _getBufferLayouts(
+    attributes: Record<string, Attribute>,
+    groups: Map<string, PackedGroup>,
+    modelInfo?: ModelInfo
+  ): BufferLayout[] {
+    const layouts: BufferLayout[] = [];
+    const emittedGroups = new Set<string>();
+    const groupedAttributeIds = new Set<string>();
+
+    for (const group of groups.values()) {
+      for (const attribute of group.attributes) {
+        groupedAttributeIds.add(attribute.id);
+      }
+    }
+
+    for (const attribute of Object.values(attributes)) {
+      const groupId = attribute.settings.bufferGroup;
+      const group = groupId && groups.get(groupId);
+      if (group && groupedAttributeIds.has(attribute.id)) {
+        if (!emittedGroups.has(group.id)) {
+          layouts.push(group.layout);
+          emittedGroups.add(group.id);
+        }
+      } else {
+        layouts.push(attribute.getBufferLayout(modelInfo));
+      }
+    }
+
+    return layouts;
+  }
+
+  private _getPackedBuffer(group: PackedGroup, upload: boolean): Buffer {
+    const byteLength = group.rowCount * group.byteStride;
+    const layoutKey = JSON.stringify(group.layout);
+    let state = this.packedBuffers[group.id];
+
+    if (!state || state.buffer.byteLength < byteLength || state.layoutKey !== layoutKey) {
+      state?.buffer.delete();
+      state = {
+        buffer: this.device.createBuffer({
+          id: `${this.id}-${group.id}`,
+          usage: Buffer.VERTEX | Buffer.COPY_DST,
+          byteLength
+        }),
+        layoutKey
+      };
+      this.packedBuffers[group.id] = state;
+      upload = true;
+    }
+
+    if (upload) {
+      const data = new Uint8Array(byteLength);
+      for (const attribute of group.attributes) {
+        const value = attribute.value as ArrayBufferView;
+        const source = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+        const sourceStride = getStride(attribute.getAccessor());
+        const targetOffset = group.byteOffsets[attribute.id];
+
+        for (let row = 0; row < group.rowCount; row++) {
+          const sourceOffset = row * sourceStride;
+          data.set(
+            source.subarray(sourceOffset, sourceOffset + sourceStride),
+            row * group.byteStride + targetOffset
+          );
+        }
+      }
+      state.buffer.write(data);
+    }
+
+    return state.buffer;
+  }
+}
+
+function alignTo4(value: number): number {
+  return Math.ceil(value / 4) * 4;
+}

--- a/modules/core/src/lib/attribute/attribute-manager.ts
+++ b/modules/core/src/lib/attribute/attribute-manager.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable guard-for-in */
 import Attribute, {AttributeOptions} from './attribute';
+import AttributeBufferGroups, {type AttributeBufferGroupBindings} from './attribute-buffer-groups';
 import log from '../../utils/log';
 import memoize from '../../utils/memoize';
 import {mergeBounds} from '../../utils/math-utils';
@@ -56,6 +57,7 @@ export default class AttributeManager {
 
   private stats?: Stats;
   private attributeTransitionManager: AttributeTransitionManager;
+  private attributeBufferGroups: AttributeBufferGroups | null;
   private mergeBoundsMemoized: any = memoize(mergeBounds);
 
   constructor(
@@ -85,12 +87,21 @@ export default class AttributeManager {
       id: `${id}-transitions`,
       timeline
     });
+    this.attributeBufferGroups =
+      device.type === 'webgpu'
+        ? new AttributeBufferGroups(device, {
+            id,
+            isTransitionAttribute: attributeName =>
+              this.attributeTransitionManager.hasAttribute(attributeName)
+          })
+        : null;
 
     // For debugging sanity, prevent uninitialized members
     Object.seal(this);
   }
 
   finalize() {
+    this.attributeBufferGroups?.finalize();
     for (const attributeName in this.attributes) {
       this.attributes[attributeName].delete();
     }
@@ -301,8 +312,39 @@ export default class AttributeManager {
       isInstanced?: boolean;
     }
   ): BufferLayout[] {
+    if (this.hasBufferGroups()) {
+      return this.attributeBufferGroups!.getBufferLayouts(this.getAttributes(), modelInfo);
+    }
     return Object.values(this.getAttributes()).map(attribute =>
       attribute.getBufferLayout(modelInfo)
+    );
+  }
+
+  /** @internal Returns whether this WebGPU manager has explicitly grouped attributes. */
+  hasBufferGroups(): boolean {
+    return Boolean(this.attributeBufferGroups?.hasGroups(this.attributes));
+  }
+
+  /**
+   * @internal Resolves runtime layouts and additional shared buffers for a grouped WebGPU model.
+   */
+  getBufferGroupBindings(
+    changedAttributes: {[id: string]: Attribute},
+    modelInfo?: {isInstanced?: boolean},
+    excludeAttributes: Record<string, boolean> = {}
+  ): AttributeBufferGroupBindings {
+    if (!this.attributeBufferGroups) {
+      return {
+        bufferLayouts: this.getBufferLayouts(modelInfo),
+        buffers: {},
+        groupedAttributeIds: new Set<string>()
+      };
+    }
+    return this.attributeBufferGroups.getBindings(
+      this.getAttributes(),
+      changedAttributes,
+      modelInfo,
+      excludeAttributes
     );
   }
 

--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -49,6 +49,12 @@ export type AttributeOptions = DataColumnOptions<{
   transition?: boolean | Partial<TransitionSettings>;
   stepMode?: 'vertex' | 'instance' | 'dynamic';
   noAlloc?: boolean;
+  /**
+   * @internal
+   * WebGPU-only hint to publish compatible CPU-backed attributes through one shared vertex
+   * buffer. WebGL and unsupported grouped states retain the legacy standalone buffer path.
+   */
+  bufferGroup?: string;
   update?: Updater;
   accessor?: Accessor<any, any> | string | string[];
   transform?: (value: any) => any;

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -766,6 +766,7 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   }
 
   /** Apply changed attributes to model */
+  // eslint-disable-next-line max-statements
   protected _setModelAttributes(
     model: Model,
     changedAttributes: {
@@ -777,12 +778,18 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
       return;
     }
 
+    const attributeManager = this.getAttributeManager();
+    if (attributeManager?.hasBufferGroups()) {
+      this._setGroupedModelAttributes(model, attributeManager, changedAttributes);
+      return;
+    }
+
     if (bufferLayoutChanged) {
       // AttributeManager is always defined when this method is called
-      const attributeManager = this.getAttributeManager()!;
-      model.setBufferLayout(attributeManager.getBufferLayouts(model));
+      const manager = this.getAttributeManager()!;
+      model.setBufferLayout(manager.getBufferLayouts(model));
       // All attributes must be reset after buffer layout change
-      changedAttributes = attributeManager.getAttributes();
+      changedAttributes = manager.getAttributes();
     }
 
     // @ts-ignore luma.gl type issue
@@ -809,6 +816,52 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
       }
     }
     // TODO - update buffer map?
+    model.setAttributes(attributeBuffers);
+    model.setConstantAttributes(constantAttributes);
+  }
+
+  /** Apply explicit WebGPU buffer groups while preserving legacy bindings for fallbacks. */
+  private _setGroupedModelAttributes(
+    model: Model,
+    attributeManager: AttributeManager,
+    changedAttributes: {[id: string]: Attribute}
+  ) {
+    // @ts-ignore luma.gl type issue
+    const excludeAttributes = model.userData?.excludeAttributes || {};
+    const bindings = attributeManager.getBufferGroupBindings(
+      changedAttributes,
+      model,
+      excludeAttributes
+    );
+
+    // Runtime state can make a declared group temporarily ineligible, e.g. during transitions.
+    // Refreshing the layout here lets the group safely fall back to standalone bindings.
+    model.setBufferLayout(bindings.bufferLayouts);
+
+    const attributeBuffers: Record<string, Buffer> = {...bindings.buffers};
+    const constantAttributes: Record<string, TypedArray> = {};
+    const attributes = attributeManager.getAttributes();
+
+    for (const name in attributes) {
+      if (excludeAttributes[name] || bindings.groupedAttributeIds.has(name)) {
+        continue;
+      }
+      const attribute = attributes[name];
+      const values = attribute.getValue();
+      for (const attributeName in values) {
+        const value = values[attributeName];
+        if (value instanceof Buffer) {
+          if (attribute.settings.isIndexed) {
+            model.setIndexBuffer(value);
+          } else {
+            attributeBuffers[attributeName] = value;
+          }
+        } else if (value) {
+          constantAttributes[attributeName] = value;
+        }
+      }
+    }
+
     model.setAttributes(attributeBuffers);
     model.setConstantAttributes(constantAttributes);
   }

--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -171,11 +171,13 @@ export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       instanceSizes: {
         size: 1,
         transition: true,
+        bufferGroup: 'icon-instance-data',
         accessor: 'getSize',
         defaultValue: 1
       },
       instanceIconDefs: {
         size: 7,
+        bufferGroup: 'icon-instance-data',
         accessor: 'getIcon',
         // eslint-disable-next-line @typescript-eslint/unbound-method
         transform: this.getInstanceIconDef,
@@ -198,17 +200,20 @@ export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         size: this.props.colorFormat.length,
         type: 'unorm8',
         transition: true,
+        bufferGroup: 'icon-instance-data',
         accessor: 'getColor',
         defaultValue: DEFAULT_COLOR
       },
       instanceAngles: {
         size: 1,
         transition: true,
+        bufferGroup: 'icon-instance-data',
         accessor: 'getAngle'
       },
       instancePixelOffset: {
         size: 2,
         transition: true,
+        bufferGroup: 'icon-instance-data',
         accessor: 'getPixelOffset'
       },
       ...((this.props.data as any)?.attributes?.rowIndexes

--- a/test/modules/core/lib/attribute/attribute-buffer-groups.node.spec.ts
+++ b/test/modules/core/lib/attribute/attribute-buffer-groups.node.spec.ts
@@ -1,0 +1,348 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import AttributeManager from '@deck.gl/core/lib/attribute/attribute-manager';
+import {Layer} from '@deck.gl/core';
+import {IconLayer} from '@deck.gl/layers';
+import {test, expect, vi} from 'vitest';
+import {device} from '@deck.gl/test-utils/vitest';
+
+import type Attribute from '@deck.gl/core/lib/attribute/attribute';
+
+function createWebGPUDevice() {
+  return Object.defineProperty(Object.create(device), 'type', {value: 'webgpu'});
+}
+
+function addSimpleGroup(attributeManager: AttributeManager) {
+  attributeManager.addInstanced({
+    a: {size: 1, accessor: 'getA', bufferGroup: 'group-a'},
+    b: {size: 1, accessor: 'getB', bufferGroup: 'group-a'}
+  });
+}
+
+function updateSimpleGroup(
+  attributeManager: AttributeManager,
+  data: Array<{a: number; b: number}>,
+  buffers = {}
+) {
+  attributeManager.update({
+    numInstances: data.length,
+    data,
+    props: {
+      getA: (object: {a: number}) => object.a,
+      getB: (object: {b: number}) => object.b
+    },
+    transitions: {},
+    buffers,
+    context: {}
+  });
+}
+
+test('AttributeManager buffer groups are ignored on WebGL', () => {
+  const attributeManager = new AttributeManager(device);
+  addSimpleGroup(attributeManager);
+  updateSimpleGroup(attributeManager, [
+    {a: 1, b: 2},
+    {a: 3, b: 4}
+  ]);
+
+  expect(attributeManager.hasBufferGroups()).toBe(false);
+  expect(attributeManager.getBufferLayouts({isInstanced: true}).map(layout => layout.name)).toEqual(
+    ['a', 'b']
+  );
+
+  attributeManager.finalize();
+});
+
+test('AttributeManager without groups keeps WebGPU layouts unchanged', () => {
+  const attributeManager = new AttributeManager(createWebGPUDevice());
+  attributeManager.addInstanced({
+    a: {size: 1, accessor: 'getA'},
+    b: {size: 1, accessor: 'getB'}
+  });
+  updateSimpleGroup(attributeManager, [
+    {a: 1, b: 2},
+    {a: 3, b: 4}
+  ]);
+
+  expect(attributeManager.hasBufferGroups()).toBe(false);
+  expect(attributeManager.getBufferLayouts({isInstanced: true}).map(layout => layout.name)).toEqual(
+    ['a', 'b']
+  );
+
+  attributeManager.finalize();
+});
+
+test('AttributeManager buffer groups pack IconLayer-style shader attributes', async () => {
+  const attributeManager = new AttributeManager(createWebGPUDevice());
+  attributeManager.addInstanced({
+    a: {size: 1, accessor: 'getA', bufferGroup: 'group-a'},
+    iconDefs: {
+      size: 7,
+      accessor: 'getIcon',
+      bufferGroup: 'group-a',
+      shaderAttributes: {
+        offsets: {size: 2, elementOffset: 0},
+        frames: {size: 4, elementOffset: 2},
+        modes: {size: 1, elementOffset: 6}
+      }
+    },
+    colors: {
+      size: 4,
+      type: 'unorm8',
+      accessor: 'getColor',
+      bufferGroup: 'group-a'
+    }
+  });
+
+  attributeManager.update({
+    numInstances: 2,
+    data: [
+      {a: 1, icon: 10, color: [1, 2, 3, 4]},
+      {a: 2, icon: 20, color: [5, 6, 7, 8]}
+    ],
+    props: {
+      getA: (object: {a: number}) => object.a,
+      getIcon: (object: {icon: number}) => [
+        object.icon,
+        object.icon + 1,
+        object.icon + 2,
+        object.icon + 3,
+        object.icon + 4,
+        object.icon + 5,
+        object.icon + 6
+      ],
+      getColor: (object: {color: number[]}) => object.color
+    },
+    transitions: {},
+    buffers: {},
+    context: {}
+  });
+
+  const layouts = attributeManager.getBufferLayouts({isInstanced: true});
+  expect(layouts.map(layout => layout.name)).toEqual(['group-a']);
+  expect(layouts[0].byteStride).toBe(36);
+  expect(
+    Object.fromEntries(
+      (layouts[0].attributes || []).map(attribute => [attribute.attribute, attribute.byteOffset])
+    )
+  ).toEqual({
+    a: 0,
+    offsets: 4,
+    frames: 12,
+    modes: 28,
+    colors: 32
+  });
+
+  const attributes = attributeManager.getAttributes();
+  expect(attributes.a.getBuffer(), 'standalone buffers remain allocated').toBeTruthy();
+
+  let bindings = attributeManager.getBufferGroupBindings(attributes, {isInstanced: true});
+  const packedBuffer = bindings.buffers['group-a'];
+  const deleteSpy = vi.spyOn(packedBuffer, 'delete');
+  let packedBytes = await packedBuffer.readAsync(0, 72);
+  let dataView = new DataView(packedBytes.buffer, packedBytes.byteOffset, packedBytes.byteLength);
+
+  expect(dataView.getFloat32(0, true)).toBe(1);
+  expect(dataView.getFloat32(4, true)).toBe(10);
+  expect(Array.from(packedBytes.slice(32, 36))).toEqual([1, 2, 3, 4]);
+  expect(dataView.getFloat32(36, true)).toBe(2);
+  expect(dataView.getFloat32(40, true)).toBe(20);
+  expect(Array.from(packedBytes.slice(68, 72))).toEqual([5, 6, 7, 8]);
+
+  attributeManager.invalidate('getA');
+  attributeManager.update({
+    numInstances: 2,
+    data: [
+      {a: 3, icon: 10, color: [1, 2, 3, 4]},
+      {a: 4, icon: 20, color: [5, 6, 7, 8]}
+    ],
+    props: {
+      getA: (object: {a: number}) => object.a,
+      getIcon: (object: {icon: number}) => [
+        object.icon,
+        object.icon + 1,
+        object.icon + 2,
+        object.icon + 3,
+        object.icon + 4,
+        object.icon + 5,
+        object.icon + 6
+      ],
+      getColor: (object: {color: number[]}) => object.color
+    },
+    transitions: {},
+    buffers: {},
+    context: {}
+  });
+
+  bindings = attributeManager.getBufferGroupBindings(
+    attributeManager.getChangedAttributes({clearChangedFlags: true}),
+    {isInstanced: true}
+  );
+  expect(bindings.buffers['group-a']).toBe(packedBuffer);
+  packedBytes = await packedBuffer.readAsync(0, 72);
+  dataView = new DataView(packedBytes.buffer, packedBytes.byteOffset, packedBytes.byteLength);
+  expect(dataView.getFloat32(0, true)).toBe(3);
+  expect(dataView.getFloat32(4, true), 'untouched column is repacked').toBe(10);
+
+  attributeManager.finalize();
+  expect(deleteSpy).toHaveBeenCalled();
+});
+
+test('AttributeManager buffer groups fall back for transitions and external buffers', () => {
+  const testDevice = createWebGPUDevice();
+  const attributeManager = new AttributeManager(testDevice);
+  addSimpleGroup(attributeManager);
+  updateSimpleGroup(attributeManager, [
+    {a: 1, b: 2},
+    {a: 3, b: 4}
+  ]);
+
+  const transitionManager = (attributeManager as any).attributeTransitionManager;
+  const transitionSpy = vi
+    .spyOn(transitionManager, 'hasAttribute')
+    .mockImplementation((attributeName: string) => attributeName === 'a');
+  (attributeManager.getAttributes().a as Attribute).value = new Float32Array([999, 999]);
+
+  let bindings = attributeManager.getBufferGroupBindings(attributeManager.getAttributes(), {
+    isInstanced: true
+  });
+  expect(bindings.buffers['group-a'], 'active transitions are not packed').toBeUndefined();
+  expect(bindings.groupedAttributeIds.size).toBe(0);
+  expect(bindings.bufferLayouts.map(layout => layout.name)).toEqual(['a', 'b']);
+  transitionSpy.mockRestore();
+
+  const externalBuffer = testDevice.createBuffer({byteLength: 16});
+  updateSimpleGroup(
+    attributeManager,
+    [
+      {a: 5, b: 6},
+      {a: 7, b: 8}
+    ],
+    {a: externalBuffer}
+  );
+  bindings = attributeManager.getBufferGroupBindings(attributeManager.getAttributes(), {
+    isInstanced: true
+  });
+  expect(bindings.buffers['group-a'], 'GPU-only values are not packed').toBeUndefined();
+  expect(bindings.groupedAttributeIds.size).toBe(0);
+  expect(bindings.bufferLayouts.map(layout => layout.name)).toEqual(['a', 'b']);
+
+  updateSimpleGroup(
+    attributeManager,
+    [
+      {a: 5, b: 6},
+      {a: 7, b: 8}
+    ],
+    {a: {value: new Float32Array([0, 5, 0, 7]), offset: 4, stride: 8}}
+  );
+  bindings = attributeManager.getBufferGroupBindings(attributeManager.getAttributes(), {
+    isInstanced: true
+  });
+  expect(bindings.buffers['group-a'], 'custom binary views are not packed').toBeUndefined();
+  expect(bindings.groupedAttributeIds.size).toBe(0);
+  expect(bindings.bufferLayouts.map(layout => layout.name)).toEqual(['a', 'b']);
+
+  externalBuffer.delete();
+  attributeManager.finalize();
+});
+
+test('Layer grouped bindings preserve legacy fallback and index binding', () => {
+  const attributeManager = new AttributeManager(createWebGPUDevice());
+  attributeManager.add({
+    indices: {size: 1, isIndexed: true, accessor: 'getIndex'},
+    constant: {size: 1, accessor: 'getConstant'}
+  });
+  addSimpleGroup(attributeManager);
+  attributeManager.update({
+    numInstances: 2,
+    data: [
+      {index: 0, a: 1, b: 2},
+      {index: 1, a: 3, b: 4}
+    ],
+    props: {
+      getIndex: (object: {index: number}) => object.index,
+      getA: (object: {a: number}) => object.a,
+      getB: (object: {b: number}) => object.b,
+      getConstant: [9]
+    },
+    transitions: {},
+    buffers: {},
+    context: {}
+  });
+
+  const layer = new Layer({id: 'grouped-layer'});
+  vi.spyOn(layer as any, 'getAttributeManager').mockReturnValue(attributeManager);
+  const model = {
+    userData: {},
+    setBufferLayout: vi.fn(),
+    setAttributes: vi.fn(),
+    setConstantAttributes: vi.fn(),
+    setIndexBuffer: vi.fn()
+  };
+
+  (layer as any)._setModelAttributes(model, attributeManager.getAttributes());
+
+  expect(model.setBufferLayout.mock.calls[0][0].map(layout => layout.name)).toEqual([
+    'indices',
+    'constant',
+    'group-a'
+  ]);
+  expect(model.setAttributes).toHaveBeenCalledWith(
+    expect.objectContaining({'group-a': expect.anything(), constant: expect.anything()})
+  );
+  expect(model.setIndexBuffer).toHaveBeenCalledTimes(1);
+
+  const excludedModel = {
+    userData: {excludeAttributes: {b: true}},
+    setBufferLayout: vi.fn(),
+    setAttributes: vi.fn(),
+    setConstantAttributes: vi.fn(),
+    setIndexBuffer: vi.fn()
+  };
+  (layer as any)._setModelAttributes(excludedModel, attributeManager.getAttributes());
+
+  expect(excludedModel.setBufferLayout.mock.calls[0][0].map(layout => layout.name)).toEqual([
+    'indices',
+    'constant',
+    'a',
+    'b'
+  ]);
+  expect(excludedModel.setAttributes.mock.calls[0][0]['group-a']).toBeUndefined();
+  expect(excludedModel.setAttributes.mock.calls[0][0].a).toBeTruthy();
+  expect(excludedModel.setAttributes.mock.calls[0][0].b).toBeUndefined();
+
+  attributeManager.finalize();
+});
+
+test('IconLayer opts into grouped WebGPU layouts without changing WebGL layouts', () => {
+  const getLayouts = (testDevice: typeof device) => {
+    const attributeManager = new AttributeManager(testDevice);
+    const layer = new IconLayer({id: 'icon-layer', data: []});
+    (layer as any).context = {device: testDevice};
+    vi.spyOn(layer as any, 'getAttributeManager').mockReturnValue(attributeManager);
+    (layer as any).initializeState();
+
+    const layouts = attributeManager
+      .getBufferLayouts({isInstanced: true})
+      .map(layout => layout.name);
+
+    layer.state.iconManager.finalize();
+    attributeManager.finalize();
+    return layouts;
+  };
+
+  const webglLayouts = getLayouts(device);
+  const webgpuLayouts = getLayouts(createWebGPUDevice());
+
+  expect(webglLayouts).toEqual([
+    'instancePositions',
+    'instanceSizes',
+    'instanceIconDefs',
+    'instanceColors',
+    'instanceAngles',
+    'instancePixelOffset'
+  ]);
+  expect(webgpuLayouts).toEqual(['instancePositions', 'icon-instance-data']);
+});


### PR DESCRIPTION
## Goals

- Add the smallest WebGPU buffer-slot reduction needed to port remaining layers in deck.gl 9.4.
- Keep existing WebGL and ungrouped `AttributeManager` behavior unchanged.
- Avoid depending on unpublished luma.gl 9.4 APIs.

## Summary and Tradeoffs

This replaces the previous planner architecture with a small, explicit WebGPU-only path.

Attributes may opt into a shared packed vertex buffer with the internal `bufferGroup` hint. Compatible attributes in the same group are interleaved into one additional WebGPU vertex buffer, reducing bound vertex-buffer slots without changing existing `Attribute` or `DataColumn` allocation behavior.

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/ac882976-9dc5-4255-91b8-2b6a9f042583" />

The main tradeoff is temporary GPU-buffer duplication: grouped attributes retain their existing standalone buffers and also receive a packed group buffer. This keeps legacy behavior intact and makes unsupported states safe to fall back. A later luma.gl 9.4 integration can remove this duplication.

Compared with the previous PR iteration, this removes the table planner, storage-buffer planning, row geometry generation, priorities, reserved-slot hints, planner docs, React churn, and unrelated layer changes.

Current diff: 6 files, +770 / -3.

## Changes

- Add internal `AttributeOptions.bufferGroup?: string`.
  - Ignored by WebGL.
  - Ignored when fewer than two compatible attributes share a group.
- Add a small internal `AttributeBufferGroups` helper.
  - Packs compatible CPU-backed attributes into one interleaved WebGPU vertex buffer.
  - Preserves shader sub-attribute views, including IconLayer’s `instanceIconDefs`.
  - Uses 4-byte-aligned column offsets and row strides.
  - Reuses cached group buffers.
  - Fully repacks only touched groups from current CPU typed arrays.
  - Deletes packed buffers during `AttributeManager.finalize()`.
- Add a narrow `Layer` binding branch only for WebGPU managers with declared groups.
  - Refreshes runtime layouts so temporary fallback is safe.
  - Binds packed group buffers while preserving legacy constants, index buffers, exclusions, and standalone attributes.
- Use IconLayer as the production canary.
  - Groups its non-position instanced attributes as `icon-instance-data`.
  - Keeps existing transition declarations.
  - Active transitions fall back instead of packing transition placeholder values.

## Legacy Behavior and Fallback Matrix

| Case | Behavior |
| --- | --- |
| WebGL | Ignores `bufferGroup`; existing standalone layouts and bindings remain unchanged. |
| WebGPU without grouped attributes | Existing standalone layouts and bindings remain unchanged. |
| Compatible WebGPU group | Adds one interleaved group buffer and binds it instead of the grouped standalone bindings. |
| Active transition | Entire group falls back to standalone bindings; transition placeholder values are never packed. |
| External or GPU-only buffer | Entire group falls back to standalone bindings. |
| Custom binary offset or stride | Entire group falls back to standalone bindings. |
| `noAlloc`, fp64, indexed attribute, mixed step modes, or mismatched row counts | Entire group falls back to standalone bindings. |
| Model-excluded attribute | Entire group falls back; excluded attributes remain excluded. |
| Constants and index buffers | Continue through the existing binding behavior. |

## Scope Deliberately Removed

- No `TableBufferPlanner`.
- No table adapter or planning API.
- No luma.gl 9.4 dependency.
- No storage-buffer work.
- No row-geometry generation.
- No priorities or reserved-slot hints.
- No fp64 remapping.
- No standalone user documentation.
- No React or unrelated layer changes.

## Validation

- `yarn lint` ✅
  - Passes with existing repository warnings only.
- `yarn build` ✅
- `npx vitest run --project node test/modules/core/lib/attribute/attribute-buffer-groups.node.spec.ts test/modules/layers/core-layers.node.spec.ts` ✅
  - 15 tests passed.
- `yarn test-render test/render/test-cases/icon-layer.spec.ts` ✅
  - 7/7 IconLayer render cases passed.
- `yarn test` ⚠️
  - 960 passed, 9 skipped, 5 unrelated failures:
    - Existing `LoadingWidget` spinner assertion.
    - Four GeoJson render baseline mismatches: `geojson-point-types`, `geojson-text`, `geojson-text-billboard`, and `geojson-text-font-settings`.