### PR TITLE
fix(issues): reduce search noise

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,15 +22,13 @@ body:
     description: Are you using one of the following platform-specific APIs?
     multiple: true
     options:
-      - label: Script tag
-      - label: React
-      - label: Python/Jupyter notebook
-      - label: MapboxOverlay
-      - label: GoogleMapsOverlay
-      - label: CARTO
-      - label: ArcGIS
-  validations:
-     required: true
+      - Script tag
+      - React
+      - Python/Jupyter notebook
+      - MapboxOverlay
+      - GoogleMapsOverlay
+      - CARTO
+      - ArcGIS
 - type: textarea
   attributes:
     label: Expected Behavior

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,11 +15,12 @@ body:
     description: What you're experiencing.
   validations:
     required: true
-- type: checkboxes
+- type: dropdown
   id: flavor
   attributes:
     label: Flavors
     description: Are you using one of the following platform-specific APIs?
+    multiple: true
     options:
       - label: Script tag
       - label: React
@@ -28,6 +29,8 @@ body:
       - label: GoogleMapsOverlay
       - label: CARTO
       - label: ArcGIS
+  validations:
+     required: true
 - type: textarea
   attributes:
     label: Expected Behavior


### PR DESCRIPTION
Changed flavor input type from checkboxes to dropdown and made it multi-select.

This should avoid the worsening of a significant problem with search relevance where [searching for `ArcGIS` returns ALL bug-report issues](https://github.com/visgl/deck.gl/issues?q=is%3Aissue%20state%3Aopen%20arcgis)...

[REF](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the GitHub issue template YAML; no runtime or library code is affected.
> 
> **Overview**
> Updates the bug report issue template so **Flavors** is a **multi-select dropdown** instead of checkboxes, with options listed in dropdown form (no per-option `label` entries).
> 
> This keeps reporters able to pick multiple platform APIs while stopping flavor names like **ArcGIS** from being embedded in issue bodies in a way that pollutes GitHub issue search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3986a7990ada0549f027997859c8c6db87cbc6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->