### PR TITLE
[codex] Improve GlobeView bitmap tile effect handling

### DIFF
--- a/modules/geo-layers/src/tile-layer/tile-layer.ts
+++ b/modules/geo-layers/src/tile-layer/tile-layer.ts
@@ -12,9 +12,11 @@ import {
   GetPickingInfoParams,
   DefaultProps,
   FilterContext,
+  COORDINATE_SYSTEM,
+  _GlobeViewport,
   _flatten as flatten
 } from '@deck.gl/core';
-import {GeoJsonLayer} from '@deck.gl/layers';
+import {BitmapLayer, GeoJsonLayer} from '@deck.gl/layers';
 import {LayersList} from '@deck.gl/core';
 
 import type {TileLoadProps, ZRange} from '../tileset-2d/index';
@@ -27,6 +29,10 @@ import {
 } from '../tileset-2d/index';
 import {urlType, URLTemplate, getURLFromTemplate} from '../tileset-2d/index';
 import {Matrix4} from '@math.gl/core';
+
+function isDefaultImageCoordinateSystem(value: unknown): boolean {
+  return value === 'default' || value === COORDINATE_SYSTEM.DEFAULT;
+}
 
 const defaultProps: DefaultProps<TileLayerProps> = {
   TilesetClass: Tileset2D,
@@ -421,12 +427,14 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
           _offset: 0,
           tile
         });
-        tile.layers = (flatten(layers, Boolean) as Layer<{tile?: Tile2DHeader}>[]).map(layer =>
-          layer.clone({
+        tile.layers = (flatten(layers, Boolean) as Layer<{tile?: Tile2DHeader}>[]).map(layer => {
+          const globeBitmapProps = this._getGlobeBitmapLayerProps(layer);
+          return layer.clone({
             tile,
+            ...globeBitmapProps,
             ...subLayerProps
-          })
-        );
+          });
+        });
       } else if (
         subLayerProps &&
         tile.layers[0] &&
@@ -438,6 +446,24 @@ export default class TileLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       }
       return tile.layers;
     });
