### PR TITLE
fix(react): remove redundant initial render redraw

### DIFF
--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -23,6 +23,7 @@ type DeckInstanceRef<ViewsT extends ViewOrViews> = {
   lastRenderedViewports?: Viewport[];
   viewStateUpdateRequested?: any;
   interactionStateUpdateRequested?: any;
+  initialRenderDone?: boolean;
   forceUpdate: () => void;
   version: number;
   control: React.ReactHTMLElement<HTMLElement> | null;
@@ -202,6 +203,10 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
   useEffect(() => {
     const DeckClass = props.Deck || Deck;
 
+    // The flag belongs to the Deck instance created below. Reset it so that a
+    // recreated instance (e.g. after a React StrictMode remount) gets its own
+    // initial render even though thisRef persists across the remount.
+    thisRef.initialRenderDone = false;
     thisRef.deck = createDeckInstance(thisRef, DeckClass, {
       ...deckProps,
       parent: containerRef.current,
@@ -226,8 +231,9 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       handleInteractionStateChange(interactionStateUpdateRequested);
     }
 
-    // Force initial render if Deck is initialized
-    if (thisRef.deck?.isInitialized) {
+    // Force initial render once when Deck is initialized
+    if (thisRef.deck?.isInitialized && !thisRef.initialRenderDone) {
+      thisRef.initialRenderDone = true;
       thisRef.deck.redraw('Initial render');
     }
   });

--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -23,7 +23,6 @@ type DeckInstanceRef<ViewsT extends ViewOrViews> = {
   lastRenderedViewports?: Viewport[];
   viewStateUpdateRequested?: any;
   interactionStateUpdateRequested?: any;
-  initialRenderDone?: boolean;
   forceUpdate: () => void;
   version: number;
   control: React.ReactHTMLElement<HTMLElement> | null;
@@ -203,10 +202,6 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
   useEffect(() => {
     const DeckClass = props.Deck || Deck;
 
-    // The flag belongs to the Deck instance created below. Reset it so that a
-    // recreated instance (e.g. after a React StrictMode remount) gets its own
-    // initial render even though thisRef persists across the remount.
-    thisRef.initialRenderDone = false;
     thisRef.deck = createDeckInstance(thisRef, DeckClass, {
       ...deckProps,
       parent: containerRef.current,
@@ -229,12 +224,6 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
     }
     if (interactionStateUpdateRequested) {
       handleInteractionStateChange(interactionStateUpdateRequested);
-    }
-
-    // Force initial render once when Deck is initialized
-    if (thisRef.deck?.isInitialized && !thisRef.initialRenderDone) {
-      thisRef.initialRenderDone = true;
-      thisRef.deck.redraw('Initial render');
     }
   });
 

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'react';
 import {createRoot} from 'react-dom/client';
 
-import {Layer, Widget, type WebMercatorViewport, type MapViewState} from '@deck.gl/core';
+import {Deck, Layer, Widget, type WebMercatorViewport, type MapViewState} from '@deck.gl/core';
 import DeckGL, {type DeckGLRef} from '@deck.gl/react';
 import {type WidgetProps, type WidgetPlacement} from '@deck.gl/core';
 
@@ -286,6 +286,47 @@ test('DeckGL#controlled view state', async () => {
   viewport = deckInstance.getViewports()[0] as WebMercatorViewport;
   expect(viewport.longitude).toBe(0);
   expect(viewport.zoom).toBe(2);
+
+  act(() => {
+    root.render(null);
+  });
+  container.remove();
+});
+
+test('DeckGL#initial render redraw happens exactly once', async () => {
+  const redrawSpy = vi.spyOn(Deck.prototype, 'redraw');
+  const ref = createRef<DeckGLRef>();
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        initialViewState: TEST_VIEW_STATE,
+        ref,
+        width: 100,
+        height: 100
+      })
+    );
+  });
+  await waitUntilReady(ref);
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        initialViewState: TEST_VIEW_STATE,
+        ref,
+        width: 200,
+        height: 100
+      })
+    );
+  });
+  await waitUntilReady(ref);
+
+  const initialRenderCalls = redrawSpy.mock.calls.filter(call => call[0] === 'Initial render');
+  expect(initialRenderCalls, 'Initial render redraw happens exactly once').toHaveLength(1);
+  redrawSpy.mockRestore();
 
   act(() => {
     root.render(null);

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -293,7 +293,7 @@ test('DeckGL#controlled view state', async () => {
   container.remove();
 });
 
-test('DeckGL#initial render redraw happens exactly once', async () => {
+test('DeckGL#rerender does not force redraw', async () => {
   const redrawSpy = vi.spyOn(Deck.prototype, 'redraw');
   const ref = createRef<DeckGLRef>();
   const container = document.createElement('div');
@@ -324,8 +324,10 @@ test('DeckGL#initial render redraw happens exactly once', async () => {
   });
   await waitUntilReady(ref);
 
-  const initialRenderCalls = redrawSpy.mock.calls.filter(call => call[0] === 'Initial render');
-  expect(initialRenderCalls, 'Initial render redraw happens exactly once').toHaveLength(1);
+  // Deck's animation loop calls redraw() without arguments on every frame to flush
+  // pending dirty flags. Only calls with a reason argument force a full redraw.
+  const forcedRedrawCalls = redrawSpy.mock.calls.filter(call => call[0] !== undefined);
+  expect(forcedRedrawCalls, 'React wrapper does not force redraws').toHaveLength(0);
   redrawSpy.mockRestore();
 
   act(() => {

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -30,11 +30,24 @@ const TEST_VIEW_STATE: MapViewState = {
   zoom: 12
 };
 
-function waitUntilReady(ref: RefObject<DeckGLRef | null>): Promise<boolean> {
-  return vi.waitUntil(() => {
-    const deck = ref.current?.deck;
-    return deck && deck.isInitialized && !deck.needsRedraw({clearRedrawFlags: false});
-  });
+/**
+ * Tracks completed draws via the deck instance's onAfterRender prop.
+ */
+function createRenderTracker(): {
+  /** Pass to the DeckGL element under test */
+  onAfterRender: () => void;
+  /** Wait until deck has completed a draw with this tracker attached */
+  waitUntilReady: (ref: RefObject<DeckGLRef | null>) => Promise<void>;
+} {
+  let drawCount = 0;
+  return {
+    onAfterRender: () => {
+      drawCount++;
+    },
+    waitUntilReady: async ref => {
+      await vi.waitUntil(() => ref.current?.deck?.isInitialized && drawCount > 0);
+    }
+  };
 }
 
 test('DeckGL#mount/unmount', async () => {
@@ -43,13 +56,15 @@ test('DeckGL#mount/unmount', async () => {
   document.body.append(container);
   const root = createRoot(container);
 
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
   act(() => {
     root.render(
       createElement(DeckGL, {
         initialViewState: TEST_VIEW_STATE,
         ref,
         width: 100,
-        height: 100
+        height: 100,
+        onAfterRender
       })
     );
   });
@@ -76,6 +91,7 @@ test('DeckGL#render', async () => {
   document.body.append(container);
   const root = createRoot(container);
 
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
   act(() => {
     root.render(
       createElement(
@@ -84,7 +100,8 @@ test('DeckGL#render', async () => {
           ref,
           initialViewState: TEST_VIEW_STATE,
           width: 100,
-          height: 100
+          height: 100,
+          onAfterRender
         },
         createElement('div', {className: 'child'}, 'Child')
       )
@@ -125,6 +142,7 @@ test('DeckGL#props omitted are reset', async () => {
   const root = createRoot(container);
 
   // Initialize widgets and layers on first render.
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
   act(() => {
     root.render(
       createElement(DeckGL, {
@@ -133,7 +151,8 @@ test('DeckGL#props omitted are reset', async () => {
         width: 100,
         height: 100,
         layers: LAYERS,
-        widgets: WIDGETS
+        widgets: WIDGETS,
+        onAfterRender
       })
     );
   });
@@ -145,15 +164,18 @@ test('DeckGL#props omitted are reset', async () => {
   expect(widgets && Array.isArray(widgets) && widgets.length, 'Widgets is set').toBe(1);
   expect(layers && Array.isArray(layers) && layers.length, 'Layers is set').toBe(1);
 
+  const {onAfterRender: onAfterRerender, waitUntilReady: waitUntilRerendered} =
+    createRenderTracker();
   act(() => {
     // Render deck a second time without setting widget or layer props.
     root.render(
       createElement(DeckGL, {
-        ref
+        ref,
+        onAfterRender: onAfterRerender
       })
     );
   });
-  await waitUntilReady(ref);
+  await waitUntilRerendered(ref);
 
   widgets = deck!.props.widgets;
   layers = deck!.props.layers;
@@ -179,6 +201,7 @@ test('DeckGL#uncontrolled view state', async () => {
   const root = createRoot(container);
   const onViewStateChange = vi.fn();
 
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
   act(() => {
     root.render(
       createElement(DeckGL, {
@@ -189,7 +212,8 @@ test('DeckGL#uncontrolled view state', async () => {
         },
         ref,
         width: 100,
-        height: 100
+        height: 100,
+        onAfterRender
       })
     );
   });
@@ -208,7 +232,6 @@ test('DeckGL#uncontrolled view state', async () => {
       }
     });
   });
-  await waitUntilReady(ref);
 
   expect(onViewStateChange.mock.lastCall?.[0]?.viewState.longitude).toBe(0);
   expect(onViewStateChange.mock.lastCall?.[0]?.viewState.zoom).toBe(1);
@@ -241,8 +264,15 @@ test('DeckGL#controlled view state', async () => {
     height: 100
   };
 
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
   act(() => {
-    root.render(createElement(DeckGL, {...deckProps, viewState: TEST_VIEW_STATE}));
+    root.render(
+      createElement(DeckGL, {
+        ...deckProps,
+        viewState: TEST_VIEW_STATE,
+        onAfterRender
+      })
+    );
   });
   await waitUntilReady(ref);
 
@@ -259,7 +289,6 @@ test('DeckGL#controlled view state', async () => {
       }
     });
   });
-  await waitUntilReady(ref);
 
   expect(onViewStateChange.mock.lastCall?.[0]?.viewState.longitude).toBe(0);
   expect(onViewStateChange.mock.lastCall?.[0]?.viewState.zoom).toBe(1);
@@ -268,6 +297,8 @@ test('DeckGL#controlled view state', async () => {
   expect(viewport.longitude).toBe(-122.45);
   expect(viewport.zoom).toBe(12);
 
+  const {onAfterRender: onAfterRerender, waitUntilReady: waitUntilRerendered} =
+    createRenderTracker();
   act(() => {
     root.render(
       createElement(DeckGL, {
@@ -276,11 +307,12 @@ test('DeckGL#controlled view state', async () => {
           longitude: 0,
           latitude: 0,
           zoom: 2
-        }
+        },
+        onAfterRender: onAfterRerender
       })
     );
   });
-  await waitUntilReady(ref);
+  await waitUntilRerendered(ref);
 
   // Deck viewport should match viewState (new value)
   viewport = deckInstance.getViewports()[0] as WebMercatorViewport;
@@ -300,29 +332,36 @@ test('DeckGL#rerender does not force redraw', async () => {
   document.body.append(container);
   const root = createRoot(container);
 
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
   act(() => {
     root.render(
       createElement(DeckGL, {
         initialViewState: TEST_VIEW_STATE,
         ref,
         width: 100,
-        height: 100
+        height: 100,
+        onAfterRender
       })
     );
   });
   await waitUntilReady(ref);
+  // Only assert on redraw calls triggered by the rerender below, not by mount/initialization
+  redrawSpy.mockClear();
 
+  const {onAfterRender: onAfterRerender, waitUntilReady: waitUntilRerendered} =
+    createRenderTracker();
   act(() => {
     root.render(
       createElement(DeckGL, {
         initialViewState: TEST_VIEW_STATE,
         ref,
         width: 200,
-        height: 100
+        height: 100,
+        onAfterRender: onAfterRerender
       })
     );
   });
-  await waitUntilReady(ref);
+  await waitUntilRerendered(ref);
 
   // Deck's animation loop calls redraw() without arguments on every frame to flush
   // pending dirty flags. Only calls with a reason argument force a full redraw.


### PR DESCRIPTION
Closes #10429

#### Background

The `DeckGL` layout effect calls `deck.redraw('Initial render')` on every React commit after mount, forcing extra full scene redraws during interaction.

#### Change List

- Remove the `deck.redraw('Initial render')` call from the layout effect.
- Add a regression test that re-renders `DeckGL` with new props and asserts the wrapper never forces a redraw (a `redraw()` call with a reason argument). Verified the test fails against master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small React integration change with a targeted regression test; relies on Deck’s normal redraw loop instead of an extra forced redraw.
> 
> **Overview**
> Stops the **DeckGL** React wrapper from calling **`deck.redraw('Initial render')`** at the end of every layout effect after the deck is initialized. That forced a full scene redraw on each commit (including during interaction), on top of the existing **`redrawDeck`** path and Deck’s animation loop.
> 
> Tests now wait for readiness via an **`onAfterRender`** draw counter instead of **`needsRedraw`**, and a new case asserts that prop-only re-renders do not trigger **`redraw(reason)`** calls with a reason argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f90d453012b2f5a51661bc7f54c742469a77d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->