### PR TITLE
fix(mapbox): avoid crash when MapboxOverlay beforeId layer is removed

### DIFF
--- a/modules/mapbox/src/resolve-layer-groups.ts
+++ b/modules/mapbox/src/resolve-layer-groups.ts
@@ -79,6 +79,10 @@ export function resolveLayerGroups(map?: Map, oldLayers?: LayersList, newLayers?
     const expectedGroupIndex =
       beforeId === UNDEFINED_BEFORE_ID ? mapLayers.length : mapLayers.indexOf(beforeId);
 
+    if (expectedGroupIndex === -1) {
+      continue;
+    }
+
     const currentGropupIndex = mapLayers.indexOf(groupId);
     if (currentGropupIndex !== expectedGroupIndex - 1) {
       const moveBeforeId = beforeId === UNDEFINED_BEFORE_ID ? undefined : beforeId;

--- a/test/modules/mapbox/resolve-layer-groups.spec.ts
+++ b/test/modules/mapbox/resolve-layer-groups.spec.ts
@@ -257,6 +257,44 @@ test('MapboxOverlay#resolveLayerGroups - style change handling', async () => {
   expect(map.style._order, 'Groups restored to correct positions').toEqual(expectedOrderInitial);
 });
 
+test('MapboxOverlay#resolveLayerGroups - beforeId layer removed from style', async () => {
+  const MAP_STYLE = {
+    layers: [{id: 'water'}, {id: 'park'}, {id: 'building'}]
+  };
+
+  const map = new MockMapboxMap({
+    center: {lng: -122.45, lat: 37.78},
+    zoom: 12,
+    style: MAP_STYLE
+  });
+
+  // Wait for style to load
+  await sleep(10);
+
+  const layers = [new ScatterplotLayer({id: 'poi', beforeId: 'park'})];
+
+  resolveLayerGroups(map, undefined, layers);
+
+  const parkGroup = 'deck-layer-group-before:park';
+  expect(map.getLayer(parkGroup), 'Park group exists').toBeTruthy();
+  expect(map.style._order, 'Group positioned before park').toEqual([
+    'water',
+    parkGroup,
+    'park',
+    'building'
+  ]);
+
+  map.removeLayer('park');
+
+  expect(
+    () => resolveLayerGroups(map, layers, layers),
+    'Does not throw on missing beforeId'
+  ).not.toThrow();
+
+  expect(map.getLayer(parkGroup), 'Group still exists').toBeTruthy();
+  expect(map.style._order, 'Group left in place').toEqual(['water', parkGroup, 'building']);
+});
+
 /* global setTimeout */
 function sleep(ms) {
   return new Promise(resolve => {


### PR DESCRIPTION
MapboxOverlay: Skip the attempt to reorder layer with `beforeId` when layer with `beforeId` doesn't exist in map instance.

#### Background:

When a MapboxOverlay layer uses `beforeId` and the referenced map layer is later removed (e.g. by `map.setStyle()` unloading it), `resolveLayerGroups` tried to move the deck layer group before a layer that no longer exists. mapbox-gl's `moveLayer` throws in that case ("Cannot move layer ... before non-existing layer ..."), and since it splices the group out of the order before throwing, the group is dropped entirely.

Closes #10309

<!-- For all the PRs -->
#### Change List
- MapboxOverlay: `resolveLayerGroups` doesn't attempt to move deck layer when it knows `beforeId` layer is missing
