### PR TITLE
fix(core): eliminate 300ms click delay and fix runtime controller prop changes

### DIFF
--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -14,7 +14,7 @@ The base Controller class supports the following options:
   + `smooth` (boolean) - smoothly transition to the new zoom. If enabled, will provide a slightly lagged but smoother experience. Default `false`.
 * `dragPan` (boolean) - enable panning with pointer drag. Default `true`
 * `dragRotate` (boolean) - enable rotating with pointer drag. Default `true`
-* `doubleClickZoom` (boolean) - enable zooming with double click. Default `true`
+* `doubleClickZoom` (boolean) - enable zooming with double click. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double clicks.
 * `doubleClickDragZoom` (boolean) - enable zooming by double clicking/tapping and dragging. Default `true`
 * `touchZoom` (boolean) - enable zooming with multi-touch pinch. Default `true`
 * `touchRotate` (boolean) - enable rotating with multi-touch. Use two-finger rotating gesture for horizontal and three-finger swiping gesture for vertical rotation. Default `false`

--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -15,7 +15,7 @@ The base Controller class supports the following options:
 * `dragPan` (boolean) - enable panning with pointer drag. Default `true`
 * `dragRotate` (boolean) - enable rotating with pointer drag. Default `true`
 * `doubleClickZoom` (boolean) - enable zooming with double click. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double clicks.
-* `doubleClickDragZoom` (boolean) - enable zooming by double clicking/tapping and dragging. Default `true`
+* `doubleClickDragZoom` (boolean) - enable zooming by double clicking/tapping and dragging. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double-click-drags.
 * `touchZoom` (boolean) - enable zooming with multi-touch pinch. Default `true`
 * `touchRotate` (boolean) - enable rotating with multi-touch. Use two-finger rotating gesture for horizontal and three-finger swiping gesture for vertical rotation. Default `false`
 * `keyboard` (boolean | object) - enable interaction with keyboard. Default `true`. If an object is supplied, it may contain the following fields to customize the keyboard behavior:

--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -14,7 +14,7 @@ The base Controller class supports the following options:
   + `smooth` (boolean) - smoothly transition to the new zoom. If enabled, will provide a slightly lagged but smoother experience. Default `false`.
 * `dragPan` (boolean) - enable panning with pointer drag. Default `true`
 * `dragRotate` (boolean) - enable rotating with pointer drag. Default `true`
-* `doubleClickZoom` (boolean) - enable zooming with double click. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double clicks.
+* `doubleClickZoom` (boolean) - enable zooming with double click. Default `true`. Adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double clicks. Set to `false` for immediate click response.
 * `doubleClickDragZoom` (boolean) - enable zooming by double clicking/tapping and dragging. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double-click-drags.
 * `touchZoom` (boolean) - enable zooming with multi-touch pinch. Default `true`
 * `touchRotate` (boolean) - enable rotating with multi-touch. Use two-finger rotating gesture for horizontal and three-finger swiping gesture for vertical rotation. Default `false`

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -43,7 +43,7 @@ export type ControllerOptions = {
   dragPan?: boolean;
   /** Enable rotating with pointer drag. Default `true` */
   dragRotate?: boolean;
-  /** Enable zooming with double click. Default `true` */
+  /** Enable zooming with double click. Default `false`. Enabling adds ~300ms latency to click events. */
   doubleClickZoom?: boolean;
   /** Enable zooming with double click/tap and drag. Default `true` */
   doubleClickDragZoom?: boolean;
@@ -326,7 +326,7 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       scrollZoom = true,
       dragPan = true,
       dragRotate = true,
-      doubleClickZoom = true,
+      doubleClickZoom = false,
       doubleClickDragZoom = true,
       touchZoom = true,
       touchRotate = false,

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -326,7 +326,7 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       scrollZoom = true,
       dragPan = true,
       dragRotate = true,
-      doubleClickZoom = false,
+      doubleClickZoom = true,
       doubleClickDragZoom = false,
       touchZoom = true,
       touchRotate = false,

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -45,7 +45,7 @@ export type ControllerOptions = {
   dragRotate?: boolean;
   /** Enable zooming with double click. Default `false`. Enabling adds ~300ms latency to click events. */
   doubleClickZoom?: boolean;
-  /** Enable zooming with double click/tap and drag. Default `true` */
+  /** Enable zooming with double click/tap and drag. Default `false`. Enabling adds ~300ms latency to click events. */
   doubleClickDragZoom?: boolean;
   /** Enable zooming with multi-touch pinch. Default `true` */
   touchZoom?: boolean;
@@ -327,7 +327,7 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       dragPan = true,
       dragRotate = true,
       doubleClickZoom = false,
-      doubleClickDragZoom = true,
+      doubleClickDragZoom = false,
       touchZoom = true,
       touchRotate = false,
       keyboard = true

--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -100,12 +100,14 @@ export const EVENT_HANDLERS = {
   panend: 'onDragEnd'
 } as const satisfies {[eventName: string]: string};
 
+// Order matters: recognizeWith/requireFailure resolve by name, so a recognizer
+// must be registered before any later entry can reference it.
 export const RECOGNIZERS = {
   multipan: [Pan, {threshold: 10, direction: InputDirection.Vertical, pointers: 2}],
   pinch: [Pinch, {}, null, ['multipan']],
   pan: [Pan, {threshold: 1}, ['pinch'], ['multipan']],
-  dblclick: [Tap, {event: 'dblclick', taps: 2}],
-  dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag'}, ['dblclick'], null],
+  dblclick: [Tap, {event: 'dblclick', taps: 2, enable: false}],
+  dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag', enable: false}, ['dblclick'], null],
   click: [Tap, {event: 'click'}, ['dblclickdrag'], ['dblclick', 'dblclickdrag']]
 } as const;
 

--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -105,7 +105,7 @@ export const RECOGNIZERS = {
   pinch: [Pinch, {}, null, ['multipan']],
   pan: [Pan, {threshold: 1}, ['pinch'], ['multipan']],
   dblclick: [Tap, {event: 'dblclick', taps: 2}],
-  click: [Tap, {event: 'click'}, null, ['dblclick']],
+  click: [Tap, {event: 'click'}, null, ['dblclick', 'dblclickdrag']],
   dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag'}, ['dblclick', 'click'], null]
 } as const;
 

--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -105,8 +105,8 @@ export const RECOGNIZERS = {
   pinch: [Pinch, {}, null, ['multipan']],
   pan: [Pan, {threshold: 1}, ['pinch'], ['multipan']],
   dblclick: [Tap, {event: 'dblclick', taps: 2}],
-  click: [Tap, {event: 'click'}, null, ['dblclick', 'dblclickdrag']],
-  dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag'}, ['dblclick', 'click'], null]
+  dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag'}, ['dblclick'], null],
+  click: [Tap, {event: 'click'}, ['dblclickdrag'], ['dblclick', 'dblclickdrag']]
 } as const;
 
 export type RecognizerOptions = {

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -1087,7 +1087,13 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
     });
 
     for (const eventType in EVENT_HANDLERS) {
-      eventManager.on(eventType, this._onEvent);
+      if (eventType === 'dblclick') {
+        // Use watch (passive) so the dblclick recognizer is only enabled by the
+        // controller's doubleClickZoom option — not by the picking system.
+        eventManager.watch(eventType, this._onEvent);
+      } else {
+        eventManager.on(eventType, this._onEvent);
+      }
     }
 
     return eventManager;

--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -1292,7 +1292,8 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
         : [new MapView({id: 'default-view'})];
     if (normalizedViews.length && this.props.controller) {
       // Backward compatibility: support controller prop
-      normalizedViews[0].props.controller = this.props.controller;
+      // Clone the view so that ViewManager._diffViews detects the change
+      normalizedViews[0] = normalizedViews[0].clone({controller: this.props.controller});
     }
     return normalizedViews;
   }

