### PR TITLE
Add trackpad gesture support to controllers

### DIFF
--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -17,7 +17,8 @@ The base Controller class supports the following options:
 * `doubleClickZoom` (boolean) - enable zooming with double click. Default `true`. Adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double clicks. Set to `false` for immediate click response. Note: disabling also prevents `onClick` from firing with `tapCount: 2` on double-click.
 * `doubleClickDragZoom` (boolean) - enable zooming by double clicking/tapping and dragging. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double-click-drags.
 * `touchZoom` (boolean) - enable zooming with multi-touch pinch. Default `true`
-* `touchRotate` (boolean) - enable rotating with multi-touch. Use two-finger rotating gesture for horizontal and three-finger swiping gesture for vertical rotation. Default `false`
+* `multiTouchDrag` (string) - behavior of two-pointer translation gestures, either `pan` or `rotate`. In `pan` mode, two-finger swiping pans the viewport. In `rotate` mode, horizontal swiping changes bearing and vertical swiping changes pitch. A two-finger twist also changes bearing in `rotate` mode. By default, two-pointer translation is disabled.
+* `trackpadGesture` (boolean) - handle trackpad gestures as continuous touch-like gestures. Trackpad pinch follows `touchZoom`, while two-finger swiping follows `multiTouchDrag`. When enabled, `scrollZoom` handles mouse wheels only. Default `false`.
 * `keyboard` (boolean | object) - enable interaction with keyboard. Default `true`. If an object is supplied, it may contain the following fields to customize the keyboard behavior:
     * `zoomSpeed` (number) - speed of zoom using +/- keys. Default `2`.
     * `moveSpeed` (number) - speed of movement using arrow keys, in pixels.
@@ -100,7 +101,7 @@ Supported events are:
 * `dblclick`
 * `pan`
 * `pinch`: 2-finger free-form manipulation, used for touch zooming and rotation
-* `multipan`: 2-finger vertical panning, used for touch pitching in `MapController`
+* `multipan`: 2-finger translation, used for touch panning or rotation
 * `keydown`
 * `keyup`
 * `pointerdown`
@@ -117,7 +118,7 @@ Note that the following events are always toggled on/off by user options:
 * `scrollZoom` - `['wheel']`
 * `dragPan` and `dragRotate` - `['pan']`
 * `touchZoom` - `['pinch']`
-* `touchRotate` - `['pinch', 'multipan']`
+* `multiTouchDrag` - `['multipan']`, and `['pinch']` in `rotate` mode
 * `doubleClickZoom` - `['dblclick']`
 * `doubleClickDragZoom` - `['pointerdown', 'pointermove', 'pointerup', 'pointercancel']`
 * `keyboard` - `['keydown']`

--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -17,8 +17,10 @@ The base Controller class supports the following options:
 * `doubleClickZoom` (boolean) - enable zooming with double click. Default `true`. Adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double clicks. Set to `false` for immediate click response. Note: disabling also prevents `onClick` from firing with `tapCount: 2` on double-click.
 * `doubleClickDragZoom` (boolean) - enable zooming by double clicking/tapping and dragging. Default `false`. Enabling adds ~300ms latency to click events due to the tap recognizer waiting to distinguish single clicks from double-click-drags.
 * `touchZoom` (boolean) - enable zooming with multi-touch pinch. Default `true`
-* `multiTouchDrag` (string) - behavior of two-pointer translation gestures, either `pan` or `rotate`. In `pan` mode, two-finger swiping pans the viewport. In `rotate` mode, horizontal swiping changes bearing and vertical swiping changes pitch. A two-finger twist also changes bearing in `rotate` mode. By default, two-pointer translation is disabled.
-* `trackpadGesture` (boolean) - handle trackpad gestures as continuous touch-like gestures. Trackpad pinch follows `touchZoom`, while two-finger swiping follows `multiTouchDrag`. When enabled, `scrollZoom` handles mouse wheels only. Default `false`.
+* `multiTouchDrag` ('pan' | 'rotate' | null) - behavior of two-pointer translation gestures. In `pan` mode, two-finger swiping pans the viewport. In `rotate` mode, horizontal swiping changes bearing and vertical swiping changes pitch. Default `null` (disabled).
+* `trackpadGesture` (boolean) - treat trackpad similar to a touch screen instead of a mouse. Default `false`.
+  + When `true`, two-finger gesture on the trackpad emits multi-touch pinch or drag events.
+  + When `false`, two-finger gesture on the trackpad emits wheel scroll events.
 * `keyboard` (boolean | object) - enable interaction with keyboard. Default `true`. If an object is supplied, it may contain the following fields to customize the keyboard behavior:
     * `zoomSpeed` (number) - speed of zoom using +/- keys. Default `2`.
     * `moveSpeed` (number) - speed of movement using arrow keys, in pixels.

