### PR TITLE
feat(core) Support multiple event managers (multi-canvas prep)

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import LayerManager from './layer-manager';
-import ViewManager from './view-manager';
+import ViewManager, {DEFAULT_CANVAS_ID} from './view-manager';
 import MapView from '../views/map-view';
 import EffectManager from './effect-manager';
 import DeckRenderer from './deck-renderer';
@@ -317,6 +317,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
   protected deckRenderer: DeckRenderer | null = null;
   protected deckPicker: DeckPicker | null = null;
   protected eventManager: EventManager | null = null;
+  protected eventManagers: Record<string, EventManager> = {};
   protected widgetManager: WidgetManager | null = null;
   protected tooltip: TooltipWidget | null = null;
   protected animationLoop: AnimationLoop | null = null;
@@ -465,6 +466,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
     this.eventManager?.destroy();
     this.eventManager = null;
+    this.eventManagers = {};
 
     this.widgetManager?.finalize();
     this.widgetManager = null;
@@ -509,12 +511,14 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       height: number;
       views: View[];
       viewState: ViewStateObject<ViewsT> | null;
+      eventManagers: Record<string, EventManager>;
     } = Object.create(this.props);
     Object.assign(resolvedProps, {
       views: this._getViews(),
       width: this.width,
       height: this.height,
-      viewState: this._getViewState()
+      viewState: this._getViewState(),
+      eventManagers: this.eventManagers
     });
 
     if (props.device && props.device.id !== this.device?.id) {
@@ -526,6 +530,8 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
         // DOM here might be a bit unexpected but it should be ok for most users.
         this.canvas?.remove();
         this.eventManager?.destroy();
+        this.eventManager = null;
+        this.eventManagers = {};
 
         // ensure we will re-attach ourselves after createDevice callbacks
         this.canvas = null;
@@ -656,6 +662,18 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
   /** Get the current canvas element. */
   getCanvas(): HTMLCanvasElement | null {
     return this.canvas;
+  }
+
+  /**
+   * Get the event manager associated with a view or the default Deck canvas.
+   */
+  getEventManager(viewId?: string): EventManager | null {
+    if (!viewId || !this.viewManager) {
+      return this.eventManager;
+    }
+
+    const canvasId = this.viewManager.getCanvasId(viewId) || DEFAULT_CANVAS_ID;
+    return this.eventManagers[canvasId] || this.eventManager;
   }
 
   /** Query the object rendered on top at a given point */
@@ -1046,6 +1064,35 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
     return canvas;
   }
 
