### PR TITLE
fix(examples): add cullMode: 'none' to globe examples and document GlobeView usage

### DIFF
--- a/docs/api-reference/geo-layers/great-circle-layer.md
+++ b/docs/api-reference/geo-layers/great-circle-layer.md
@@ -172,6 +172,19 @@ new deck.GreatCircleLayer({});
 
 Inherits from all [Base Layer](../core/layer.md) and [ArcLayer](../layers/arc-layer.md) properties.
 
+## Remarks
+
+### Using with GlobeView
+
+When using this layer with [GlobeView](../core/globe-view.md) or MapLibre's globe projection, arcs may be invisible when viewed from certain angles because `GlobeView` enables back-face culling by default. To ensure arcs are visible from both sides, set:
+
+```js
+new GreatCircleLayer({
+  // ...other props
+  parameters: {cullMode: 'none'}
+});
+```
+
 ## Source
 
 [great-circle-layer](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/great-circle-layer)

--- a/docs/api-reference/geo-layers/trips-layer.md
+++ b/docs/api-reference/geo-layers/trips-layer.md
@@ -214,6 +214,19 @@ Returns an array of timestamps, one for each navigation point in the geometry re
 Because timestamps are stored as 32-bit floating numbers, raw unix epoch time can not be used. You may test the validity of a timestamp by calling `Math.fround(t)` to check if there would be any loss of precision.
 
 
+## Remarks
+
+### Using with GlobeView
+
+When using this layer with [GlobeView](../core/globe-view.md) or MapLibre's globe projection, trails may be invisible when viewed from certain angles because `GlobeView` enables back-face culling by default. To ensure trails are visible from both sides, set:
+
+```js
+new TripsLayer({
+  // ...other props
+  parameters: {cullMode: 'none'}
+});
+```
+
 # Source
 
 [modules/geo-layers/src/trips-layer](https://github.com/visgl/deck.gl/tree/master/modules/geo-layers/src/trips-layer)

--- a/docs/api-reference/layers/arc-layer.md
+++ b/docs/api-reference/layers/arc-layer.md
@@ -261,6 +261,19 @@ Multiplier of layer height. `0` will make the layer flat.
 Use to tilt the arc to the side if you have multiple arcs with the same source and target positions.
 In degrees, can be positive or negative (`-90 to +90`).
 
+## Remarks
+
+### Using with GlobeView
+
+When using this layer with [GlobeView](../core/globe-view.md) or MapLibre's globe projection, arcs may be invisible when viewed from certain angles because `GlobeView` enables back-face culling by default. To ensure arcs are visible from both sides, set:
+
+```js
+new ArcLayer({
+  // ...other props
+  parameters: {cullMode: 'none'}
+});
+```
+
 ## Source
 
 [modules/layers/src/arc-layer](https://github.com/visgl/deck.gl/tree/master/modules/layers/src/arc-layer)

--- a/docs/api-reference/layers/line-layer.md
+++ b/docs/api-reference/layers/line-layer.md
@@ -229,6 +229,19 @@ The line width of each object, in units specified by `widthUnits` (default pixel
 * If a number is provided, it is used as the line width for all objects.
 * If a function is provided, it is called on each object to retrieve its line width.
 
+## Remarks
+
+### Using with GlobeView
+
+When using this layer with [GlobeView](../core/globe-view.md) or MapLibre's globe projection, lines may be invisible when viewed from certain angles because `GlobeView` enables back-face culling by default. To ensure lines are visible from both sides, set:
+
+```js
+new LineLayer({
+  // ...other props
+  parameters: {cullMode: 'none'}
+});
+```
+
 ## Source
 
 [modules/layers/src/line-layer](https://github.com/visgl/deck.gl/tree/master/modules/layers/src/line-layer)

--- a/docs/api-reference/layers/path-layer.md
+++ b/docs/api-reference/layers/path-layer.md
@@ -325,6 +325,19 @@ new PathLayer({
 })
 ```
 
+## Remarks
+
+### Using with GlobeView
+
+When using this layer with [GlobeView](../core/globe-view.md) or MapLibre's globe projection, paths may be invisible when viewed from certain angles because `GlobeView` enables back-face culling by default. To ensure paths are visible from both sides, set:
+
+```js
+new PathLayer({
+  // ...other props
+  parameters: {cullMode: 'none'}
+});
+```
+
 ## Source
 
 [modules/layers/src/path-layer](https://github.com/visgl/deck.gl/tree/master/modules/layers/src/path-layer)

--- a/examples/get-started/pure-js/globe/app.js
+++ b/examples/get-started/pure-js/globe/app.js
@@ -71,7 +71,8 @@ new Deck({
       getTargetPosition: f => f.geometry.coordinates,
       getSourceColor: [0, 128, 200],
       getTargetColor: [200, 0, 80],
-      getWidth: 1
+      getWidth: 1,
+      parameters: {cullMode: 'none'}
     })
   ]
 });

--- a/examples/website/globe/app.tsx
+++ b/examples/website/globe/app.tsx
@@ -118,7 +118,8 @@ export default function App({data}: {data?: DailyFlights[]}) {
           getWidth: 1,
           timeRange,
           getSourceColor: [255, 0, 128],
-          getTargetColor: [0, 128, 255]
+          getTargetColor: [0, 128, 255],
+          parameters: {cullMode: 'none'}
         })
     );
 


### PR DESCRIPTION
#### Background
`GlobeView` enables back-face culling by default (`parameters: {cullMode: 'back'}`). This causes arc, line, and path layers to be invisible when viewed from certain angles on the globe, because their thin geometry gets culled when facing away from the camera.

The MapLibre globe examples already had `cullMode: 'none'` set correctly, but the pure `GlobeView` examples were missing it.

#### Change List
- Add `parameters: {cullMode: 'none'}` to the ArcLayer in `examples/get-started/pure-js/globe/app.js`
- Add `parameters: {cullMode: 'none'}` to the AnimatedArcLayer in `examples/website/globe/app.tsx`
- Add "Using with GlobeView" documentation remarks to:
  - ArcLayer
  - LineLayer
  - PathLayer
  - GreatCircleLayer
  - TripsLayer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes; no runtime library behavior is modified.
> 
> **Overview**
> Fixes **GlobeView** globe demos where arc layers could disappear at some camera angles, and documents the same workaround for line/path layers.
> 
> Pure `GlobeView` examples now set **`parameters: {cullMode: 'none'}`** on **`ArcLayer`** (`examples/get-started/pure-js/globe/app.js`) and **`AnimatedArcLayer`** (`examples/website/globe/app.tsx`), matching MapLibre globe examples that already used this.
> 
> API docs for **ArcLayer**, **LineLayer**, **PathLayer**, **GreatCircleLayer**, and **TripsLayer** gain a **Using with GlobeView** remark explaining default back-face culling and recommending `cullMode: 'none'` for thin geometry on the globe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14776757450745d396a2c1fcaba83e6eead8b216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->