### PR TITLE
fix(geo-layers): Pass zoomOffset through TerrainLayer to child TileLayer.

### DIFF
--- a/examples/website/map-tile/app.tsx
+++ b/examples/website/map-tile/app.tsx
@@ -57,6 +57,7 @@ export default function App({
   maxZoom = 7,
   visibleMinZoom,
   visibleMaxZoom = 7,
+  zoomOffset = 0,
   useExtent = false
 }: {
   showBorder?: boolean;
@@ -66,6 +67,7 @@ export default function App({
   maxZoom?: number;
   visibleMinZoom?: number;
   visibleMaxZoom?: number;
+  zoomOffset?: number;
   useExtent?: boolean;
 }) {
   const [zoom, setZoom] = useState(INITIAL_VIEW_STATE.zoom);
@@ -95,6 +97,7 @@ export default function App({
     tileSize: 512,
     visibleMinZoom,
     visibleMaxZoom,
+    zoomOffset,
     extent: useExtent ? FRANCE_EXTENT : undefined,
     renderSubLayers: props => {
       const [[west, south], [east, north]] = props.tile.boundingBox;

--- a/examples/website/terrain/app.tsx
+++ b/examples/website/terrain/app.tsx
@@ -38,11 +38,13 @@ export default function App({
   texture = SURFACE_IMAGE,
   wireframe = false,
   globeView = false,
+  zoomOffset = 0,
   initialViewState = INITIAL_VIEW_STATE
 }: {
   texture?: string;
   wireframe?: boolean;
   globeView?: boolean;
+  zoomOffset?: number;
   initialViewState?: MapViewState;
 }) {
   const [viewState, setViewState] = useState(initialViewState);
@@ -57,6 +59,7 @@ export default function App({
     elevationData: TERRAIN_IMAGE,
     texture,
     wireframe,
+    zoomOffset,
     color: [255, 255, 255],
     pickable: '3d'
   });

--- a/examples/website/terrain/app.tsx
+++ b/examples/website/terrain/app.tsx
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import React, {useState, useCallback} from 'react';
-import {createRoot} from 'react-dom/client';
 import {DeckGL} from '@deck.gl/react';
+import React, {useCallback, useState} from 'react';
+import {createRoot} from 'react-dom/client';
 
-import {TerrainLayer, TerrainLayerProps} from '@deck.gl/geo-layers';
-import {MapView, _GlobeView as GlobeView} from '@deck.gl/core';
 import type {MapViewState} from '@deck.gl/core';
+import {_GlobeView as GlobeView, MapView} from '@deck.gl/core';
+import {TerrainLayer, TerrainLayerProps} from '@deck.gl/geo-layers';
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
@@ -39,21 +39,39 @@ export default function App({
   wireframe = false,
   globeView = false,
   zoomOffset = 0,
-  initialViewState = INITIAL_VIEW_STATE
+  minZoom = 0,
+  maxZoom = 14,
+  visibleMinZoom = 0,
+  visibleMaxZoom = 14,
+  initialViewState = INITIAL_VIEW_STATE,
+  onZoomChange
 }: {
   texture?: string;
   wireframe?: boolean;
   globeView?: boolean;
   zoomOffset?: number;
+  minZoom?: number;
+  maxZoom?: number;
+  visibleMinZoom?: number;
+  visibleMaxZoom?: number;
   initialViewState?: MapViewState;
+  onZoomChange?: (zoom: number) => void;
 }) {
   const [viewState, setViewState] = useState(initialViewState);
-  const onViewStateChange = useCallback(({viewState: vs}) => setViewState(vs), []);
+  const onViewStateChange = useCallback(
+    ({viewState: vs}) => {
+      setViewState(vs);
+      onZoomChange?.(vs.zoom);
+    },
+    [onZoomChange]
+  );
 
   const layer = new TerrainLayer({
     id: 'terrain',
-    minZoom: 0,
-    maxZoom: 14,
+    minZoom,
+    maxZoom,
+    visibleMinZoom,
+    visibleMaxZoom,
     refinementStrategy: 'best-available',
     elevationDecoder: ELEVATION_DECODER,
     elevationData: TERRAIN_IMAGE,

--- a/modules/geo-layers/src/terrain-layer/terrain-layer.ts
+++ b/modules/geo-layers/src/terrain-layer/terrain-layer.ts
@@ -6,17 +6,17 @@ import {
   Color,
   CompositeLayer,
   CompositeLayerProps,
+  COORDINATE_SYSTEM,
   DefaultProps,
+  _GlobeViewport as GlobeViewport,
   Layer,
   LayersList,
   log,
   Material,
   TextureSource,
-  UpdateParameters,
-  _GlobeViewport as GlobeViewport
+  UpdateParameters
 } from '@deck.gl/core';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
-import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import type {MeshAttributes} from '@loaders.gl/schema';
 import {TerrainWorkerLoader} from '@loaders.gl/terrain';
 import TileLayer, {TileLayerProps} from '../tile-layer/tile-layer';
@@ -27,7 +27,7 @@ import type {
   TileLoadProps,
   ZRange
 } from '../tileset-2d/index';
-import {Tile2DHeader, urlType, getURLFromTemplate, URLTemplate} from '../tileset-2d/index';
+import {getURLFromTemplate, Tile2DHeader, URLTemplate, urlType} from '../tileset-2d/index';
 
 const DUMMY_DATA = [1];
 const TILE_OVERLAP_PIXELS = 1;
@@ -356,7 +356,8 @@ export default class TerrainLayer<ExtraPropsT extends {} = {}> extends Composite
       onTileError,
       maxCacheSize,
       maxCacheByteSize,
-      refinementStrategy
+      refinementStrategy,
+      zoomOffset
     } = this.props;
 
     if (this.state.isTiled) {
@@ -373,7 +374,8 @@ export default class TerrainLayer<ExtraPropsT extends {} = {}> extends Composite
               texture: urlTemplateToUpdateTrigger(texture),
               meshMaxError,
               elevationDecoder,
-              projectionMode: this.context.viewport.projectionMode
+              projectionMode: this.context.viewport.projectionMode,
+              zoomOffset
             }
           },
           onViewportLoad: this.onViewportLoad.bind(this),
@@ -388,7 +390,8 @@ export default class TerrainLayer<ExtraPropsT extends {} = {}> extends Composite
           onTileError,
           maxCacheSize,
           maxCacheByteSize,
-          refinementStrategy
+          refinementStrategy,
+          zoomOffset
         }
       );
     }

--- a/test/modules/geo-layers/terrain-layer-loading.spec.ts
+++ b/test/modules/geo-layers/terrain-layer-loading.spec.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {test, expect} from 'vitest';
-import {COORDINATE_SYSTEM, MapView, _GlobeView as GlobeView} from '@deck.gl/core';
+import {COORDINATE_SYSTEM, _GlobeView as GlobeView, MapView} from '@deck.gl/core';
 import {TerrainLayer} from '@deck.gl/geo-layers';
 import {testInitializeLayerAsync} from '@deck.gl/test-utils/vitest';
 import {TruncatedConeGeometry} from '@luma.gl/engine';
+import {expect, test} from 'vitest';
 
 function createDeferred() {
   let resolve;
@@ -132,25 +132,64 @@ test('TerrainLayer#isLoaded waits for elevation and texture in tiled mode', asyn
   handle?.finalize();
 });
 
-test('TerrainLayer forwards zoomOffset to TileLayer in tiled mode', async () => {
-  const layer = new TerrainLayer({
-    id: 'terrain-zoom-offset',
-    elevationData: 'https://example.com/elevation/{z}/{x}/{y}.png',
-    zoomOffset: 1,
-    minZoom: 0,
-    maxZoom: 0,
-    fetch: () => Promise.resolve(createTestMesh())
+test('TerrainLayer fetches tiles at correct zoom levels for different zoomOffset values', async () => {
+  // Create a viewport at zoom 3 to test various zoomOffset values
+  const viewportZoom3 = new MapView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 3}
   });
 
-  const handle = await testInitializeLayerAsync({
-    layer,
-    viewport: TEST_VIEWPORT,
-    finalize: false
-  });
+  const testCases = [
+    {zoomOffset: -1, expectedZ: 2, description: 'zoomOffset: -1 (lower detail)'},
+    {zoomOffset: 0, expectedZ: 3, description: 'zoomOffset: 0 (normal)'},
+    {zoomOffset: 1, expectedZ: 4, description: 'zoomOffset: +1 (higher detail)'}
+  ];
 
-  const tileLayer = layer.getSubLayers()[0];
-  expect(tileLayer.props.zoomOffset, 'zoomOffset forwarded to TileLayer').toBe(1);
-  handle?.finalize();
+  for (const testCase of testCases) {
+    const fetchedUrls: {elevation: string[]; texture: string[]} = {
+      elevation: [],
+      texture: []
+    };
+
+    const layer = new TerrainLayer({
+      id: `terrain-zoom-offset-${testCase.zoomOffset}`,
+      elevationData: 'https://example.com/elevation/{z}/{x}/{y}.png',
+      texture: 'https://example.com/texture/{z}/{x}/{y}.png',
+      zoomOffset: testCase.zoomOffset,
+      minZoom: 0,
+      maxZoom: 6,
+      fetch: (url, {propName}) => {
+        if (propName === 'elevationData') {
+          fetchedUrls.elevation.push(url);
+        } else if (propName === 'texture') {
+          fetchedUrls.texture.push(url);
+        }
+        return Promise.resolve(createTestMesh());
+      }
+    });
+
+    const handle = await testInitializeLayerAsync({
+      layer,
+      viewport: viewportZoom3,
+      finalize: false
+    });
+
+    await sleep();
+
+    // Verify tiles are fetched at the expected zoom level for both elevation and texture
+    const expectedZoomPath = `/${testCase.expectedZ}/`;
+    expect(
+      fetchedUrls.elevation.some(url => url.includes(expectedZoomPath)),
+      `${testCase.description}: elevation tiles fetched at z=${testCase.expectedZ}`
+    ).toBe(true);
+    expect(
+      fetchedUrls.texture.some(url => url.includes(expectedZoomPath)),
+      `${testCase.description}: texture tiles fetched at z=${testCase.expectedZ}`
+    ).toBe(true);
+
+    handle?.finalize();
+  }
 });
 
 test('TerrainLayer renders tiled Martini meshes in lng/lat coordinates on GlobeView', async () => {

--- a/test/modules/geo-layers/terrain-layer-loading.spec.ts
+++ b/test/modules/geo-layers/terrain-layer-loading.spec.ts
@@ -132,6 +132,27 @@ test('TerrainLayer#isLoaded waits for elevation and texture in tiled mode', asyn
   handle?.finalize();
 });
 
+test('TerrainLayer forwards zoomOffset to TileLayer in tiled mode', async () => {
+  const layer = new TerrainLayer({
+    id: 'terrain-zoom-offset',
+    elevationData: 'https://example.com/elevation/{z}/{x}/{y}.png',
+    zoomOffset: 1,
+    minZoom: 0,
+    maxZoom: 0,
+    fetch: () => Promise.resolve(createTestMesh())
+  });
+
+  const handle = await testInitializeLayerAsync({
+    layer,
+    viewport: TEST_VIEWPORT,
+    finalize: false
+  });
+
+  const tileLayer = layer.getSubLayers()[0];
+  expect(tileLayer.props.zoomOffset, 'zoomOffset forwarded to TileLayer').toBe(1);
+  handle?.finalize();
+});
+
 test('TerrainLayer renders tiled Martini meshes in lng/lat coordinates on GlobeView', async () => {
   const layer = new TerrainLayer({
     id: 'terrain-tiled-globe',

--- a/website/src/examples/terrain-layer.js
+++ b/website/src/examples/terrain-layer.js
@@ -75,7 +75,15 @@ class TerrainDemo extends Component {
       options: Object.keys(SURFACE_IMAGES),
       value: 'Satellite'
     },
-    wireframe: {displayName: 'Wireframe', type: 'checkbox', value: false}
+    wireframe: {displayName: 'Wireframe', type: 'checkbox', value: false},
+    zoomOffset: {
+      displayName: 'Zoom Offset',
+      type: 'range',
+      value: 0,
+      min: -2,
+      max: 2,
+      step: 1
+    }
   };
 
   static mapStyle = MAPBOX_STYLES.BLANK;
@@ -106,7 +114,7 @@ class TerrainDemo extends Component {
 
   render() {
     const {params, data, ...otherProps} = this.props;
-    const {location, surface, wireframe, globeView} = params;
+    const {location, surface, wireframe, globeView, zoomOffset} = params;
 
     const initialViewState = LOCATIONS[location.value];
     initialViewState.pitch = 45;
@@ -120,6 +128,7 @@ class TerrainDemo extends Component {
           texture={SURFACE_IMAGES[surface.value]}
           wireframe={wireframe.value}
           globeView={globeView.value}
+          zoomOffset={zoomOffset.value}
         />
       </div>
     );

--- a/website/src/examples/terrain-layer.js
+++ b/website/src/examples/terrain-layer.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import React, {Component} from 'react';
-import {MAPBOX_STYLES, GITHUB_TREE} from '../constants/defaults';
+import {Component} from 'react';
 import App from 'website-examples/terrain/app';
+import {GITHUB_TREE, MAPBOX_STYLES} from '../constants/defaults';
 
 import {makeExample} from '../components';
 
@@ -76,6 +76,42 @@ class TerrainDemo extends Component {
       value: 'Satellite'
     },
     wireframe: {displayName: 'Wireframe', type: 'checkbox', value: false},
+    minZoom: {
+      displayName: 'Min Zoom',
+      type: 'range',
+      value: 0,
+      step: 1,
+      min: 0,
+      max: 19,
+      accentColor: '#0275ff'
+    },
+    maxZoom: {
+      displayName: 'Max Zoom',
+      type: 'range',
+      value: 14,
+      step: 1,
+      min: 0,
+      max: 19,
+      accentColor: '#0275ff'
+    },
+    visibleMinZoom: {
+      displayName: 'Visible Min Zoom',
+      type: 'range',
+      value: 0,
+      step: 1,
+      min: 0,
+      max: 19,
+      accentColor: '#1a2b4a'
+    },
+    visibleMaxZoom: {
+      displayName: 'Visible Max Zoom',
+      type: 'range',
+      value: 19,
+      step: 1,
+      min: 0,
+      max: 19,
+      accentColor: '#1a2b4a'
+    },
     zoomOffset: {
       displayName: 'Zoom Offset',
       type: 'range',
@@ -108,13 +144,32 @@ class TerrainDemo extends Component {
             <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>
           </div>
         </p>
+        <div className="layout">
+          <div className="stat col-1-2">
+            Viewport Zoom<b>{meta.zoom != null ? meta.zoom.toFixed(1) : '-'}</b>
+          </div>
+        </div>
       </div>
     );
   }
 
+  _onZoomChange = zoom => {
+    this.props.onStateChange({zoom});
+  };
+
   render() {
     const {params, data, ...otherProps} = this.props;
-    const {location, surface, wireframe, globeView, zoomOffset} = params;
+    const {
+      location,
+      surface,
+      wireframe,
+      globeView,
+      minZoom,
+      maxZoom,
+      visibleMinZoom,
+      visibleMaxZoom,
+      zoomOffset
+    } = params;
 
     const initialViewState = LOCATIONS[location.value];
     initialViewState.pitch = 45;
@@ -128,7 +183,12 @@ class TerrainDemo extends Component {
           texture={SURFACE_IMAGES[surface.value]}
           wireframe={wireframe.value}
           globeView={globeView.value}
+          minZoom={minZoom.value}
+          maxZoom={maxZoom.value}
+          visibleMinZoom={visibleMinZoom.value}
+          visibleMaxZoom={visibleMaxZoom.value}
           zoomOffset={zoomOffset.value}
+          onZoomChange={this._onZoomChange}
         />
       </div>
     );

--- a/website/src/examples/tile-layer.js
+++ b/website/src/examples/tile-layer.js
@@ -19,6 +19,7 @@ class MapTileDemo extends Component {
     maxZoom: {displayName: 'Max Zoom', type: 'range', value: 8, step: 1, min: 0, max: 19, accentColor: '#0275ff'},
     visibleMinZoom: {displayName: 'Visible Min Zoom', type: 'range', value: 1, step: 1, min: 0, max: 19, accentColor: '#1a2b4a'},
     visibleMaxZoom: {displayName: 'Visible Max Zoom', type: 'range', value: 12, step: 1, min: 0, max: 19, accentColor: '#1a2b4a'},
+    zoomOffset: {displayName: 'Zoom Offset', type: 'range', value: 0, step: 1, min: -2, max: 2},
     showBorder: {displayName: 'Show tile borders', type: 'checkbox', value: false},
     useExtent: {displayName: 'Extent (France)', type: 'checkbox', value: false}
   };
@@ -65,6 +66,7 @@ class MapTileDemo extends Component {
         maxZoom={params.maxZoom.value}
         visibleMinZoom={params.visibleMinZoom.value}
         visibleMaxZoom={params.visibleMaxZoom.value}
+        zoomOffset={params.zoomOffset.value}
         useExtent={params.useExtent.value}
         onTilesLoad={this._onTilesLoad}
         onZoomChange={this._onZoomChange}


### PR DESCRIPTION


https://github.com/user-attachments/assets/f977318b-b39a-4b0c-838a-2d3710165b8d

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #10366 

<!-- For all the PRs -->
#### Change List
- Expand Tile example to include zoomOffset parameter.
- Update Terrain example to include (zoomOffset, maxZoom, ...) parameters matching Tile example.
- Update TerrainLayer to properly pass zoomOffset parameter to underlying Tile layer.
- Add test that zoomOffset parameter properly affects which tiles are loaded.

 Manually verified zoomOffset behavior in updated example in addition to automated test.