+  private _createEventManager(root: HTMLElement): EventManager {
+    const eventManager = new EventManager(root, {
+      touchAction: this.props.touchAction,
+      recognizers: Object.keys(RECOGNIZERS).map((eventName: string) => {
+        // Resolve recognizer settings
+        const [RecognizerConstructor, defaultOptions, recognizeWith, requireFailure] =
+          RECOGNIZERS[eventName];
+        const optionsOverride = this.props.eventRecognizerOptions?.[eventName];
+        const options = {...defaultOptions, ...optionsOverride, event: eventName};
+        return {
+          recognizer: new RecognizerConstructor(options),
+          recognizeWith,
+          requireFailure
+        };
+      }),
+      events: {
+        pointerdown: this._onPointerDown,
+        pointermove: this._onPointerMove,
+        pointerleave: this._onPointerMove
+      }
+    });
+
+    for (const eventType in EVENT_HANDLERS) {
+      eventManager.on(eventType, this._onEvent);
+    }
+
+    return eventManager;
+  }
+
   private _setCanvasContext(canvasContext: CanvasContext): void {
     this._canvasContext = canvasContext;
 
@@ -1377,33 +1424,14 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
     const eventRoot =
       this.props.parent?.querySelector<HTMLDivElement>('.deck-events-root') || this.canvas;
-    this.eventManager = new EventManager(eventRoot, {
-      touchAction: this.props.touchAction,
-      recognizers: Object.keys(RECOGNIZERS).map((eventName: string) => {
-        // Resolve recognizer settings
-        const [RecognizerConstructor, defaultOptions, recognizeWith, requireFailure] =
-          RECOGNIZERS[eventName];
-        const optionsOverride = this.props.eventRecognizerOptions?.[eventName];
-        const options = {...defaultOptions, ...optionsOverride, event: eventName};
-        return {
-          recognizer: new RecognizerConstructor(options),
-          recognizeWith,
-          requireFailure
-        };
-      }),
-      events: {
-        pointerdown: this._onPointerDown,
-        pointermove: this._onPointerMove,
-        pointerleave: this._onPointerMove
-      }
-    });
-    for (const eventType in EVENT_HANDLERS) {
-      this.eventManager.on(eventType, this._onEvent);
-    }
+    assert(eventRoot);
+    this.eventManager = this._createEventManager(eventRoot);
+    this.eventManagers = {[DEFAULT_CANVAS_ID]: this.eventManager};
 
     this.viewManager = new ViewManager({
       timeline,
       eventManager: this.eventManager,
+      eventManagers: this.eventManagers,
       onViewStateChange: this._onViewStateChange.bind(this),
       onInteractionStateChange: this._onInteractionStateChange.bind(this),
       pickPosition: this._pickPositionForController.bind(this),

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -40,6 +40,11 @@ export type ViewStateObject<ViewsT extends ViewOrViews> =
 /** Canvas id used by views that do not declare a presentation canvas. */
 export const DEFAULT_CANVAS_ID = 'default-canvas';
 
+type ViewEventManager = {
+  canvasId: string;
+  eventManager: EventManager;
+};
+
 /** ViewManager props directly supplied by the user */
 type ViewManagerProps<ViewsT extends ViewOrViews> = {
   views: ViewsT;
@@ -68,8 +73,7 @@ export default class ViewManager<ViewsT extends View[]> {
   private _needsUpdate: string | false;
   private _eventManager: EventManager;
   private _eventManagers: Record<string, EventManager>;
-  private _previousEventManagers: Record<string, EventManager> | null;
-  private _viewCanvasIds: {[viewId: string]: string};
+  private _viewEventManagers: {[viewId: string]: ViewEventManager};
   private _eventCallbacks: {
     onViewStateChange?: (params: ViewStateChangeParameters) => void;
     onInteractionStateChange?: (state: InteractionState) => void;
@@ -99,8 +103,7 @@ export default class ViewManager<ViewsT extends View[]> {
 
     this._eventManager = props.eventManager;
     this._eventManagers = props.eventManagers || {};
-    this._previousEventManagers = null;
-    this._viewCanvasIds = {};
+    this._viewEventManagers = {};
     this._eventCallbacks = {
       onViewStateChange: props.onViewStateChange,
       onInteractionStateChange: props.onInteractionStateChange
@@ -202,7 +205,9 @@ export default class ViewManager<ViewsT extends View[]> {
   /** Return the presentation canvas id assigned to a view. */
   getCanvasId(viewOrViewId: string | View): string | undefined {
     const view = typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
-    return view ? view.props.canvasId || DEFAULT_CANVAS_ID : undefined;
+    return view
+      ? this._viewEventManagers[view.id]?.canvasId || view.props.canvasId || DEFAULT_CANVAS_ID
+      : undefined;
   }
 
   /**
@@ -320,64 +325,45 @@ export default class ViewManager<ViewsT extends View[]> {
   }
 
   private _setEventManagers(eventManagers: Record<string, EventManager>): void {
-    if (this._eventManagers === eventManagers) {
-      return;
+    if (this._eventManagers !== eventManagers) {
+      this._eventManagers = eventManagers;
+      this.setNeedsUpdate('eventManagers changed');
     }
-
-    const eventManagerIds = Object.keys(eventManagers);
-    const previousEventManagerIds = Object.keys(this._eventManagers);
-    if (
-      deepEqual(eventManagerIds, previousEventManagerIds, 1) &&
-      eventManagerIds.every(id => eventManagers[id] === this._eventManagers[id])
-    ) {
-      return;
-    }
-
-    this._previousEventManagers ||= this._eventManagers;
-    this._eventManagers = eventManagers;
-    this.setNeedsUpdate('eventManagers changed');
   }
 
-  private _getEventManager(canvasId: string): EventManager {
-    return this._eventManagers[canvasId] || this._eventManager;
+  private _getViewEventManager(view: View): ViewEventManager {
+    const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
+    return {
+      canvasId,
+      eventManager: this._eventManagers[canvasId] || this._eventManager
+    };
   }
 
   private _startViewportRebuild(): {
     oldControllers: {[viewId: string]: Controller<any> | null};
-    oldEventManagers: Record<string, EventManager>;
-    oldViewCanvasIds: {[viewId: string]: string};
+    oldViewEventManagers: {[viewId: string]: ViewEventManager};
   } {
     const oldControllers = this.controllers;
-    const oldEventManagers = this._previousEventManagers || this._eventManagers;
-    const oldViewCanvasIds = this._viewCanvasIds;
+    const oldViewEventManagers = this._viewEventManagers;
     this._viewports = [];
     this.controllers = {};
-    this._viewCanvasIds = {};
-    this._previousEventManagers = null;
-    return {oldControllers, oldEventManagers, oldViewCanvasIds};
-  }
-
-  private _registerCanvasId(view: View): void {
-    this._viewCanvasIds[view.id] = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
+    this._viewEventManagers = {};
+    return {oldControllers, oldViewEventManagers};
   }
 
   private _getReusableController(
-    view: View,
     controller: Controller<any> | null | undefined,
-    oldCanvasId: string | undefined,
-    oldEventManagers: Record<string, EventManager>
+    oldViewEventManager: ViewEventManager | undefined,
+    viewEventManager: ViewEventManager
   ): Controller<any> | null | undefined {
-    if (!controller) {
-      return controller;
-    }
-
-    const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
-    const oldEventManager = (oldCanvasId && oldEventManagers[oldCanvasId]) || this._eventManager;
-    if (oldCanvasId !== canvasId || oldEventManager !== this._getEventManager(canvasId)) {
+    if (
+      controller &&
+      (oldViewEventManager?.canvasId !== viewEventManager.canvasId ||
+        oldViewEventManager?.eventManager !== viewEventManager.eventManager)
+    ) {
       controller.finalize();
       return null;
     }
-
     return controller;
   }
 
@@ -386,11 +372,10 @@ export default class ViewManager<ViewsT extends View[]> {
     props: {id: string; type: ConstructorOf<Controller<any>>}
   ): Controller<any> {
     const Controller = props.type;
-    const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
 
     const controller = new Controller({
       timeline: this.timeline,
-      eventManager: this._getEventManager(canvasId),
+      eventManager: this._getViewEventManager(view).eventManager,
       // Set an internal callback that calls the prop callback if provided
       onViewStateChange: this._eventCallbacks.onViewStateChange,
       onStateChange: this._eventCallbacks.onInteractionStateChange,
@@ -441,21 +426,21 @@ export default class ViewManager<ViewsT extends View[]> {
   private _rebuildViewports(): void {
     const {views} = this;
 
-    const {oldControllers, oldEventManagers, oldViewCanvasIds} = this._startViewportRebuild();
+    const {oldControllers, oldViewEventManagers} = this._startViewportRebuild();
 
     let invalidateControllers = false;
     // Create controllers in reverse order, so that views on top receive events first
     for (let i = views.length; i--; ) {
       const view = views[i];
-      this._registerCanvasId(view);
+      const viewEventManager = this._getViewEventManager(view);
+      this._viewEventManagers[view.id] = viewEventManager;
       const viewState = this.getViewState(view);
       const viewport = view.makeViewport({viewState, width: this.width, height: this.height});
 
       let oldController = this._getReusableController(
-        view,
         oldControllers[view.id],
-        oldViewCanvasIds[view.id],
-        oldEventManagers
+        oldViewEventManagers[view.id],
+        viewEventManager
       );
       const hasController = Boolean(view.controller);
       if (hasController && !oldController) {

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -37,6 +37,9 @@ export type ViewStateObject<ViewsT extends ViewOrViews> =
   | AnyViewStateOf<ViewsT>
   | {[viewId: string]: AnyViewStateOf<ViewsT>};
 
+/** Canvas id used by views that do not declare a presentation canvas. */
+export const DEFAULT_CANVAS_ID = 'default-canvas';
+
 /** ViewManager props directly supplied by the user */
 type ViewManagerProps<ViewsT extends ViewOrViews> = {
   views: ViewsT;
@@ -46,6 +49,8 @@ type ViewManagerProps<ViewsT extends ViewOrViews> = {
   pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
   width?: number;
   height?: number;
+  /** Event managers keyed by presentation canvas id. */
+  eventManagers?: Record<string, EventManager>;
 };
 
 export default class ViewManager<ViewsT extends View[]> {
@@ -62,6 +67,9 @@ export default class ViewManager<ViewsT extends View[]> {
   private _needsRedraw: string | false;
   private _needsUpdate: string | false;
   private _eventManager: EventManager;
+  private _eventManagers: Record<string, EventManager>;
+  private _previousEventManagers: Record<string, EventManager> | null;
+  private _viewCanvasIds: {[viewId: string]: string};
   private _eventCallbacks: {
     onViewStateChange?: (params: ViewStateChangeParameters) => void;
     onInteractionStateChange?: (state: InteractionState) => void;
@@ -90,6 +98,9 @@ export default class ViewManager<ViewsT extends View[]> {
     this._needsUpdate = 'Initialize';
 
     this._eventManager = props.eventManager;
+    this._eventManagers = props.eventManagers || {};
+    this._previousEventManagers = null;
+    this._viewCanvasIds = {};
     this._eventCallbacks = {
       onViewStateChange: props.onViewStateChange,
       onInteractionStateChange: props.onInteractionStateChange
@@ -188,6 +199,12 @@ export default class ViewManager<ViewsT extends View[]> {
     return this._viewportMap[viewId];
   }
 
+  /** Return the presentation canvas id assigned to a view. */
+  getCanvasId(viewOrViewId: string | View): string | undefined {
+    const view = typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
+    return view ? view.props.canvasId || DEFAULT_CANVAS_ID : undefined;
+  }
+
   /**
    * Unproject pixel coordinates on screen onto world coordinates,
    * (possibly [lon, lat]) on map.
@@ -229,6 +246,10 @@ export default class ViewManager<ViewsT extends View[]> {
 
     if ('pickPosition' in props) {
       this._pickPosition = props.pickPosition;
+    }
+
+    if ('eventManagers' in props) {
+      this._setEventManagers(props.eventManagers || {});
     }
 
     // Important: avoid invoking _update() inside itself
@@ -298,15 +319,78 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
+  private _setEventManagers(eventManagers: Record<string, EventManager>): void {
+    if (this._eventManagers === eventManagers) {
+      return;
+    }
+
+    const eventManagerIds = Object.keys(eventManagers);
+    const previousEventManagerIds = Object.keys(this._eventManagers);
+    if (
+      deepEqual(eventManagerIds, previousEventManagerIds, 1) &&
+      eventManagerIds.every(id => eventManagers[id] === this._eventManagers[id])
+    ) {
+      return;
+    }
+
+    this._previousEventManagers ||= this._eventManagers;
+    this._eventManagers = eventManagers;
+    this.setNeedsUpdate('eventManagers changed');
+  }
+
+  private _getEventManager(canvasId: string): EventManager {
+    return this._eventManagers[canvasId] || this._eventManager;
+  }
+
+  private _startViewportRebuild(): {
+    oldControllers: {[viewId: string]: Controller<any> | null};
+    oldEventManagers: Record<string, EventManager>;
+    oldViewCanvasIds: {[viewId: string]: string};
+  } {
+    const oldControllers = this.controllers;
+    const oldEventManagers = this._previousEventManagers || this._eventManagers;
+    const oldViewCanvasIds = this._viewCanvasIds;
+    this._viewports = [];
+    this.controllers = {};
+    this._viewCanvasIds = {};
+    this._previousEventManagers = null;
+    return {oldControllers, oldEventManagers, oldViewCanvasIds};
+  }
+
+  private _registerCanvasId(view: View): void {
+    this._viewCanvasIds[view.id] = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
+  }
+
+  private _getReusableController(
+    view: View,
+    controller: Controller<any> | null | undefined,
+    oldCanvasId: string | undefined,
+    oldEventManagers: Record<string, EventManager>
+  ): Controller<any> | null | undefined {
+    if (!controller) {
+      return controller;
+    }
+
+    const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
+    const oldEventManager = (oldCanvasId && oldEventManagers[oldCanvasId]) || this._eventManager;
+    if (oldCanvasId !== canvasId || oldEventManager !== this._getEventManager(canvasId)) {
+      controller.finalize();
+      return null;
+    }
+
+    return controller;
+  }
+
   private _createController(
     view: View,
     props: {id: string; type: ConstructorOf<Controller<any>>}
   ): Controller<any> {
     const Controller = props.type;
+    const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
 
     const controller = new Controller({
       timeline: this.timeline,
-      eventManager: this._eventManager,
+      eventManager: this._getEventManager(canvasId),
       // Set an internal callback that calls the prop callback if provided
       onViewStateChange: this._eventCallbacks.onViewStateChange,
       onStateChange: this._eventCallbacks.onInteractionStateChange,
@@ -357,18 +441,22 @@ export default class ViewManager<ViewsT extends View[]> {
   private _rebuildViewports(): void {
     const {views} = this;
 
-    const oldControllers = this.controllers;
-    this._viewports = [];
-    this.controllers = {};
+    const {oldControllers, oldEventManagers, oldViewCanvasIds} = this._startViewportRebuild();
 
     let invalidateControllers = false;
     // Create controllers in reverse order, so that views on top receive events first
     for (let i = views.length; i--; ) {
       const view = views[i];
+      this._registerCanvasId(view);
       const viewState = this.getViewState(view);
       const viewport = view.makeViewport({viewState, width: this.width, height: this.height});
 
-      let oldController = oldControllers[view.id];
+      let oldController = this._getReusableController(
+        view,
+        oldControllers[view.id],
+        oldViewCanvasIds[view.id],
+        oldEventManagers
+      );
       const hasController = Boolean(view.controller);
       if (hasController && !oldController) {
         // When a new controller is added, invalidate all controllers below it so that

--- a/modules/core/src/views/view.ts
+++ b/modules/core/src/views/view.ts
@@ -18,6 +18,12 @@ export type CommonViewState = TransitionProps;
 export type CommonViewProps<ViewState> = {
   /** A unique id of the view. In a multi-view use case, this is important for matching view states and place contents into this view. */
   id?: string;
+  /**
+   * Optional id of the presentation canvas associated with this view.
+   * Integrations that render views into multiple canvases can use this id to route view-scoped
+   * resources such as event managers.
+   */
+  canvasId?: string;
   /** A relative (e.g. `'50%'`) or absolute position. Default `0`. */
   x?: number | string;
   /** A relative (e.g. `'50%'`) or absolute position. Default `0`. */

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -165,6 +165,36 @@ test('Deck wires mjolnir requireFailure between recognizers', async () => {
   });
 });
 
+test('Deck#getEventManager resolves the default manager for views', async () => {
+  await new Promise<void>((resolve, reject) => {
+    const deck = new Deck({
+      device,
+      width: 1,
+      height: 1,
+      views: [new MapView({id: 'main'}), new MapView({id: 'overlay', canvasId: 'overlay'})],
+      viewState: {
+        main: {longitude: 0, latitude: 0, zoom: 0},
+        overlay: {longitude: 0, latitude: 0, zoom: 0}
+      },
+      layers: [],
+      onLoad: () => {
+        try {
+          const eventManager = (deck as any).eventManager;
+          expect(deck.getEventManager()).toBe(eventManager);
+          expect(deck.getEventManager('main')).toBe(eventManager);
+          expect(deck.getEventManager('overlay')).toBe(eventManager);
+          expect(Object.keys((deck as any).eventManagers)).toEqual(['default-canvas']);
+
+          deck.finalize();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+  });
+});
+
 test('Deck#abort', async () => {
   const deck = new Deck({
     device,

--- a/test/modules/core/lib/view-manager.spec.ts
+++ b/test/modules/core/lib/view-manager.spec.ts
@@ -245,7 +245,18 @@ test('ViewManager#routes controllers by canvas event manager', () => {
   expect((viewManager.controllers.left as any).eventManager).toBe(leftEventManager);
   expect((viewManager.controllers.right as any).eventManager).toBe(rightEventManager);
 
+  const originalLeftController = viewManager.controllers.left;
   const originalRightController = viewManager.controllers.right;
+  viewManager.setProps({
+    eventManagers: {
+      'left-canvas': leftEventManager,
+      'right-canvas': rightEventManager
+    }
+  });
+
+  expect(viewManager.controllers.left).toBe(originalLeftController);
+  expect(viewManager.controllers.right).toBe(originalRightController);
+
   viewManager.setProps({
     eventManagers: {
       'left-canvas': leftEventManager,

--- a/test/modules/core/lib/view-manager.spec.ts
+++ b/test/modules/core/lib/view-manager.spec.ts
@@ -6,6 +6,7 @@ import {test, expect} from 'vitest';
 import {MapView} from '@deck.gl/core';
 import ViewManager from '@deck.gl/core/lib/view-manager';
 import {equals} from '@math.gl/core';
+import {EventManager} from 'mjolnir.js';
 
 test('ViewManager#constructor', () => {
   const viewManager = new ViewManager({
@@ -213,6 +214,65 @@ test('ViewManager#update view props', () => {
   ).toBeTruthy();
 
   viewManager.finalize();
+});
+
+test('ViewManager#routes controllers by canvas event manager', () => {
+  const defaultEventManager = new EventManager(document.createElement('div'));
+  const leftEventManager = new EventManager(document.createElement('div'));
+  const rightEventManager = new EventManager(document.createElement('div'));
+  const replacementRightEventManager = new EventManager(document.createElement('div'));
+  const leftView = new MapView({id: 'left', canvasId: 'left-canvas', controller: true});
+  const rightView = new MapView({id: 'right', canvasId: 'right-canvas', controller: true});
+
+  const viewManager = new ViewManager({
+    views: [leftView, rightView],
+    viewState: {
+      left: {longitude: -122, latitude: 38, zoom: 10},
+      right: {longitude: -74, latitude: 40.7, zoom: 11}
+    },
+    width: 100,
+    height: 100,
+    eventManager: defaultEventManager,
+    eventManagers: {
+      'left-canvas': leftEventManager,
+      'right-canvas': rightEventManager
+    }
+  });
+
+  expect(viewManager.getCanvasId('left')).toBe('left-canvas');
+  expect(viewManager.getCanvasId('right')).toBe('right-canvas');
+  expect(viewManager.getCanvasId(new MapView({id: 'default'}))).toBe('default-canvas');
+  expect((viewManager.controllers.left as any).eventManager).toBe(leftEventManager);
+  expect((viewManager.controllers.right as any).eventManager).toBe(rightEventManager);
+
+  const originalRightController = viewManager.controllers.right;
+  viewManager.setProps({
+    eventManagers: {
+      'left-canvas': leftEventManager,
+      'right-canvas': replacementRightEventManager
+    }
+  });
+
+  expect(viewManager.controllers.right).not.toBe(originalRightController);
+  expect((viewManager.controllers.left as any).eventManager).toBe(leftEventManager);
+  expect((viewManager.controllers.right as any).eventManager).toBe(replacementRightEventManager);
+
+  const leftController = viewManager.controllers.left;
+  const rightController = viewManager.controllers.right;
+  viewManager.setProps({
+    views: [new MapView({id: 'left', canvasId: 'right-canvas', controller: true}), rightView]
+  });
+
+  expect(viewManager.getCanvasId('left')).toBe('right-canvas');
+  expect(viewManager.controllers.left).not.toBe(leftController);
+  expect((viewManager.controllers.left as any).eventManager).toBe(replacementRightEventManager);
+  expect(viewManager.controllers.right).toBe(rightController);
+
+  viewManager.finalize();
+  defaultEventManager.destroy();
+  leftEventManager.destroy();
+  rightEventManager.destroy();
+  replacementRightEventManager.destroy();
 });
 
 /* eslint-disable max-statements */


### PR DESCRIPTION
## Summary

Prepare the multi-canvas RFC by landing the view-scoped event-manager routing seam separately from the full rendering work.

## Why

The follow-up `ib/multi-canvas-rfc` branch needs per-canvas `EventManager` instances, but the event-manager / Mjolnir.js-facing part is easier to review independently from `CanvasManager`, presentation contexts, render/pick changes, and React multi-canvas DOM structure.

This prep diff is behavior-preserving on `master`: Deck still creates and uses the existing singleton `EventManager`, but Deck and ViewManager now route through a stable canvas-id seam so the RFC branch can later provide distinct managers per presentation canvas.

## What changed

- Added latent `canvasId?: string` view identity plumbing.
- Added `ViewManager.getCanvasId(viewOrViewId)` with a stable `default-canvas` fallback.
- Factored Deck's existing singleton `EventManager` creation and stored it in `eventManagers` under the default canvas id.
- Added `Deck.getEventManager(viewId?: string)`; on this prep branch it still resolves the current singleton.
- Passed `eventManagers` into `ViewManager` and routed controller creation through each view's resolved canvas id/event manager binding.
- Recreate controllers only when a view's canvas id or mapped event manager changes.
- Updated React positioning context to use the public `deck.getEventManager(viewId)` seam.
- Added focused Deck, ViewManager, and React tests for the new seam.

## Intentionally not included

- No `CanvasManager`.
- No `DeckProps.canvases`.
- No presentation contexts or canvas metrics.
- No multi-canvas render, pick, or DOM event routing.
- No React multi-canvas host or portal changes.

## Validation

- `yarn build`
- `yarn test-headless test/modules/core/lib/view-manager.spec.ts test/modules/core/lib/deck.spec.ts`
- `yarn test-headless test/modules/react/utils/position-children-under-views.spec.ts test/modules/react/deckgl.spec.ts`
- `yarn lint`

`yarn lint` passes with warnings only. The focused React test still emits the existing `act(...)` warning while passing.