--- a/docs/api-reference/core/deck.md
+++ b/docs/api-reference/core/deck.md
@@ -415,8 +415,8 @@ By default, the deck canvas captures all touch interactions. This prop is useful
 Set options for gesture recognition. May contain the following fields:
 
 - `pan` - an object that is [Pan](https://visgl.github.io/mjolnir.js/docs/api-reference/pan) options. This gesture is used for `onDrag` events, viewport panning (mouse/touch) and rotating (mouse+ctrl). Default `{threshold: 1}`.
-- `pinch` - an object that is [Pinch](https://visgl.github.io/mjolnir.js/docs/api-reference/pinch) options This gesture is used for multi-touch zooming/rotating.
-- `multipan` - an object that is [Pan](https://visgl.github.io/mjolnir.js/docs/api-reference/pan) options. This gesture is used for multi-touch pitching. Default `{threshold: 10, direction: InputDirection.Vertical, pointers: 2}`.
+- `pinch` - an object that is [Pinch](https://visgl.github.io/mjolnir.js/docs/api-reference/pinch) options. This gesture is used for multi-touch zooming/rotating and trackpad pinch. Default `{trackpad: true}`.
+- `multipan` - an object that is [Pan](https://visgl.github.io/mjolnir.js/docs/api-reference/pan) options. This gesture is used for multi-touch and trackpad panning/rotation. Default `{threshold: 10, pointers: 2, trackpad: true}`.
 - `click` - an object that is [Tap](https://visgl.github.io/mjolnir.js/docs/api-reference/tap) options. This gesture is used for the `onClick` event.
 - `dblclick` - an object that is [Tap](https://visgl.github.io/mjolnir.js/docs/api-reference/tap) options. This gesture is used for double-click zooming.
 

--- a/docs/api-reference/core/globe-controller.md
+++ b/docs/api-reference/core/globe-controller.md
@@ -39,7 +39,7 @@ Supports all [Controller options](./controller.md#options) with the following de
 
 - `dragPan`: default `'pan'` (drag to pan)
 - `dragRotate`: shift+drag or right-click drag to change bearing and pitch
-- `touchRotate`: multi-touch rotate to change bearing
+- `multiTouchDrag`: two-pointer translation can pan or change bearing and pitch
 - `keyboard`: arrow keys to pan, +/- to zoom
 - `inertia`: when set to a number (milliseconds), the globe continues spinning after a fling gesture with exponential decay
 - `maxBounds` - constrains the viewport to the specified bounding box `[[minLng, minLat], [maxLng, maxLat]]`

--- a/docs/api-reference/core/orthographic-controller.md
+++ b/docs/api-reference/core/orthographic-controller.md
@@ -40,7 +40,7 @@ Supports all [Controller options](./controller.md#options) with the following de
 
 - `dragPan`: default `'pan'` (drag to pan)
 - `dragRotate`: not effective, this view cannot be rotated
-- `touchRotate`: not effective, this view cannot be rotated
+- `multiTouchDrag`: supports `pan`; `rotate` is not effective because this view cannot be rotated
 - `keyboard`: arrow keys to pan, +/- to zoom
 
 Also accepts additional options:

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,6 +2,26 @@
 
 ## Upgrading to v9.4
 
+### Controller touch gestures
+
+The `touchRotate` controller option is deprecated. Historically, `touchRotate: true` enabled two touchscreen gestures: a two-finger twist changed bearing, and a two-finger vertical drag changed pitch.
+
+`touchRotate: true` is now treated as an alias for `multiTouchDrag: 'rotate'`. This preserves the existing twist and vertical-drag behaviors, and also allows a horizontal two-finger drag to change bearing. If both options are supplied, `multiTouchDrag` takes precedence. Trackpad gestures still require the separate `trackpadGesture: true` opt-in.
+
+Use `multiTouchDrag: 'rotate'` instead:
+
+```ts
+// Before
+controller: {
+  touchRotate: true
+}
+
+// After
+controller: {
+  multiTouchDrag: 'rotate'
+}
+```
+
 #### `pickMultipleObjects()` pick depth limits
 
 For layers that use built-in shader instance ids instead of explicit picking index buffers, `pickMultipleObjects()` now only guarantees the default `depth` of 10 unique objects per layer. Applications that call `pickMultipleObjects()` with a custom `depth` above the default may receive duplicate results for these layers. Layers with explicit picking index buffers keep their previous buffer-mutation behavior.

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -59,7 +59,7 @@
     "@probe.gl/stats": "^4.1.1",
     "@types/offscreencanvas": "^2019.6.4",
     "gl-matrix": "^3.0.0",
-    "mjolnir.js": "^3.0.1"
+    "mjolnir.js": "^3.1.0-beta.3"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -49,8 +49,14 @@ export type ControllerOptions = {
   doubleClickDragZoom?: boolean;
   /** Enable zooming with multi-touch pinch. Default `true` */
   touchZoom?: boolean;
-  /** Enable rotating with multi-touch. Use two-finger rotating gesture for horizontal and three-finger swiping gesture for vertical rotation. Default `false` */
+  /** Enable rotating with multi-touch. Default `false`.
+   * @deprecated Use `multiTouchDrag: 'rotate'`.
+   */
   touchRotate?: boolean;
+  /** Behavior of two-pointer translation gestures. Default disabled. */
+  multiTouchDrag?: 'pan' | 'rotate' | null;
+  /** Enable gestures synthesized from trackpad input. Default `false`. */
+  trackpadGesture?: boolean;
   /** Enable interaction with keyboard. Default `true`. */
   keyboard?:
     | boolean
@@ -137,6 +143,8 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
   private _customEvents: string[] = [];
   private _eventStartBlocked: any = null;
   private _panMove: boolean = false;
+  private _multiPanMode: 'pan' | 'rotate' | null = null;
+  private _multiPanStartCenter: {x: number; y: number} | null = null;
   private _doubleClickDragAnchor: [number, number] | null = null;
   private _suppressDoubleClickUntil: number = 0;
 
@@ -150,6 +158,8 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
   protected doubleClickDragZoom: boolean = true;
   protected touchZoom: boolean = true;
   protected touchRotate: boolean = false;
+  protected multiTouchDrag: 'pan' | 'rotate' | null = null;
+  protected trackpadGesture: boolean = false;
   protected keyboard:
     | boolean
     | {
@@ -220,11 +230,13 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       case 'panend':
         return this._onPanEnd(event);
       case 'pinchstart':
-        return eventStartBlocked ? false : this._onPinchStart(event);
+        return eventStartBlocked || !this._isTrackpadGestureAllowed(event)
+          ? false
+          : this._onPinchStart(event);
       case 'pinchmove':
-        return this._onPinch(event);
+        return this._isTrackpadGestureAllowed(event) ? this._onPinch(event) : false;
       case 'pinchend':
-        return this._onPinchEnd(event);
+        return this._isTrackpadGestureAllowed(event) ? this._onPinchEnd(event) : false;
       case 'multipanstart':
         return eventStartBlocked ? false : this._onMultiPanStart(event);
       case 'multipanmove':
@@ -330,6 +342,8 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       doubleClickDragZoom = false,
       touchZoom = true,
       touchRotate = false,
+      multiTouchDrag = touchRotate ? 'rotate' : null,
+      trackpadGesture = false,
       keyboard = true
     } = props;
 
@@ -338,8 +352,11 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     this.toggleEvents(EVENT_TYPES.WHEEL, isInteractive && scrollZoom);
     // We always need the pan events to set the correct isDragging state, even if dragPan & dragRotate are both false
     this.toggleEvents(EVENT_TYPES.PAN, isInteractive);
-    this.toggleEvents(EVENT_TYPES.PINCH, isInteractive && (touchZoom || touchRotate));
-    this.toggleEvents(EVENT_TYPES.MULTI_PAN, isInteractive && touchRotate);
+    this.toggleEvents(
+      EVENT_TYPES.PINCH,
+      isInteractive && (touchZoom || multiTouchDrag === 'rotate')
+    );
+    this.toggleEvents(EVENT_TYPES.MULTI_PAN, isInteractive && Boolean(multiTouchDrag));
     this.toggleEvents(EVENT_TYPES.DOUBLE_CLICK, isInteractive && doubleClickZoom);
     this.toggleEvents(EVENT_TYPES.DOUBLE_CLICK_DRAG, isInteractive && doubleClickDragZoom);
     this.toggleEvents(EVENT_TYPES.KEYBOARD, isInteractive && keyboard);
@@ -351,7 +368,9 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     this.doubleClickZoom = doubleClickZoom;
     this.doubleClickDragZoom = doubleClickDragZoom;
     this.touchZoom = touchZoom;
-    this.touchRotate = touchRotate;
+    this.touchRotate = multiTouchDrag === 'rotate';
+    this.multiTouchDrag = multiTouchDrag;
+    this.trackpadGesture = trackpadGesture;
     this.keyboard = keyboard;
 
     // Normalize view state if maxBounds is defined
@@ -555,6 +574,9 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     if (!this.scrollZoom) {
       return false;
     }
+    if (this.trackpadGesture && event.device !== 'mouse') {
+      return false;
+    }
 
     const pos = this.getCenter(event);
     if (!this.isPointInBounds(pos, event)) {
@@ -594,64 +616,94 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
   }
 
   protected _onMultiPanStart(event: MjolnirGestureEvent): boolean {
-    const pos = this.getCenter(event);
-    if (!this.isPointInBounds(pos, event)) {
+    const {multiTouchDrag} = this;
+    if (!multiTouchDrag || !this._isMultiPanEventAllowed(event, multiTouchDrag)) {
       return false;
     }
-    const newControllerState = this.controllerState.rotateStart({pos});
+
+    const currentCenter = event.offsetCenter;
+    if (!this.isPointInBounds(this.getCenter(event), event)) {
+      return false;
+    }
+
+    const isTrackpad = event.pointerType === 'trackpad';
+    const startCenter = {
+      x: currentCenter.x - (isTrackpad ? 0 : event.deltaX),
+      y: currentCenter.y - (isTrackpad ? 0 : event.deltaY)
+    };
+    const startEvent = {...event, offsetCenter: startCenter};
+    const pos = this.getCenter(startEvent);
+    const newControllerState =
+      multiTouchDrag === 'pan'
+        ? this.controllerState.panStart({pos})
+        : this.controllerState.rotateStart({pos});
+
+    this._multiPanMode = multiTouchDrag;
+    this._multiPanStartCenter = startCenter;
     this.updateViewport(newControllerState, NO_TRANSITION_PROPS, {isDragging: true});
     return true;
   }
 
   protected _onMultiPan(event: MjolnirGestureEvent): boolean {
-    if (!this.touchRotate) {
-      return false;
-    }
-    if (!this.isDragging()) {
+    const {mode, event: panEvent} = this._getMultiPanEvent(event);
+    if (!mode || !panEvent || !this.isDragging()) {
       return false;
     }
 
-    const pos = this.getCenter(event);
-    pos[0] -= event.deltaX;
-
-    const newControllerState = this.controllerState.rotate({pos});
-    this.updateViewport(newControllerState, NO_TRANSITION_PROPS, {
-      isDragging: true,
-      isRotating: true
-    });
-    return true;
+    return mode === 'pan' ? this._onPanMove(panEvent) : this._onPanRotate(panEvent);
   }
 
   protected _onMultiPanEnd(event: MjolnirGestureEvent): boolean {
-    if (!this.isDragging()) {
+    const {mode, event: panEvent} = this._getMultiPanEvent(event);
+    if (!mode || !panEvent || !this.isDragging()) {
+      this._resetMultiPan();
       return false;
     }
-    const {inertia} = this;
-    if (this.touchRotate && inertia && event.velocityY) {
-      const pos = this.getCenter(event);
-      const endPos: [number, number] = [pos[0], (pos[1] += (event.velocityY * inertia) / 2)];
-      const newControllerState = this.controllerState.rotate({pos: endPos});
-      this.updateViewport(
-        newControllerState,
-        {
-          ...this._getTransitionProps(),
-          transitionDuration: inertia,
-          transitionEasing: INERTIA_EASING
-        },
-        {
-          isDragging: false,
-          isRotating: true
-        }
-      );
-      this.blockEvents(inertia);
-    } else {
-      const newControllerState = this.controllerState.rotateEnd();
-      this.updateViewport(newControllerState, null, {
-        isDragging: false,
-        isRotating: false
-      });
+
+    const handled =
+      mode === 'pan' ? this._onPanMoveEnd(panEvent) : this._onPanRotateEnd(panEvent);
+    this._resetMultiPan();
+    return handled;
+  }
+
+  private _isTrackpadGestureAllowed(event: MjolnirGestureEvent): boolean {
+    return event.pointerType !== 'trackpad' || this.trackpadGesture;
+  }
+
+  private _isMultiPanEventAllowed(
+    event: MjolnirGestureEvent,
+    mode: 'pan' | 'rotate'
+  ): boolean {
+    if (event.pointerType === 'trackpad') {
+      return this.trackpadGesture && (mode === 'pan' ? this.dragPan : this.dragRotate);
     }
-    return true;
+    return event.pointerType === 'touch' && (mode === 'pan' ? this.dragPan : this.dragRotate);
+  }
+
+  private _getMultiPanEvent(event: MjolnirGestureEvent): {
+    mode: 'pan' | 'rotate' | null;
+    event: MjolnirGestureEvent | null;
+  } {
+    const mode = this._multiPanMode;
+    const startCenter = this._multiPanStartCenter;
+    if (!mode || !startCenter) {
+      return {mode: null, event: null};
+    }
+    return {
+      mode,
+      event: {
+        ...event,
+        offsetCenter: {
+          x: startCenter.x + event.deltaX,
+          y: startCenter.y + event.deltaY
+        }
+      }
+    };
+  }
+
+  private _resetMultiPan(): void {
+    this._multiPanMode = null;
+    this._multiPanStartCenter = null;
   }
 
   // Default handler for the `pinchstart` event.

--- a/modules/core/src/controllers/globe-controller.ts
+++ b/modules/core/src/controllers/globe-controller.ts
@@ -267,6 +267,11 @@ export default class GlobeController extends Controller<MapState> {
     return super._onPanStart(event);
   }
 
+  protected _onMultiPanStart(event: MjolnirGestureEvent): boolean {
+    this._panHistory = [];
+    return super._onMultiPanStart(event);
+  }
+
   protected _onPanMove(event: MjolnirGestureEvent): boolean {
     if (!this.dragPan) {
       return false;

--- a/modules/core/src/controllers/orthographic-controller.ts
+++ b/modules/core/src/controllers/orthographic-controller.ts
@@ -8,6 +8,7 @@ import ViewState from './view-state';
 
 import type Viewport from '../viewports/viewport';
 import LinearInterpolator from '../transitions/linear-interpolator';
+import type {MjolnirGestureEvent} from 'mjolnir.js';
 
 export type OrthographicStateProps = {
   width: number;
@@ -437,6 +438,10 @@ export default class OrthographicController extends Controller<OrthographicState
   setProps(props: ControllerProps & OrthographicStateProps) {
     Object.assign(props, normalizeZoom(props));
     super.setProps(props);
+  }
+
+  protected _onMultiPanStart(event: MjolnirGestureEvent): boolean {
+    return this.multiTouchDrag === 'pan' && super._onMultiPanStart(event);
   }
 
   _onPanRotate() {

--- a/modules/core/src/lib/constants.ts
+++ b/modules/core/src/lib/constants.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import log from '../utils/log';
-import {Pan, DoubleClickDrag, InputDirection, Pinch, Tap} from 'mjolnir.js';
+import {Pan, DoubleClickDrag, Pinch, Tap} from 'mjolnir.js';
 import type {PanRecognizerOptions, PinchRecognizerOptions, TapRecognizerOptions} from 'mjolnir.js';
 
 /**
@@ -103,8 +103,8 @@ export const EVENT_HANDLERS = {
 // Order matters: recognizeWith/requireFailure resolve by name, so a recognizer
 // must be registered before any later entry can reference it.
 export const RECOGNIZERS = {
-  multipan: [Pan, {threshold: 10, direction: InputDirection.Vertical, pointers: 2}],
-  pinch: [Pinch, {}, null, ['multipan']],
+  multipan: [Pan, {threshold: 10, pointers: 2, trackpad: true}],
+  pinch: [Pinch, {trackpad: true}, null, ['multipan']],
   pan: [Pan, {threshold: 1}, ['pinch'], ['multipan']],
   dblclick: [Tap, {event: 'dblclick', taps: 2, enable: false}],
   dblclickdrag: [DoubleClickDrag, {event: 'dblclickdrag', enable: false}, ['dblclick'], null],

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -24,6 +24,34 @@ const makeDoubleClickDragEvent = (type: string, y: number, scale: number = 1) =>
   stopPropagation() {}
 });
 
+const makeGestureEvent = (
+  type: string,
+  {
+    x = 50,
+    y = 50,
+    deltaX = 0,
+    deltaY = 0,
+    pointerType = 'touch'
+  }: {
+    x?: number;
+    y?: number;
+    deltaX?: number;
+    deltaY?: number;
+    pointerType?: 'touch' | 'trackpad';
+  } = {}
+) => ({
+  type,
+  pointerType,
+  offsetCenter: {x, y},
+  deltaX,
+  deltaY,
+  velocity: 0,
+  velocityX: 0,
+  velocityY: 0,
+  srcEvent: {},
+  stopPropagation() {}
+});
+
 test('MapController', async () => {
   await testController(MapView, {
     longitude: -122.45,
@@ -32,6 +60,150 @@ test('MapController', async () => {
     pitch: 30,
     bearing: -45
   });
+});
+
+test('MapController supports panning with multi-touch translation', () => {
+  const controller = createTestController({
+    view: new MapView({controller: {multiTouchDrag: 'pan'}}),
+    initialViewState: {
+      longitude: -122.45,
+      latitude: 37.78,
+      zoom: 10,
+      pitch: 30,
+      bearing: -45
+    }
+  });
+
+  controller.handleEvent(makeGestureEvent('multipanstart') as any);
+  controller.handleEvent(makeGestureEvent('multipanmove', {x: 60, deltaX: 10, deltaY: 0}) as any);
+  controller.handleEvent(makeGestureEvent('multipanend', {x: 60, deltaX: 10, deltaY: 0}) as any);
+
+  expect(controller.props.longitude, 'horizontal translation pans the viewport').not.toBe(-122.45);
+  expect(controller.props.bearing, 'translation does not change bearing').toBe(-45);
+  expect(controller.props.pitch, 'translation does not change pitch').toBe(30);
+});
+
+test('MapController supports rotating with multi-touch translation', () => {
+  const controller = createTestController({
+    view: new MapView({controller: {multiTouchDrag: 'rotate'}}),
+    initialViewState: {
+      longitude: -122.45,
+      latitude: 37.78,
+      zoom: 10,
+      pitch: 30,
+      bearing: -45
+    }
+  });
+
+  controller.handleEvent(makeGestureEvent('multipanstart') as any);
+  controller.handleEvent(
+    makeGestureEvent('multipanmove', {x: 60, y: 60, deltaX: 10, deltaY: 10}) as any
+  );
+  controller.handleEvent(
+    makeGestureEvent('multipanend', {x: 60, y: 60, deltaX: 10, deltaY: 10}) as any
+  );
+
+  expect(controller.props.bearing, 'horizontal translation changes bearing').not.toBe(-45);
+  expect(controller.props.pitch, 'vertical translation changes pitch').not.toBe(30);
+});
+
+test('MapController only handles synthesized trackpad gestures when enabled', () => {
+  const initialViewState = {
+    longitude: -122.45,
+    latitude: 37.78,
+    zoom: 10,
+    pitch: 30,
+    bearing: -45
+  };
+  const disabledController = createTestController({
+    view: new MapView({controller: {multiTouchDrag: 'pan'}}),
+    initialViewState
+  });
+
+  disabledController.handleEvent(
+    makeGestureEvent('multipanstart', {pointerType: 'trackpad'}) as any
+  );
+  disabledController.handleEvent(
+    makeGestureEvent('multipanmove', {pointerType: 'trackpad', deltaX: 10}) as any
+  );
+  expect(disabledController.props.longitude, 'trackpad gesture is ignored by default').toBe(
+    -122.45
+  );
+
+  const enabledController = createTestController({
+    view: new MapView({controller: {multiTouchDrag: 'pan', trackpadGesture: true}}),
+    initialViewState
+  });
+  enabledController.handleEvent(
+    makeGestureEvent('multipanstart', {pointerType: 'trackpad'}) as any
+  );
+  enabledController.handleEvent(
+    makeGestureEvent('multipanmove', {pointerType: 'trackpad', deltaX: 10}) as any
+  );
+  expect(
+    enabledController.props.longitude,
+    'trackpad delta is converted to pointer movement'
+  ).not.toBe(-122.45);
+});
+
+test('MapController only handles trackpad pinch when trackpad gestures are enabled', () => {
+  const initialViewState = {
+    longitude: -122.45,
+    latitude: 37.78,
+    zoom: 10,
+    pitch: 30,
+    bearing: -45
+  };
+  const makePinchEvent = (type: string, scale: number) => ({
+    ...makeGestureEvent(type, {pointerType: 'trackpad'}),
+    scale,
+    rotation: 0,
+    deltaTime: type === 'pinchstart' ? 0 : 16
+  });
+  const disabledController = createTestController({
+    view: new MapView({controller: true}),
+    initialViewState
+  });
+  disabledController.handleEvent(makePinchEvent('pinchstart', 1) as any);
+  disabledController.handleEvent(makePinchEvent('pinchmove', 1.2) as any);
+  expect(disabledController.props.zoom, 'trackpad pinch is ignored by default').toBe(10);
+
+  const enabledController = createTestController({
+    view: new MapView({controller: {trackpadGesture: true}}),
+    initialViewState
+  });
+  enabledController.handleEvent(makePinchEvent('pinchstart', 1) as any);
+  enabledController.handleEvent(makePinchEvent('pinchmove', 1.2) as any);
+  expect(enabledController.props.zoom, 'trackpad pinch follows touchZoom').toBeGreaterThan(10);
+});
+
+test('MapController restricts wheel zoom to mouse input when trackpad gestures are enabled', () => {
+  const controller = createTestController({
+    view: new MapView({controller: {trackpadGesture: true}}),
+    initialViewState: {
+      longitude: -122.45,
+      latitude: 37.78,
+      zoom: 10,
+      pitch: 30,
+      bearing: -45
+    }
+  });
+  const makeWheelEvent = (device: 'mouse' | 'trackpad' | 'unknown') => ({
+    type: 'wheel',
+    device,
+    pointerType: 'mouse',
+    offsetCenter: {x: 50, y: 50},
+    delta: -1,
+    srcEvent: {preventDefault() {}},
+    stopPropagation() {}
+  });
+
+  controller.handleEvent(makeWheelEvent('trackpad') as any);
+  controller.handleEvent(makeWheelEvent('unknown') as any);
+  expect(controller.props.zoom, 'non-mouse wheel input is ignored').toBe(10);
+
+  controller.handleEvent(makeWheelEvent('mouse') as any);
+  expect(controller.props.zoom, 'mouse wheel input still zooms').not.toBe(10);
 });
 
 test('MapController#inertia', async () => {
@@ -103,6 +275,26 @@ test('GlobeController', async () => {
   );
 });
 
+test('GlobeController initializes multipan like pointer pan', () => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {multiTouchDrag: 'pan'}}),
+    initialViewState: {
+      longitude: -122.45,
+      latitude: 37.78,
+      zoom: 0
+    }
+  });
+  controller._panHistory = [{longitude: 0, latitude: 0, timestamp: 0}];
+
+  controller.handleEvent(makeGestureEvent('multipanstart') as any);
+  expect(controller._panHistory, 'multipan start clears globe inertia history').toEqual([]);
+
+  controller.handleEvent(makeGestureEvent('multipanmove', {x: 60, deltaX: 10}) as any);
+  expect(controller.props.longitude, 'multipan uses globe panning').not.toBe(-122.45);
+
+  controller.handleEvent(makeGestureEvent('multipanend', {x: 60, deltaX: 10}) as any);
+});
+
 test('OrbitController', async () => {
   await testController(OrbitView, {
     orbitAxis: 'Y',
@@ -129,6 +321,29 @@ test('OrthographicController', async () => {
       'keyboard#function key'
     ]
   );
+});
+
+test('OrthographicController supports multipan only in pan mode', () => {
+  const panController = createTestController({
+    view: new OrthographicView({controller: {multiTouchDrag: 'pan'}}),
+    initialViewState: {
+      target: [1, 1, 0],
+      zoom: 1
+    }
+  });
+  panController.handleEvent(makeGestureEvent('multipanstart') as any);
+  panController.handleEvent(makeGestureEvent('multipanmove', {x: 60, deltaX: 10}) as any);
+  expect(panController.props.target, 'multipan uses orthographic panning').not.toEqual([1, 1, 0]);
+
+  const rotateController = createTestController({
+    view: new OrthographicView({controller: {multiTouchDrag: 'rotate'}}),
+    initialViewState: {
+      target: [1, 1, 0],
+      zoom: 1
+    }
+  });
+  const handled = rotateController.handleEvent(makeGestureEvent('multipanstart') as any);
+  expect(handled, 'unsupported multipan rotation is ignored').toBe(false);
 });
 
 test('OrthographicController#2d zoom', async () => {

--- a/test/modules/core/controllers/test-controller.ts
+++ b/test/modules/core/controllers/test-controller.ts
@@ -14,6 +14,8 @@ function makeEvent(type, opts, seed) {
   const event = {
     type,
     handled: opts.handled,
+    pointerType: opts.pointerType || (type === 'wheel' ? 'mouse' : 'touch'),
+    device: opts.device,
     offsetCenter: {x: 100 + seed, y: 100 - seed},
     delta: -seed - 1,
     deltaX: seed / 2,
@@ -134,8 +136,8 @@ const TEST_CASES = [
     title: 'multipan#disabled',
     props: {touchRotate: false},
     events: () => makeEvents(['multipanstart', 'multipanmove', 'multipanend']),
-    viewStateChanges: 2,
-    interactionStates: 1 // isDragging
+    viewStateChanges: 0,
+    interactionStates: 0
   },
 
   {

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -155,6 +155,12 @@ test('Deck wires mjolnir requireFailure between recognizers', async () => {
           expect(requiredFailures('pan'), 'pan waits for multipan').toContain('multipan');
           expect(requiredFailures('click'), 'click waits for dblclick').toContain('dblclick');
 
+          const multipan = recognizers.find(r => r.options.event === 'multipan');
+          const pinch = recognizers.find(r => r.options.event === 'pinch');
+          expect(multipan.options.direction, 'multipan accepts movement in any direction').toBe(15);
+          expect(multipan.options.trackpad, 'multipan recognizes trackpad swipes').toBe(true);
+          expect(pinch.options.trackpad, 'pinch recognizes trackpad pinch').toBe(true);
+
           deck.finalize();
           resolve();
         } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7931,7 +7931,7 @@ mitt@^3.0.1:
 
 mjolnir.js@^3.1.0-beta.3:
   version "3.1.0-beta.3"
-  resolved "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/mjolnir.js/-/mjolnir.js-3.1.0-beta.3.tgz#3ce7450c944092d28e555175b0831dfcbcbba1dd"
+  resolved "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-3.1.0-beta.3.tgz#3ce7450c944092d28e555175b0831dfcbcbba1dd"
   integrity sha512-wOby2pVVA4Xp+b40xifY8WQBw0ohGkvd7O5TkDMKHn6ZjWuD5YHjwV4Vsvw3zqFSfLhLMLCNfJzzW1YGVUHXpQ==
 
 mkdirp@^1.0.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7929,10 +7929,10 @@ mitt@^3.0.1:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
-mjolnir.js@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-3.0.1.tgz#68c87869a277d9b96f41b642734d269273034c4a"
-  integrity sha512-/RMi8Jm3NKleOkVI8D2ai+1OVwtfRJsSVBVjbTXNm83nfsN4uORYaN3u1/hsg5CqVI+di8enTkvgDNDOywn6cQ==
+mjolnir.js@^3.1.0-beta.3:
+  version "3.1.0-beta.3"
+  resolved "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/mjolnir.js/-/mjolnir.js-3.1.0-beta.3.tgz#3ce7450c944092d28e555175b0831dfcbcbba1dd"
+  integrity sha512-wOby2pVVA4Xp+b40xifY8WQBw0ohGkvd7O5TkDMKHn6ZjWuD5YHjwV4Vsvw3zqFSfLhLMLCNfJzzW1YGVUHXpQ==
 
 mkdirp@^1.0.3:
   version "1.0.4"
@@ -9969,16 +9969,7 @@ streamx@^2.21.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10084,7 +10075,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10097,13 +10088,6 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11065,7 +11049,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.1.tgz#bfd1eb426f0f7eec73b7df32cf7df1f618bfb3a9"
   integrity sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11078,15 +11062,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
#### Background

Currently using the controllers from a trackpad has this behavior:
- Click + drag to pan
- Any multi-touch gesture results in zooming (via wheel event)

This PR adds an opt-in option `trackpadGesture` to all controllers. If enabled:
- Pinch on trackpad to zoom
- Two-finger drag on trackpad to pan (or rotate, controlled by new `multiTouchDrag` option)

This allows apps, especially with top-down flat map/orthographic views, to provide a more natural interaction that is consistent with the built-in webpage UX.

#### Change List
- Bump mjolnir.js to v3.1-beta
- Global recognizer config
- Base Controller class and GlobeController/OrthographicController overrides
- Documentation, upgrade guide
- Unit tests