### PR TITLE
docs: Add v9.4 whats-new for alpha release

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -27,7 +27,7 @@ Release date: TBD
 
 ### @deck.gl/arcgis
 
-- `DeckRenderer` now integrates with ArcGIS `SceneView` through the modern `RenderNode` API instead of the deprecated `externalRenderers`. This aligns with ArcGIS JS API 4.x best practices and improves rendering lifecycle management.
+- `DeckRenderer` now integrates with ArcGIS `SceneView` through the modern `RenderNode` API instead of the deprecated `externalRenderers`.
 
 ### Performance
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -6,21 +6,29 @@ This page contains highlights of each deck.gl release. Also check our [vis.gl bl
 
 Release date: TBD
 
-### Controllers
+### Core Performance
 
-- New `doubleClickDragZoom` gesture on all controllers enables smooth zoom by double-clicking and dragging up/down.
+- Picking in most instanced layers no longer allocates an `instancePickingColors` attribute buffer, reducing memory usage and initialization times. (deck.gl now using shader builtins `instance_index` / `gl_InstanceID`). 
 
-### GlobeView
+### Views and Controllers
+
+#### GlobeView
+
+`GlobeView`, while still experimental, is improved and nearing graduation: 
 
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now renders correctly on `GlobeView`, producing properly projected terrain meshes on the globe.
 - [TerrainExtension](./api-reference/extensions/terrain-extension.md) now supports `GlobeView`, enabling terrain-draped layers on the globe.
 - [Tile3DLayer](./api-reference/geo-layers/tile-3d-layer.md) renders correctly on `GlobeView`.
 
-### Views
+#### Views
 
 - Views now support a `parameters` prop for per-view GPU draw state overrides. `GlobeView` uses this to enable back-face culling by default, and applications can override it with `new GlobeView({parameters: {cullMode: 'none'}})`.
 
-### Geo Layers
+#### Controllers
+
+- New `doubleClickDragZoom` gesture on all controllers enables smooth zoom by double-clicking and dragging up/down.
+
+### @deck.gl/geo-layers
 
 - [TileLayer](./api-reference/geo-layers/tile-layer.md) now prioritizes tile requests closest to the viewport center, improving perceived load times during panning and zooming.
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now correctly passes `zoomOffset` through to its child `TileLayer`.
@@ -29,9 +37,9 @@ Release date: TBD
 
 - `DeckRenderer` now integrates with ArcGIS `SceneView` through the modern `RenderNode` API instead of the deprecated `externalRenderers`.
 
-### Performance
+### @deck.gl/widgets
 
-- Picking in most instanced layers no longer allocates an `instancePickingColors` attribute buffer, instead using shader builtins `instance_index` / `gl_InstanceID`, reducing memory usage and initialization times.
+A new experimental `ViewLayout` system with a helper function `buildViewsFromViewLayout()` allows advanced nested and relative view layouts to be specified using a declarative layout tree.
 
 ## deck.gl v9.3
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -25,6 +25,10 @@ Release date: TBD
 - [TileLayer](./api-reference/geo-layers/tile-layer.md) now prioritizes tile requests closest to the viewport center, improving perceived load times during panning and zooming.
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now correctly passes `zoomOffset` through to its child `TileLayer`.
 
+### @deck.gl/arcgis
+
+- `DeckRenderer` now integrates with ArcGIS `SceneView` through the modern `RenderNode` API instead of the deprecated `externalRenderers`. This aligns with ArcGIS JS API 4.x best practices and improves rendering lifecycle management.
+
 ### Performance
 
 - Picking in most instanced layers no longer allocates an `instancePickingColors` attribute buffer, instead using shader builtins `instance_index` / `gl_InstanceID`, reducing memory usage and initialization times.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,9 +4,26 @@ This page contains highlights of each deck.gl release. Also check our [vis.gl bl
 
 ## deck.gl v9.4
 
+Release date: TBD
+
+### Controllers
+
+- New `doubleClickDragZoom` gesture on all controllers enables smooth zoom by double-clicking and dragging up/down.
+
+### GlobeView
+
+- [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now renders correctly on `GlobeView`, producing properly projected terrain meshes on the globe.
+- [TerrainExtension](./api-reference/extensions/terrain-extension.md) now supports `GlobeView`, enabling terrain-draped layers on the globe.
+- [Tile3DLayer](./api-reference/geo-layers/tile-3d-layer.md) renders correctly on `GlobeView`.
+
 ### Views
 
 - Views now support a `parameters` prop for per-view GPU draw state overrides. `GlobeView` uses this to enable back-face culling by default, and applications can override it with `new GlobeView({parameters: {cullMode: 'none'}})`.
+
+### Geo Layers
+
+- [TileLayer](./api-reference/geo-layers/tile-layer.md) now prioritizes tile requests closest to the viewport center, improving perceived load times during panning and zooming.
+- [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now correctly passes `zoomOffset` through to its child `TileLayer`.
 
 ### Performance
 


### PR DESCRIPTION
## Summary

- Expand docs/whats-new.md with 9.4 highlights: Controllers, GlobeView, Geo Layers, Performance

## Test plan

- [ ] Review whats-new prose for accuracy
- [ ] Website builds cleanly with updated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the release notes page; no runtime or API code is modified.
> 
> **Overview**
> Adds a full **deck.gl v9.4** section to `docs/whats-new.md` with release date **TBD**, reorganizing and expanding what was previously a single views bullet into themed subsections.
> 
> **Core performance** documents instanced-layer picking without `instancePickingColors`, using shader builtins `instance_index` / `gl_InstanceID`.
> 
> **Views and controllers** groups **GlobeView** improvements (TerrainLayer, TerrainExtension, Tile3DLayer), the views **`parameters`** prop (including GlobeView back-face culling), and the **`doubleClickDragZoom`** controller gesture.
> 
> **Package callouts** add bullets for **@deck.gl/geo-layers** (TileLayer viewport-center prioritization, TerrainLayer `zoomOffset`), **@deck.gl/arcgis** (`DeckRenderer` / `RenderNode` vs `externalRenderers`), and **@deck.gl/widgets** (experimental `ViewLayout` + `buildViewsFromViewLayout()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c185f28f385cecd906a1d2b8b730f44d2875298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->