### PR TITLE
fix(PointCloudLayer): add TypeScript types for loaders.gl point cloud data format

### DIFF
--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -26,16 +26,14 @@ import {pointCloudUniforms, PointCloudProps} from './point-cloud-layer-uniforms'
 import vs from './point-cloud-layer-vertex.glsl';
 import fs from './point-cloud-layer-fragment.glsl';
 import source from './point-cloud-layer.wgsl';
-import type {MeshAttributes} from '@loaders.gl/schema';
+import type {Mesh} from '@loaders.gl/schema';
 
 const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 const DEFAULT_NORMAL = [0, 0, 1] as const;
 
-export type LoadersGLPointCloudData = {
-  header: {
-    vertexCount: number;
-  };
-  attributes: MeshAttributes;
+export type LoadersGLPointCloudData = Partial<Mesh> & {
+  header: {vertexCount: number};
+  attributes: Mesh['attributes'];
 };
 
 const defaultProps: DefaultProps<PointCloudLayerProps> = {

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -30,6 +30,24 @@ import source from './point-cloud-layer.wgsl';
 const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 const DEFAULT_NORMAL = [0, 0, 1] as const;
 
+type LoadersGLAttribute = {
+  size: number;
+  value: ArrayBufferView;
+  type?: number;
+};
+
+export type LoadersGLPointCloudData = {
+  header: {
+    vertexCount: number;
+  };
+  attributes: {
+    POSITION?: LoadersGLAttribute;
+    NORMAL?: LoadersGLAttribute;
+    COLOR_0?: LoadersGLAttribute;
+    [key: string]: LoadersGLAttribute | undefined;
+  };
+};
+
 const defaultProps: DefaultProps<PointCloudLayerProps> = {
   sizeUnits: 'pixels',
   pointSize: {type: 'number', min: 0, value: 10}, //  point radius in pixels
@@ -70,7 +88,7 @@ export type PointCloudLayerProps<DataT = unknown> = _PointCloudLayerProps<DataT>
 
 /** Properties added by PointCloudLayer. */
 type _PointCloudLayerProps<DataT> = {
-  data: LayerDataSource<DataT>;
+  data: LayerDataSource<DataT> | LoadersGLPointCloudData;
   /**
    * The units of the point size, one of `'meters'`, `'common'`, and `'pixels'`.
    * @default 'pixels'

--- a/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
+++ b/modules/layers/src/point-cloud-layer/point-cloud-layer.ts
@@ -26,26 +26,16 @@ import {pointCloudUniforms, PointCloudProps} from './point-cloud-layer-uniforms'
 import vs from './point-cloud-layer-vertex.glsl';
 import fs from './point-cloud-layer-fragment.glsl';
 import source from './point-cloud-layer.wgsl';
+import type {MeshAttributes} from '@loaders.gl/schema';
 
 const DEFAULT_COLOR = [0, 0, 0, 255] as const;
 const DEFAULT_NORMAL = [0, 0, 1] as const;
-
-type LoadersGLAttribute = {
-  size: number;
-  value: ArrayBufferView;
-  type?: number;
-};
 
 export type LoadersGLPointCloudData = {
   header: {
     vertexCount: number;
   };
-  attributes: {
-    POSITION?: LoadersGLAttribute;
-    NORMAL?: LoadersGLAttribute;
-    COLOR_0?: LoadersGLAttribute;
-    [key: string]: LoadersGLAttribute | undefined;
-  };
+  attributes: MeshAttributes;
 };
 
 const defaultProps: DefaultProps<PointCloudLayerProps> = {


### PR DESCRIPTION
## Problem

`PointCloudLayer` has a `normalizeData` function that supports the loaders.gl 
point cloud data format at runtime, but the `data` prop type only accepted 
`LayerDataSource<DataT>`, causing a TypeScript error when passing a conforming 
loaders.gl object.

Fixes #10219

## Changes

- Added `LoadersGLAttribute` type to describe a typed array attribute in the loaders.gl mesh format
- Added `LoadersGLPointCloudData` type to describe the full loaders.gl point cloud data shape
- Updated the `data` prop in `_PointCloudLayerProps` to accept `LayerDataSource<DataT> | LoadersGLPointCloudData`

## Testing

- Existing test `PointCloudLayer#loaders.gl support` in `test/modules/layers/point-cloud-layer.spec.ts` passes
- Verified that passing a loaders.gl-format object to `data` no longer produces a TypeScript error