### PR TITLE
fix(examples): bump vite to ^7.3.3 to fix security vulnerabilities

### DIFF
--- a/examples/basemap-browser/package.json
+++ b/examples/basemap-browser/package.json
@@ -27,6 +27,6 @@
     "@types/react-dom": "^18.2.0",
     "@types/stats.js": "^0.17.4",
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/experimental/bezier/package.json
+++ b/examples/experimental/bezier/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/experimental/h3-grid/package.json
+++ b/examples/experimental/h3-grid/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/experimental/interleaved-buffer/package.json
+++ b/examples/experimental/interleaved-buffer/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/experimental/tfjs/package.json
+++ b/examples/experimental/tfjs/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/apple-maps/package.json
+++ b/examples/get-started/pure-js/apple-maps/package.json
@@ -13,6 +13,6 @@
     "@deck.gl/layers": "^9.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/arcgis/package.json
+++ b/examples/get-started/pure-js/arcgis/package.json
@@ -15,6 +15,6 @@
     "@deck.gl/layers": "^9.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/basic/package.json
+++ b/examples/get-started/pure-js/basic/package.json
@@ -13,6 +13,6 @@
     "@deck.gl/layers": "^9.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/carto/package.json
+++ b/examples/get-started/pure-js/carto/package.json
@@ -13,7 +13,7 @@
     "maplibre-gl": "^5.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   },
   "eslintConfig": {
     "globals": {

--- a/examples/get-started/pure-js/globe/package.json
+++ b/examples/get-started/pure-js/globe/package.json
@@ -13,6 +13,6 @@
     "@deck.gl/layers": "^9.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/google-maps/package.json
+++ b/examples/get-started/pure-js/google-maps/package.json
@@ -15,6 +15,6 @@
     "@googlemaps/js-api-loader": "^1.16.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/leaflet/package.json
+++ b/examples/get-started/pure-js/leaflet/package.json
@@ -15,6 +15,6 @@
     "leaflet": "^1.7.1"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/mapbox/package.json
+++ b/examples/get-started/pure-js/mapbox/package.json
@@ -15,6 +15,6 @@
     "mapbox-gl": "^3.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/maplibre-globe/package.json
+++ b/examples/get-started/pure-js/maplibre-globe/package.json
@@ -15,6 +15,6 @@
     "maplibre-gl": "^5.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/maplibre/package.json
+++ b/examples/get-started/pure-js/maplibre/package.json
@@ -15,6 +15,6 @@
     "maplibre-gl": "^5.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/openlayers/package.json
+++ b/examples/get-started/pure-js/openlayers/package.json
@@ -14,6 +14,6 @@
     "ol": "^7.1.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/pure-js/widgets/package.json
+++ b/examples/get-started/pure-js/widgets/package.json
@@ -14,6 +14,6 @@
     "@deck.gl/widgets": "^9.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/react/arcgis/package.json
+++ b/examples/get-started/react/arcgis/package.json
@@ -17,6 +17,6 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/react/basic/package.json
+++ b/examples/get-started/react/basic/package.json
@@ -14,6 +14,6 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/react/google-maps/package.json
+++ b/examples/get-started/react/google-maps/package.json
@@ -15,6 +15,6 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/react/mapbox/package.json
+++ b/examples/get-started/react/mapbox/package.json
@@ -16,6 +16,6 @@
     "react-map-gl": "^8.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/get-started/react/maplibre/package.json
+++ b/examples/get-started/react/maplibre/package.json
@@ -16,6 +16,6 @@
     "react-map-gl": "^8.0.0"
   },
   "devDependencies": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/layer-browser/package.json
+++ b/examples/layer-browser/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/360-video/package.json
+++ b/examples/website/360-video/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/3d-heatmap/package.json
+++ b/examples/website/3d-heatmap/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/arc/package.json
+++ b/examples/website/arc/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/brushing/package.json
+++ b/examples/website/brushing/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/carto-sql/package.json
+++ b/examples/website/carto-sql/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/collision-filter/package.json
+++ b/examples/website/collision-filter/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/contour/package.json
+++ b/examples/website/contour/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/data-filter/package.json
+++ b/examples/website/data-filter/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/geojson/package.json
+++ b/examples/website/geojson/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/global-grids/package.json
+++ b/examples/website/global-grids/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/globe/package.json
+++ b/examples/website/globe/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/google-3d-tiles/package.json
+++ b/examples/website/google-3d-tiles/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/google-3d/package.json
+++ b/examples/website/google-3d/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/heatmap/package.json
+++ b/examples/website/heatmap/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/highway/package.json
+++ b/examples/website/highway/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/i3s/package.json
+++ b/examples/website/i3s/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/icon/package.json
+++ b/examples/website/icon/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/image-tile/package.json
+++ b/examples/website/image-tile/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/line/package.json
+++ b/examples/website/line/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/map-tile/package.json
+++ b/examples/website/map-tile/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/mapbox/package.json
+++ b/examples/website/mapbox/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/maplibre/package.json
+++ b/examples/website/maplibre/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/mask-extension/package.json
+++ b/examples/website/mask-extension/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/mesh/package.json
+++ b/examples/website/mesh/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/orthographic/package.json
+++ b/examples/website/orthographic/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/plot/package.json
+++ b/examples/website/plot/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/point-cloud/package.json
+++ b/examples/website/point-cloud/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/radio/package.json
+++ b/examples/website/radio/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/scatterplot/package.json
+++ b/examples/website/scatterplot/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/scenegraph/package.json
+++ b/examples/website/scenegraph/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/screen-grid/package.json
+++ b/examples/website/screen-grid/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/terrain-extension/package.json
+++ b/examples/website/terrain-extension/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/terrain/package.json
+++ b/examples/website/terrain/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/text/package.json
+++ b/examples/website/text/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/treemap/package.json
+++ b/examples/website/treemap/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/trips/package.json
+++ b/examples/website/trips/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }

--- a/examples/website/wms/package.json
+++ b/examples/website/wms/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^4.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.3"
   }
 }


### PR DESCRIPTION
#### Background

Vite versions < 7.3.3 have two high-severity CVEs:
- GHSA-4w7w-66w2-5vf9 (Path Traversal in Optimized Deps `.map` Handling)
- GHSA-p9ff-h696-f583 (Arbitrary File Read via Dev Server WebSocket)

All 62 examples specified `"vite": "^7.3.1"` which allows installation of vulnerable versions.

#### Change List
- Bump vite minimum version from `^7.3.1` to `^7.3.3` across all 62 example package.json files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a devDependency-only patch bump across example apps, with no runtime/library code changes; main risk is potential example build/dev-server behavior changes from the newer Vite patch.
> 
> **Overview**
> Updates all example projects to require `vite` `^7.3.3` (from `^7.3.1`) in `devDependencies`, ensuring installs pick up the patched Vite release that addresses known security issues in older versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5dcffa5f91be8badb5571fbe8f4443dbcf356a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->