--- a/test/apps/gesture-timing/README.md
+++ b/test/apps/gesture-timing/README.md
@@ -1,0 +1,51 @@
+# Gesture Timing Test App
+
+Interactive tool for measuring deck.gl event handling delays, specifically the ~300ms click latency introduced by the `doubleClickZoom` controller option.
+
+## Run
+
+```bash
+cd test/apps/gesture-timing
+npm run start-local
+```
+
+## Reading the Event Log
+
+Each row in the event timeline shows:
+
+| Column | Meaning |
+|--------|---------|
+| **Event type** | The recognized gesture or picking event |
+| **Delta (ms)** | Latency measurement (see below) |
+| **Timestamp** | Wall-clock time |
+
+### Color coding
+
+- **Green (<50ms)** — Immediate response, no recognizer delay
+- **Yellow (50–200ms)** — Noticeable but sub-threshold delay
+- **Red (>300ms)** — Significant delay (typically the dblclick `requireFailure` timeout)
+
+### What delta means per event type
+
+| Event pattern | Delta measures |
+|---------------|----------------|
+| `click`, `dblclick`, `pick:click(tap=N)` | **Recognizer delay** — time from `pointerup` to recognized event. This is the ~0ms vs ~300ms this PR addresses. |
+| `panstart`, `pinchstart`, `dblclickdragstart` | **Activation delay** — time from `pointerdown` to gesture recognition (usually just the movement threshold). |
+| `panmove`, `pinchmove`, `dblclickdragmove` | **Frame interval** — time between consecutive move events (~16ms at 60fps). |
+| `panend`, `pinchend`, `dblclickdragend` | **Gesture duration** — total time from start to end of the gesture. |
+| `wheel`, `keydown` | **Processing delay** — time from raw DOM event to EventManager dispatch (~0ms, no recognizer). |
+| `pick:dragstart`, `pick:dragend` | **Picking callback delay** — time from `pointerdown`/`pointerup` to layer callback. |
+
+### Key things to observe
+
+1. **Click with `doubleClickZoom: true` (default)** — click events show ~300ms (red). The Tap recognizer waits to see if a double-click follows.
+
+2. **Click with `doubleClickZoom: false`** — click events show ~1-5ms (green). No `requireFailure` delay.
+
+3. **`pick:click(tap=2)` only appears when `doubleClickZoom` is on** — the dblclick recognizer must be active for the picking system to receive double-click events (PR #9629).
+
+4. **Runtime toggling** — use the checkboxes or preset buttons to toggle `doubleClickZoom` at runtime and see the click delay change immediately.
+
+## Click Latency Stats
+
+The stats panel at the top shows running avg/min/max of the last 20 `click` events. Use preset buttons to quickly compare Default (~300ms avg) vs Fast Clicks (~3ms avg).

--- a/test/apps/gesture-timing/app.js
+++ b/test/apps/gesture-timing/app.js
@@ -1,0 +1,330 @@
+import {Deck, MapView} from '@deck.gl/core';
+import {ScatterplotLayer} from '@deck.gl/layers';
+
+// --- State ---
+
+const controllerOptions = {
+  doubleClickZoom: true,
+  doubleClickDragZoom: false,
+  dragPan: true,
+  dragRotate: true,
+  scrollZoom: true,
+  touchZoom: true,
+  touchRotate: false,
+  keyboard: true,
+  inertia: false
+};
+
+const INITIAL_VIEW_STATE = {
+  longitude: -122.45,
+  latitude: 37.78,
+  zoom: 11,
+  pitch: 30,
+  bearing: 0
+};
+
+const timing = {
+  lastPointerDown: 0,
+  lastPointerUp: 0,
+  lastWheel: 0,
+  lastKeyDown: 0,
+  lastMoveTime: {},
+  gestureStartTime: {},
+  log: [],
+  clickDelays: []
+};
+
+// --- Deck Setup ---
+
+const DATA = [];
+for (let i = 0; i < 20; i++) {
+  for (let j = 0; j < 20; j++) {
+    DATA.push({
+      position: [-122.45 + i * 0.005, 37.78 + j * 0.005],
+      radius: 50 + (((i * 20 + j) * 7) % 100),
+      color: [70 + ((i * 13) % 180), 100 + ((j * 17) % 155), 200]
+    });
+  }
+}
+
+let viewState = {...INITIAL_VIEW_STATE};
+
+const deck = new Deck({
+  parent: document.getElementById('deck-container'),
+  views: new MapView(),
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: {...controllerOptions},
+  onViewStateChange: ({viewState: vs}) => {
+    viewState = vs;
+    deck.setProps({viewState});
+  },
+  onClick: (info, event) => {
+    const tapCount = event.tapCount || 1;
+    onGesture(`pick:click(tap=${tapCount})`);
+  },
+  onDragStart: () => onGesture('pick:dragstart'),
+  onDragEnd: () => onGesture('pick:dragend'),
+  layers: [
+    new ScatterplotLayer({
+      id: 'scatter',
+      data: DATA,
+      pickable: true,
+      getPosition: d => d.position,
+      getRadius: d => d.radius,
+      getFillColor: d => d.color,
+      radiusMinPixels: 5,
+      radiusMaxPixels: 30
+    })
+  ],
+  onLoad: () => setupTimingListeners()
+});
+
+// --- Timing Measurement ---
+
+function setupTimingListeners() {
+  const canvas = deck.getCanvas();
+  const eventManager = deck.getEventManager();
+
+  // Raw DOM events — capture phase for earliest possible timestamp
+  canvas.addEventListener(
+    'pointerdown',
+    () => {
+      timing.lastPointerDown = performance.now();
+    },
+    {capture: true}
+  );
+
+  canvas.addEventListener(
+    'pointerup',
+    () => {
+      timing.lastPointerUp = performance.now();
+    },
+    {capture: true}
+  );
+
+  canvas.addEventListener(
+    'wheel',
+    () => {
+      timing.lastWheel = performance.now();
+    },
+    {capture: true}
+  );
+
+  canvas.addEventListener(
+    'keydown',
+    () => {
+      timing.lastKeyDown = performance.now();
+    },
+    {capture: true}
+  );
+
+  // Recognized gesture events — all passive (watch) to avoid affecting recognizer state
+  const gestureEvents = [
+    'click',
+    'dblclick',
+    'panstart',
+    'panmove',
+    'panend',
+    'pinchstart',
+    'pinchmove',
+    'pinchend',
+    'dblclickdragstart',
+    'dblclickdragmove',
+    'dblclickdragend'
+  ];
+
+  for (const eventType of gestureEvents) {
+    eventManager.watch(eventType, () => onGesture(eventType));
+  }
+
+  // Wheel and keyboard go through EventManager too
+  eventManager.watch('wheel', () => onGesture('wheel'));
+  eventManager.watch('keydown', () => onGesture('keydown'));
+}
+
+function onGesture(type) {
+  const now = performance.now();
+  let delta = null;
+
+  if (type === 'click' || type === 'dblclick' || type.startsWith('pick:click')) {
+    // Recognizer delay: time from pointerup to recognized click
+    delta = timing.lastPointerUp ? now - timing.lastPointerUp : null;
+  } else if (type === 'wheel') {
+    delta = timing.lastWheel ? now - timing.lastWheel : null;
+  } else if (type === 'keydown') {
+    delta = timing.lastKeyDown ? now - timing.lastKeyDown : null;
+  } else if (type.endsWith('start')) {
+    // Start events: delay from pointerdown to gesture recognition
+    delta = timing.lastPointerDown ? now - timing.lastPointerDown : null;
+  } else if (type.endsWith('move')) {
+    // Move events: frame interval (time since last move of same type)
+    const lastMove = timing.lastMoveTime[type];
+    delta = lastMove ? now - lastMove : null;
+    timing.lastMoveTime[type] = now;
+  } else if (type.endsWith('end') || type.endsWith('cancel')) {
+    // End events: total gesture duration from start
+    const startKey = type.replace(/end$|cancel$/, 'start');
+    const startTime = timing.gestureStartTime[startKey];
+    delta = startTime ? now - startTime : null;
+  }
+
+  // Track gesture start times for duration measurement
+  if (type.endsWith('start')) {
+    timing.gestureStartTime[type] = now;
+  }
+
+  const entry = {type, delta, time: now};
+  timing.log.unshift(entry);
+  if (timing.log.length > 80) timing.log.pop();
+
+  if (type === 'click' && delta !== null) {
+    timing.clickDelays.unshift(delta);
+    if (timing.clickDelays.length > 20) timing.clickDelays.pop();
+  }
+
+  renderLog();
+  renderStats();
+}
+
+// --- UI Rendering ---
+
+function renderControls() {
+  const section = document.getElementById('controls-section');
+  const toggles = [
+    {key: 'doubleClickZoom', label: 'doubleClickZoom', hint: '+300ms / enables onClick(tap=2)'},
+    {key: 'doubleClickDragZoom', label: 'doubleClickDragZoom', hint: '+300ms click delay'},
+    {key: 'dragPan', label: 'dragPan'},
+    {key: 'dragRotate', label: 'dragRotate'},
+    {key: 'scrollZoom', label: 'scrollZoom'},
+    {key: 'touchZoom', label: 'touchZoom'},
+    {key: 'touchRotate', label: 'touchRotate'},
+    {key: 'keyboard', label: 'keyboard'},
+    {key: 'inertia', label: 'inertia'}
+  ];
+
+  let html = '<h2>Controller Options</h2>';
+  for (const {key, label, hint} of toggles) {
+    const checked = controllerOptions[key] ? 'checked' : '';
+    const hintHtml = hint ? `<span class="hint">${hint}</span>` : '';
+    html += `<label class="toggle-row">
+      <input type="checkbox" data-key="${key}" ${checked}>
+      ${label}${hintHtml}
+    </label>`;
+  }
+  html += `<div style="margin-top:8px;font-size:10px;color:#888;line-height:1.4">
+    <b>Note:</b> doubleClickZoom controls both zoom-on-dblclick AND whether
+    onClick fires with tapCount=2 on double-click (PR #9629). Disabling it
+    gives instant clicks but loses onClick(tap=2).
+  </div>`;
+  section.innerHTML = html;
+
+  section.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const key = cb.dataset.key;
+      if (key === 'inertia') {
+        controllerOptions[key] = cb.checked ? 300 : false;
+      } else {
+        controllerOptions[key] = cb.checked;
+      }
+      deck.setProps({controller: {...controllerOptions}});
+    });
+  });
+}
+
+function renderPresets() {
+  const section = document.getElementById('presets-section');
+  section.innerHTML = `<h2>Presets</h2>
+    <div class="presets">
+      <button id="preset-default">Default (dblclick on)</button>
+      <button id="preset-fast">Fast Clicks (dblclick off)</button>
+      <button id="preset-clear">Clear Log</button>
+    </div>`;
+
+  document.getElementById('preset-default').addEventListener('click', () => {
+    controllerOptions.doubleClickZoom = true;
+    controllerOptions.doubleClickDragZoom = false;
+    deck.setProps({controller: {...controllerOptions}});
+    timing.clickDelays.length = 0;
+    renderControls();
+  });
+
+  document.getElementById('preset-fast').addEventListener('click', () => {
+    controllerOptions.doubleClickZoom = false;
+    controllerOptions.doubleClickDragZoom = false;
+    deck.setProps({controller: {...controllerOptions}});
+    timing.clickDelays.length = 0;
+    renderControls();
+  });
+
+  document.getElementById('preset-clear').addEventListener('click', () => {
+    timing.log.length = 0;
+    timing.clickDelays.length = 0;
+    renderLog();
+    renderStats();
+  });
+}
+
+function renderStats() {
+  const section = document.getElementById('stats-section');
+  const delays = timing.clickDelays;
+
+  if (delays.length === 0) {
+    section.innerHTML = `<h2>Click Latency</h2>
+      <div class="stats">
+        <div class="stat-box"><div class="stat-value">—</div><div class="stat-label">avg</div></div>
+        <div class="stat-box"><div class="stat-value">—</div><div class="stat-label">min</div></div>
+        <div class="stat-box"><div class="stat-value">—</div><div class="stat-label">max</div></div>
+      </div>`;
+    return;
+  }
+
+  const avg = delays.reduce((s, d) => s + d, 0) / delays.length;
+  const min = Math.min(...delays);
+  const max = Math.max(...delays);
+
+  const colorClass = avg < 50 ? 'color-green' : avg < 200 ? 'color-yellow' : 'color-red';
+
+  section.innerHTML = `<h2>Click Latency (n=${delays.length})</h2>
+    <div class="stats">
+      <div class="stat-box"><div class="stat-value ${colorClass}">${avg.toFixed(0)}ms</div><div class="stat-label">avg</div></div>
+      <div class="stat-box"><div class="stat-value">${min.toFixed(0)}ms</div><div class="stat-label">min</div></div>
+      <div class="stat-box"><div class="stat-value">${max.toFixed(0)}ms</div><div class="stat-label">max</div></div>
+    </div>`;
+}
+
+function renderLog() {
+  const section = document.getElementById('event-log');
+  let html = '<h2>Event Timeline</h2>';
+
+  for (const entry of timing.log.slice(0, 50)) {
+    const colorClass = getColorClass(entry.delta);
+    const deltaStr = entry.delta !== null ? `${entry.delta.toFixed(1)}ms` : '—';
+    const timeStr = formatTime(entry.time);
+    html += `<div class="log-entry ${colorClass}">
+      <span class="log-type">${entry.type}</span>
+      <span class="log-delta">${deltaStr}</span>
+      <span class="log-time">${timeStr}</span>
+    </div>`;
+  }
+
+  section.innerHTML = html;
+}
+
+function getColorClass(delta) {
+  if (delta === null) return 'color-gray';
+  if (delta < 50) return 'color-green';
+  if (delta < 200) return 'color-yellow';
+  return 'color-red';
+}
+
+function formatTime(perfNow) {
+  const d = new Date(performance.timeOrigin + perfNow);
+  return d.toISOString().slice(11, 23);
+}
+
+// --- Init ---
+
+renderControls();
+renderPresets();
+renderStats();
+renderLog();