+  }
+
+  private _getGlobeBitmapLayerProps(layer: Layer): Record<string, unknown> | null {
+    if (
+      !(this.context.viewport instanceof _GlobeViewport) ||
+      !(layer instanceof BitmapLayer) ||
+      !isDefaultImageCoordinateSystem(
+        (layer.props as Record<string, unknown>)._imageCoordinateSystem
+      )
+    ) {
+      return null;
+    }
+
+    return {
+      // XYZ/slippy tile imagery is Web Mercator encoded. In GlobeView, BitmapLayer
+      // positions the mesh in lng/lat, so the image needs Mercator-to-lnglat UV conversion.
+      _imageCoordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+    };
   }
 
   filterSubLayer({layer, cullRect}: FilterContext) {

--- a/test/modules/geo-layers/tile-layer/tile-layer.spec.ts
+++ b/test/modules/geo-layers/tile-layer/tile-layer.spec.ts
@@ -3,13 +3,63 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
-import {WebMercatorViewport} from '@deck.gl/core';
-import {ScatterplotLayer} from '@deck.gl/layers';
+import {COORDINATE_SYSTEM, WebMercatorViewport, _GlobeView as GlobeView} from '@deck.gl/core';
+import {BitmapLayer, ScatterplotLayer} from '@deck.gl/layers';
 import {generateLayerTests, testLayerAsync, testLayer} from '@deck.gl/test-utils/vitest';
 import {TileLayer} from '@deck.gl/geo-layers';
 
 const DUMMY_DATA =
   'https://raw.githubusercontent.com/visgl/deck.gl-data/master/test-data/geojson-point.json';
+
+function getGlobeViewport() {
+  return new GlobeView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {
+      longitude: 0,
+      latitude: 0,
+      zoom: 2
+    }
+  });
+}
+
+function getBitmapRenderSubLayers(BitmapLayerClass = BitmapLayer, bitmapProps = {}) {
+  return props => {
+    const {west, south, east, north} = props.tile.bbox;
+    return new BitmapLayerClass(props, {
+      id: `${props.id}-bitmap`,
+      image: '/test/data/icon-atlas.png',
+      bounds: [west, south, east, north],
+      ...bitmapProps
+    });
+  };
+}
+
+async function expectGlobeBitmapImageCoordinateSystem({
+  title,
+  renderSubLayers,
+  expectedImageCoordinateSystem
+}) {
+  await testLayerAsync({
+    Layer: TileLayer,
+    viewport: getGlobeViewport(),
+    testCases: [
+      {
+        title,
+        props: {
+          getTileData: () => ({}),
+          renderSubLayers
+        },
+        onAfterUpdate: ({layer, subLayers}) => {
+          if (layer.isLoaded) {
+            expect(subLayers[0].props._imageCoordinateSystem).toBe(expectedImageCoordinateSystem);
+          }
+        }
+      }
+    ],
+    onError: err => expect(err).toBeFalsy()
+  });
+}
 
 test('TileLayer', async () => {
   const testCases = generateLayerTests({
@@ -205,6 +255,46 @@ test('TileLayer#MapView:repeat', async () => {
     viewport: testViewport,
     testCases,
     onError: err => expect(err).toBeFalsy()
+  });
+});
+
+test('TileLayer#GlobeView:BitmapLayer image coordinate system', async () => {
+  await expectGlobeBitmapImageCoordinateSystem({
+    title: 'defaults BitmapLayer image coordinates to Web Mercator',
+    renderSubLayers: getBitmapRenderSubLayers(),
+    expectedImageCoordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+  });
+});
+
+test('TileLayer#GlobeView:custom BitmapLayer image coordinate system', async () => {
+  class CustomBitmapLayer extends BitmapLayer {
+    static layerName = 'CustomBitmapLayer';
+  }
+
+  await expectGlobeBitmapImageCoordinateSystem({
+    title: 'defaults custom BitmapLayer image coordinates to Web Mercator',
+    renderSubLayers: getBitmapRenderSubLayers(CustomBitmapLayer),
+    expectedImageCoordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+  });
+});
+
+test('TileLayer#GlobeView:enum-default BitmapLayer image coordinate system', async () => {
+  await expectGlobeBitmapImageCoordinateSystem({
+    title: 'treats enum default image coordinates as Web Mercator',
+    renderSubLayers: getBitmapRenderSubLayers(BitmapLayer, {
+      _imageCoordinateSystem: COORDINATE_SYSTEM.DEFAULT
+    }),
+    expectedImageCoordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+  });
+});
+
+test('TileLayer#GlobeView:preserves explicit BitmapLayer image coordinate system', async () => {
+  await expectGlobeBitmapImageCoordinateSystem({
+    title: 'preserves explicit BitmapLayer image coordinate system',
+    renderSubLayers: getBitmapRenderSubLayers(BitmapLayer, {
+      _imageCoordinateSystem: COORDINATE_SYSTEM.LNGLAT
+    }),
+    expectedImageCoordinateSystem: COORDINATE_SYSTEM.LNGLAT
   });
 });
 


### PR DESCRIPTION
## Summary

This improves TileLayer's GlobeView handling for bitmap tile sublayers so image-coordinate setup stays compatible with deck.gl effects after BitmapLayer gains lighting/material support.

TileLayer now detects BitmapLayer sublayers rendered in GlobeView and, when their `_imageCoordinateSystem` is still default, clones them with `_imageCoordinateSystem: COORDINATE_SYSTEM.CARTESIAN`. This preserves explicit user-provided coordinate systems, including `COORDINATE_SYSTEM.LNGLAT`.

## Why

XYZ/slippy tile imagery is Web Mercator encoded. In GlobeView, BitmapLayer positions the tile mesh in lng/lat, so tile imagery needs Mercator-to-lnglat UV conversion for the bitmap surface to line up correctly. That becomes more visible once lighting/effects are applied to BitmapLayer-backed tile imagery.

## Dependency

This draft PR is stacked on and merge-blocked by #10352. Please do not merge this until #10352 lands, because the effect behavior depends on BitmapLayer lighting/material support from that PR.

## Validation

- `npx vitest run --project headless test/modules/geo-layers/tile-layer/tile-layer.spec.ts`
- `git diff --check`
- Attempted `npx eslint modules/geo-layers/src/tile-layer/tile-layer.ts test/modules/geo-layers/tile-layer/tile-layer.spec.ts`, but the local checkout's deck.gl ESLint 8.57.0 process loaded the parent workspace's ESLint 9-era `@typescript-eslint/no-unused-expressions` rule and failed before linting these changes: `Cannot read properties of undefined (reading 'allowShortCircuit')`.
