### PR TITLE
feat(core): skip pinch zoom inertia on touch input

### DIFF
--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -692,7 +692,17 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     }
     const {inertia} = this;
     const {_lastPinchEvent} = pinchEventWorkaround;
-    if (this.touchZoom && inertia && _lastPinchEvent && event.scale !== _lastPinchEvent.scale) {
+    // Skip pinch zoom inertia on touch: the final-lift frame is almost always
+    // noisy, and any forward projection reads as the camera "flinging" past
+    // the gesture. Trackpad / mouse pinches are unaffected.
+    const isTouchPinch = (event.srcEvent as PointerEvent)?.pointerType === 'touch';
+    if (
+      this.touchZoom &&
+      inertia &&
+      !isTouchPinch &&
+      _lastPinchEvent &&
+      event.scale !== _lastPinchEvent.scale
+    ) {
       const pos = this.getCenter(event);
       let newControllerState = this.controllerState.rotateEnd();
       const z = Math.log2(event.scale);

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -35,6 +35,49 @@ test('MapController#inertia', async () => {
   });
 });
 
+test('MapController skips pinch zoom inertia on touch lift', () => {
+  // Touch pinches lift with a noisy final frame that can produce a large
+  // synthetic velocity. The end zoom should equal the last live pinch zoom,
+  // not the inertia-projected zoom.
+  const makePinchEvent = (
+    type: string,
+    scale: number,
+    deltaTime: number,
+    pointerType: 'touch' | 'mouse' = 'touch'
+  ) => ({
+    type,
+    offsetCenter: {x: 50, y: 50},
+    scale,
+    rotation: 0,
+    deltaTime,
+    srcEvent: {preventDefault() {}, pointerType},
+    stopPropagation() {}
+  });
+
+  const controller = createTestController({
+    view: new MapView({controller: true}),
+    initialViewState: {
+      longitude: -122.45,
+      latitude: 37.78,
+      zoom: 10,
+      pitch: 30,
+      bearing: -45,
+      inertia: 300
+    }
+  });
+
+  controller.handleEvent(makePinchEvent('pinchstart', 1, 0) as any);
+  controller.handleEvent(makePinchEvent('pinchmove', 1.1, 16) as any);
+  const zoomAfterMove = controller.props.zoom as number;
+  // 100x scale spike on the lift frame — pre-fix would fling the zoom way past.
+  controller.handleEvent(makePinchEvent('pinchend', 100, 17) as any);
+
+  expect(
+    controller.props.zoom,
+    'touch pinch end stays at the last live zoom (no inertia projection)'
+  ).toBeCloseTo(zoomAfterMove);
+});
+
 test('GlobeController', async () => {
   await testController(
     GlobeView,


### PR DESCRIPTION
## Summary
Stops touch pinch gestures from applying the existing pinch-end inertia projection on final finger lift.

## Why
Touch `pinchend` frequently carries a noisy final scale delta as fingers leave the screen. The current inertia path turns that last-frame delta into a projected velocity, which can fling the camera beyond the user’s actual gesture. Trackpad and mouse pinch input do not show the same lift-frame noise.

## Change
- Detect touch pinch end via `pointerType === 'touch'`.
- Skip the inertia branch only for touch pinch end.
- Preserve existing mouse/trackpad pinch inertia.
- Avoid new damping constants or projection math.

## Validation
- Added `MapController skips pinch zoom inertia on touch lift`, covering a 100x final-frame scale spike and asserting the final zoom stays at the last live pinch zoom.

## Merge Notes
Independent split from #10303. Complements #10328, which smooths noisy live pinch frames before this pinch-end path runs.