### PR TITLE
feat(core): improve touch zoom gestures

### DIFF
--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -20,6 +20,12 @@ const NO_TRANSITION_PROPS = {
 
 const DEFAULT_INERTIA = 300;
 const INERTIA_EASING = t => 1 - (1 - t) * (1 - t);
+const MAX_PINCH_ZOOM_DELTA_PER_EVENT = 0.18;
+const DOUBLE_TAP_DRAG_INTERVAL = 500;
+const DOUBLE_TAP_DRAG_MAX_TAP_DURATION = 350;
+const DOUBLE_TAP_DRAG_MAX_TAP_DISTANCE = 28;
+const DOUBLE_TAP_DRAG_START_THRESHOLD = 1;
+const DOUBLE_TAP_DRAG_PIXELS_PER_ZOOM = 120;
 
 const EVENT_TYPES = {
   WHEEL: ['wheel'],
@@ -27,6 +33,7 @@ const EVENT_TYPES = {
   PINCH: ['pinchstart', 'pinchmove', 'pinchend'],
   MULTI_PAN: ['multipanstart', 'multipanmove', 'multipanend'],
   DOUBLE_CLICK: ['dblclick'],
+  DOUBLE_TAP_DRAG: ['pointerdown', 'pointermove', 'pointerup', 'pointercancel'],
   KEYBOARD: ['keydown']
 } as const;
 
@@ -112,6 +119,28 @@ export type ViewStateChangeParameters<ViewStateT = any> = {
 
 const pinchEventWorkaround: any = {};
 
+type OneFingerTapState = {
+  pos: [number, number];
+  time: number;
+  pointerId?: number;
+};
+
+type OneFingerZoomState = {
+  startPos: [number, number];
+  pointerId?: number;
+  active: boolean;
+};
+
+function getDistance(a: [number, number], b: [number, number]): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function clampPinchZoomDelta(delta: number): number {
+  return Math.max(-MAX_PINCH_ZOOM_DELTA_PER_EVENT, Math.min(MAX_PINCH_ZOOM_DELTA_PER_EVENT, delta));
+}
+
 export default abstract class Controller<ControllerState extends IViewState<ControllerState>> {
   abstract get ControllerState(): ConstructorOf<ControllerState>;
   abstract get transition(): TransitionProps;
@@ -135,6 +164,10 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
   private _customEvents: string[] = [];
   private _eventStartBlocked: any = null;
   private _panMove: boolean = false;
+  private _tapStart: OneFingerTapState | null = null;
+  private _lastTap: OneFingerTapState | null = null;
+  private _oneFingerZoom: OneFingerZoomState | null = null;
+  private _suppressDoubleClickUntil: number = 0;
 
   protected invertPan: boolean = false;
   protected dragMode: 'pan' | 'rotate' = 'rotate';
@@ -209,10 +242,19 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
 
     switch (event.type) {
       case 'panstart':
+        if (this._oneFingerZoom) {
+          return false;
+        }
         return eventStartBlocked ? false : this._onPanStart(event);
       case 'panmove':
+        if (this._oneFingerZoom) {
+          return false;
+        }
         return this._onPan(event);
       case 'panend':
+        if (this._oneFingerZoom) {
+          return false;
+        }
         return this._onPanEnd(event);
       case 'pinchstart':
         return eventStartBlocked ? false : this._onPinchStart(event);
@@ -228,6 +270,13 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
         return this._onMultiPanEnd(event);
       case 'dblclick':
         return this._onDoubleClick(event);
+      case 'pointerdown':
+        return this._onPointerDown(event);
+      case 'pointermove':
+        return this._onPointerMove(event);
+      case 'pointerup':
+      case 'pointercancel':
+        return this._onPointerUp(event);
       case 'wheel':
         return this._onWheel(event as MjolnirWheelEvent);
       case 'keydown':
@@ -328,6 +377,7 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     this.toggleEvents(EVENT_TYPES.PINCH, isInteractive && (touchZoom || touchRotate));
     this.toggleEvents(EVENT_TYPES.MULTI_PAN, isInteractive && touchRotate);
     this.toggleEvents(EVENT_TYPES.DOUBLE_CLICK, isInteractive && doubleClickZoom);
+    this.toggleEvents(EVENT_TYPES.DOUBLE_TAP_DRAG, isInteractive && touchZoom);
     this.toggleEvents(EVENT_TYPES.KEYBOARD, isInteractive && keyboard);
 
     // Interaction toggles
@@ -641,6 +691,7 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
 
   // Default handler for the `pinchstart` event.
   protected _onPinchStart(event: MjolnirGestureEvent): boolean {
+    this._resetOneFingerZoom();
     const pos = this.getCenter(event);
     if (!this.isPointInBounds(pos, event)) {
       return false;
@@ -649,7 +700,7 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     const newControllerState = this.controllerState.zoomStart({pos}).rotateStart({pos});
     // hack - hammer's `rotation` field doesn't seem to produce the correct angle
     pinchEventWorkaround._startPinchRotation = event.rotation;
-    pinchEventWorkaround._lastPinchEvent = event;
+    pinchEventWorkaround._smoothedPinchScaleLog = 0;
     this.updateViewport(newControllerState, NO_TRANSITION_PROPS, {isDragging: true});
     return true;
   }
@@ -667,7 +718,12 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     if (this.touchZoom) {
       const {scale} = event;
       const pos = this.getCenter(event);
-      newControllerState = newControllerState.zoom({pos, scale});
+      const rawScaleLog = Math.log2(scale);
+      const previousScaleLog = pinchEventWorkaround._smoothedPinchScaleLog ?? 0;
+      const smoothedScaleLog =
+        previousScaleLog + clampPinchZoomDelta(rawScaleLog - previousScaleLog);
+      pinchEventWorkaround._smoothedPinchScaleLog = smoothedScaleLog;
+      newControllerState = newControllerState.zoom({pos, scale: Math.pow(2, smoothedScaleLog)});
     }
     if (this.touchRotate) {
       const {rotation} = event;
@@ -682,7 +738,6 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       isZooming: this.touchZoom,
       isRotating: this.touchRotate
     });
-    pinchEventWorkaround._lastPinchEvent = event;
     return true;
   }
 
@@ -690,49 +745,24 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     if (!this.isDragging()) {
       return false;
     }
-    const {inertia} = this;
-    const {_lastPinchEvent} = pinchEventWorkaround;
-    if (this.touchZoom && inertia && _lastPinchEvent && event.scale !== _lastPinchEvent.scale) {
-      const pos = this.getCenter(event);
-      let newControllerState = this.controllerState.rotateEnd();
-      const z = Math.log2(event.scale);
-      const velocityZ =
-        (z - Math.log2(_lastPinchEvent.scale)) / (event.deltaTime - _lastPinchEvent.deltaTime);
-      const endScale = Math.pow(2, z + (velocityZ * inertia) / 2);
-      newControllerState = newControllerState.zoom({pos, scale: endScale}).zoomEnd();
-
-      this.updateViewport(
-        newControllerState,
-        {
-          ...this._getTransitionProps({around: pos}),
-          transitionDuration: inertia,
-          transitionEasing: INERTIA_EASING
-        },
-        {
-          isDragging: false,
-          isPanning: this.touchZoom,
-          isZooming: this.touchZoom,
-          isRotating: false
-        }
-      );
-      this.blockEvents(inertia);
-    } else {
-      const newControllerState = this.controllerState.zoomEnd().rotateEnd();
-      this.updateViewport(newControllerState, null, {
-        isDragging: false,
-        isPanning: false,
-        isZooming: false,
-        isRotating: false
-      });
-    }
+    const newControllerState = this.controllerState.zoomEnd().rotateEnd();
+    this.updateViewport(newControllerState, null, {
+      isDragging: false,
+      isPanning: false,
+      isZooming: false,
+      isRotating: false
+    });
     pinchEventWorkaround._startPinchRotation = null;
-    pinchEventWorkaround._lastPinchEvent = null;
+    pinchEventWorkaround._smoothedPinchScaleLog = null;
     return true;
   }
 
   // Default handler for the `dblclick` event.
   protected _onDoubleClick(event: MjolnirGestureEvent): boolean {
     if (!this.doubleClickZoom) {
+      return false;
+    }
+    if (Date.now() < this._suppressDoubleClickUntil) {
       return false;
     }
     const pos = this.getCenter(event);
@@ -749,6 +779,147 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     });
     this.blockEvents(100);
     return true;
+  }
+
+  protected _onPointerDown(event: MjolnirEvent): boolean {
+    if (!this.touchZoom || !this._isPrimaryPointer(event)) {
+      this._resetOneFingerZoom();
+      return false;
+    }
+
+    const pos = this.getCenter(event as MjolnirGestureEvent);
+    if (!this.isPointInBounds(pos, event)) {
+      this._resetOneFingerZoom();
+      return false;
+    }
+
+    const time = this._getEventTime(event);
+    const pointerId = (event.srcEvent as PointerEvent).pointerId;
+    if (
+      this._lastTap &&
+      time - this._lastTap.time <= DOUBLE_TAP_DRAG_INTERVAL &&
+      getDistance(pos, this._lastTap.pos) <= DOUBLE_TAP_DRAG_MAX_TAP_DISTANCE
+    ) {
+      this._tapStart = null;
+      this._lastTap = null;
+      this._oneFingerZoom = {startPos: pos, pointerId, active: false};
+      event.srcEvent.preventDefault();
+      event.stopPropagation();
+      return true;
+    }
+
+    this._tapStart = {pos, time, pointerId};
+    this._lastTap = null;
+    if ((event.srcEvent as PointerEvent).pointerType === 'touch') {
+      event.srcEvent.preventDefault();
+    }
+    return false;
+  }
+
+  protected _onPointerMove(event: MjolnirEvent): boolean {
+    const oneFingerZoom = this._oneFingerZoom;
+    if (!oneFingerZoom || !this._isSamePointer(event, oneFingerZoom.pointerId)) {
+      return false;
+    }
+
+    const pos = this.getCenter(event as MjolnirGestureEvent);
+    const dy = oneFingerZoom.startPos[1] - pos[1];
+    if (!oneFingerZoom.active && Math.abs(dy) < DOUBLE_TAP_DRAG_START_THRESHOLD) {
+      event.srcEvent.preventDefault();
+      event.stopPropagation();
+      return true;
+    }
+
+    const scale = Math.pow(2, dy / DOUBLE_TAP_DRAG_PIXELS_PER_ZOOM);
+    const startPos = oneFingerZoom.startPos;
+    let newControllerState = this.controllerState;
+    if (!oneFingerZoom.active) {
+      oneFingerZoom.active = true;
+      newControllerState = newControllerState.zoomStart({pos: startPos});
+    }
+    newControllerState = newControllerState.zoom({pos: startPos, scale});
+    this.updateViewport(newControllerState, NO_TRANSITION_PROPS, {
+      isDragging: true,
+      isPanning: true,
+      isZooming: true
+    });
+
+    event.srcEvent.preventDefault();
+    event.stopPropagation();
+    return true;
+  }
+
+  protected _onPointerUp(event: MjolnirEvent): boolean {
+    const oneFingerZoom = this._oneFingerZoom;
+    if (oneFingerZoom && this._isSamePointer(event, oneFingerZoom.pointerId)) {
+      this._oneFingerZoom = null;
+      if (oneFingerZoom.active) {
+        const newControllerState = this.controllerState.zoomEnd();
+        this.updateViewport(newControllerState, null, {
+          isDragging: false,
+          isPanning: false,
+          isZooming: false
+        });
+        this._suppressDoubleClickUntil = Date.now() + 100;
+        this.blockEvents(100);
+        event.srcEvent.preventDefault();
+        event.stopPropagation();
+        return true;
+      }
+      return false;
+    }
+
+    if (event.type === 'pointercancel') {
+      this._resetOneFingerZoom();
+      return false;
+    }
+
+    const tapStart = this._tapStart;
+    if (!tapStart || !this._isSamePointer(event, tapStart.pointerId)) {
+      return false;
+    }
+
+    const pos = this.getCenter(event as MjolnirGestureEvent);
+    const time = this._getEventTime(event);
+    if (
+      time - tapStart.time <= DOUBLE_TAP_DRAG_MAX_TAP_DURATION &&
+      getDistance(pos, tapStart.pos) <= DOUBLE_TAP_DRAG_MAX_TAP_DISTANCE
+    ) {
+      this._lastTap = {pos, time, pointerId: tapStart.pointerId};
+    } else {
+      this._lastTap = null;
+    }
+    this._tapStart = null;
+    if ((event.srcEvent as PointerEvent).pointerType === 'touch') {
+      event.srcEvent.preventDefault();
+    }
+    return false;
+  }
+
+  private _resetOneFingerZoom(): void {
+    this._tapStart = null;
+    this._lastTap = null;
+    this._oneFingerZoom = null;
+  }
+
+  private _getEventTime(event: MjolnirEvent): number {
+    return (event as any).timeStamp || event.srcEvent.timeStamp || Date.now();
+  }
+
+  private _isPrimaryPointer(event: MjolnirEvent): boolean {
+    const pointers = (event as any).pointers;
+    if (pointers && pointers.length > 1) {
+      return false;
+    }
+    const srcEvent = event.srcEvent as PointerEvent;
+    if (srcEvent.pointerType === 'mouse') {
+      return (event as any).leftButton !== false;
+    }
+    return true;
+  }
+
+  private _isSamePointer(event: MjolnirEvent, pointerId?: number): boolean {
+    return pointerId === undefined || (event.srcEvent as PointerEvent).pointerId === pointerId;
   }
 
   // Default handler for the `keydown` event

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -35,6 +35,84 @@ test('MapController#inertia', async () => {
   });
 });
 
