### PR TITLE
docs: v9.4 whats-new - an attempt to make it read better.

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,17 +4,23 @@ This page contains highlights of each deck.gl release. Also check our [vis.gl bl
 
 ## deck.gl v9.4
 
-Release date: TBD
+Release date: July 2026
+
+deck.gl v9.4 is expected to be the final release in the v9 series. It brings together a collection of completed improvements focused on performance, stability, and usability, and is intended to be a highly compatible, highly recommended upgrade for all v9 applications.
+
+Looking ahead, deck.gl v10 is expected to introduce larger architectural changes, including luma.gl v10, loaders.gl v5, and support for more advanced binary data pipelines and GPU rendering techniques. As a result, v10 will likely be a more substantial and intentional upgrade for applications than this release.
 
 ### Core Performance
 
-- Picking in most instanced layers no longer allocates an `instancePickingColors` attribute buffer, reducing memory usage and initialization times. (deck.gl now using shader builtins `instance_index` / `gl_InstanceID`). 
+- Picking in most instanced layers now uses shader builtins (`instance_index` / `gl_InstanceID`) instead of allocating an `instancePickingColors` attribute buffer, reducing GPU memory usage and layer initialization time.
 
 ### Views and Controllers
 
+Views and controllers were a substantial focus of v9.3, and that long-running theme continues in v9.4 with improvements across core, geo layers, ArcGIS integration, and widgets.
+
 #### GlobeView
 
-`GlobeView`, while still experimental, is improved and nearing graduation: 
+[`GlobeView`](./api-reference/core/globe-view.md) remains experimental, but continues to mature with significantly expanded layer compatibility:
 
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now renders correctly on `GlobeView`, producing properly projected terrain meshes on the globe.
 - [TerrainExtension](./api-reference/extensions/terrain-extension.md) now supports `GlobeView`, enabling terrain-draped layers on the globe.
@@ -22,24 +28,32 @@ Release date: TBD
 
 #### Views
 
-- Views now support a `parameters` prop for per-view GPU draw state overrides. `GlobeView` uses this to enable back-face culling by default, and applications can override it with `new GlobeView({parameters: {cullMode: 'none'}})`.
+- [Views](./api-reference/core/view.md#parameters) now support a `parameters` prop for per-view GPU draw state overrides. `GlobeView` uses this to enable back-face culling by default, and applications can override it with:
+
+```js
+new GlobeView({
+  parameters: {
+    cullMode: 'none'
+  }
+});
+```
 
 #### Controllers
 
-- New `doubleClickDragZoom` gesture on all controllers enables smooth zoom by double-clicking and dragging up/down.
+- All [controllers](./api-reference/core/controller.md) now support a `doubleClickDragZoom` gesture that enables continuous zooming by double-clicking and dragging vertically.
+
+#### @deck.gl/arcgis
+
+- [`DeckRenderer`](./api-reference/arcgis/deck-renderer.md) now integrates with ArcGIS `SceneView` through the modern [`RenderNode`](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-3d-webgl-RenderNode.html) API instead of the deprecated `externalRenderers` API.
+
+#### @deck.gl/widgets
+
+- A new experimental [`ViewLayout`](./api-reference/widgets/view-layout.md) system supports declarative nested and relative view layouts. The `buildViewsFromViewLayout()` helper generates `View` instances from a layout tree, making complex multi-view applications easier to build.
 
 ### @deck.gl/geo-layers
 
 - [TileLayer](./api-reference/geo-layers/tile-layer.md) now prioritizes tile requests closest to the viewport center, improving perceived load times during panning and zooming.
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now correctly passes `zoomOffset` through to its child `TileLayer`.
-
-### @deck.gl/arcgis
-
-- `DeckRenderer` now integrates with ArcGIS `SceneView` through the modern `RenderNode` API instead of the deprecated `externalRenderers`.
-
-### @deck.gl/widgets
-
-A new experimental `ViewLayout` system with a helper function `buildViewsFromViewLayout()` allows advanced nested and relative view layouts to be specified using a declarative layout tree.
 
 ## deck.gl v9.3
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,11 +16,11 @@ Looking ahead, deck.gl v10 is expected to introduce larger architectural changes
 
 ### Views and Controllers
 
-Views and controllers are a multi-release work stream in deck.gl. Following the substantial changes in v9.3, v9.4 continues this long-running theme with improvements across core, geo layers, and widgets.
+deck.gl v9.4 brings additional view and controller improvements on top of the substantial changes in v9.3.
 
 #### GlobeView
 
-[`GlobeView`](./api-reference/core/globe-view.md) remains experimental, but continues to mature with significantly expanded layer compatibility:
+[`GlobeView`](./api-reference/core/globe-view.md) continues to mature, including significantly expanded layer compatibility:
 
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now renders correctly on `GlobeView`, producing properly projected terrain meshes on the globe.
 - [TerrainExtension](./api-reference/extensions/terrain-extension.md) now supports `GlobeView`, enabling terrain-draped layers on the globe.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,7 +16,7 @@ Looking ahead, deck.gl v10 is expected to introduce larger architectural changes
 
 ### Views and Controllers
 
-Views and controllers were a substantial focus of v9.3, and that long-running theme continues in v9.4 with improvements across core, geo layers, ArcGIS integration, and widgets.
+Views and controllers are a multi-release work stream in deck.gl. Following the substantial changes in v9.3, v9.4 continues this long-running theme with improvements across core, geo layers, and widgets.
 
 #### GlobeView
 
@@ -42,18 +42,18 @@ new GlobeView({
 
 - All [controllers](./api-reference/core/controller.md) now support a `doubleClickDragZoom` gesture that enables continuous zooming by double-clicking and dragging vertically.
 
-#### @deck.gl/arcgis
+#### View Layout
 
-- [`DeckRenderer`](./api-reference/arcgis/deck-renderer.md) now integrates with ArcGIS `SceneView` through the modern [`RenderNode`](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-3d-webgl-RenderNode.html) API instead of the deprecated `externalRenderers` API.
-
-#### @deck.gl/widgets
-
-- A new experimental [`ViewLayout`](./api-reference/widgets/view-layout.md) system supports declarative nested and relative view layouts. The `buildViewsFromViewLayout()` helper generates `View` instances from a layout tree, making complex multi-view applications easier to build.
+- A new experimental [`ViewLayout`](./api-reference/widgets/view-layout.md) system in `@deck.gl/widgets` supports declarative nested and relative view layouts. The `buildViewsFromViewLayout()` helper generates `View` instances from a layout tree, making complex multi-view applications easier to build.
 
 ### @deck.gl/geo-layers
 
 - [TileLayer](./api-reference/geo-layers/tile-layer.md) now prioritizes tile requests closest to the viewport center, improving perceived load times during panning and zooming.
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now correctly passes `zoomOffset` through to its child `TileLayer`.
+
+### @deck.gl/arcgis
+
+- [`DeckRenderer`](./api-reference/arcgis/deck-renderer.md) now integrates with ArcGIS `SceneView` through the modern [`RenderNode`](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-3d-webgl-RenderNode.html) API instead of the deprecated `externalRenderers` API.
 
 ## deck.gl v9.3
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -44,7 +44,7 @@ new GlobeView({
 
 #### View Layout
 
-- A new experimental [`ViewLayout`](./api-reference/widgets/view-layout.md) system in `@deck.gl/widgets` supports declarative nested and relative view layouts. The `buildViewsFromViewLayout()` helper generates `View` instances from a layout tree, making complex multi-view applications easier to build.
+- A new [`ViewLayout`](./api-reference/widgets/view-layout.md) system makes responsive and dynamic multi-view applications easier to build. Applications define nested, relative view layouts in a simple declarative syntax. The `buildViewsFromViewLayout()` helper then automatically regenerates `View` instances from the specified view layout tree based on browser window size, splitter widget positions, etc.
 
 ### @deck.gl/geo-layers
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,7 +12,7 @@ Looking ahead, deck.gl v10 is expected to introduce larger architectural changes
 
 ### Core Performance
 
-- Picking in most instanced layers now uses shader builtins (`instance_index` / `gl_InstanceID`) instead of allocating an `instancePickingColors` attribute buffer, reducing GPU memory usage and layer initialization time.
+- Picking has been optimized. Most layers now use shader builtins (`instance_index`) instead of picking color buffers, reducing GPU memory usage and layer initialization costs.
 
 ### Views and Controllers
 


### PR DESCRIPTION
## Summary

- Position deck.gl v9.4 as the expected final v9-series release, a highly compatible recommended upgrade for v9 applications, and a bridge before the more intentional v10 upgrade.
- Present Views and Controllers as a multi-release work stream continued from v9.3, grouping GlobeView compatibility, per-view GPU parameters, controller gestures, and experimental ViewLayout support under one theme.
- Document the core picking and geo-layer loading improvements, then close the release highlights with ArcGIS SceneView integration through RenderNode.

## Validation

- `yarn prettier --check docs/whats-new.md`
- `yarn lint` (passes with existing warnings)
- `yarn test-website` (passes; Docusaurus reports existing third-party source-map warnings and the pre-existing `/docs/TEST-STATUS` broken-anchor warning)
- Reviewed the rendered `/docs/whats-new` page locally for heading hierarchy, wrapping, code formatting, and internal links.
