### PR TITLE
fix(tile-3d-layer): change getPosition from static array to accessor function

### DIFF
--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
@@ -374,7 +374,7 @@ export default class Tile3DLayer<DataT = any, ExtraPropsT extends {} = {}> exten
         coordinateOrigin: cartographicOrigin,
         modelMatrix,
         getTransformMatrix: instance => instance.modelMatrix,
-        getPosition: [0, 0, 0],
+        getPosition: () => [0, 0, 0],
         _offset: 0,
         onFirstDraw: () => {
           tileHeader.tileDrawn = true;


### PR DESCRIPTION
fixes the issue with showing 3d tiles on maplibre using deckgl's tile-3d-layer