### PR TITLE
feat: Row index based picking for layers with specialized picking

### DIFF
--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -773,7 +773,7 @@ Parameters:
 * `y` (number) - y position in pixels
 * `radius` (number, optional) - radius of tolerance in pixels. Default `0`.
 * `layerIds` (string[], optional) - a list of layer ids to query from. If not specified, then all pickable and visible layers are queried.
-* `depth` - Specifies the max number of objects to return. Default `10`. For layers without explicit picking color buffers, only the default depth of 10 unique objects per layer is guaranteed; higher custom depths may return duplicate results for these layers.
+* `depth` - Specifies the max number of objects to return. Default `10`. For layers without explicit picking index buffers, only the default depth of 10 unique objects per layer is guaranteed; higher custom depths may return duplicate results for these layers.
 * `unproject3D` (boolean, optional) - if `true`, `info.coordinate` will be a 3D point by unprojecting the `x, y` screen coordinates onto the picked geometry. Default `false`.
 
 Returns:
@@ -783,7 +783,7 @@ Returns:
 Notes:
 
 * Deep picking is implemented as a sequence of simpler picking operations and can have a performance impact. Should this become a concern, you can use the `depth` parameter to limit the number of matches that can be returned, and thus the maximum number of picking operations.
-* Layers that provide explicit picking color buffers support buffer mutation between picking passes and are not subject to the default-depth unique-object guarantee.
+* Layers that provide explicit picking index buffers support buffer mutation between picking passes and are not subject to the default-depth unique-object guarantee.
 
 
 #### `pickObjects` {#pickobjects}

--- a/docs/developer-guide/custom-layers/attribute-management.md
+++ b/docs/developer-guide/custom-layers/attribute-management.md
@@ -47,7 +47,7 @@ While most apps rely on their layers to automatically generate appropriate GPU b
 
 While this allows for ultimate performance and control of updates, as well as potential sharing of buffers between layers, the application will need to generate attributes in exactly the format that the layer shaders expect, creating a strong coupling between the application and the layer.
 
-**Note:** The application can provide some buffers and let others be managed by the layer. Explicit picking color buffers are only needed when the logical picking id differs from the rendered instance id.
+**Note:** The application can provide some buffers and let others be managed by the layer. Explicit picking index buffers are only needed when the logical picking id differs from the rendered instance id.
 
 
 ## More information

--- a/docs/developer-guide/custom-layers/layer-attributes.md
+++ b/docs/developer-guide/custom-layers/layer-attributes.md
@@ -55,7 +55,7 @@ For _variable primitive layers_ there are two options:
 
 2) Copy each descriptive attribute `N` times (`N` being the number of vertices generated for that row during tesselation). This is the method that is used in deck.gl today.
 
-3) Add a single `rowIndex` attribute and copy the same index `N` times as above. In this approach, descriptive values could then be read from textures where they are stored a single time. This provides flexibility at the price of performance (texture access latency) and complexity (working with data in textures).
+3) Add a single `rowIndexes` attribute and copy the same index `N` times as above. In this approach, descriptive values could then be read from textures where they are stored a single time. This provides flexibility at the price of performance (texture access latency) and complexity (working with data in textures).
 
 
 Remarks:

--- a/docs/developer-guide/custom-layers/picking.md
+++ b/docs/developer-guide/custom-layers/picking.md
@@ -55,49 +55,44 @@ The following sections describe common ways to implement custom picking.
 
 Instanced layer shaders can derive picking colors from the built-in instance id when each rendered instance maps to one picked object. In GLSL, use `picking_setPickingColorFromInstanceID()` or assign `geometry.pickingColor = picking_getPickingColorFromInstanceID()`. In WGSL, add `@builtin(instance_index)` to the vertex inputs and use `picking_getPickingColorFromIndex(instanceIndex)`.
 
-Add an explicit picking color attribute only when the logical picking id within the current layer is different from the rendered instance id. For example:
+Add an explicit picking index attribute only when the logical picking id within the current layer is different from the rendered instance id. For example:
 
 * Binary GeoJSON or MVT point sublayers may render local point instances while picking should return a global feature index.
 
-* `PathLayer` tessellates one path into multiple rendered segment or joint instances, so its generated geometry needs explicit picking colors that map back to the source path index instead of each rendered segment's instance id.
+* `PathLayer` tessellates one path into multiple rendered segment or joint instances, so its generated geometry needs explicit picking indexes that map back to the source path index instead of each rendered segment's instance id.
 
-### Creating A Picking Color Attribute
+### Creating A Picking Index Attribute
 
-Add an attribute for each vertex using the layer's [AttributeManager](../../api-reference/core/attribute-manager.md):
+Add an attribute for each vertex or instance using the layer's [AttributeManager](../../api-reference/core/attribute-manager.md). Use the `rowIndexes` attribute name to let deck.gl handle deep-picking buffer mutation.
 
 ```js
-import {GL} from '@luma.gl/webgl/constants';
-
 class MyLayer extends Layer {
   initializeState() {
     this.state.attributeManager.add({
-      customPickingColors: {
-        size: 3,
-        type: GL.UNSIGNED_BYTE,
-        update: this.calculatePickingColors
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
+        update: this.calculatePickingIndexes
       }
     });
   }
 }
 ```
 
