### PR TITLE
fix(aggregation-layers): init geometry.uv in Heatmap/ScreenGrid fragment shaders (#10300)

### DIFF
--- a/modules/aggregation-layers/src/heatmap-layer/weights-fs.glsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/weights-fs.glsl.ts
@@ -15,6 +15,7 @@ float gaussianKDE(float u){
 }
 void main()
 {
+  geometry.uv = vec2(0.);
   float dist = length(gl_PointCoord - vec2(0.5, 0.5));
   if (dist > 0.5) {
     discard;

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer-fragment.glsl.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer-fragment.glsl.ts
@@ -14,6 +14,7 @@ in vec4 vColor;
 out vec4 fragColor;
 
 void main(void) {
+  geometry.uv = vec2(0.);
   fragColor = vColor;
 
   DECKGL_FILTER_COLOR(fragColor, geometry);


### PR DESCRIPTION
Closes #10300

#### Background

HeatmapLayer and ScreenGridLayer fail to compile their fragment shaders on Chrome/Android with Adreno GPUs ("Fragment shader is not compiled", empty info log) — see #10300. Works in Firefox (non-ANGLE) and on desktop.

Root cause: `weights-fs.glsl.ts` and `screen-grid-layer-fragment.glsl.ts` call `DECKGL_FILTER_COLOR(color, geometry)` but never initialize the global `geometry` (FragmentGeometry). Every other layer fragment sets `geometry.uv = ...` before the hook call (see column-layer / solid-polygon-layer). Passing an uninitialized struct into a function is translated by ANGLE into code the Adreno driver's compiler silently rejects (chrome://gpu shows the `dontInitializeUninitializedLocals` Adreno workaround active).

Tested on Xiaomi Redmi Note 13 (Adreno 710), Chrome + Brave.

#### Change List

- HeatmapLayer: init `geometry.uv = vec2(0.);` at the top of `main()` in `weights-fs.glsl.ts`
- ScreenGridLayer: init `geometry.uv = vec2(0.);` at the top of `main()` in `screen-grid-layer-fragment.glsl.ts`