### PR TITLE
fix(core): use correct mjolnir requireFailure key for recognizers

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -1318,14 +1318,14 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       touchAction: this.props.touchAction,
       recognizers: Object.keys(RECOGNIZERS).map((eventName: string) => {
         // Resolve recognizer settings
-        const [RecognizerConstructor, defaultOptions, recognizeWith, requestFailure] =
+        const [RecognizerConstructor, defaultOptions, recognizeWith, requireFailure] =
           RECOGNIZERS[eventName];
         const optionsOverride = this.props.eventRecognizerOptions?.[eventName];
         const options = {...defaultOptions, ...optionsOverride, event: eventName};
         return {
           recognizer: new RecognizerConstructor(options),
           recognizeWith,
-          requestFailure
+          requireFailure
         };
       }),
       events: {

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -116,6 +116,40 @@ test('Deck#constructor', async () => {
   console.log('Deck constructor did not throw');
 });
 
+test('Deck wires mjolnir requireFailure between recognizers', async () => {
+  // Regression guard: deck.gl previously emitted `requestFailure` instead of
+  // `requireFailure`, which mjolnir silently dropped — so pinch/pan/click no
+  // longer waited for their blocking recognizer to fail.
+  await new Promise<void>((resolve, reject) => {
+    const deck = new Deck({
+      device,
+      width: 1,
+      height: 1,
+      viewState: {longitude: 0, latitude: 0, zoom: 0},
+      layers: [],
+      controller: true,
+      onLoad: () => {
+        try {
+          const recognizers = (deck as any).eventManager?.manager?.recognizers ?? [];
+          const requiredFailures = (event: string): string[] =>
+            (recognizers.find(r => r.options.event === event)?.requireFail ?? []).map(
+              (r: any) => r.options.event
+            );
+
+          expect(requiredFailures('pinch'), 'pinch waits for multipan').toContain('multipan');
+          expect(requiredFailures('pan'), 'pan waits for multipan').toContain('multipan');
+          expect(requiredFailures('click'), 'click waits for dblclick').toContain('dblclick');
+
+          deck.finalize();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+  });
+});
+
 test('Deck#abort', async () => {
   const deck = new Deck({
     device,


### PR DESCRIPTION
## Summary
Fixes Deck’s mjolnir recognizer setup so `requireFailure` relationships are actually passed to `EventManager`.

## Problem
Deck normalized recognizer tuples using `requestFailure`, but mjolnir reads `requireFailure`. The typo silently dropped the failure dependencies declared in `RECOGNIZERS`, so gestures such as two-finger pitch could be beaten by pinch recognition on touch devices.

## Change
- Rename the normalized tuple key from `requestFailure` to `requireFailure`.
- Add regression coverage that constructs a `Deck` and verifies pinch, pan, and click have the expected blocking recognizers in mjolnir’s `requireFail` arrays.

## Validation
- Hand-tested on iOS WKWebView with `GlobeController`: two-finger vertical drag now pitches instead of being interpreted as a pinch/pan wobble.
- CI is green on the PR.

## Merge Notes
Approved. Reviewer-requested regression coverage was added in follow-up commit `b8f30a09`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small naming fix in touch event wiring plus a test; no auth, data, or rendering pipeline changes.
> 
> **Overview**
> Fixes **Deck**’s mjolnir `EventManager` setup so gesture **require-failure** links from `RECOGNIZERS` are actually applied: the recognizer config now uses the `requireFailure` key mjolnir expects instead of the misspelled `requestFailure`, which was silently ignored.
> 
> That restores intended touch behavior (e.g. **pinch** and **pan** wait for **multipan** to fail before recognizing, and **click** waits for **dblclick**), which matters for two-finger pitch vs pinch on touch devices.
> 
> Adds a **Deck** unit test that inspects mjolnir’s `requireFail` arrays after `onLoad` to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec29c52e134863c407746fed9a802d99cc68c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->