### PR TITLE
hotfix: HeatmapLayer GLSL ES 3.10 compilation failure on Qualcomm Adreno 660

### DIFF
--- a/modules/core/src/shaderlib/misc/geometry.ts
+++ b/modules/core/src/shaderlib/misc/geometry.ts
@@ -63,7 +63,8 @@ ${defines}
 
 struct FragmentGeometry {
   vec2 uv;
-} geometry;
+};
+FragmentGeometry geometry;
 
 float smoothedge(float edge, float x) {
   return smoothstep(edge - SMOOTH_EDGE_RADIUS, edge + SMOOTH_EDGE_RADIUS, x);


### PR DESCRIPTION
Here is the summary generated by Claude:

```
From: fix: split combined struct+instance declaration in fragment geometry module
Subject: [PATCH] fix: HeatmapLayer GLSL ES 3.10 compilation failure on Qualcomm Adreno 660

The combined struct+instance declaration syntax `struct Foo { ... } bar;`
is rejected by the Qualcomm Adreno 660 GLSL ES 3.10 compiler introduced
in the Google Play System Update (April 2026), causing HeatmapLayer to
silently fail on Snapdragon 888 devices (Galaxy S21 series) running Chrome.

Chrome's ANGLE layer upconverts shaders from GLSL ES 3.00 to GLSL ES 3.10
when the device supports it. The new strict Qualcomm driver rejects the
combined declaration in the translated output, returning an empty shader
info log with no error details.

Splitting into a separate type declaration followed by a variable declaration
is valid in all GLSL ES versions and resolves the issue. Desktop Chrome is
unaffected because ANGLE translates to HLSL/MSL rather than GLSL ES, and
desktop OpenGL drivers tolerate the combined form regardless.

Confirmed fix on: Adreno 660 / Snapdragon 888, driver V@0530.55.1,
Chrome with ANGLE 2.1.27471, One UI 7.0, Google Play System Update April 2026.
```

Closes #10300


#### Change List
- Split combined struct+instance declaration in fragment geometry module