-Populate the attribute by providing a different picking color for every object that you need to differentiate. The default implementation of [`layer.encodePickingColor()`](../../api-reference/core/layer.md#encodepickingcolor) and [`layer.decodePickingColor()`](../../api-reference/core/layer.md#decodepickingcolor) is likely sufficient, but you may need to implement your own pair.
+Populate the attribute by providing the logical object index for every rendered vertex or instance that you need to differentiate.
 
 ```js
 class MyLayer extends Layer {
 
   ...
 
-  calculatePickingColors(attribute) {
+  calculatePickingIndexes(attribute) {
       const {data} = this.props;
       const {value} = attribute;
 
       let i = 0;
       for (const object of data) {
-        const pickingColor = this.encodePickingColor(i);
-        value[i * 3] = pickingColor[0];
-        value[i * 3 + 1] = pickingColor[1];
-        value[i * 3 + 2] = pickingColor[2];
+        value[i] = i;
         i++;
       }
   }
@@ -129,15 +124,15 @@ All core layers (including composite layers) support picking using luma.gl's `pi
 
 #### Vertex Shader
 
-Vertex shader should set current picking color using `picking_setPickingColor` method provided by picking shader module.
+Vertex shader should set current picking color using helpers provided by the picking shader module.
 
 ```glsl
-attribute vec3 customPickingColors;
+in float rowIndexes;
 
 void main(void) {
   ...
 
-  picking_setPickingColor(customPickingColors);
+  geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
 }
 ```
 

--- a/docs/developer-guide/custom-layers/primitive-layers.md
+++ b/docs/developer-guide/custom-layers/primitive-layers.md
@@ -149,4 +149,4 @@ By always using the following shader functions for handling projections and scal
 
 If your layer is instanced (`data` prop is an array and each element is rendered as one primitive), then you may take advantage of the default implementation of the [layer picking methods](../../api-reference/core/layer.md#layer-picking-methods).
 
-By default, instanced layer shaders can derive picking colors from the built-in instance id. Add an explicit picking color attribute only when the logical picking id within the current layer is different from the rendered instance id. See [Implementing Custom Picking](./picking.md#implementing-custom-picking) for custom picking details and examples.
+By default, instanced layer shaders can derive picking colors from the built-in instance id. Add an explicit picking index attribute only when the logical picking id within the current layer is different from the rendered instance id. See [Implementing Custom Picking](./picking.md#implementing-custom-picking) for custom picking details and examples.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,7 +4,7 @@
 
 #### `pickMultipleObjects()` pick depth limits
 
-For layers that use built-in shader instance ids instead of explicit picking color buffers, `pickMultipleObjects()` now only guarantees the default `depth` of 10 unique objects per layer. Applications that call `pickMultipleObjects()` with a custom `depth` above the default may receive duplicate results for these layers. Layers with explicit picking color buffers keep their previous buffer-mutation behavior.
+For layers that use built-in shader instance ids instead of explicit picking index buffers, `pickMultipleObjects()` now only guarantees the default `depth` of 10 unique objects per layer. Applications that call `pickMultipleObjects()` with a custom `depth` above the default may receive duplicate results for these layers. Layers with explicit picking index buffers keep their previous buffer-mutation behavior.
 
 ### `instancePickingColors` attribute is no longer automatically generated
 
@@ -13,7 +13,7 @@ Most built-in and custom instanced layers now derive picking colors from built-i
 In rare cases, custom WebGL layer shaders may need an update if they explicitly read the `instancePickingColors` attribute.
 
 - In such cases, use the new picking shader helper functions to derive the color from the instance id, for example `picking_setPickingColorFromInstanceID()` in GLSL or `picking_getPickingColorFromIndex(instanceIndex)` in WGSL.
-- However, if the logical picking id is different from the rendered instance id, layers can still continue to register and populate an explicit picking color attribute as before.
+- However, if the logical picking id is different from the rendered instance id, layers can register and populate an explicit `rowIndexes` attribute.
 
 ## Upgrading to v9.3
 

--- a/modules/core/src/lib/layer-state.ts
+++ b/modules/core/src/lib/layer-state.ts
@@ -37,7 +37,8 @@ export default class LayerState<LayerT extends Layer> extends ComponentState<Lay
    */
   usesPickingColorCache: boolean;
   /**
-   * If the layer has picking buffer (pickingColors or instancePickingColors)
+   * If the layer has a picking buffer
+   * (rowIndexes, pickingColors or instancePickingColors)
    */
   hasPickingBuffer?: boolean;
   /**

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -17,7 +17,7 @@ import memoize from '../utils/memoize';
 import {mergeShaders} from '../utils/shader';
 import {projectPosition, getWorldPosition} from '../shaderlib/project/project-functions';
 import typedArrayManager from '../utils/typed-array-manager';
-import {disablePickingIndex} from '../shaderlib/picking/picking';
+import {disablePickingIndex, PICKING_INVALID_INDEX} from '../shaderlib/picking/picking';
 
 import Component from '../lifecycle/component';
 import LayerState, {ChangeFlags} from './layer-state';
@@ -58,6 +58,18 @@ const areViewportsEqual = memoize(
 );
 
 let pickingColorCache = new Uint8ClampedArray(0);
+
+function getPickingAttribute(attributes: Record<string, Attribute>): Attribute | undefined {
+  return attributes.rowIndexes || attributes.pickingColors || attributes.instancePickingColors;
+}
+
+function getPickingIndexAttribute(attributes: Record<string, Attribute>): Attribute | undefined {
+  return attributes.rowIndexes;
+}
+
+function getPickingColorAttribute(attributes: Record<string, Attribute>): Attribute | undefined {
+  return attributes.pickingColors || attributes.instancePickingColors;
+}
 
 const defaultProps: DefaultProps<LayerProps> = {
   // data: Special handling for null, see below
@@ -498,16 +510,17 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
       // Only generate picking buffer if needed
       if (hasPickingBuffer !== needsPickingBuffer) {
         this.internalState!.hasPickingBuffer = needsPickingBuffer;
-        const {pickingColors, instancePickingColors} = attributeManager.attributes;
-        const pickingColorsAttribute = pickingColors || instancePickingColors;
-        if (pickingColorsAttribute) {
-          if (needsPickingBuffer && pickingColorsAttribute.constant) {
-            pickingColorsAttribute.constant = false;
-            attributeManager.invalidate(pickingColorsAttribute.id);
+        const pickingAttribute = getPickingAttribute(attributeManager.attributes);
+        if (pickingAttribute) {
+          if (needsPickingBuffer && pickingAttribute.constant) {
+            pickingAttribute.constant = false;
+            attributeManager.invalidate(pickingAttribute.id);
           }
-          if (!pickingColorsAttribute.value && !needsPickingBuffer) {
-            pickingColorsAttribute.constant = true;
-            pickingColorsAttribute.value = [0, 0, 0];
+          if (!pickingAttribute.value && !needsPickingBuffer) {
+            pickingAttribute.constant = true;
+            pickingAttribute.value = getPickingIndexAttribute(attributeManager.attributes)
+              ? [PICKING_INVALID_INDEX]
+              : [0, 0, 0];
           }
         }
       }
@@ -808,8 +821,23 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
     }
 
     // @ts-ignore (TS2531) this method is only called internally with attributeManager defined
-    const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
-    const colors = pickingColors || instancePickingColors;
+    const attributes = this.getAttributeManager().attributes;
+    const indexes = getPickingIndexAttribute(attributes);
+    const colors = getPickingColorAttribute(attributes);
+
+    const externalIndexAttribute =
+      indexes && data.attributes && (data.attributes[indexes.id] as BinaryAttribute);
+    if (externalIndexAttribute && externalIndexAttribute.value) {
+      const values = externalIndexAttribute.value;
+      for (let index = 0; index < data.length; index++) {
+        const i = indexes.getVertexOffset(index);
+        if (values[i] === objectIndex) {
+          this._disablePickingIndex(index);
+        }
+      }
+      return;
+    }
+
     const externalColorAttribute =
       colors && data.attributes && (data.attributes[colors.id] as BinaryAttribute);
     if (externalColorAttribute && externalColorAttribute.value) {
@@ -833,8 +861,18 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   // TODO - simplify subclassing interface
   protected _disablePickingIndex(objectIndex: number): void {
     // @ts-ignore (TS2531) this method is only called internally with attributeManager defined
-    const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
-    const colors = pickingColors || instancePickingColors;
+    const attributes = this.getAttributeManager().attributes;
+    const indexes = getPickingIndexAttribute(attributes);
+    if (indexes) {
+      const start = indexes.getVertexOffset(objectIndex);
+      const end = indexes.getVertexOffset(objectIndex + 1);
+      const invalidIndexes = new Uint32Array(end - start);
+      invalidIndexes.fill(PICKING_INVALID_INDEX);
+      indexes.buffer.write(invalidIndexes, start * invalidIndexes.BYTES_PER_ELEMENT);
+      return;
+    }
+
+    const colors = getPickingColorAttribute(attributes);
     if (!colors) {
       if (this.internalState) {
         disablePickingIndex(this.internalState.disabledPickingIndices, objectIndex);
@@ -852,23 +890,25 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   /** (Internal) Re-enable all picking indices after multi-depth picking */
   restorePickingColors(): void {
     // @ts-ignore (TS2531) this method is only called internally with attributeManager defined
-    const {pickingColors, instancePickingColors} = this.getAttributeManager().attributes;
-    const colors = pickingColors || instancePickingColors;
-    if (!colors) {
+    const attributes = this.getAttributeManager().attributes;
+    const pickingAttribute = getPickingAttribute(attributes);
+    if (!pickingAttribute) {
       if (this.internalState) {
         this.internalState.disabledPickingIndices.length = 0;
       }
       return;
     }
+    const colors = getPickingColorAttribute(attributes);
     // The picking color cache may have been freed and then reallocated. This ensures we read from the currently allocated cache.
     if (
       // @ts-ignore (TS2531) this method is only called internally with internalState defined
       this.internalState.usesPickingColorCache &&
+      colors &&
       (colors.value as Uint8ClampedArray).buffer !== pickingColorCache.buffer
     ) {
       colors.value = pickingColorCache.subarray(0, (colors.value as Uint8ClampedArray).length);
     }
-    colors.updateSubBuffer({startOffset: 0});
+    pickingAttribute.updateSubBuffer({startOffset: 0});
   }
 
   /* eslint-disable max-statements */

--- a/modules/core/src/shaderlib/picking/picking.ts
+++ b/modules/core/src/shaderlib/picking/picking.ts
@@ -6,11 +6,12 @@ import {picking} from '@luma.gl/shadertools';
 import log from '../../utils/log';
 
 export const PICKING_MAX_DISABLED_INDICES = 10;
+export const PICKING_INVALID_INDEX = 16777215;
 
 export function disablePickingIndex(disabledPickingIndices: number[], objectIndex: number): void {
   if (disabledPickingIndices.length === PICKING_MAX_DISABLED_INDICES) {
     log.warn(
-      `pickMultipleObjects can only exclude ${PICKING_MAX_DISABLED_INDICES} previously picked objects for layers without picking color buffers`
+      `pickMultipleObjects can only exclude ${PICKING_MAX_DISABLED_INDICES} previously picked objects for layers without picking buffers`
     )();
   } else {
     disabledPickingIndices.push(objectIndex);
@@ -42,7 +43,7 @@ function packDisabledPickingIndices(disabledPickingIndices: number[], startIndex
 
 const pickingHelpersGLSL = /* glsl */ `\
 vec3 picking_getPickingColorFromIndex(float objectIndex) {
-  if (objectIndex < 0.0 || objectIndex > 16777214.0) {
+  if (objectIndex < 0.0 || objectIndex >= ${PICKING_INVALID_INDEX}.0) {
     return vec3(0.0);
   }
 
@@ -65,6 +66,10 @@ vec3 picking_getPickingColorFromIndex(float objectIndex) {
     mod(floor(encodedIndex / 256.0), 256.0),
     mod(floor(encodedIndex / 65536.0), 256.0)
   );
+}
+
+vec3 picking_getPickingColorFromIndex(uint objectIndex) {
+  return picking_getPickingColorFromIndex(float(objectIndex));
 }
 
 vec3 picking_getPickingColorFromInstanceID() {
@@ -109,7 +114,7 @@ fn picking_isColorValid(color: vec3<f32>) -> bool {
 }
 
 fn picking_getPickingColorFromIndex(objectIndex: u32) -> vec3<f32> {
-  if (objectIndex > 16777214u) {
+  if (objectIndex >= ${PICKING_INVALID_INDEX}u) {
     return vec3<f32>(0.0);
   }
 

--- a/modules/geo-layers/src/mesh-layer/mesh-layer-vertex.glsl.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer-vertex.glsl.ts
@@ -11,7 +11,7 @@ in vec3 normals;
 in vec3 colors;
 in vec2 texCoords;
 in vec4 uvRegions;
-in vec3 featureIdsPickingColors;
+in float rowIndexes;
 
 // Instance attributes
 in vec4 instanceColors;
@@ -40,7 +40,7 @@ void main(void) {
   geometry.uv = uv;
 
   if (mesh.pickFeatureIds) {
-    geometry.pickingColor = featureIdsPickingColors;
+    geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
   } else {
     geometry.pickingColor = picking_getPickingColorFromInstanceID();
   }

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.ts
@@ -75,12 +75,13 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
     if (featureIds) {
       // attributeManager is always defined in a primitive layer
       attributeManager!.add({
-        featureIdsPickingColors: {
-          type: 'uint8',
-          size: 3,
+        /** Feature id for each mesh vertex. */
+        rowIndexes: {
+          type: 'uint32',
+          size: 1,
           noAlloc: true,
           // eslint-disable-next-line @typescript-eslint/unbound-method
-          update: this.calculateFeatureIdsPickingColors
+          update: this.calculateFeatureIdsPickingIndexes
         }
       });
     }
@@ -179,21 +180,10 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
     );
   }
 
-  calculateFeatureIdsPickingColors(attribute) {
+  calculateFeatureIdsPickingIndexes(attribute) {
     // This updater is only called if featureIds is not null
     const featureIds = this.props.featureIds!;
-    const value = new Uint8ClampedArray(featureIds.length * attribute.size);
-
-    const pickingColor = [];
-    for (let index = 0; index < featureIds.length; index++) {
-      this.encodePickingColor(featureIds[index], pickingColor);
-
-      value[index * 3] = pickingColor[0];
-      value[index * 3 + 1] = pickingColor[1];
-      value[index * 3 + 2] = pickingColor[2];
-    }
-
-    attribute.value = value;
+    attribute.value = new Uint32Array(featureIds);
   }
 
   finalizeState(context: LayerContext) {

--- a/modules/layers/src/geojson-layer/geojson-binary.ts
+++ b/modules/layers/src/geojson-layer/geojson-binary.ts
@@ -62,28 +62,19 @@ function getPropertiesForIndex(
   return feature;
 }
 
-// Custom picking color to keep binary indexes
-export function calculatePickingColors(
-  geojsonBinary: Required<ExtendedBinaryFeatureCollection>,
-  encodePickingColor: (id: number, result: number[]) => void
-): Record<string, Uint8ClampedArray | null> {
-  const pickingColors: Record<string, Uint8ClampedArray | null> = {
+// Custom picking indexes preserve global feature ids in binary data.
+export function calculatePickingIndexes(
+  geojsonBinary: Required<ExtendedBinaryFeatureCollection>
+): Record<string, Uint32Array | null> {
+  const pickingIndexes: Record<string, Uint32Array | null> = {
     points: null,
     lines: null,
     polygons: null
   };
-  for (const key in pickingColors) {
+  for (const key in pickingIndexes) {
     const featureIds = geojsonBinary[key].globalFeatureIds.value;
-    pickingColors[key] = new Uint8ClampedArray(featureIds.length * 4);
-    const pickingColor = [];
-    for (let i = 0; i < featureIds.length; i++) {
-      encodePickingColor(featureIds[i], pickingColor);
-      pickingColors[key][i * 4 + 0] = pickingColor[0];
-      pickingColors[key][i * 4 + 1] = pickingColor[1];
-      pickingColors[key][i * 4 + 2] = pickingColor[2];
-      pickingColors[key][i * 4 + 3] = 255;
-    }
+    pickingIndexes[key] = new Uint32Array(featureIds);
   }
 
-  return pickingColors;
+  return pickingIndexes;
 }

--- a/modules/layers/src/geojson-layer/geojson-layer-props.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer-props.ts
@@ -4,7 +4,7 @@
 
 import {LayerData, LayerProps} from '@deck.gl/core';
 import {PolygonLayerProps, ScatterplotLayerProps} from '..';
-import {calculatePickingColors} from './geojson-binary';
+import {calculatePickingIndexes} from './geojson-binary';
 import type {ExtendedBinaryFeatureCollection} from './geojson-binary';
 import {SeparatedGeometries} from './geojson';
 
@@ -60,8 +60,7 @@ export function createLayerPropsFromFeatures(
 }
 
 export function createLayerPropsFromBinary(
-  geojsonBinary: Required<ExtendedBinaryFeatureCollection>,
-  encodePickingColor: (id: number, result: number[]) => void
+  geojsonBinary: Required<ExtendedBinaryFeatureCollection>
 ): SubLayersProps {
   // The binary data format is documented here
   // https://github.com/visgl/loaders.gl/blob/master/modules/gis/docs/api-reference/geojson-to-binary.md
@@ -70,16 +69,18 @@ export function createLayerPropsFromBinary(
   const layerProps = createEmptyLayerProps();
   const {points, lines, polygons} = geojsonBinary;
 
-  const customPickingColors = calculatePickingColors(geojsonBinary, encodePickingColor);
+  const customPickingIndexes = calculatePickingIndexes(geojsonBinary);
 
   layerProps.points.data = {
     length: points.positions.value.length / points.positions.size,
     attributes: {
       ...points.attributes,
       getPosition: points.positions,
-      instancePickingColors: {
-        size: 4,
-        value: customPickingColors.points!
+      /** Global feature id for the rendered point geometry. */
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
+        value: customPickingIndexes.points!
       }
     },
     properties: points.properties,
@@ -93,9 +94,11 @@ export function createLayerPropsFromBinary(
     attributes: {
       ...lines.attributes,
       getPath: lines.positions,
-      instancePickingColors: {
-        size: 4,
-        value: customPickingColors.lines!
+      /** Global feature id for the rendered path geometry. */
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
+        value: customPickingIndexes.lines!
       }
     },
     properties: lines.properties,
@@ -120,9 +123,11 @@ export function createLayerPropsFromBinary(
         size: 1,
         value: new Uint16Array(vertexValid)
       },
-      pickingColors: {
-        size: 4,
-        value: customPickingColors.polygons!
+      /** Global feature id for the rendered polygon geometry. */
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
+        value: customPickingIndexes.polygons!
       }
     },
     properties: polygons.properties,
@@ -140,9 +145,11 @@ export function createLayerPropsFromBinary(
     attributes: {
       ...polygons.attributes,
       getPath: polygons.positions,
-      instancePickingColors: {
-        size: 4,
-        value: customPickingColors.polygons!
+      /** Global feature id for the rendered polygon outline geometry. */
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
+        value: customPickingIndexes.polygons!
       }
     },
     properties: polygons.properties,

--- a/modules/layers/src/geojson-layer/geojson-layer.ts
+++ b/modules/layers/src/geojson-layer/geojson-layer.ts
@@ -367,7 +367,7 @@ export default class GeoJsonLayer<
 
   private _updateStateBinary({props, changeFlags}): void {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const layerProps = createLayerPropsFromBinary(props.data, this.encodePickingColor);
+    const layerProps = createLayerPropsFromBinary(props.data);
     this.setState({layerProps});
   }
 
@@ -535,13 +535,13 @@ export default class GeoJsonLayer<
         let pointsLayerProps = layerProps.points;
 
         if (type === 'text' && binary) {
-          // Picking colors are per-point but for text per-character are required
+          // Picking indexes are per-point but for text per-character are required
           // getPickingInfo() maps back to the correct index
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           // @ts-expect-error TODO - type binary data
 
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const {instancePickingColors, ...rest} = pointsLayerProps.data.attributes;
+          const {rowIndexes, ...rest} = pointsLayerProps.data.attributes;
           pointsLayerProps = {
             ...pointsLayerProps,
             // @ts-expect-error TODO - type binary data

--- a/modules/layers/src/icon-layer/icon-layer-vertex.glsl.ts
+++ b/modules/layers/src/icon-layer/icon-layer-vertex.glsl.ts
@@ -13,8 +13,8 @@ in vec3 instancePositions64Low;
 in float instanceSizes;
 in float instanceAngles;
 in vec4 instanceColors;
-#ifdef USE_INSTANCE_PICKING_COLORS
-in vec3 instancePickingColors;
+#ifdef USE_ROW_INDEXES
+in float rowIndexes;
 #endif
 in vec4 instanceIconFrames;
 in float instanceColorModes;
@@ -37,8 +37,8 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
 void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = positions;
-#ifdef USE_INSTANCE_PICKING_COLORS
-  geometry.pickingColor = instancePickingColors;
+#ifdef USE_ROW_INDEXES
+  geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
 #else
   geometry.pickingColor = picking_getPickingColorFromInstanceID();
 #endif

--- a/modules/layers/src/icon-layer/icon-layer.ts
+++ b/modules/layers/src/icon-layer/icon-layer.ts
@@ -140,14 +140,12 @@ export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends
   };
 
   getShaders() {
-    const useInstancePickingColors = Boolean(
-      (this.props.data as any)?.attributes?.instancePickingColors
-    );
+    const useRowIndexes = Boolean((this.props.data as any)?.attributes?.rowIndexes);
     return super.getShaders({
       vs,
       fs,
-      source: getShaderWGSL(useInstancePickingColors),
-      defines: useInstancePickingColors ? {USE_INSTANCE_PICKING_COLORS: true} : {},
+      source: getShaderWGSL(useRowIndexes),
+      defines: useRowIndexes ? {USE_ROW_INDEXES: true} : {},
       modules: [project32, color, picking, iconUniforms]
     });
   }
@@ -213,11 +211,12 @@ export default class IconLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         transition: true,
         accessor: 'getPixelOffset'
       },
-      ...((this.props.data as any)?.attributes?.instancePickingColors
+      ...((this.props.data as any)?.attributes?.rowIndexes
         ? {
-            instancePickingColors: {
-              size: 4,
-              type: 'uint8',
+            /** Caller-provided logical picking index per icon instance. */
+            rowIndexes: {
+              size: 1,
+              type: 'uint32',
               noAlloc: true
             }
           }

--- a/modules/layers/src/icon-layer/icon-layer.wgsl.ts
+++ b/modules/layers/src/icon-layer/icon-layer.wgsl.ts
@@ -155,16 +155,13 @@ fn fragmentMain(inp: Varyings) -> @location(0) vec4<f32> {
 }
 `;
 
-export function getShaderWGSL(useInstancePickingColors: boolean): string {
+export function getShaderWGSL(useRowIndexes: boolean): string {
   return shaderWGSL
-    .replace(
-      'PICKING_COLOR_ATTRIBUTE',
-      useInstancePickingColors ? '@location(10) instancePickingColors: vec4<f32>,' : ''
-    )
+    .replace('PICKING_COLOR_ATTRIBUTE', useRowIndexes ? '@location(10) rowIndexes: u32,' : '')
     .replace(
       'PICKING_COLOR_VALUE',
-      useInstancePickingColors
-        ? 'inp.instancePickingColors.rgb'
+      useRowIndexes
+        ? 'picking_getPickingColorFromIndex(inp.rowIndexes)'
         : 'picking_getPickingColorFromIndex(inp.instanceIndex)'
     );
 }

--- a/modules/layers/src/path-layer/path-layer-vertex.glsl.ts
+++ b/modules/layers/src/path-layer/path-layer-vertex.glsl.ts
@@ -19,7 +19,7 @@ in vec3 instanceEndPositions64Low;
 in vec3 instanceRightPositions64Low;
 in float instanceStrokeWidths;
 in vec4 instanceColors;
-in vec3 instancePickingColors;
+in float rowIndexes;
 
 uniform float opacity;
 
@@ -148,7 +148,7 @@ void clipLine(inout vec4 position, vec4 refPosition) {
 }
 
 void main() {
-  geometry.pickingColor = instancePickingColors;
+  geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
 
   vColor = vec4(instanceColors.rgb, instanceColors.a * layer.opacity);
 

--- a/modules/layers/src/path-layer/path-layer.ts
+++ b/modules/layers/src/path-layer/path-layer.ts
@@ -197,11 +197,11 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         transition: ATTRIBUTE_TRANSITION,
         defaultValue: DEFAULT_COLOR
       },
-      instancePickingColors: {
-        size: 4,
-        type: 'uint8',
-        accessor: (object, {index, target: value}) =>
-          this.encodePickingColor(object && object.__source ? object.__source.index : index, value)
+      /** Source path row for each generated segment/joint instance. */
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
+        accessor: (object, {index}) => (object && object.__source ? object.__source.index : index)
       }
     });
     /* eslint-enable max-len */

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.ts
@@ -14,8 +14,8 @@ in float instanceRadius;
 in float instanceLineWidths;
 in vec4 instanceFillColors;
 in vec4 instanceLineColors;
-#ifdef USE_INSTANCE_PICKING_COLORS
-in vec3 instancePickingColors;
+#ifdef USE_ROW_INDEXES
+in float rowIndexes;
 #endif
 in vec2 instancePixelOffset;
 
@@ -49,8 +49,8 @@ void main(void) {
   // position on the containing square in [-1, 1] space
   unitPosition = edgePadding * positions.xy;
   geometry.uv = unitPosition;
-#ifdef USE_INSTANCE_PICKING_COLORS
-  geometry.pickingColor = instancePickingColors;
+#ifdef USE_ROW_INDEXES
+  geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
 #else
   geometry.pickingColor = picking_getPickingColorFromInstanceID();
 #endif

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -176,27 +176,27 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT extends {} = {}> 
   };
 
   getShaders() {
-    const useInstancePickingColors = Boolean(
-      (this.props.data as any)?.attributes?.instancePickingColors
-    );
+    const useRowIndexes = Boolean((this.props.data as any)?.attributes?.rowIndexes);
     return super.getShaders({
       vs,
       fs,
-      source: getShaderWGSL(useInstancePickingColors),
-      defines: useInstancePickingColors ? {USE_INSTANCE_PICKING_COLORS: true} : {},
+      source: getShaderWGSL(useRowIndexes),
+      defines: useRowIndexes ? {USE_ROW_INDEXES: true} : {},
       modules: [project32, color, picking, scatterplotUniforms]
     });
   }
 
   initializeState() {
-    const attributes: Record<string, any> = {};
-    if ((this.props.data as any)?.attributes?.instancePickingColors) {
-      attributes.instancePickingColors = {
-        size: 4,
-        type: 'uint8',
-        noAlloc: true
-      };
-    }
+    const attributes: Record<string, any> = (this.props.data as any)?.attributes?.rowIndexes
+      ? {
+          /** Caller-provided logical picking index per point instance. */
+          rowIndexes: {
+            size: 1,
+            type: 'uint32',
+            noAlloc: true
+          }
+        }
+      : {};
     this.getAttributeManager()!.addInstanced({
       instancePositions: {
         size: 3,

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.wgsl.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.wgsl.ts
@@ -224,16 +224,13 @@ fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
 }
 `;
 
-export function getShaderWGSL(useInstancePickingColors: boolean): string {
+export function getShaderWGSL(useRowIndexes: boolean): string {
   return shaderWGSL
-    .replace(
-      'PICKING_COLOR_ATTRIBUTE',
-      useInstancePickingColors ? '@location(8) instancePickingColors: vec4<f32>,' : ''
-    )
+    .replace('PICKING_COLOR_ATTRIBUTE', useRowIndexes ? '@location(8) rowIndexes: u32,' : '')
     .replace(
       'PICKING_COLOR_VALUE',
-      useInstancePickingColors
-        ? 'attributes.instancePickingColors.rgb'
+      useRowIndexes
+        ? 'picking_getPickingColorFromIndex(attributes.rowIndexes)'
         : 'picking_getPickingColorFromIndex(attributes.instanceIndex)'
     );
 }

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer-vertex-main.glsl.ts
@@ -6,7 +6,7 @@ export default `\
 
 in vec4 fillColors;
 in vec4 lineColors;
-in vec3 pickingColors;
+in float rowIndexes;
 
 out vec4 vColor;
 
@@ -33,7 +33,7 @@ void calculatePosition(PolygonProps props) {
   vec4 colors = solidPolygon.isWireframe ? lineColors : fillColors;
 
   geometry.worldPosition = props.positions;
-  geometry.pickingColor = pickingColors;
+  geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
 
   if (solidPolygon.extruded) {
     pos.z += props.elevations * solidPolygon.elevationScale;

--- a/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
+++ b/modules/layers/src/solid-polygon-layer/solid-polygon-layer.ts
@@ -238,12 +238,12 @@ export default class SolidPolygonLayer<DataT = any, ExtraPropsT extends {} = {}>
         accessor: 'getLineColor',
         defaultValue: DEFAULT_COLOR
       },
-      pickingColors: {
-        size: 4,
-        type: 'uint8',
+      /** Source polygon row, including __source.index for composite data. */
+      rowIndexes: {
+        size: 1,
+        type: 'uint32',
         stepMode: 'dynamic',
-        accessor: (object, {index, target: value}) =>
-          this.encodePickingColor(object && object.__source ? object.__source.index : index, value)
+        accessor: (object, {index}) => (object && object.__source ? object.__source.index : index)
       }
     });
     /* eslint-enable max-len */

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
@@ -13,7 +13,7 @@ in vec3 instancePositions64Low;
 in float instanceSizes;
 in float instanceAngles;
 in vec4 instanceColors;
-in vec3 instancePickingColors;
+in float rowIndexes;
 in vec4 instanceIconFrames;
 in float instanceColorModes;
 in vec2 instanceOffsets;
@@ -52,7 +52,7 @@ float getPixelOffsetFromAlignment(float anchor, float extent, float clipStart, f
 void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = positions;
-  geometry.pickingColor = instancePickingColors;
+  geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
   uv = positions;
 
   vec2 iconSize = instanceIconFrames.zw;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -80,10 +80,11 @@ export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     instanceIconDefs.settings.update = this.calculateInstanceIconDefs;
     attributeManager!.addInstanced({
-      instancePickingColors: {
-        type: 'uint8',
-        size: 4,
-        accessor: (object, {index, target: value}) => this.encodePickingColor(index, value)
+      /** Source text row for each generated character instance. */
+      rowIndexes: {
+        type: 'uint32',
+        size: 1,
+        accessor: (object, {index}) => index
       },
       instanceClipRect: {
         size: 4,

--- a/test/modules/layers/data/fixtures.ts
+++ b/test/modules/layers/data/fixtures.ts
@@ -43,14 +43,4 @@ export const geoJSONData = [
   }
 ];
 
-// prettier-ignore
-export const pickingColorsSample = Uint8ClampedArray.from([
-  1, 0, 0, 255,
-  1, 0, 0, 255,
-  1, 0, 0, 255,
-  1, 0, 0, 255,
-  2, 0, 0, 255,
-  2, 0, 0, 255,
-  2, 0, 0, 255,
-  2, 0, 0, 255,
-]);
+export const pickingIndexesSample = Uint32Array.from([0, 0, 0, 0, 1, 1, 1, 1]);

--- a/test/modules/layers/geojson-binary.spec.ts
+++ b/test/modules/layers/geojson-binary.spec.ts
@@ -4,24 +4,19 @@
 
 import {test, expect} from 'vitest';
 import {geojsonToBinary} from '@loaders.gl/gis';
-import {calculatePickingColors} from '@deck.gl/layers/geojson-layer/geojson-binary';
-import {Layer} from '@deck.gl/core';
-import {geoJSONData, pickingColorsSample} from './data/fixtures';
+import {calculatePickingIndexes} from '@deck.gl/layers/geojson-layer/geojson-binary';
+import {geoJSONData, pickingIndexesSample} from './data/fixtures';
 
 const geoJSONBinaryData = geojsonToBinary(geoJSONData);
-const dummyLayer = new Layer();
 
-test('calculatePickingColors', () => {
-  const customPickingColors = calculatePickingColors(
-    geoJSONBinaryData,
-    dummyLayer.encodePickingColor
-  );
+test('calculatePickingIndexes', () => {
+  const customPickingIndexes = calculatePickingIndexes(geoJSONBinaryData);
   expect(
-    Object.keys(customPickingColors),
-    'creates a picking color object for the three types of geometry'
+    Object.keys(customPickingIndexes),
+    'creates a picking index object for the three types of geometry'
   ).toEqual(['points', 'lines', 'polygons']);
   expect(
-    customPickingColors.polygons,
-    'creates a right picking colors array for binary geojson'
-  ).toEqual(pickingColorsSample);
+    customPickingIndexes.polygons,
+    'creates a right picking indexes array for binary geojson'
+  ).toEqual(pickingIndexesSample);
 });


### PR DESCRIPTION
# row-index based picking

- This is PR 2 of 3 
- Follow-up to 1st PR #10275 
- Future 3rd PR: switch to the luma.gl indexPicking module, which will remove the now shader-internal use of picking colors as well as lift restrictions on number of layers and instances in picking.

## Summary

This PR replaces remaining explicit color-encoded picking buffers with semantic `rowIndexes` uint32 buffers.

All custom picking attributes are now called rowIndexes and contain canonical uint32 row/feature ids rather than obscure picking colors.

Instead of storing pre-encoded RGB picking colors in `pickingColors` / `instancePickingColors`, layers that need custom vertex/instance to row mappings now store the logical object or feature id directly in `rowIndexes`, and the shader derives the picking color with `picking_getPickingColorFromIndex(rowIndexes)`.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/6080e35c-919b-4117-abd3-f2f3704061cc" />


## Why

`rowIndexes` are a more natural representation than encoded color bytes:

- they directly express the logical row/object/feature id used for picking
- they avoid CPU-side RGB color encoding for explicit picking buffers
- they use one `uint32` value instead of RGB/RGBA byte tuples
- they are useful beyond picking, for example as indexes into storage buffers or metadata tables

Built-in one-instance-per-object layers still use `gl_InstanceID` / `instance_index`. Explicit `rowIndexes` are only used where the logical picking id differs from the rendered instance id.

## What Changed

- Added `rowIndexes` as the unified explicit picking-index attribute.
- Converted special built-in layers from explicit picking color buffers to `rowIndexes`.
- Updated GLSL/WGSL shaders to derive picking colors from row indexes.
- Kept legacy explicit `pickingColors` / `instancePickingColors` support in core for compatibility.
- Updated binary GeoJSON picking helpers from color arrays to uint32 index arrays.
- Updated custom layer docs and upgrade notes to recommend `rowIndexes`.

## Layer Cases

| Layer / Path | `rowIndexes` Represents |
|---|---|
| `PathLayer` | source path row for each generated segment/joint instance |
| `MultiIconLayer` | source text row for each generated character instance |
| `SolidPolygonLayer` | source polygon row, including `__source.index` for composite data |
| Binary GeoJSON/MVT points | global feature id for rendered point geometry |
| Binary GeoJSON/MVT lines | global feature id for rendered path geometry |
| Binary GeoJSON/MVT polygons | global feature id for rendered polygon geometry |
| Binary GeoJSON/MVT polygon outlines | global feature id for rendered outline geometry |
| `IconLayer` / `ScatterplotLayer` binary hooks | caller-provided logical picking index per instance |
| `MeshLayer` feature-id picking | feature id for each mesh vertex |

## Testing

- `npx tsc -p modules/core/tsconfig.json --noEmit`
- `npx tsc -p modules/layers/tsconfig.json --noEmit`
- `npx t
