### PR TITLE
feat(pydeck): register GlobeView canonical alias in jupyter-widget

### DIFF
--- a/bindings/pydeck/examples/globe_view.py
+++ b/bindings/pydeck/examples/globe_view.py
@@ -3,7 +3,7 @@ GlobeView
 =========
 
 Over 33,000 power plants of the world plotted by their production capacity (given by height)
-and fuel type (green if renewable) on an experimental deck.gl GlobeView.
+and fuel type (green if renewable) on a deck.gl GlobeView.
 """
 
 import pydeck as pdk
@@ -27,7 +27,7 @@ df["color"] = df["primary_fuel"].apply(is_green)
 view_state = pdk.ViewState(latitude=51.47, longitude=0.45, zoom=2, min_zoom=2)
 
 # Set height and width variables
-view = pdk.View(type="_GlobeView", controller=True, width=1000, height=700)
+view = pdk.View(type="GlobeView", controller=True, width=1000, height=700)
 
 
 layers = [

--- a/modules/jupyter-widget/src/playground/create-deck.js
+++ b/modules/jupyter-widget/src/playground/create-deck.js
@@ -42,6 +42,8 @@ function extractElements(library = {}, filter) {
 const JSON_CONVERTER_CONFIGURATION = {
   classes: {
     ...extractElements(deckExports, classesFilter),
+    // Register views exported with _ prefix under their canonical names
+    GlobeView: deckExports._GlobeView,
     // Register widgets exported with _ prefix under their canonical names
     StatsWidget: deckExports._StatsWidget,
     ScaleWidget: deckExports._ScaleWidget,

--- a/test/modules/jupyter-widget/create-deck.spec.ts
+++ b/test/modules/jupyter-widget/create-deck.spec.ts
@@ -6,7 +6,7 @@
 /* global document, window, global */
 import {test, expect, describe} from 'vitest';
 
-import {CompositeLayer, LayerExtension} from '@deck.gl/core';
+import {CompositeLayer, LayerExtension, _GlobeView as GlobeView} from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {DataFilterExtension, MaskExtension} from '@deck.gl/extensions';
 import {addCustomLibraries, jsonConverter} from '@deck.gl/jupyter-widget/playground/create-deck';
@@ -94,6 +94,28 @@ describe('jupyter-widget: extensions-registration', () => {
     expect(
       extension instanceof DataFilterExtension,
       'Layer extension is hydrated into a class instance'
+    ).toBeTruthy();
+  });
+});
+
+describe('jupyter-widget: view aliases', () => {
+  test('GlobeView canonical alias', () => {
+    const props = jsonConverter.convert({
+      views: [{'@@type': 'GlobeView', id: 'globe', controller: true}]
+    });
+    expect(
+      props.views[0] instanceof GlobeView,
+      'GlobeView @@type hydrates into a GlobeView instance'
+    ).toBeTruthy();
+  });
+
+  test('_GlobeView experimental name still works', () => {
+    const props = jsonConverter.convert({
+      views: [{'@@type': '_GlobeView', id: 'globe', controller: true}]
+    });
+    expect(
+      props.views[0] instanceof GlobeView,
+      '_GlobeView @@type remains registered for back-compat'
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Let pydeck users reference deck.gl's globe view under its canonical name — `View(type="GlobeView")` — instead of the experimental `View(type="_GlobeView")`.

The jupyter-widget catalog only auto-registers `_GlobeView` under its underscore name, so canonical names need a manual alias (same precedent as `StatsWidget`, etc.). This is purely additive: `_GlobeView` stays registered, so existing payloads keep working.

## Changes
- `create-deck.js` — add `GlobeView: deckExports._GlobeView` to the converter catalog
- `examples/globe_view.py` — use canonical `type="GlobeView"`
- `create-deck.spec.ts` — assert both `GlobeView` and `_GlobeView` hydrate

## Validation
Not run: `yarn build`, `yarn lint`, vitest — no Node runtime in the working environment. `yarn vitest run test/modules/jupyter-widget/create-deck.spec.ts` should confirm the new tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive alias and example/test updates only; no changes to core view rendering or auth/data paths.
> 
> **Overview**
> Pydeck and Jupyter widget JSON can now use **`GlobeView`** as the view `@@type` / `View(type=...)` instead of only the experimental **`_GlobeView`** name.
> 
> The jupyter-widget **`JSONConverter`** catalog in `create-deck.js` maps **`GlobeView`** to **`deckExports._GlobeView`**, matching the existing pattern for widgets like **`StatsWidget`**. **`_GlobeView`** stays registered, so older payloads keep working.
> 
> The **`globe_view.py`** example and docstring switch to the canonical name. New vitest coverage asserts both **`GlobeView`** and **`_GlobeView`** hydrate to a **`GlobeView`** instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d770140d7a197a0f0b5aa207f9dbfebdbba14a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->