### PR TITLE
fix(core,geo-layers): fix satellite tile rendering at globe poles

### DIFF
--- a/modules/core/src/viewports/globe-viewport.ts
+++ b/modules/core/src/viewports/globe-viewport.ts
@@ -156,9 +156,9 @@ export default class GlobeViewport extends Viewport {
 
     return [
       Math.min(left[0], right[0], top[0], bottom[0]),
-      Math.min(left[1], right[1], top[1], bottom[1]),
+      Math.max(-MAX_LATITUDE, Math.min(left[1], right[1], top[1], bottom[1])),
       Math.max(left[0], right[0], top[0], bottom[0]),
-      Math.max(left[1], right[1], top[1], bottom[1])
+      Math.min(MAX_LATITUDE, Math.max(left[1], right[1], top[1], bottom[1]))
     ];
   }
 
@@ -188,10 +188,19 @@ export default class GlobeViewport extends Viewport {
       const sSqr = (4 * l0Sqr * l1Sqr - (lSqr - l0Sqr - l1Sqr) ** 2) / 16;
       const dSqr = (4 * sSqr) / lSqr;
       const r0 = Math.sqrt(l0Sqr - dSqr);
-      const dr = Math.sqrt(Math.max(0, lt * lt - dSqr));
-      const t = (r0 - dr) / Math.sqrt(lSqr);
+      const discriminant = lt * lt - dSqr;
 
-      coord = vec3.lerp([], coord0, coord1, t);
+      if (discriminant < 0) {
+        // Ray misses the sphere — project the closest-approach point onto the sphere surface
+        const tClosest = r0 / Math.sqrt(lSqr);
+        const closest = vec3.lerp([], coord0, coord1, tClosest);
+        const len = vec3.len(closest);
+        coord = len > 0 ? vec3.scale([], closest, lt / len) : [0, 0, lt];
+      } else {
+        const dr = Math.sqrt(discriminant);
+        const t = (r0 - dr) / Math.sqrt(lSqr);
+        coord = vec3.lerp([], coord0, coord1, t);
+      }
     }
     const [X, Y, Z] = this.unprojectPosition(coord);
 

--- a/modules/geo-layers/src/tileset-2d/utils.ts
+++ b/modules/geo-layers/src/tileset-2d/utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Viewport} from '@deck.gl/core';
+import {Viewport, _GlobeViewport} from '@deck.gl/core';
 import {Matrix4} from '@math.gl/core';
 import {getOSMTileIndices} from './tile-2d-traversal';
 import {Bounds, GeoBoundingBox, TileBoundingBox, TileIndex, ZRange} from './types';
@@ -226,6 +226,19 @@ export function tileToBoundingBox(
   if (viewport.isGeospatial) {
     const [west, north] = osmTile2lngLat(x, y, z);
     const [east, south] = osmTile2lngLat(x + 1, y + 1, z);
+
+    // On a globe, stretch polar-edge tiles to ±90° to fill the Mercator hole at the poles.
+    // Web Mercator tiles only cover ~±85.05° — this stretches the texture to the pole.
+    if (viewport instanceof _GlobeViewport) {
+      const scale = Math.pow(2, z);
+      return {
+        west,
+        north: y === 0 ? 90 : north,
+        east,
+        south: y === scale - 1 ? -90 : south
+      };
+    }
+
     return {west, north, east, south};
   }
   const [left, top] = tile2XY(x, y, z, tileSize);


### PR DESCRIPTION
## Summary

Three fixes for GlobeView tile rendering near the North/South poles where satellite tiles warp, thrash, and eventually disappear:

- **Fix ray-miss in `GlobeViewport.unproject()`** — when the camera looks at a pole, screen-edge rays miss the sphere entirely. The old code fell through with a non-sphere coordinate (via `Math.max(0, ...)` clamping the discriminant), causing `getBounds()` to return invalid bounds → tile selection returns zero tiles → globe disappears. Now projects the closest-approach point onto the sphere surface.
- **Clamp `getBounds()` latitude to ±MAX_LATITUDE** — prevents tile selection from receiving out-of-range latitude bounds, which caused tile selection instability near the poles.
- **Extend polar tile bounds to ±90° on GlobeView** — Web Mercator tiles only cover ~±85.05° latitude. On a GlobeView, tiles at the top/bottom row of the Mercator grid (y=0, y=2^z-1) now have their latitude bounds stretched to the pole, filling the visible hole with stretched texture. This is GlobeView-only and does not affect WebMercatorViewport.

## Changed files
- `modules/core/src/viewports/globe-viewport.ts` — `unproject()` ray-miss handling + `getBounds()` latitude clamping
- `modules/geo-layers/src/tileset-2d/utils.ts` — polar tile bounds extension (GlobeView only)

## Before / After

**Before:** Approaching the North Pole — tiles warp, a hole appears at the pole, and eventually the globe disappears entirely when looking directly at the pole.

**After:** Tiles remain stable near the poles, the Mercator gap is filled by stretching the nearest tile, and the globe is always visible regardless of camera angle.

## Test plan
- [ ] View globe at equatorial latitudes — no change in behavior
- [ ] Pan toward North Pole — tiles should remain stable, no warping/thrashing
- [ ] Look directly at North Pole — globe should NOT disappear, pole should be filled
- [ ] Pan toward South Pole — same behavior as North
- [ ] Zoom in/out near poles — tile LOD should transition smoothly
- [ ] Verify Web Mercator (non-globe) views are unaffected (polar stretch is `_GlobeViewport`-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)