+test('MapController does not apply pinch zoom inertia after quick lift', () => {
+  const makePinchEvent = (type: string, scale: number, deltaTime: number) => ({
+    type,
+    offsetCenter: {x: 50, y: 50},
+    scale,
+    rotation: 0,
+    deltaTime,
+    srcEvent: {preventDefault() {}},
+    stopPropagation() {}
+  });
+
+  for (const {moveScale, endScale} of [
+    {moveScale: 0.01, endScale: 0.001},
+    {moveScale: 100, endScale: 1000}
+  ]) {
+    const controller = createTestController({
+      view: new MapView({controller: true}),
+      initialViewState: {
+        longitude: -122.45,
+        latitude: 37.78,
+        zoom: 10,
+        pitch: 30,
+        bearing: -45,
+        inertia: 300
+      }
+    });
+
+    controller.handleEvent(makePinchEvent('pinchstart', 1, 0) as any);
+    controller.handleEvent(makePinchEvent('pinchmove', moveScale, 16) as any);
+    const zoomAfterMove = controller.props.zoom;
+
+    controller.handleEvent(makePinchEvent('pinchend', endScale, 17) as any);
+
+    expect(
+      controller.props.zoom,
+      'quick two-finger lift should end at the last live pinch zoom'
+    ).toBeCloseTo(zoomAfterMove);
+  }
+});
+
+test('MapController supports double-tap drag zoom when double click zoom is disabled', () => {
+  const controller = createTestController({
+    view: new MapView({controller: {touchZoom: true, doubleClickZoom: false}}),
+    initialViewState: {
+      longitude: -122.45,
+      latitude: 37.78,
+      zoom: 10,
+      pitch: 30,
+      bearing: -45,
+      inertia: 300
+    }
+  });
+
+  const makePointerEvent = (type: string, y: number, timeStamp: number) => ({
+    type,
+    offsetCenter: {x: 50, y},
+    timeStamp,
+    srcEvent: {
+      pointerId: 1,
+      pointerType: 'touch',
+      timeStamp,
+      preventDefault() {}
+    },
+    stopPropagation() {}
+  });
+
+  controller.handleEvent(makePointerEvent('pointerdown', 50, 0) as any);
+  controller.handleEvent(makePointerEvent('pointerup', 50, 50) as any);
+  controller.handleEvent(makePointerEvent('pointerdown', 50, 120) as any);
+  controller.handleEvent(makePointerEvent('pointermove', 20, 150) as any);
+  const zoomAfterMove = controller.props.zoom;
+
+  controller.handleEvent(makePointerEvent('pointerup', 20, 180) as any);
+
+  expect(zoomAfterMove, 'dragging up after double tap zooms in').toBeGreaterThan(10);
+  expect(controller.props.zoom, 'release should not change zoom').toBeCloseTo(zoomAfterMove);
+});
+
 test('GlobeController', async () => {
   await testController(
     GlobeView,


### PR DESCRIPTION
## Summary

- add one-finger double-tap-drag zoom gated by `touchZoom`
- smooth noisy mobile pinch frames
- stop pinch zoom exactly on touch lift instead of applying zoom inertia

## Why

Mobile touch zoom could jump on noisy pinch-end frames. This keeps pinch zoom responsive while preventing the final lift frame from flicking the viewport, and adds the common double-tap-drag zoom gesture used by mobile map tools.

## Split

GlobeView cursor/touch anchored zoom has been split into #10307 so this PR can stay focused on generic controller touch gesture behavior.

## Tests

- `./node_modules/.bin/vitest run --project browser test/modules/core/controllers/controllers.spec.ts`
- commit hook: module/test/example lint + prettier checks, lockfile validation, node vitest subset