### PR TITLE
feat(core):  Expose animation clocks through layer uniforms (v10 exploration)

### DIFF
--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -57,6 +57,7 @@ export default class DeckPicker {
   pickLayersPass: PickLayersPass;
   layerFilter?: (context: FilterContext) => boolean;
   stats?: Stats;
+  shaderModuleProps?: Record<string, any>;
 
   /** Identifiers of the previously picked object, for callback tracking and auto highlight */
   lastPickedInfo: {
@@ -85,6 +86,10 @@ export default class DeckPicker {
 
     if ('_pickable' in props) {
       this._pickable = props._pickable;
+    }
+
+    if ('shaderModuleProps' in props) {
+      this.shaderModuleProps = props.shaderModuleProps;
     }
   }
 
@@ -814,7 +819,8 @@ export default class DeckPicker {
       pass,
       pickZ,
       preRenderStats: {},
-      isPicking: true
+      isPicking: true,
+      shaderModuleProps: this.shaderModuleProps
     };
 
     for (const effect of effects) {
@@ -987,7 +993,8 @@ export default class DeckPicker {
       pass,
       pickZ,
       preRenderStats: {},
-      isPicking: true
+      isPicking: true,
+      shaderModuleProps: this.shaderModuleProps
     };
 
     for (const effect of effects) {

--- a/modules/core/src/lib/deck-renderer.ts
+++ b/modules/core/src/lib/deck-renderer.ts
@@ -68,6 +68,7 @@ export default class DeckRenderer {
     layerFilter?: LayerFilter;
     clearStack?: boolean;
     clearCanvas?: boolean;
+    shaderModuleProps?: Record<string, any>;
   }) {
     if (!opts.viewports.length) {
       return;

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -20,7 +20,7 @@ import {luma} from '@luma.gl/core';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {GL} from '@luma.gl/webgl/constants';
 import {Timeline} from '@luma.gl/engine';
-import {AnimationLoop} from '@luma.gl/engine';
+import {AnimationLoop, type AnimationProps} from '@luma.gl/engine';
 import type {
   CanvasContext,
   CanvasContextProps,
@@ -92,6 +92,12 @@ type InternalPickingMode = 'sync' | 'async';
 type PointPickResult = {
   result: PickingInfo[];
   emptyInfo: PickingInfo;
+};
+
+type LayerAnimationProps = {
+  timelineTime: number;
+  engineTime: number;
+  frameIndex: number;
 };
 
 export type DeckProps<ViewsT extends ViewOrViews = null> = {
@@ -358,6 +364,11 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
     gpuMemory: 0
   };
   private _metricsCounter: number = 0;
+  private _layerAnimationProps: LayerAnimationProps = {
+    timelineTime: 0,
+    engineTime: 0,
+    frameIndex: 0
+  };
   private _hoverPickSequence: number = 0;
   private _pointerDownPickSequence: number = 0;
 
@@ -1492,6 +1503,7 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       effects?: Effect[];
       clearStack?: boolean;
       clearCanvas?: boolean;
+      shaderModuleProps?: Record<string, any>;
     }
   ) {
     const {device, gl} = this.layerManager!.context;
@@ -1506,7 +1518,14 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
       views: this.viewManager!.getViews(),
       pass: 'screen',
       effects: this.effectManager!.getEffects(),
-      ...renderOptions
+      ...renderOptions,
+      shaderModuleProps: {
+        ...renderOptions?.shaderModuleProps,
+        layer: {
+          ...this._layerAnimationProps,
+          ...renderOptions?.shaderModuleProps?.layer
+        }
+      }
     };
     this.deckRenderer?.renderLayers(opts);
 
@@ -1524,7 +1543,14 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
 
   // Callbacks
 
-  private _onRenderFrame() {
+  private _onRenderFrame(animationProps: AnimationProps) {
+    this._layerAnimationProps.timelineTime = animationProps.time / 1000;
+    this._layerAnimationProps.engineTime = animationProps.engineTime / 1000;
+    this._layerAnimationProps.frameIndex = animationProps.tock;
+    this.deckPicker?.setProps({
+      shaderModuleProps: {layer: this._layerAnimationProps}
+    });
+
     this._getFrameStats();
 
     // Log perf stats every second

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -432,7 +432,8 @@ export default class LayersPass extends Pass {
     const layerProps = layer.internalState?.propsInTransition || layer.props;
 
     const shaderModuleProps = {
-      layer: layerProps,
+      // Layer props are frozen. Clone only when a render pass adds global layer module props.
+      layer: overrides?.layer ? {...layerProps} : layerProps,
       picking: {
         isActive: false
       } satisfies PickingProps,

--- a/modules/core/src/shaderlib/misc/layer-uniforms.ts
+++ b/modules/core/src/shaderlib/misc/layer-uniforms.ts
@@ -8,6 +8,9 @@ import type {LayerProps} from '../../types/layer-props';
 const uniformBlockWGSL = /* wgsl */ `\
 struct LayerUniforms {
   opacity: f32,
+  timelineTime: f32,
+  engineTime: f32,
+  frameIndex: u32,
 };
 
 @group(0) @binding(auto)
@@ -17,11 +20,20 @@ var<uniform> layer: LayerUniforms;
 const uniformBlock = `\
 layout(std140) uniform layerUniforms {
   uniform float opacity;
+  uniform float timelineTime;
+  uniform float engineTime;
+  uniform highp uint frameIndex;
 } layer;
 `;
 
 export type LayerUniforms = {
   opacity?: number;
+  /** Current attached timeline time, in seconds. */
+  timelineTime?: number;
+  /** Monotonic engine time since the animation loop started, in seconds. */
+  engineTime?: number;
+  /** Number of animation frames processed by the animation loop. */
+  frameIndex?: number;
 };
 
 export const layerUniforms = {
@@ -29,14 +41,20 @@ export const layerUniforms = {
   source: uniformBlockWGSL,
   vs: uniformBlock,
   fs: uniformBlock,
-  getUniforms: (props: Partial<LayerProps>) => {
+  getUniforms: (props: Partial<LayerProps & LayerUniforms>) => {
     return {
       // apply gamma to opacity to make it visually "linear"
       // TODO - v10: use raw opacity?
-      opacity: Math.pow(props.opacity!, 1 / 2.2)
+      opacity: Math.pow(props.opacity!, 1 / 2.2),
+      timelineTime: props.timelineTime ?? 0,
+      engineTime: props.engineTime ?? 0,
+      frameIndex: props.frameIndex ?? 0
     };
   },
   uniformTypes: {
-    opacity: 'f32'
+    opacity: 'f32',
+    timelineTime: 'f32',
+    engineTime: 'f32',
+    frameIndex: 'u32'
   }
-} as const satisfies ShaderModule<LayerProps, LayerUniforms>;
+} as const satisfies ShaderModule<LayerProps & LayerUniforms, LayerUniforms>;

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -1010,3 +1010,49 @@ test('Deck#props omitted are unchanged', async () => {
     });
   });
 });
+
+test('Deck forwards retained animation clocks to screen, picking, and offscreen passes', async () => {
+  await new Promise<void>((resolve, reject) => {
+    const renderedPasses: Array<Record<string, any>> = [];
+    const deck = new Deck({
+      device,
+      width: 1,
+      height: 1,
+      viewState: {longitude: 0, latitude: 0, zoom: 0},
+      layers: [],
+      onLoad: () => {
+        try {
+          const internalDeck = deck as any;
+          internalDeck.animationLoop.stop();
+          internalDeck.deckRenderer.renderLayers = options => renderedPasses.push(options);
+          internalDeck._needsRedraw = 'animation clock test';
+
+          internalDeck._onRenderFrame({
+            ...internalDeck.animationLoop.animationProps,
+            time: 12_500,
+            engineTime: 4_250,
+            tock: 7
+          });
+          internalDeck._drawLayers('offscreen clock test', {pass: 'offscreen'});
+
+          const expectedClocks = {
+            timelineTime: 12.5,
+            engineTime: 4.25,
+            frameIndex: 7
+          };
+          expect(renderedPasses[0].pass).toBe('screen');
+          expect(renderedPasses[0].shaderModuleProps.layer).toEqual(expectedClocks);
+          expect(renderedPasses[1].pass).toBe('offscreen');
+          expect(renderedPasses[1].shaderModuleProps.layer).toEqual(expectedClocks);
+          expect(internalDeck.deckPicker.shaderModuleProps.layer).toEqual(expectedClocks);
+
+          deck.finalize();
+          resolve();
+        } catch (error) {
+          deck.finalize();
+          reject(error);
+        }
+      }
+    });
+  });
+});

--- a/test/modules/core/shaderlib/index.ts
+++ b/test/modules/core/shaderlib/index.ts
@@ -7,3 +7,4 @@ import './project/project-functions.spec';
 import './project/viewport-uniforms.spec';
 import './project/project-32-64-glsl.spec';
 import './shadow/shadow.spec';
+import './layer-uniforms.spec';

--- a/test/modules/core/shaderlib/layer-uniforms.spec.ts
+++ b/test/modules/core/shaderlib/layer-uniforms.spec.ts
@@ -1,0 +1,32 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {layerUniforms} from '@deck.gl/core/shaderlib/misc/layer-uniforms';
+
+test('layerUniforms exposes animation clocks without another binding', () => {
+  expect(layerUniforms.uniformTypes).toEqual({
+    opacity: 'f32',
+    timelineTime: 'f32',
+    engineTime: 'f32',
+    frameIndex: 'u32'
+  });
+  expect(
+    layerUniforms.source.match(/var<uniform>/g),
+    'all four values share the existing layer uniform binding'
+  ).toHaveLength(1);
+  expect(
+    layerUniforms.getUniforms({
+      opacity: 1,
+      timelineTime: 12.5,
+      engineTime: 4.25,
+      frameIndex: 7
+    })
+  ).toEqual({
+    opacity: 1,
+    timelineTime: 12.5,
+    engineTime: 4.25,
+    frameIndex: 7
+  });
+});


### PR DESCRIPTION
## What changed

- Forward luma.gl `AnimationProps` through Deck's screen, picking, and offscreen render paths.
- Expand the existing `layer` uniform block with timeline time, engine time, and frame index.
- Keep the clocks in seconds and reuse the existing binding rather than allocating another uniform buffer.
- Add coverage for uniform defaults and consistent clock propagation across render passes.

## Why

Arrow WebGPU storage renderers intentionally bind Deck's lightweight `layer` module without the full projection module. Exposing Deck's existing animation clocks through that already-bound block lets temporal shaders animate without recreating layers each frame or consuming another scarce uniform-buffer binding.

## Validation

- Build passed.
- Focused screen/picking/offscreen and layer-uniform tests passed.
- Commit hooks passed lint, formatting, and node tests; lint reported only existing warnings.