### PR TITLE
fix(core): suppress mobile DOM touch affordances

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -50,6 +50,19 @@ import {CreateDeviceProps} from '@luma.gl/core';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop() {}
 
+const CANVAS_TOUCH_STYLES = [
+  ['-webkit-user-select', 'none'],
+  ['-webkit-user-drag', 'none'],
+  ['-webkit-touch-callout', 'none'],
+  ['-webkit-tap-highlight-color', 'rgba(0,0,0,0)']
+] as const;
+
+function applyCanvasTouchStyles(canvas: HTMLCanvasElement): void {
+  for (const [property, value] of CANVAS_TOUCH_STYLES) {
+    canvas.style.setProperty(property, value);
+  }
+}
+
 const getCursor = ({isDragging}) => (isDragging ? 'grabbing' : 'grab');
 
 export type DeckMetrics = {
@@ -1029,6 +1042,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       parent.appendChild(canvas);
     }
 
+    applyCanvasTouchStyles(canvas);
     Object.assign(canvas.style, props.style);
 
     return canvas;


### PR DESCRIPTION
## Summary
- apply iOS/WebKit touch affordance suppression styles directly to the Deck canvas
- keep mjolnir responsible for event-root CSS/touch-action handling

## Why
mjolnir already applies its default gesture CSS to the event root. The remaining gap for the plain canvas demo is making sure the canvas itself explicitly opts out of Safari text selection, touch callout, drag, and tap highlight affordances.

## Tests
- `yarn vitest run --project browser test/modules/core/lib/deck.spec.ts`
- commit hook: module/test/example lint + format checks, lockfile check, node vitest subset