### PR TITLE
fix(core): reduce GlobeView near-plane clipping

### DIFF
--- a/modules/core/src/viewports/globe-viewport.ts
+++ b/modules/core/src/viewports/globe-viewport.ts
@@ -54,7 +54,7 @@ export type GlobeViewportOptions = {
   orthographic?: boolean;
   /** Camera fovy in degrees. If provided, overrides `altitude` */
   fovy?: number;
-  /** Scaler for the near plane, 1 unit equals to the height of the viewport. Default `0.5` */
+  /** Scaler for the near plane, 1 unit equals to the height of the viewport. Default `0.01` */
   nearZMultiplier?: number;
   /** Scaler for the far plane, 1 unit equals to the distance from the camera to the edge of the screen. Default `1` */
   farZMultiplier?: number;
@@ -78,9 +78,9 @@ export default class GlobeViewport extends Viewport {
     const {
       longitude = 0,
       zoom = 0,
-      // Matches Maplibre defaults
-      // https://github.com/maplibre/maplibre-gl-js/blob/f8ab4b48d59ab8fe7b068b102538793bbdd4c848/src/geo/projection/globe_transform.ts#L632-L633
-      nearZMultiplier = 0.5,
+      // Keep the near plane close enough for terrain flythroughs.
+      // Higher values clip nearby elevated mesh peaks when the camera is low.
+      nearZMultiplier = 0.01,
       farZMultiplier = 1,
       resolution = 10
     } = opts;


### PR DESCRIPTION
## Summary

Lowers the default GlobeViewport near plane from `0.5` to `0.01`.

This reduces close-camera clipping artifacts in GlobeView without changing app-level view setup or adding layer-specific globe code.

## Test plan

- [x] `pnpm exec prettier --write /tmp/deck-nearz-push/modules/core/src/viewports/globe-viewport.ts`
- [x] Manual validation in downstream globe terrain scene