### PR TITLE
docs(h3-hexagon-layer): add GeoJSON FeatureCollection example

### DIFF
--- a/docs/api-reference/geo-layers/h3-hexagon-layer.md
+++ b/docs/api-reference/geo-layers/h3-hexagon-layer.md
@@ -123,6 +123,38 @@ function App() {
 </Tabs>
 
 
+### Consuming H3 cells from a GeoJSON FeatureCollection
+
+A common export pattern is GeoJSON where each feature's `properties`
+carries the H3 cell ID as a string (produced by `geopandas`, QGIS,
+`h3-py`, or a custom spatial-index pipeline). The default
+`getHexagon: object => object.hexagon` accessor returns `undefined`
+for these features because GeoJSON parsers surface them as
+`{type, geometry, properties}` objects.
+
+Override `getHexagon` to pull the cell ID out of `properties`:
+
+```js
+import {H3HexagonLayer} from '@deck.gl/geo-layers';
+
+new H3HexagonLayer({
+  id: 'h3-cells-from-geojson',
+  data: 'cells.geojson',  // FeatureCollection; each feature.properties carries h3_id
+  pickable: true,
+  filled: true,
+  extruded: true,
+  getHexagon: d => d.properties.h3_id,
+  getFillColor: d => [255, (1 - d.properties.value) * 255, 0],
+  getElevation: d => d.properties.value * 1000
+});
+```
+
+Any per-feature value to be styled or extruded by lives under
+`d.properties.*` in this shape. The geometry on each feature is
+ignored — `H3HexagonLayer` reconstructs the hexagon from the cell
+ID via `cellToBoundary`.
+
+
 ## Installation
 
 To install the dependencies from NPM:


### PR DESCRIPTION
## Description

When ingesting a GeoJSON `FeatureCollection` where each feature's `properties` carries the H3 cell ID (a common export pattern from `geopandas`, QGIS, `h3-py`, and custom spatial-index pipelines), the default `getHexagon` accessor (`object => object.hexagon`) silently returns `undefined` because GeoJSON parsers surface features as `{type, geometry, properties}` objects.

This adds a small worked example to the `H3HexagonLayer` docs page showing the `getHexagon: d => d.properties.h3_id` override so the pattern is discoverable without reading the source.

## Motivation

The existing examples on the page assume the data shape `[{hex, count}, …]`. Many H3-cell pipelines emit GeoJSON instead, and the override needed for the `H3HexagonLayer` to render those is one line — but currently has to be derived rather than copied. This PR makes the recipe copy-pastable.

Tested against a real-world 1,665-feature GeoJSON `FeatureCollection` of H3 res-5 cells.

## Change

- `docs/api-reference/geo-layers/h3-hexagon-layer.md` — adds one new subsection ("Consuming H3 cells from a GeoJSON FeatureCollection") with a 13-line `H3HexagonLayer` example, immediately after the existing `Tabs` block and before `## Installation`.

Docs-only; no code touched. **+32 / -0** on the one file.