### PR TITLE
[geo-layers] Fix globe tile culling near poles

### DIFF
--- a/modules/geo-layers/src/tileset-2d/tileset-2d.ts
+++ b/modules/geo-layers/src/tileset-2d/tileset-2d.ts
@@ -305,7 +305,7 @@ export class Tileset2D {
       return false;
     }
 
-    if (cullRect && this._viewport) {
+    if (cullRect && this._viewport && !this._viewport.resolution) {
       const boundsArr = this._getCullBounds({
         viewport: this._viewport,
         z: this._zRange,

--- a/test/modules/geo-layers/tileset-2d/tileset-2d.spec.ts
+++ b/test/modules/geo-layers/tileset-2d/tileset-2d.spec.ts
@@ -4,7 +4,12 @@
 
 import {test, expect} from 'vitest';
 import {_Tileset2D as Tileset2D} from '@deck.gl/geo-layers';
-import {WebMercatorViewport, OrthographicView, Viewport} from '@deck.gl/core';
+import {
+  WebMercatorViewport,
+  OrthographicView,
+  Viewport,
+  _GlobeView as GlobeView
+} from '@deck.gl/core';
 import {Matrix4} from '@math.gl/core';
 
 const testViewState = {
@@ -427,6 +432,7 @@ test('Tileset2D#traversal', async () => {
 
 test('Tileset2D#isTileVisible', async () => {
   const cullRect = {x: 50, y: 48, width: 100, height: 1};
+  const fullViewportCullRect = {x: 0, y: 0, width: 400, height: 400};
 
   const testCases = [
     {
@@ -496,6 +502,32 @@ test('Tileset2D#isTileVisible', async () => {
         {id: '7-3-3', cullRect, result: true},
         {id: '7-4-3', cullRect, result: true}
       ]
+    },
+    {
+      title: 'globe culling near north pole',
+      viewport: new GlobeView().makeViewport({
+        width: 400,
+        height: 400,
+        viewState: {
+          longitude: 0,
+          latitude: 89,
+          zoom: 2
+        }
+      }),
+      checks: [{id: '0-0-2', cullRect: fullViewportCullRect, result: true}]
+    },
+    {
+      title: 'globe culling near south pole',
+      viewport: new GlobeView().makeViewport({
+        width: 400,
+        height: 400,
+        viewState: {
+          longitude: 0,
+          latitude: -89,
+          zoom: 2
+        }
+      }),
+      checks: [{id: '0-3-2', cullRect: fullViewportCullRect, result: true}]
     }
   ];
 


### PR DESCRIPTION
## Summary

Fixes TileLayer/Tileset2D visibility in GlobeView near the poles by bypassing screen `cullRect` lng/lat bounds culling for globe viewports.

`getOSMTileIndices` already uses the globe frustum traversal to select visible tiles. The later `cullRect` path approximates the screen rectangle as a simple lng/lat bbox from corner unprojection, which breaks around polar caps and can hide every selected tile.

## Validation

- `npx vitest run --project headless test/modules/geo-layers/tileset-2d/tileset-2d.spec.ts`

Stacked on #10250 / `cr/feat/terrain-layer-globe-grid`.