--- a/test/apps/gesture-timing/index.html
+++ b/test/apps/gesture-timing/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>deck.gl - Gesture Timing</title>
+    <style>
+      * { box-sizing: border-box; }
+      body { margin: 0; font-family: 'SF Mono', 'Fira Code', monospace; background: #1a1a2e; color: #e0e0e0; }
+      #app { display: flex; height: 100vh; }
+      #deck-container { flex: 1; position: relative; }
+      #panel {
+        width: 400px; overflow-y: auto; padding: 16px;
+        background: #16213e; border-left: 1px solid #334;
+        display: flex; flex-direction: column; gap: 16px;
+      }
+      h2 { margin: 0 0 8px; font-size: 14px; color: #8ab4f8; text-transform: uppercase; letter-spacing: 1px; }
+      .section { background: #0f3460; border-radius: 6px; padding: 12px; }
+      .toggle-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer; font-size: 12px; }
+      .toggle-row input { cursor: pointer; }
+      .toggle-row .hint { color: #f88; font-size: 10px; margin-left: auto; }
+      .presets { display: flex; gap: 8px; flex-wrap: wrap; }
+      .presets button {
+        padding: 6px 12px; border: 1px solid #445; border-radius: 4px;
+        background: #1a1a3e; color: #e0e0e0; cursor: pointer; font-size: 11px; font-family: inherit;
+      }
+      .presets button:hover { background: #2a2a5e; }
+      .presets button.active { border-color: #8ab4f8; background: #1a2a4e; }
+      .stats { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+      .stat-box { text-align: center; padding: 8px; background: #1a1a2e; border-radius: 4px; }
+      .stat-value { font-size: 20px; font-weight: bold; }
+      .stat-label { font-size: 10px; color: #888; margin-top: 2px; }
+      #event-log { flex: 1; overflow-y: auto; min-height: 200px; }
+      .log-entry {
+        display: flex; align-items: center; gap: 8px; padding: 4px 8px;
+        border-left: 3px solid #666; margin-bottom: 2px; font-size: 11px;
+        background: #0a0a1e; border-radius: 0 3px 3px 0;
+      }
+      .log-type { min-width: 110px; font-weight: bold; }
+      .log-delta { min-width: 70px; text-align: right; }
+      .log-time { color: #666; margin-left: auto; }
+      .color-green { color: #4caf50; border-left-color: #4caf50; }
+      .color-yellow { color: #ff9800; border-left-color: #ff9800; }
+      .color-red { color: #f44336; border-left-color: #f44336; }
+      .color-gray { color: #666; border-left-color: #666; }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <div id="deck-container"></div>
+      <div id="panel">
+        <div class="section" id="controls-section"></div>
+        <div class="section" id="presets-section"></div>
+        <div class="section" id="stats-section"></div>
+        <div class="section" id="event-log"></div>
+      </div>
+    </div>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/test/apps/gesture-timing/package.json
+++ b/test/apps/gesture-timing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "deckgl-test-gesture-timing",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "start": "vite --open",
+    "start-local": "vite --config ../vite.config.local.mjs"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0"
+  },
+  "devDependencies": {
+    "vite": "^7.3.1"
+  }
+}

--- a/test/interaction/map-controller.spec.ts
+++ b/test/interaction/map-controller.spec.ts
@@ -29,8 +29,9 @@ function getCanvas(): HTMLCanvasElement {
   return canvas;
 }
 
-async function dispatchPointerTap(x: number, y: number) {
+async function dispatchPointerTap(x: number, y: number, opts?: {shiftKey?: boolean}) {
   const canvas = getCanvas();
+  const shiftKey = opts?.shiftKey ?? false;
   const down = new PointerEvent('pointerdown', {
     clientX: x,
     clientY: y,
@@ -40,7 +41,8 @@ async function dispatchPointerTap(x: number, y: number) {
     pointerType: 'mouse',
     isPrimary: true,
     button: 0,
-    buttons: 1
+    buttons: 1,
+    shiftKey
   });
   canvas.dispatchEvent(down);
   await sleep(10);
@@ -53,10 +55,17 @@ async function dispatchPointerTap(x: number, y: number) {
     pointerType: 'mouse',
     isPrimary: true,
     button: 0,
-    buttons: 0
+    buttons: 0,
+    shiftKey
   });
   // PointerEventInput listens for pointerup on window, not on the element
   window.dispatchEvent(up);
+}
+
+async function dispatchPointerDoubleTap(x: number, y: number, opts?: {shiftKey?: boolean}) {
+  await dispatchPointerTap(x, y, opts);
+  await sleep(50);
+  await dispatchPointerTap(x, y, opts);
 }
 
 // Shared Deck instance and state
@@ -161,35 +170,42 @@ test('MapController rotate', async () => {
   ).toBeTruthy();
 });
 
-// These dblclick tests are skipped: page.mouse.dblclick() doesn't properly
-// dispatch pointer events to the canvas inside the vitest browser iframe.
-// The dblclick zoom feature is covered by unit tests in controllers.spec.ts.
-test.skip('MapController dblclick zoom in', async () => {
-  await resetViewState();
-  deck!.setProps({controller: {doubleClickZoom: true}});
-  await emulateEvent({wait: 100});
-  const oldViewport = getViewport();
+test('MapController dblclick zoom in', async () => {
+  const testDeck = new Deck({
+    ...deckProps,
+    id: 'dblclick-zoom-in-deck',
+    controller: {doubleClickZoom: true}
+  });
+  await new Promise<void>(resolve => {
+    testDeck.setProps({onLoad: resolve});
+  });
 
-  await emulateEvent({type: 'dblclick', x: 200, y: 100});
-  await emulateEvent({wait: 300});
+  const oldZoom = testDeck.getViewports()[0].zoom;
+  await dispatchPointerDoubleTap(200, 100);
+  await sleep(500);
 
-  const newViewport = getViewport();
-  expect(newViewport.zoom > oldViewport.zoom, 'map zoomed in').toBeTruthy();
-  deck!.setProps({controller: true});
+  const newZoom = testDeck.getViewports()[0].zoom;
+  testDeck.finalize();
+  expect(newZoom > oldZoom, 'map zoomed in').toBeTruthy();
 });
 
-test.skip('MapController shift-dblclick zoom out', async () => {
-  await resetViewState();
-  deck!.setProps({controller: {doubleClickZoom: true}});
-  await emulateEvent({wait: 100});
-  const oldViewport = getViewport();
+test('MapController shift-dblclick zoom out', async () => {
+  const testDeck = new Deck({
+    ...deckProps,
+    id: 'dblclick-zoom-out-deck',
+    controller: {doubleClickZoom: true}
+  });
+  await new Promise<void>(resolve => {
+    testDeck.setProps({onLoad: resolve});
+  });
 
-  await emulateEvent({type: 'dblclick', x: 200, y: 100, shiftKey: true});
-  await emulateEvent({wait: 300});
+  const oldZoom = testDeck.getViewports()[0].zoom;
+  await dispatchPointerDoubleTap(200, 100, {shiftKey: true});
+  await sleep(500);
 
-  const newViewport = getViewport();
-  expect(newViewport.zoom < oldViewport.zoom, 'map zoomed out').toBeTruthy();
-  deck!.setProps({controller: true});
+  const newZoom = testDeck.getViewports()[0].zoom;
+  testDeck.finalize();
+  expect(newZoom < oldZoom, 'map zoomed out').toBeTruthy();
 });
 
 test('MapController keyboard left', async () => {

--- a/test/interaction/map-controller.spec.ts
+++ b/test/interaction/map-controller.spec.ts
@@ -19,6 +19,46 @@ async function emulateEvent(event: any): Promise<void> {
   }
 }
 
+function getCanvas(): HTMLCanvasElement {
+  const canvases = Array.from(document.querySelectorAll('canvas'));
+  const canvas = canvases.reverse().find(el => {
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  });
+  if (!canvas) throw new Error('No canvas found');
+  return canvas;
+}
+
+async function dispatchPointerTap(x: number, y: number) {
+  const canvas = getCanvas();
+  const down = new PointerEvent('pointerdown', {
+    clientX: x,
+    clientY: y,
+    bubbles: true,
+    cancelable: true,
+    pointerId: 1,
+    pointerType: 'mouse',
+    isPrimary: true,
+    button: 0,
+    buttons: 1
+  });
+  canvas.dispatchEvent(down);
+  await sleep(10);
+  const up = new PointerEvent('pointerup', {
+    clientX: x,
+    clientY: y,
+    bubbles: true,
+    cancelable: true,
+    pointerId: 1,
+    pointerType: 'mouse',
+    isPrimary: true,
+    button: 0,
+    buttons: 0
+  });
+  // PointerEventInput listens for pointerup on window, not on the element
+  window.dispatchEvent(up);
+}
+
 // Shared Deck instance and state
 let deck: Deck<any> | null = null;
 
@@ -121,8 +161,13 @@ test('MapController rotate', async () => {
   ).toBeTruthy();
 });
 
-test('MapController dblclick zoom in', async () => {
+// These dblclick tests are skipped: page.mouse.dblclick() doesn't properly
+// dispatch pointer events to the canvas inside the vitest browser iframe.
+// The dblclick zoom feature is covered by unit tests in controllers.spec.ts.
+test.skip('MapController dblclick zoom in', async () => {
   await resetViewState();
+  deck!.setProps({controller: {doubleClickZoom: true}});
+  await emulateEvent({wait: 100});
   const oldViewport = getViewport();
 
   await emulateEvent({type: 'dblclick', x: 200, y: 100});
@@ -130,10 +175,13 @@ test('MapController dblclick zoom in', async () => {
 
   const newViewport = getViewport();
   expect(newViewport.zoom > oldViewport.zoom, 'map zoomed in').toBeTruthy();
+  deck!.setProps({controller: true});
 });
 
-test('MapController shift-dblclick zoom out', async () => {
+test.skip('MapController shift-dblclick zoom out', async () => {
   await resetViewState();
+  deck!.setProps({controller: {doubleClickZoom: true}});
+  await emulateEvent({wait: 100});
   const oldViewport = getViewport();
 
   await emulateEvent({type: 'dblclick', x: 200, y: 100, shiftKey: true});
@@ -141,6 +189,7 @@ test('MapController shift-dblclick zoom out', async () => {
 
   const newViewport = getViewport();
   expect(newViewport.zoom < oldViewport.zoom, 'map zoomed out').toBeTruthy();
+  deck!.setProps({controller: true});
 });
 
 test('MapController keyboard left', async () => {
@@ -207,4 +256,69 @@ test('MapController keyboard shift-plus zoom in', async () => {
 
   const newViewport = getViewport();
   expect(newViewport.zoom > oldViewport.zoom, 'map zoomed').toBeTruthy();
+});
+
+test('MapController click fires immediately with default controller options', async () => {
+  // Create a fresh Deck instance with defaults to avoid state pollution from prior tests
+  const testDeck = new Deck({
+    ...deckProps,
+    id: 'click-test-deck',
+    controller: true
+  });
+  await new Promise<void>(resolve => {
+    testDeck.setProps({onLoad: resolve});
+  });
+
+  const timestamps: number[] = [];
+  const eventManager = testDeck.getEventManager()!;
+
+  const handler = () => {
+    timestamps.push(performance.now());
+  };
+  eventManager.on('click', handler);
+
+  const beforeClick = performance.now();
+  await dispatchPointerTap(400, 200);
+  await sleep(50);
+
+  eventManager.off('click', handler);
+  testDeck.finalize();
+
+  expect(timestamps.length, 'click event fired').toBeGreaterThan(0);
+  const delay = timestamps[0] - beforeClick;
+  expect(delay, 'click fired without 300ms recognizer delay').toBeLessThan(100);
+});
+
+test('MapController click is delayed when doubleClickZoom is enabled', async () => {
+  const testDeck = new Deck({
+    ...deckProps,
+    id: 'click-delay-test-deck',
+    controller: {doubleClickZoom: true}
+  });
+  await new Promise<void>(resolve => {
+    testDeck.setProps({onLoad: resolve});
+  });
+
+  const timestamps: number[] = [];
+  const eventManager = testDeck.getEventManager()!;
+
+  const handler = () => {
+    timestamps.push(performance.now());
+  };
+  eventManager.on('click', handler);
+
+  const beforeClick = performance.now();
+  await dispatchPointerTap(400, 200);
+  await sleep(100);
+
+  expect(timestamps.length, 'click has not fired within 100ms').toBe(0);
+
+  await sleep(250);
+
+  expect(timestamps.length, 'click fired after recognizer delay').toBeGreaterThan(0);
+  const delay = timestamps[0] - beforeClick;
+  expect(delay, 'click took at least 250ms (300ms recognizer delay)').toBeGreaterThan(250);
+
+  eventManager.off('click', handler);
+  testDeck.finalize();
 });

--- a/test/interaction/map-controller.spec.ts
+++ b/test/interaction/map-controller.spec.ts
@@ -274,12 +274,11 @@ test('MapController keyboard shift-plus zoom in', async () => {
   expect(newViewport.zoom > oldViewport.zoom, 'map zoomed').toBeTruthy();
 });
 
-test('MapController click fires immediately with default controller options', async () => {
-  // Create a fresh Deck instance with defaults to avoid state pollution from prior tests
+test('MapController click fires immediately when doubleClickZoom is disabled', async () => {
   const testDeck = new Deck({
     ...deckProps,
     id: 'click-test-deck',
-    controller: true
+    controller: {doubleClickZoom: false}
   });
   await new Promise<void>(resolve => {
     testDeck.setProps({onLoad: resolve});
@@ -334,6 +333,48 @@ test('MapController click is delayed when doubleClickZoom is enabled', async () 
   expect(timestamps.length, 'click fired after recognizer delay').toBeGreaterThan(0);
   const delay = timestamps[0] - beforeClick;
   expect(delay, 'click took at least 250ms (300ms recognizer delay)').toBeGreaterThan(250);
+
+  eventManager.off('click', handler);
+  testDeck.finalize();
+});
+
+test('MapController runtime controller prop change takes effect', async () => {
+  // Start with doubleClickZoom enabled (click is delayed ~300ms)
+  const testDeck = new Deck({
+    ...deckProps,
+    id: 'runtime-toggle-deck',
+    controller: {doubleClickZoom: true}
+  });
+  await new Promise<void>(resolve => {
+    testDeck.setProps({onLoad: resolve});
+  });
+
+  const timestamps: number[] = [];
+  const eventManager = testDeck.getEventManager()!;
+  const handler = () => {
+    timestamps.push(performance.now());
+  };
+  eventManager.on('click', handler);
+
+  // Confirm click is delayed with doubleClickZoom on
+  await dispatchPointerTap(400, 200);
+  await sleep(100);
+  expect(timestamps.length, 'click delayed with doubleClickZoom:true').toBe(0);
+  await sleep(300);
+  timestamps.length = 0;
+
+  // Toggle doubleClickZoom off at runtime
+  testDeck.setProps({controller: {doubleClickZoom: false}});
+  await sleep(50);
+
+  // Click should now fire immediately
+  const beforeClick = performance.now();
+  await dispatchPointerTap(400, 200);
+  await sleep(50);
+
+  expect(timestamps.length, 'click fires after runtime toggle').toBeGreaterThan(0);
+  const delay = timestamps[0] - beforeClick;
+  expect(delay, 'click is immediate after disabling doubleClickZoom').toBeLessThan(100);
 
   eventManager.off('click', handler);
   testDeck.finalize();

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {test, expect} from 'vitest';
+import {test, expect, vi} from 'vitest';
 import {
   MapView,
   OrbitView,
@@ -10,6 +10,8 @@ import {
   FirstPersonView,
   _GlobeView as GlobeView
 } from '@deck.gl/core';
+import {EventManager} from 'mjolnir.js';
+import {RECOGNIZERS} from '@deck.gl/core/lib/constants';
 import {Timeline} from '@luma.gl/engine';
 
 import testController, {createTestController} from './test-controller';
@@ -265,4 +267,135 @@ test('FirstPersonController', async () => {
     // FirstPersonController does not pan
     ['pan#function key', 'pan#function key#disabled']
   );
+});
+
+// --- Click delay tests ---
+// These test the recognizer-level timing behavior through the full EventManager pipeline.
+
+function createEventManager(opts: {doubleClickZoom?: boolean; doubleClickDragZoom?: boolean} = {}) {
+  const element = document.createElement('div');
+  element.style.width = '100px';
+  element.style.height = '100px';
+  document.body.appendChild(element);
+
+  const eventManager = new EventManager(element, {
+    recognizers: Object.keys(RECOGNIZERS).map((eventName: string) => {
+      const [RecognizerConstructor, defaultOptions, recognizeWith, requireFailure] =
+        RECOGNIZERS[eventName];
+      return {
+        recognizer: new RecognizerConstructor({...defaultOptions, event: eventName}),
+        recognizeWith,
+        requireFailure
+      };
+    })
+  });
+
+  // Toggle recognizers based on options (mimics controller.setProps behavior)
+  if (opts.doubleClickZoom !== undefined) {
+    const dblclickRecognizer = eventManager['manager'].get('dblclick');
+    if (dblclickRecognizer) {
+      dblclickRecognizer.set({enable: opts.doubleClickZoom});
+    }
+  }
+  if (opts.doubleClickDragZoom !== undefined) {
+    const dblclickdragRecognizer = eventManager['manager'].get('dblclickdrag');
+    if (dblclickdragRecognizer) {
+      dblclickdragRecognizer.set({enable: opts.doubleClickDragZoom});
+    }
+  }
+
+  return {element, eventManager};
+}
+
+function simulateTap(element: HTMLElement) {
+  const pointerDown = new PointerEvent('pointerdown', {
+    pointerId: 1,
+    clientX: 50,
+    clientY: 50,
+    buttons: 1,
+    bubbles: true
+  });
+  const pointerUp = new PointerEvent('pointerup', {
+    pointerId: 1,
+    clientX: 50,
+    clientY: 50,
+    buttons: 0,
+    bubbles: true
+  });
+  element.dispatchEvent(pointerDown);
+  element.dispatchEvent(pointerUp);
+}
+
+function cleanup(element: HTMLElement, eventManager: EventManager) {
+  eventManager.destroy();
+  element.remove();
+}
+
+test('click fires immediately when doubleClickZoom and doubleClickDragZoom are disabled', () => {
+  vi.useFakeTimers();
+  const {element, eventManager} = createEventManager({
+    doubleClickZoom: false,
+    doubleClickDragZoom: false
+  });
+
+  let clickFired = false;
+  eventManager.on('click', () => {
+    clickFired = true;
+  });
+
+  simulateTap(element);
+
+  expect(clickFired, 'click fires immediately with no delay').toBe(true);
+
+  cleanup(element, eventManager);
+  vi.useRealTimers();
+});
+
+test('click is delayed ~300ms when doubleClickZoom is enabled', () => {
+  vi.useFakeTimers();
+  const {element, eventManager} = createEventManager({
+    doubleClickZoom: true,
+    doubleClickDragZoom: false
+  });
+
+  let clickFired = false;
+  eventManager.on('click', () => {
+    clickFired = true;
+  });
+
+  simulateTap(element);
+
+  expect(clickFired, 'click does not fire immediately').toBe(false);
+
+  vi.advanceTimersByTime(299);
+  expect(clickFired, 'click has not fired at 299ms').toBe(false);
+
+  vi.advanceTimersByTime(1);
+  expect(clickFired, 'click fires at 300ms').toBe(true);
+
+  cleanup(element, eventManager);
+  vi.useRealTimers();
+});
+
+test('click is delayed ~300ms when doubleClickDragZoom is enabled', () => {
+  vi.useFakeTimers();
+  const {element, eventManager} = createEventManager({
+    doubleClickZoom: false,
+    doubleClickDragZoom: true
+  });
+
+  let clickFired = false;
+  eventManager.on('click', () => {
+    clickFired = true;
+  });
+
+  simulateTap(element);
+
+  expect(clickFired, 'click does not fire immediately').toBe(false);
+
+  vi.advanceTimersByTime(300);
+  expect(clickFired, 'click fires after 300ms').toBe(true);
+
+  cleanup(element, eventManager);
+  vi.useRealTimers();
 });

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {test, expect, vi} from 'vitest';
+import {test, expect} from 'vitest';
 import {
   MapView,
   OrbitView,
@@ -10,8 +10,6 @@ import {
   FirstPersonView,
   _GlobeView as GlobeView
 } from '@deck.gl/core';
-import {EventManager} from 'mjolnir.js';
-import {RECOGNIZERS} from '@deck.gl/core/lib/constants';
 import {Timeline} from '@luma.gl/engine';
 
 import testController, {createTestController} from './test-controller';
@@ -267,135 +265,4 @@ test('FirstPersonController', async () => {
     // FirstPersonController does not pan
     ['pan#function key', 'pan#function key#disabled']
   );
-});
-
-// --- Click delay tests ---
-// These test the recognizer-level timing behavior through the full EventManager pipeline.
-
-function createEventManager(opts: {doubleClickZoom?: boolean; doubleClickDragZoom?: boolean} = {}) {
-  const element = document.createElement('div');
-  element.style.width = '100px';
-  element.style.height = '100px';
-  document.body.appendChild(element);
-
-  const eventManager = new EventManager(element, {
-    recognizers: Object.keys(RECOGNIZERS).map((eventName: string) => {
-      const [RecognizerConstructor, defaultOptions, recognizeWith, requireFailure] =
-        RECOGNIZERS[eventName];
-      return {
-        recognizer: new RecognizerConstructor({...defaultOptions, event: eventName}),
-        recognizeWith,
-        requireFailure
-      };
-    })
-  });
-
-  // Toggle recognizers based on options (mimics controller.setProps behavior)
-  if (opts.doubleClickZoom !== undefined) {
-    const dblclickRecognizer = eventManager['manager'].get('dblclick');
-    if (dblclickRecognizer) {
-      dblclickRecognizer.set({enable: opts.doubleClickZoom});
-    }
-  }
-  if (opts.doubleClickDragZoom !== undefined) {
-    const dblclickdragRecognizer = eventManager['manager'].get('dblclickdrag');
-    if (dblclickdragRecognizer) {
-      dblclickdragRecognizer.set({enable: opts.doubleClickDragZoom});
-    }
-  }
-
-  return {element, eventManager};
-}
-
-function simulateTap(element: HTMLElement) {
-  const pointerDown = new PointerEvent('pointerdown', {
-    pointerId: 1,
-    clientX: 50,
-    clientY: 50,
-    buttons: 1,
-    bubbles: true
-  });
-  const pointerUp = new PointerEvent('pointerup', {
-    pointerId: 1,
-    clientX: 50,
-    clientY: 50,
-    buttons: 0,
-    bubbles: true
-  });
-  element.dispatchEvent(pointerDown);
-  element.dispatchEvent(pointerUp);
-}
-
-function cleanup(element: HTMLElement, eventManager: EventManager) {
-  eventManager.destroy();
-  element.remove();
-}
-
-test('click fires immediately when doubleClickZoom and doubleClickDragZoom are disabled', () => {
-  vi.useFakeTimers();
-  const {element, eventManager} = createEventManager({
-    doubleClickZoom: false,
-    doubleClickDragZoom: false
-  });
-
-  let clickFired = false;
-  eventManager.on('click', () => {
-    clickFired = true;
-  });
-
-  simulateTap(element);
-
-  expect(clickFired, 'click fires immediately with no delay').toBe(true);
-
-  cleanup(element, eventManager);
-  vi.useRealTimers();
-});
-
-test('click is delayed ~300ms when doubleClickZoom is enabled', () => {
-  vi.useFakeTimers();
-  const {element, eventManager} = createEventManager({
-    doubleClickZoom: true,
-    doubleClickDragZoom: false
-  });
-
-  let clickFired = false;
-  eventManager.on('click', () => {
-    clickFired = true;
-  });
-
-  simulateTap(element);
-
-  expect(clickFired, 'click does not fire immediately').toBe(false);
-
-  vi.advanceTimersByTime(299);
-  expect(clickFired, 'click has not fired at 299ms').toBe(false);
-
-  vi.advanceTimersByTime(1);
-  expect(clickFired, 'click fires at 300ms').toBe(true);
-
-  cleanup(element, eventManager);
-  vi.useRealTimers();
-});
-
-test('click is delayed ~300ms when doubleClickDragZoom is enabled', () => {
-  vi.useFakeTimers();
-  const {element, eventManager} = createEventManager({
-    doubleClickZoom: false,
-    doubleClickDragZoom: true
-  });
-
-  let clickFired = false;
-  eventManager.on('click', () => {
-    clickFired = true;
-  });
-
-  simulateTap(element);
-
-  expect(clickFired, 'click does not fire immediately').toBe(false);
-
-  vi.advanceTimersByTime(300);
-  expect(clickFired, 'click fires after 300ms').toBe(true);
-
-  cleanup(element, eventManager);
-  vi.useRealTimers();
 });


### PR DESCRIPTION
## Summary

- Fixes a bug where runtime changes to the `controller` prop via `deck.setProps()` had no effect (e.g., toggling `doubleClickZoom` at runtime)
- Ensures the `dblclick` and `dblclickdrag` recognizers start disabled and are only activated by their respective controller options
- Uses `watch()` (passive) for dblclick in Deck's picking registration so the picking system doesn't force-enable the recognizer
- Adds `dblclickdrag` to click's `requireFailure` list so enabling double-click-drag zoom also correctly delays click
- Adds a `test/apps/gesture-timing` interactive test app for measuring event handling delays
- Documents the ~300ms click latency tradeoff when `doubleClickZoom` is enabled

## Background

When `doubleClickZoom` is enabled (the default), the `click` recognizer has `requireFailure: ['dblclick', 'dblclickdrag']`. This causes mjolnir.js's TapRecognizer to defer click emission by ~300ms while waiting to see if a double-click follows. Setting `doubleClickZoom: false` disables the recognizer, causing `hasRequireFailures()` to skip it and allowing clicks to fire immediately.

### Runtime controller prop bug (new fix)

`Deck._getViews()` was mutating the View instance's `props.controller` in-place. When `ViewManager._diffViews` compared old and new views, they were the same object (`this === view` → true in `equals()`), so it never triggered `_rebuildViewports` and `controller.setProps()` was never called. Fixed by cloning the view instead of mutating it.

### Interaction with PR #9629 (onClick for double-click)

PR #9629 added `dblclick: 'onClick'` to `EVENT_HANDLERS` so that double-clicking fires the layer `onClick` callback with `event.tapCount: 2`. This only works when the dblclick recognizer is active (i.e., `doubleClickZoom: true`). Disabling `doubleClickZoom` gives instant clicks but loses `onClick(tapCount=2)`.

See discussion in #10388 and the revert in #10420. Relates to #10384.

## Changes

| File | Change |
|------|--------|
| `modules/core/src/lib/deck.ts` | Clone view in `_getViews()` instead of mutating; use `watch()` for dblclick picking |
| `modules/core/src/lib/constants.ts` | Add `enable: false` to dblclick/dblclickdrag; add dblclickdrag to click's requireFailure; document ordering |
| `modules/core/src/controllers/controller.ts` | Default `doubleClickDragZoom = false` (new feature, hasn't shipped) |
| `docs/api-reference/core/controller.md` | Document latency tradeoff |
| `test/interaction/map-controller.spec.ts` | Integration tests for dblclick zoom, click delay, and runtime prop propagation |
| `test/apps/gesture-timing/` | Interactive test app for measuring gesture delays |

## Test plan

- [x] All 13 integration tests pass (including runtime toggle regression test)
- [x] All 36 controller unit tests pass
- [x] All 542 core module tests pass
- [x] Runtime toggle regression test: red without fix, green with fix
- [x] Gesture timing test app demonstrates ~300ms vs ~0ms click delay
- [x] Double-click zoom works when explicitly enabled
- [x] RECOGNIZERS ordering confirmed: swapping causes runtime error

## How to test the gesture-timing app

```bash
cd test/apps/gesture-timing && npm run start-local
```

Click the map and observe the event log. Toggle `doubleClickZoom` checkbox or use preset buttons to see click latency change in real-time. See `test/apps/gesture-timing/README.md` for details on reading the log.

---
Generated with [Claude Code](https://claude.com/claude-code)