### PR TITLE
feat(widgets): ScrollbarWidget falls back to controller.maxBounds

### DIFF
--- a/docs/api-reference/widgets/scrollbar-widget.md
+++ b/docs/api-reference/widgets/scrollbar-widget.md
@@ -162,7 +162,8 @@ The `ScrollbarWidget` accepts the generic [`WidgetProps`](../core/widget.md#widg
 
 The full extent of the scrollable content, in world coordinates.
 The widget relies on this value to calculate the position and size of the slider button and track.
-If not supplied, the scrollbar will always be hidden.
+If not supplied, falls back to [maxBounds](../core/controller.md#options) of the controller.
+If no bounds definition is found, the scrollbar will always be hidden.
 
 #### orientation (string, optional)
 

--- a/modules/widgets/src/scrollbar-widget.tsx
+++ b/modules/widgets/src/scrollbar-widget.tsx
@@ -148,6 +148,10 @@ export class ScrollbarWidget extends Widget<ScrollbarWidgetProps> {
     super.onRemove();
   }
 
+  private getContentBounds(viewId: string): ContentBounds | null {
+    return this.props.contentBounds ?? this.deck?.getView(viewId)?.controller?.maxBounds ?? null;
+  }
+
   private updateViewport(viewport?: Viewport): void {
     if (!viewport) {
       this.contentSize = 0;
@@ -156,7 +160,7 @@ export class ScrollbarWidget extends Widget<ScrollbarWidgetProps> {
       return;
     }
 
-    const {contentBounds} = this.props;
+    const contentBounds = this.getContentBounds(viewport.id);
     const isVertical = this.isVertical();
     const projectedBounds = contentBounds
       ? projectBounds(contentBounds, viewport, isVertical)
@@ -168,8 +172,12 @@ export class ScrollbarWidget extends Widget<ScrollbarWidgetProps> {
   }
 
   private getDecorations(viewport?: Viewport): RangeInputDecoration[] {
-    const {decorations = [], contentBounds} = this.props;
-    if (!viewport || !contentBounds || decorations.length === 0) {
+    const {decorations = []} = this.props;
+    if (!viewport || decorations.length === 0) {
+      return [];
+    }
+    const contentBounds = this.getContentBounds(viewport.id);
+    if (!contentBounds) {
       return [];
     }
 

--- a/website/src/doc-demos/widgets.js
+++ b/website/src/doc-demos/widgets.js
@@ -376,7 +376,6 @@ export function ScrollbarWidgetDemo() {
       new ScrollbarWidget({
         placement: 'bottom-right',
         viewId: 'ortho',
-        contentBounds,
         orientation: 'horizontal',
         captureWheel: true
       })


### PR DESCRIPTION
#### Change List
- Fall back to `controller.maxBounds` if `contentBounds` is not supplied
