### PR TITLE
chore: Upgrade module peer dependencies to ~9.3.0-beta.2

### DIFF
--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -44,8 +44,8 @@
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
-    "@deck.gl/layers": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/layers": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3"
   },

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@arcgis/core": "^4.0.0",
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3",
     "@luma.gl/webgl": "~9.3.3"

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -67,11 +67,11 @@
     "quadbin": "^0.4.0"
   },
   "peerDependencies": {
-    "@deck.gl/aggregation-layers": "~9.3.0-alpha.1",
-    "@deck.gl/core": "~9.3.0-alpha.1",
-    "@deck.gl/extensions": "~9.3.0-alpha.1",
-    "@deck.gl/geo-layers": "~9.3.0-alpha.1",
-    "@deck.gl/layers": "~9.3.0-alpha.1",
+    "@deck.gl/aggregation-layers": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/extensions": "~9.3.0-beta.2",
+    "@deck.gl/geo-layers": "~9.3.0-beta.2",
+    "@deck.gl/layers": "~9.3.0-beta.2",
     "@loaders.gl/core": "^4.4.1",
     "@luma.gl/core": "~9.3.3"
   },

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -43,7 +43,7 @@
     "@math.gl/core": "^4.1.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3"
   },

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -57,10 +57,10 @@
     "long": "^3.2.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
-    "@deck.gl/extensions": "~9.3.0-alpha.1",
-    "@deck.gl/layers": "~9.3.0-alpha.1",
-    "@deck.gl/mesh-layers": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/extensions": "~9.3.0-beta.2",
+    "@deck.gl/layers": "~9.3.0-beta.2",
+    "@deck.gl/mesh-layers": "~9.3.0-beta.2",
     "@loaders.gl/core": "^4.4.1",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3"

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -43,7 +43,7 @@
     "@types/google.maps": "^3.48.6"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/webgl": "~9.3.3"
   },

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -41,7 +41,7 @@
     "jsep": "^0.3.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1"
+    "@deck.gl/core": "~9.3.0-beta.2"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -47,7 +47,7 @@
     "earcut": "^2.2.4"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@loaders.gl/core": "^4.4.1",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3"

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -41,7 +41,7 @@
     "@math.gl/web-mercator": "^4.1.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@math.gl/web-mercator": "^4.1.0"
   },

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -44,7 +44,7 @@
     "@luma.gl/shadertools": "^9.3.3"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3",
     "@luma.gl/gltf": "~9.3.3",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -33,8 +33,8 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
-    "@deck.gl/widgets": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/widgets": "~9.3.0-beta.2",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -41,7 +41,7 @@
     "@luma.gl/webgl": "^9.3.3"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3",
     "@luma.gl/engine": "~9.3.3",
     "@probe.gl/test-utils": "^4.1.1",

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -46,7 +46,7 @@
     "preact": "^10.17.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-alpha.1",
+    "@deck.gl/core": "~9.3.0-beta.2",
     "@luma.gl/core": "~9.3.3"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"


### PR DESCRIPTION
<!-- Reference the issue that this closes -->
For #10321

#### Background
Split out from #10321 — upgrades the internal `@deck.gl/*` peer dependency version ranges from `~9.3.0-alpha.1` to `~9.3.0-beta.2`.

#### Change List
- Updated `@deck.gl/*` peer dependency ranges from `~9.3.0-alpha.1` to `~9.3.0-beta.2` across 13 module package.json files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that updates peer dependency version ranges; main risk is downstream install/compatibility constraints for consumers pinned to the previous alpha.
> 
> **Overview**
> Updates multiple `modules/*/package.json` files to require `@deck.gl/*` peer dependencies at `~9.3.0-beta.2` instead of `~9.3.0-alpha.1`, aligning internal module compatibility on the beta release line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf8cc68a30c4729fc72393893909d182726b75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->