### PR TITLE
fix(core): destroy CanvasContext on finalize to prevent memory leak

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -474,6 +474,10 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       this.canvas.parentElement?.removeChild(this.canvas);
       this.canvas = null;
     }
+
+    if (!this.props.device && !this.props.gl) {
+      this._canvasContext?.destroy();
+    }
     this._canvasContext = null;
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #10355 

#### Background
When unmounting a `Deck` instance (both standalone and via wrappers like `MapboxOverlay`), a memory leak occurs where detached DOM nodes (the `<canvas>`) and `Deck` instances are never garbage collected. 

Previously, `Deck.finalize()` simply dropped the reference to `this._canvasContext`. Because `this._canvasContext?.destroy()` was never explicitly called, `luma.gl`'s `Surface` superclass never ran `_stopObservers()`. As a result, the `ResizeObserver` and `matchMedia` listeners remained permanently bound to the Window, creating a strong GC root that kept the detached canvas and `Deck` instance alive indefinitely. 

*Note: This was originally observed using `MapboxOverlay`.* 

<!-- For all the PRs -->
#### Change List
- [destroy CanvasContext on finalize to prevent memory leak](https://github.com/visgl/deck.gl/commit/0a31d4a16e10e947c590da8d6f9595f8030abfd2)