### PR TITLE
Revert "fix: remove 300ms click delay by setting click interval to 0"

### DIFF
--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -105,7 +105,7 @@ export const RECOGNIZERS = {
   pinch: [Pinch, {}, null, ['multipan']],
   pan: [Pan, {threshold: 1}, ['pinch'], ['multipan']],
   dblclick: [Tap, {event: 'dblclick', taps: 2}],
-  click: [Tap, {event: 'click', interval: 0}, null, ['dblclick']]
+  click: [Tap, {event: 'click'}, null, ['dblclick']]
 } as const;
 
 export type RecognizerOptions = {


### PR DESCRIPTION
Reverts visgl/deck.gl#10388

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pointer/click gesture configuration used by every Deck instance; may reintroduce click delay or alter click vs double-click timing without changing application code.
> 
> **Overview**
> **Reverts** the prior change that set `interval: 0` on the `click` entry in `RECOGNIZERS` (`modules/core/src/lib/constants.ts`).
> 
> The click gesture is again configured as `[Tap, {event: 'click'}, ...]` without a zero interval, so **mjolnir’s default tap interval** applies when `Deck` builds its `EventManager` recognizers. That undoes the behavior meant to remove the typical ~300ms click delay.
> 
> **User-facing effect:** single-click handling may feel slower again, and timing relative to double-click recognition may match pre-#10388 behavior rather than the immediate-click variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3e8ba38ade05718c6caf819f0f2e4cff1481d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->