### PR TITLE
fix(core): arm doubleClickDragZoom by coordinating the dblclickdrag recognizer

### DIFF
--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -106,7 +106,7 @@ export const RECOGNIZERS = {
   pan: [Pan, {threshold: 1}, ['pinch'], ['multipan']],
   dblclick: [Tap, {event: 'dblclick', taps: 2}],
   click: [Tap, {event: 'click'}, null, ['dblclick']],
-  dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag'}]
+  dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag'}, ['dblclick', 'click'], null]
 } as const;
 
 export type RecognizerOptions = {


### PR DESCRIPTION
## Problem

`doubleClickDragZoom` (added in #10327, enabled by the mjolnir.js 3.0.1 upgrade in this PR) never fires — a double-click-drag silently **pans** instead of zooming.

## Cause

`dblclickdrag` was registered in `RECOGNIZERS` with no `recognizeWith` relationship. mjolnir's manager calls `reset()` on any non-active recognizer that can't recognize-with the currently active one. So the moment `click`/`dblclick` activate during the first tap, `DoubleClickDrag`'s cross-tap memory (`_lastTap`) is wiped **before the pointer-up is even processed**. The second press then never matches a prior tap, the gesture never arms, and the drag falls through to `pan`.

## Fix

Register `dblclickdrag` to recognize simultaneously with `click`/`dblclick`. Its tap memory survives the first tap; it then becomes the active recognizer on the second press, which also suppresses the competing `pan` (no zoom+pan jitter).

## Verification (headless pointer input)

- **Double-click-drag up** → zooms `4.0 → 5.2`, latitude drifts only monotonically (anchored-zoom pivot), no pan sawtooth.
- **Plain drag** → still pans (lng changes, zoom unchanged).
- **Plain double-click** → still zooms in one step.

cc @pessimistress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
