### PR TITLE
feat(core): ViewProps.parameters

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -179,7 +179,8 @@ new Deck({
 
 Notes:
 
-- Any GPU `parameters` prop supplied to individual layers will still override the global `parameters` when that layer is rendered.
+- GPU `parameters` supplied to a view override the global `parameters` for layers rendered in that view.
+- GPU `parameters` supplied to individual layers override both view and global `parameters` when that layer is rendered.
 
 #### `layers` (LayersList) {#layers}
 

--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -54,6 +54,16 @@ Scaler for the near plane, 1 unit equals to the height of the viewport. Default 
 
 Scaler for the far plane, 1 unit equals to the distance from the camera to the edge of the screen. Default to `2`. Overwrites the `far` parameter.
 
+#### `parameters` (object, optional) {#parameters}
+
+`GlobeView` enables back-face culling by default with `parameters: {cullMode: 'back'}`. To override this behavior, supply the desired GPU parameters to the constructor:
+
+```js
+new GlobeView({
+  parameters: {cullMode: 'none'}
+});
+```
+
 
 ## View State
 

--- a/docs/api-reference/core/view.md
+++ b/docs/api-reference/core/view.md
@@ -107,6 +107,12 @@ Specifies the stencil buffer value to clear the viewport with, as number between
 
 Default `0` (clear).
 
+#### `parameters` (object, optional) {#parameters}
+
+Override the GPU parameters used to draw layers in this view. See the luma.gl [GPU parameters](https://luma.gl/docs/api-reference/core/parameters) documentation for supported parameters and values.
+
+View parameters override the `Deck.parameters` defaults for layers rendered in this view. Layer `parameters` still take precedence over both.
+
 **Examples:**
 
 *   Clearing to a solid color: `new View({clear: true, clearColor: [80, 120, 200, 255]})`

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,12 @@
 
 This page contains highlights of each deck.gl release. Also check our [vis.gl blog](https://medium.com/vis-gl) for news about new releases and features in deck.gl.
 
+## deck.gl v9.4
+
+### Views
+
+- Views now support a `parameters` prop for per-view GPU draw state overrides. `GlobeView` uses this to enable back-face culling by default, and applications can override it with `new GlobeView({parameters: {cullMode: 'none'}})`.
+
 ## deck.gl v9.3
 
 Release date: April 13, 2026

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -181,6 +181,7 @@ export default class LayersPass extends Pass {
       isPicking = false,
       layerFilter,
       cullRect,
+      views,
       effects,
       shaderModuleProps
     }: LayersPassRenderOptions,
@@ -228,6 +229,7 @@ export default class LayersPass extends Pass {
         layerParam.layerParameters = {
           ...defaultParams,
           ...layer.context.deck?.props.parameters,
+          ...views?.[viewport.id]?.props.parameters,
           ...this.getLayerParameters(layer, layerIndex, viewport)
         };
       }

--- a/modules/core/src/views/globe-view.ts
+++ b/modules/core/src/views/globe-view.ts
@@ -6,6 +6,11 @@ import View, {CommonViewState, CommonViewProps} from './view';
 import GlobeViewport from '../viewports/globe-viewport';
 import WebMercatorViewport from '../viewports/web-mercator-viewport';
 import GlobeController from '../controllers/globe-controller';
+import type {Parameters} from '@luma.gl/core';
+
+const GLOBE_VIEW_DEFAULT_PARAMETERS: Parameters = {
+  cullMode: 'back'
+};
 
 export type GlobeViewState = {
   /** Longitude of the map center */
@@ -39,7 +44,13 @@ export default class GlobeView extends View<GlobeViewState, GlobeViewProps> {
   static displayName = 'GlobeView';
 
   constructor(props: GlobeViewProps = {}) {
-    super(props);
+    super({
+      ...props,
+      parameters: {
+        ...GLOBE_VIEW_DEFAULT_PARAMETERS,
+        ...props.parameters
+      }
+    });
   }
 
   getViewportType(viewState: GlobeViewState) {

--- a/modules/core/src/views/view.ts
+++ b/modules/core/src/views/view.ts
@@ -11,6 +11,7 @@ import type {ControllerOptions} from '../controllers/controller';
 import type {TransitionProps} from '../controllers/transition-manager';
 import type {Padding} from '../viewports/viewport';
 import type {ConstructorOf} from '../types/types';
+import type {Parameters} from '@luma.gl/core';
 
 export type CommonViewState = TransitionProps;
 
@@ -40,6 +41,8 @@ export type CommonViewProps<ViewState> = {
   clearDepth?: number | false;
   /** Stencil buffer Value to clear the viewport with, between 0 - 255. Default `0` (clear). */
   clearStencil?: number | false;
+  /** Override the GPU parameters used to draw layers in this view. */
+  parameters?: Parameters;
   /** State of the view */
   viewState?:
     | string

--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -111,9 +111,6 @@ export function getDefaultParameters(map: Map, interleaved: boolean): Parameters
         blendAlphaOperation: 'add'
       }
     : {};
-  if (getProjection(map) === 'globe') {
-    result.cullMode = 'back';
-  }
   return result;
 }
 

--- a/test/modules/core/passes/layers-pass.spec.ts
+++ b/test/modules/core/passes/layers-pass.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect} from 'vitest';
 
-import {Layer, CompositeLayer, LayerManager, Viewport} from '@deck.gl/core';
+import {Layer, CompositeLayer, LayerManager, Viewport, MapView} from '@deck.gl/core';
 import {layerIndexResolver} from '@deck.gl/core/passes/layers-pass';
 import DrawLayersPass from '@deck.gl/core/passes/draw-layers-pass';
 import {device} from '@deck.gl/test-utils/vitest';
@@ -13,6 +13,12 @@ import {GL} from '@luma.gl/webgl/constants';
 
 class TestLayer extends Layer {
   initializeState() {}
+}
+
+class RecordingLayer extends TestLayer {
+  draw({parameters}) {
+    (this.props as any).onDraw({viewport: this.context.viewport.id, parameters});
+  }
 }
 
 class TestCompositeLayer extends CompositeLayer {
@@ -266,6 +272,78 @@ test('LayersPass#shouldDrawLayer', () => {
     'Total # of layers'
   ).toBeTruthy();
   expect(renderStats.visibleCount, '# of rendered layers').toBe(1); // test-primitive-visible
+});
+
+test('LayersPass#viewParameters', () => {
+  const drawCalls = [];
+  const layers = [
+    new RecordingLayer({
+      id: 'test',
+      parameters: {
+        depthWriteEnabled: true,
+        blend: false
+      },
+      onDraw: drawCall => drawCalls.push(drawCall)
+    })
+  ];
+
+  const layerManager = new LayerManager(device, {
+    deck: {
+      props: {
+        parameters: {
+          blend: true,
+          depthWriteEnabled: false,
+          depthCompare: 'less',
+          blendColorSrcFactor: 'src-alpha'
+        }
+      }
+    } as any
+  });
+  const layersPass = new DrawLayersPass(device);
+  layerManager.setLayers(layers);
+
+  const views = {
+    A: new MapView({
+      id: 'A',
+      parameters: {
+        depthCompare: 'always',
+        cullMode: 'back'
+      }
+    }),
+    B: new MapView({
+      id: 'B',
+      parameters: {
+        depthCompare: 'greater',
+        cullMode: 'none'
+      }
+    })
+  };
+
+  layersPass.render({
+    viewports: [new Viewport({id: 'A'}), new Viewport({id: 'B'})],
+    views,
+    layers: layerManager.getLayers(),
+    onViewportActive: layerManager.activateViewport,
+    onError: err => expect(err).toBeFalsy()
+  });
+
+  expect(drawCalls, 'layer drawn once in each view').toHaveLength(2);
+  expect(drawCalls[0].viewport, 'first viewport id').toBe('A');
+  expect(drawCalls[0].parameters, 'view parameters are merged for view A').toMatchObject({
+    blend: false,
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    blendColorSrcFactor: 'src-alpha',
+    cullMode: 'back'
+  });
+  expect(drawCalls[1].viewport, 'second viewport id').toBe('B');
+  expect(drawCalls[1].parameters, 'view parameters are merged for view B').toMatchObject({
+    blend: false,
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    blendColorSrcFactor: 'src-alpha',
+    cullMode: 'none'
+  });
 });
 
 test('LayersPass#GLViewport', () => {

--- a/test/modules/core/views/view.spec.ts
+++ b/test/modules/core/views/view.spec.ts
@@ -65,7 +65,15 @@ test('View#equals', () => {
     zoom: 11,
     position: [0, 1]
   });
-  const mapView4 = new View({
+  const mapView4 = new MapView({
+    id: 'default-view',
+    latitude: 0,
+    longitude: 0,
+    zoom: 11,
+    position: [0, 0],
+    parameters: {depthCompare: 'always'}
+  });
+  const baseView = new View({
     id: 'default-view',
     latitude: 0,
     longitude: 0,
@@ -75,7 +83,8 @@ test('View#equals', () => {
 
   expect(mapView1.equals(mapView2), 'Identical view props').toBeTruthy();
   expect(mapView1.equals(mapView3), 'Different view props').toBeFalsy();
-  expect(mapView1.equals(mapView4), 'Different type').toBeFalsy();
+  expect(mapView1.equals(mapView4), 'Different parameters').toBeFalsy();
+  expect(mapView1.equals(baseView), 'Different type').toBeFalsy();
 });
 
 test('MapView', () => {
@@ -142,6 +151,18 @@ test('GlobeView', () => {
     'Viewport has correct size'
   ).toBeTruthy();
   expect(viewport.zoom, 'Viewport has correct parameters').toBe(12);
+});
+
+test('GlobeView#parameters', () => {
+  const defaultView = new GlobeView();
+  const customView = new GlobeView({parameters: {cullMode: 'none'}});
+
+  expect(defaultView.props.parameters, 'GlobeView has default culling').toMatchObject({
+    cullMode: 'back'
+  });
+  expect(customView.props.parameters, 'GlobeView culling can be overridden').toMatchObject({
+    cullMode: 'none'
+  });
 });
 
 test('OrbitView', () => {


### PR DESCRIPTION
## Summary

Adds a `parameters` prop to deck.gl `View` classes so GPU draw parameters can be configured per view.

- Adds `parameters?: Parameters` to `CommonViewProps`
- Merges view parameters during layer rendering with precedence: `Deck.parameters` < `View.parameters` < layer/pass parameters
- Sets `GlobeView` default `parameters: {cullMode: 'back'}` while allowing per-instance overrides
- Documents the new View API, Deck precedence behavior, GlobeView default culling, and adds a v9.4 whats-new note

## Testing

- `git diff --check`
- `yarn test test/modules/core/views/view.spec.ts test/modules/core/passes/layers-pass.spec.ts`
- `yarn lint`
- `yarn build`
