### PR TITLE
chore: 2026 Collab Summit temp header move to live header

### DIFF
--- a/website/static/events/zurich-summit-2026/index.html
+++ b/website/static/events/zurich-summit-2026/index.html
@@ -8,26 +8,18 @@
         <meta name="description" content="Come together with the deck.gl, kepler.gl, GeoDa, and Cosmos community to discuss the present & future of the leading open source libraries for visualization applications in the Web.">
         <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,800|Open+Sans:400,600,700" rel="stylesheet">
         <link rel="stylesheet" href="./style.css">
-        <style>
-            .header_img {
-                width:100%; height:100%; background-size:cover; background-position:center;
-                background-repeat: no-repeat;
-            }
-
-            @media screen and (max-width: 480px) {
-                 .header_img { background-size: contain; }
-                 #where_text { order: 1; }
-            }
+        <style type="text/css">
         </style>
     </head>
     
     <body class="is-bgWhite" cz-shortcut-listen="true">
         <header class="section">
-           <div class="header" style="width:100%;height:100%;background-image:url(https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/zurich-summit-2026/banner_summit-2026-zurich.png);" >
-            <!-- div class="container">
-              <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/zurich-summit-2026/openjs_foundation-logo-horizontal-white.png" />
-              <h1><b>Open Visualization</b><br/>Collaborator Summit 2026</h1>
-            </div-->
+           <img class="header_bg_img" width="100%" height="100%" srcset="https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/zurich-summit-2026/header_bg_800.jpg 800w, https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/zurich-summit-2026/header_bg_1200.png 1200w, https://raw.githubusercontent.com/visgl/deck.gl-data/master/events/zurich-summit-2026/header_bg_2400.jpg 2400w" style="object-fit: cover" />
+           <div class="header" style="width:100%;height:100%;" >
+            <div class="container">
+              <img src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/logos/openjsf-color-textw-logow.svg" />
+              <h1><b>Open Visualization</b><br/><nobr>Collaborator Summit</nobr> 2026</h1>
+            </div>
            </div>
         </header>
         
@@ -55,11 +47,11 @@
                     </div>
                     <div class="grid-cell grid-cell--col6 grid-cell--col10--tablet">
                         <p class="f32 f24--tablet paragraph-2">
-                            On October 9-10, 2026, come together with the
+                            On September 9-10, 2026, come together with the
                             <a href="https://vis.gl/" target="_blank" rel="noopener noreferrer">vis.gl</a>/<a
                                 href="https://deck.gl/" target="_blank" rel="noopener noreferrer">deck.gl</a>
                             community to discuss the present &amp; future of the leading open source
-                            library for visualization in the Web.
+                            library for visualization on the web.
                         </p>
                     </div>
                 </div>

--- a/website/static/events/zurich-summit-2026/style.css
+++ b/website/static/events/zurich-summit-2026/style.css
@@ -2638,18 +2638,20 @@ a {
 }
 
 header {
+    position: relative;
     height: 628px;
     background-color: #202020;
 }
 
 .header {
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
     display: flex;
     flex-direction: column;
     color: #fff;
     justify-content: center;
+
+    position: absolute;
+    top: 0;
+    height: 100%;
 }
 
 .header .container {
@@ -2683,5 +2685,39 @@ h1 b {
     .header img {
         width: 260px;
         max-width: 50%;
+    }
+
+    .top-paragraphs {
+        padding-top: 45px;
+    }
+
+    header h1 {
+        font-size: calc(1em + 3vw);
+    }
+
+    header .container {
+        margin-left: calc(1em - 1.5vw);
+    }
+
+    header  {
+        height: 410px;
+    }
+}
+
+@media (max-width:400px) {
+    header h1 {
+        font-size: calc(1em + 3vw);
+    }
+    header .container {
+        margin-left: calc(1em - 3.5vw);
+    }
+}
+
+@media (max-width:360px) {
+    .top-paragraphs {
+        padding-top: 20px;
+    }
+    header .container {
+        margin-left: calc(1em - 6.25vw);
     }
 }


### PR DESCRIPTION
#### Background
Update of 2026 Summit from temporary header banner to live images.  Additional pixel pushing for mobile.

<!-- For all the PRs -->
#### Change List
- chore: Updated index.html for live header images, including additional header image scale set.
- chore: Update style.css for mobile adjustments across various screen sizes (360, 400, 800).
