### PR TITLE
feat(layers): add simple WebGPU layer ports

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -35,14 +35,14 @@ The table below covers the public layer exports from the layer packages. It is d
 
 | Module | Layer | WebGL | WebGPU |
 | --- | --- | --- | --- |
-| `@deck.gl/layers` | `ArcLayer` | ✅ | ❌ |
+| `@deck.gl/layers` | `ArcLayer` | ✅ | ✅ |
 | `@deck.gl/layers` | `BitmapLayer` | ✅ | ❌ |
 | `@deck.gl/layers` | `IconLayer` | ✅ | ✅ |
 | `@deck.gl/layers` | `LineLayer` | ✅ | ✅ |
 | `@deck.gl/layers` | `PointCloudLayer` | ✅ | ✅ |
 | `@deck.gl/layers` | `ScatterplotLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `ColumnLayer` | ✅ | ❌ |
-| `@deck.gl/layers` | `GridCellLayer` | ✅ | ❌ |
+| `@deck.gl/layers` | `ColumnLayer` | ✅ | ✅ |
+| `@deck.gl/layers` | `GridCellLayer` | ✅ | ✅ |
 | `@deck.gl/layers` | `PathLayer` | ✅ | ✅ |
 | `@deck.gl/layers` | `PolygonLayer` | ✅ | ❌ |
 | `@deck.gl/layers` | `GeoJsonLayer` | ✅ | ❌ |

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -26,11 +26,11 @@ const WEBGPU_DEFAULT_DRAW_PARAMETERS: RenderPipelineParameters = {
   depthWriteEnabled: true,
   depthCompare: 'less-equal',
   blendColorOperation: 'add',
-  blendColorSrcFactor: 'src-alpha',
-  blendColorDstFactor: 'one',
+  blendColorSrcFactor: 'one',
+  blendColorDstFactor: 'one-minus-src-alpha',
   blendAlphaOperation: 'add',
-  blendAlphaSrcFactor: 'one-minus-dst-alpha',
-  blendAlphaDstFactor: 'one'
+  blendAlphaSrcFactor: 'one',
+  blendAlphaDstFactor: 'one-minus-src-alpha'
 };
 
 export type LayersPassRenderOptions = {

--- a/modules/layers/src/arc-layer/arc-layer-uniforms.ts
+++ b/modules/layers/src/arc-layer/arc-layer-uniforms.ts
@@ -4,6 +4,20 @@
 
 import type {ShaderModule} from '@luma.gl/shadertools';
 
+const uniformBlockWGSL = /* wgsl */ `\
+struct ArcUniforms {
+  greatCircle: f32,
+  useShortestPath: f32,
+  numSegments: f32,
+  widthScale: f32,
+  widthMinPixels: f32,
+  widthMaxPixels: f32,
+  widthUnits: i32,
+};
+
+@group(0) @binding(auto) var<uniform> arc: ArcUniforms;
+`;
+
 const uniformBlock = `\
 layout(std140) uniform arcUniforms {
   bool greatCircle;
@@ -28,6 +42,7 @@ export type ArcProps = {
 
 export const arcUniforms = {
   name: 'arc',
+  source: uniformBlockWGSL,
   vs: uniformBlock,
   fs: uniformBlock,
   uniformTypes: {

--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -5,6 +5,7 @@
 import {
   Layer,
   project32,
+  color,
   picking,
   UNIT,
   UpdateParameters,
@@ -21,6 +22,7 @@ import {
 import {Model} from '@luma.gl/engine';
 
 import {arcUniforms, ArcProps} from './arc-layer-uniforms';
+import source from './arc-layer.wgsl';
 import vs from './arc-layer-vertex.glsl';
 import fs from './arc-layer-fragment.glsl';
 
@@ -148,7 +150,14 @@ export default class ArcLayer<DataT = any, ExtraPropsT extends {} = {}> extends 
   }
 
   getShaders() {
-    return super.getShaders({vs, fs, modules: [project32, picking, arcUniforms]}); // 'project' module added by default.
+    const isWebGPU = this.context.device.type === 'webgpu';
+
+    return super.getShaders({
+      vs,
+      fs,
+      ...(isWebGPU ? {source} : {}),
+      modules: [project32, ...(isWebGPU ? [color] : []), picking, arcUniforms]
+    }); // 'project' module added by default.
   }
 
   // This layer has its own wrapLongitude logic

--- a/modules/layers/src/arc-layer/arc-layer.wgsl.ts
+++ b/modules/layers/src/arc-layer/arc-layer.wgsl.ts
@@ -1,0 +1,169 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+const ZERO_OFFSET: vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
+
+struct Attributes {
+  @location(0) instanceSourcePositions: vec3<f32>,
+  @location(1) instanceSourcePositions64Low: vec3<f32>,
+  @location(2) instanceTargetPositions: vec3<f32>,
+  @location(3) instanceTargetPositions64Low: vec3<f32>,
+  @location(4) instanceSourceColors: vec4<f32>,
+  @location(5) instanceTargetColors: vec4<f32>,
+  @location(6) instanceWidths: f32,
+  @location(7) instanceHeights: f32,
+  @location(8) instanceTilts: f32,
+};
+
+struct Varyings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) uv: vec2<f32>,
+  @location(2) pickingColor: vec3<f32>,
+};
+
+fn paraboloid(
+  distance: f32,
+  sourceZ: f32,
+  targetZ: f32,
+  ratio: f32,
+  height: f32
+) -> f32 {
+  let deltaZ = targetZ - sourceZ;
+  let dh = distance * height;
+  if (dh == 0.0) {
+    return sourceZ + deltaZ * ratio;
+  }
+  let unitZ = deltaZ / dh;
+  let p2 = unitZ * unitZ + 1.0;
+  let dir = select(0.0, 1.0, deltaZ <= 0.0);
+  let z0 = mix(sourceZ, targetZ, dir);
+  let r = mix(ratio, 1.0 - ratio, dir);
+  return sqrt(max(r * (p2 - r), 0.0)) * dh + z0;
+}
+
+fn getExtrusionOffset(lineClipspace: vec2<f32>, side: f32, width: f32) -> vec2<f32> {
+  var direction = normalize(lineClipspace * project.viewportSize);
+  direction = vec2<f32>(-direction.y, direction.x);
+  return direction * side * width / 2.0;
+}
+
+fn getSegmentRatio(index: f32) -> f32 {
+  return smoothstep(0.0, 1.0, index / max(arc.numSegments - 1.0, 1.0));
+}
+
+fn interpolateFlat(
+  source: vec3<f32>,
+  targetPosition: vec3<f32>,
+  ratio: f32,
+  height: f32,
+  tiltDegrees: f32
+) -> vec3<f32> {
+  let distance = length(source.xy - targetPosition.xy);
+  let z = paraboloid(distance, source.z, targetPosition.z, ratio, height);
+  let tiltAngle = radians(tiltDegrees);
+  let tiltDirection = normalize(targetPosition.xy - source.xy);
+  let tilt = vec2<f32>(-tiltDirection.y, tiltDirection.x) * z * sin(tiltAngle);
+  return vec3<f32>(mix(source.xy, targetPosition.xy, ratio) + tilt, z * cos(tiltAngle));
+}
+
+@vertex
+fn vertexMain(
+  attributes: Attributes,
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> Varyings {
+  geometry.worldPosition = attributes.instanceSourcePositions;
+  geometry.worldPositionAlt = attributes.instanceTargetPositions;
+
+  let segmentIndex = f32(vertexIndex / 2u);
+  let segmentSide = select(-1.0, 1.0, vertexIndex % 2u == 1u);
+  let segmentRatio = getSegmentRatio(segmentIndex);
+  let previousRatio = getSegmentRatio(max(0.0, segmentIndex - 1.0));
+  let nextRatio = getSegmentRatio(min(arc.numSegments - 1.0, segmentIndex + 1.0));
+
+  var sourceWorld = attributes.instanceSourcePositions;
+  var targetWorld = attributes.instanceTargetPositions;
+  if (arc.useShortestPath != 0.0) {
+    sourceWorld.x = ((sourceWorld.x + 180.0) % 360.0) - 180.0;
+    targetWorld.x = ((targetWorld.x + 180.0) % 360.0) - 180.0;
+    let deltaLongitude = targetWorld.x - sourceWorld.x;
+    if (deltaLongitude > 180.0) {
+      targetWorld.x -= 360.0;
+    }
+    if (deltaLongitude < -180.0) {
+      sourceWorld.x -= 360.0;
+    }
+  }
+
+  let source = project_position_vec3_f64(sourceWorld, attributes.instanceSourcePositions64Low);
+  let targetPosition = project_position_vec3_f64(
+    targetWorld,
+    attributes.instanceTargetPositions64Low
+  );
+  let currentPosition = interpolateFlat(
+    source,
+    targetPosition,
+    segmentRatio,
+    attributes.instanceHeights,
+    attributes.instanceTilts
+  );
+  let directionRatio = select(nextRatio, previousRatio, segmentIndex > 0.0);
+  let nextPosition = interpolateFlat(
+    source,
+    targetPosition,
+    directionRatio,
+    attributes.instanceHeights,
+    attributes.instanceTilts
+  );
+
+  geometry.position = vec4<f32>(currentPosition, 1.0);
+  geometry.uv = vec2<f32>(segmentRatio, segmentSide);
+  geometry.pickingColor = picking_getPickingColorFromIndex(instanceIndex);
+
+  let currentClip = project_common_position_to_clipspace(geometry.position);
+  let nextClip = project_common_position_to_clipspace(vec4<f32>(nextPosition, 1.0));
+  let widthPixels = clamp(
+    project_unit_size_to_pixel(attributes.instanceWidths * arc.widthScale, arc.widthUnits),
+    arc.widthMinPixels,
+    arc.widthMaxPixels
+  );
+  let offset = getExtrusionOffset(nextClip.xy - currentClip.xy, segmentSide, widthPixels);
+
+  var output: Varyings;
+  output.position = currentClip + vec4<f32>(project_pixel_size_to_clipspace(offset), 0.0, 0.0);
+  let color = mix(attributes.instanceSourceColors, attributes.instanceTargetColors, segmentRatio);
+  output.color = vec4<f32>(color.rgb, color.a * layer.opacity);
+  output.uv = geometry.uv;
+  output.pickingColor = geometry.pickingColor;
+  return output;
+}
+
+@fragment
+fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
+  var color = varyings.color;
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(varyings.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(varyings.pickingColor, 1.0);
+  }
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedObjectColor = picking_normalizeColor(picking.highlightedObjectColor);
+    if (picking_isColorZero(abs(varyings.pickingColor - highlightedObjectColor))) {
+      let highlightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highlightAlpha + color.a * (1.0 - highlightAlpha);
+      if (blendedAlpha > 0.0) {
+        let highlightRatio = highlightAlpha / blendedAlpha;
+        color = vec4<f32>(
+          mix(color.rgb, picking.highlightColor.rgb, highlightRatio),
+          blendedAlpha
+        );
+      }
+    }
+  }
+  return deckgl_premultiplied_alpha(color);
+}
+`;

--- a/modules/layers/src/arc-layer/arc-layer.wgsl.ts
+++ b/modules/layers/src/arc-layer/arc-layer.wgsl.ts
@@ -22,6 +22,7 @@ struct Varyings {
   @location(0) color: vec4<f32>,
   @location(1) uv: vec2<f32>,
   @location(2) pickingColor: vec3<f32>,
+  @location(3) isValid: f32,
 };
 
 fn paraboloid(
@@ -69,6 +70,52 @@ fn interpolateFlat(
   return vec3<f32>(mix(source.xy, targetPosition.xy, ratio) + tilt, z * cos(tiltAngle));
 }
 
+// Great circle interpolation
+// http://www.movable-type.co.uk/scripts/latlong.html
+fn getAngularDistance(source: vec2<f32>, targetPosition: vec2<f32>) -> f32 {
+  let sourceRadians = radians(source);
+  let targetRadians = radians(targetPosition);
+  let sinHalfDelta = sin((sourceRadians - targetRadians) / 2.0);
+  let sinHalfDeltaSquared = sinHalfDelta * sinHalfDelta;
+  let a = sinHalfDeltaSquared.y +
+    cos(sourceRadians.y) * cos(targetRadians.y) * sinHalfDeltaSquared.x;
+  return 2.0 * asin(sqrt(a));
+}
+
+fn interpolateGreatCircle(
+  source: vec3<f32>,
+  targetPosition: vec3<f32>,
+  source3D: vec3<f32>,
+  target3D: vec3<f32>,
+  angularDistance: f32,
+  ratio: f32,
+  height: f32
+) -> vec3<f32> {
+  var longitudeLatitude: vec2<f32>;
+
+  // If the angular distance is PI, use linear interpolation. Otherwise use spherical interpolation.
+  if (abs(angularDistance - PI) < 0.001) {
+    longitudeLatitude = (1.0 - ratio) * source.xy + ratio * targetPosition.xy;
+  } else {
+    let a = sin((1.0 - ratio) * angularDistance);
+    let b = sin(ratio * angularDistance);
+    let p = source3D.yxz * a + target3D.yxz * b;
+    longitudeLatitude = degrees(vec2<f32>(
+      atan2(p.y, -p.x),
+      atan2(p.z, length(p.xy))
+    ));
+  }
+
+  let z = paraboloid(
+    angularDistance * EARTH_RADIUS,
+    source.z,
+    targetPosition.z,
+    ratio,
+    height
+  );
+  return vec3<f32>(longitudeLatitude, z);
+}
+
 @vertex
 fn vertexMain(
   attributes: Attributes,
@@ -80,57 +127,170 @@ fn vertexMain(
 
   let segmentIndex = f32(vertexIndex / 2u);
   let segmentSide = select(-1.0, 1.0, vertexIndex % 2u == 1u);
-  let segmentRatio = getSegmentRatio(segmentIndex);
+  var segmentRatio = getSegmentRatio(segmentIndex);
   let previousRatio = getSegmentRatio(max(0.0, segmentIndex - 1.0));
-  let nextRatio = getSegmentRatio(min(arc.numSegments - 1.0, segmentIndex + 1.0));
+  var nextRatio = getSegmentRatio(min(arc.numSegments - 1.0, segmentIndex + 1.0));
+  // If this is the first point, use next - current as direction.
+  var indexDirection = select(-1.0, 1.0, segmentIndex <= 0.0);
+  var isValid = 1.0;
 
-  var sourceWorld = attributes.instanceSourcePositions;
-  var targetWorld = attributes.instanceTargetPositions;
-  if (arc.useShortestPath != 0.0) {
-    sourceWorld.x = ((sourceWorld.x + 180.0) % 360.0) - 180.0;
-    targetWorld.x = ((targetWorld.x + 180.0) % 360.0) - 180.0;
-    let deltaLongitude = targetWorld.x - sourceWorld.x;
-    if (deltaLongitude > 180.0) {
-      targetWorld.x -= 360.0;
+  var currentClip: vec4<f32>;
+  var nextClip: vec4<f32>;
+
+  if (
+    (arc.greatCircle != 0.0 || project.projectionMode == PROJECTION_MODE_GLOBE) &&
+    project.coordinateSystem == COORDINATE_SYSTEM_LNGLAT
+  ) {
+    let source = project_globe_(vec3<f32>(attributes.instanceSourcePositions.xy, 0.0));
+    let targetPosition = project_globe_(vec3<f32>(attributes.instanceTargetPositions.xy, 0.0));
+    let angularDistance = getAngularDistance(
+      attributes.instanceSourcePositions.xy,
+      attributes.instanceTargetPositions.xy
+    );
+
+    let previousPosition = interpolateGreatCircle(
+      attributes.instanceSourcePositions,
+      attributes.instanceTargetPositions,
+      source,
+      targetPosition,
+      angularDistance,
+      previousRatio,
+      attributes.instanceHeights
+    );
+    var currentPosition = interpolateGreatCircle(
+      attributes.instanceSourcePositions,
+      attributes.instanceTargetPositions,
+      source,
+      targetPosition,
+      angularDistance,
+      segmentRatio,
+      attributes.instanceHeights
+    );
+    var nextPosition = interpolateGreatCircle(
+      attributes.instanceSourcePositions,
+      attributes.instanceTargetPositions,
+      source,
+      targetPosition,
+      angularDistance,
+      nextRatio,
+      attributes.instanceHeights
+    );
+
+    if (abs(currentPosition.x - previousPosition.x) > 180.0) {
+      indexDirection = -1.0;
+      isValid = 0.0;
+    } else if (abs(currentPosition.x - nextPosition.x) > 180.0) {
+      indexDirection = 1.0;
+      isValid = 0.0;
     }
-    if (deltaLongitude < -180.0) {
-      sourceWorld.x -= 360.0;
+    nextPosition = select(nextPosition, previousPosition, indexDirection < 0.0);
+    nextRatio = select(nextRatio, previousRatio, indexDirection < 0.0);
+
+    if (isValid == 0.0) {
+      // Split at the antimeridian.
+      nextPosition.x += select(360.0, -360.0, nextPosition.x > 0.0);
+      let ratio = (
+        select(-180.0, 180.0, currentPosition.x > 0.0) - currentPosition.x
+      ) / (nextPosition.x - currentPosition.x);
+      currentPosition = mix(currentPosition, nextPosition, ratio);
+      segmentRatio = mix(segmentRatio, nextRatio, ratio);
     }
+
+    let currentPosition64Low = mix(
+      attributes.instanceSourcePositions64Low,
+      attributes.instanceTargetPositions64Low,
+      segmentRatio
+    );
+    let nextPosition64Low = mix(
+      attributes.instanceSourcePositions64Low,
+      attributes.instanceTargetPositions64Low,
+      nextRatio
+    );
+    let currentProjection = project_position_to_clipspace_and_commonspace(
+      currentPosition,
+      currentPosition64Low,
+      ZERO_OFFSET
+    );
+    currentClip = currentProjection.clipPosition;
+    nextClip = project_position_to_clipspace(nextPosition, nextPosition64Low, ZERO_OFFSET);
+    geometry.position = currentProjection.commonPosition;
+  } else {
+    var sourceWorld = attributes.instanceSourcePositions;
+    var targetWorld = attributes.instanceTargetPositions;
+    if (arc.useShortestPath != 0.0) {
+      sourceWorld.x = ((sourceWorld.x + 180.0) % 360.0) - 180.0;
+      targetWorld.x = ((targetWorld.x + 180.0) % 360.0) - 180.0;
+      let deltaLongitude = targetWorld.x - sourceWorld.x;
+      if (deltaLongitude > 180.0) {
+        targetWorld.x -= 360.0;
+      }
+      if (deltaLongitude < -180.0) {
+        sourceWorld.x -= 360.0;
+      }
+    }
+
+    let source = project_position_vec3_f64(
+      sourceWorld,
+      attributes.instanceSourcePositions64Low
+    );
+    let targetPosition = project_position_vec3_f64(
+      targetWorld,
+      attributes.instanceTargetPositions64Low
+    );
+
+    // Common x at longitude=-180.
+    var antimeridianX = 0.0;
+    if (arc.useShortestPath != 0.0) {
+      if (project.projectionMode == PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET) {
+        antimeridianX = -(project.coordinateOrigin.x + 180.0) / 360.0 * TILE_SIZE;
+      }
+      let thresholdRatio = (antimeridianX - source.x) / (targetPosition.x - source.x);
+      if (previousRatio <= thresholdRatio && nextRatio > thresholdRatio) {
+        isValid = 0.0;
+        indexDirection = sign(segmentRatio - thresholdRatio);
+        segmentRatio = thresholdRatio;
+      }
+    }
+
+    nextRatio = select(nextRatio, previousRatio, indexDirection < 0.0);
+    var currentPosition = interpolateFlat(
+      source,
+      targetPosition,
+      segmentRatio,
+      attributes.instanceHeights,
+      attributes.instanceTilts
+    );
+    var nextPosition = interpolateFlat(
+      source,
+      targetPosition,
+      nextRatio,
+      attributes.instanceHeights,
+      attributes.instanceTilts
+    );
+
+    if (arc.useShortestPath != 0.0 && nextPosition.x < antimeridianX) {
+      currentPosition.x += TILE_SIZE;
+      nextPosition.x += TILE_SIZE;
+    }
+
+    currentClip = project_common_position_to_clipspace(vec4<f32>(currentPosition, 1.0));
+    nextClip = project_common_position_to_clipspace(vec4<f32>(nextPosition, 1.0));
+    geometry.position = vec4<f32>(currentPosition, 1.0);
   }
 
-  let source = project_position_vec3_f64(sourceWorld, attributes.instanceSourcePositions64Low);
-  let targetPosition = project_position_vec3_f64(
-    targetWorld,
-    attributes.instanceTargetPositions64Low
-  );
-  let currentPosition = interpolateFlat(
-    source,
-    targetPosition,
-    segmentRatio,
-    attributes.instanceHeights,
-    attributes.instanceTilts
-  );
-  let directionRatio = select(nextRatio, previousRatio, segmentIndex > 0.0);
-  let nextPosition = interpolateFlat(
-    source,
-    targetPosition,
-    directionRatio,
-    attributes.instanceHeights,
-    attributes.instanceTilts
-  );
-
-  geometry.position = vec4<f32>(currentPosition, 1.0);
   geometry.uv = vec2<f32>(segmentRatio, segmentSide);
   geometry.pickingColor = picking_getPickingColorFromIndex(instanceIndex);
 
-  let currentClip = project_common_position_to_clipspace(geometry.position);
-  let nextClip = project_common_position_to_clipspace(vec4<f32>(nextPosition, 1.0));
   let widthPixels = clamp(
     project_unit_size_to_pixel(attributes.instanceWidths * arc.widthScale, arc.widthUnits),
     arc.widthMinPixels,
     arc.widthMaxPixels
   );
-  let offset = getExtrusionOffset(nextClip.xy - currentClip.xy, segmentSide, widthPixels);
+  let offset = getExtrusionOffset(
+    (nextClip.xy - currentClip.xy) * indexDirection,
+    segmentSide,
+    widthPixels
+  );
 
   var output: Varyings;
   output.position = currentClip + vec4<f32>(project_pixel_size_to_clipspace(offset), 0.0, 0.0);
@@ -138,11 +298,16 @@ fn vertexMain(
   output.color = vec4<f32>(color.rgb, color.a * layer.opacity);
   output.uv = geometry.uv;
   output.pickingColor = geometry.pickingColor;
+  output.isValid = isValid;
   return output;
 }
 
 @fragment
 fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
+  if (varyings.isValid == 0.0) {
+    discard;
+  }
+
   var color = varyings.color;
   if (picking.isActive > 0.5) {
     if (!picking_isColorValid(varyings.pickingColor)) {

--- a/modules/layers/src/column-layer/column-layer-uniforms.ts
+++ b/modules/layers/src/column-layer/column-layer-uniforms.ts
@@ -4,6 +4,27 @@
 
 import type {ShaderModule} from '@luma.gl/shadertools';
 
+const uniformBlockWGSL = /* wgsl */ `\
+struct ColumnUniforms {
+  radius: f32,
+  angle: f32,
+  offset: vec2<f32>,
+  extruded: f32,
+  stroked: f32,
+  isStroke: f32,
+  coverage: f32,
+  elevationScale: f32,
+  edgeDistance: f32,
+  widthScale: f32,
+  widthMinPixels: f32,
+  widthMaxPixels: f32,
+  radiusUnits: i32,
+  widthUnits: i32,
+};
+
+@group(0) @binding(auto) var<uniform> column: ColumnUniforms;
+`;
+
 const uniformBlock = `\
 layout(std140) uniform columnUniforms {
   float radius;
@@ -42,6 +63,7 @@ export type ColumnProps = {
 
 export const columnUniforms = {
   name: 'column',
+  source: uniformBlockWGSL,
   vs: uniformBlock,
   fs: uniformBlock,
   uniformTypes: {

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -5,6 +5,7 @@
 import {
   Layer,
   project32,
+  color,
   picking,
   UNIT,
   LayerProps,
@@ -24,6 +25,7 @@ import {Geometry, Model} from '@luma.gl/engine';
 import ColumnGeometry from './column-geometry';
 
 import {columnUniforms, ColumnProps} from './column-layer-uniforms';
+import {getColumnLayerWGSL as source} from './column-layer.wgsl';
 import vs from './column-layer-vertex.glsl';
 import fs from './column-layer-fragment.glsl';
 
@@ -231,14 +233,22 @@ export default class ColumnLayer<DataT = any, ExtraPropsT extends {} = {}> exten
     const defines: Record<string, any> = {};
 
     const {flatShading} = this.props;
+    const isWebGPU = this.context.device.type === 'webgpu';
     if (flatShading) {
       defines.FLAT_SHADING = 1;
     }
     return super.getShaders({
+      ...(isWebGPU ? {source: source(flatShading)} : {}),
       vs,
       fs,
       defines,
-      modules: [project32, flatShading ? phongMaterial : gouraudMaterial, picking, columnUniforms]
+      modules: [
+        project32,
+        ...(isWebGPU ? [color] : []),
+        flatShading ? phongMaterial : gouraudMaterial,
+        picking,
+        columnUniforms
+      ]
     });
   }
 

--- a/modules/layers/src/column-layer/column-layer.wgsl.ts
+++ b/modules/layers/src/column-layer/column-layer.wgsl.ts
@@ -1,0 +1,216 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const sharedSource = /* wgsl */ `\
+struct Attributes {
+  @builtin(instance_index) instanceIndex: u32,
+  @location(0) positions: vec3<f32>,
+  @location(1) normals: vec3<f32>,
+  @location(2) instancePositions: vec3<f32>,
+  @location(3) instancePositions64Low: vec3<f32>,
+  @location(4) instanceElevations: f32,
+  @location(5) instanceFillColors: vec4<f32>,
+  @location(6) instanceLineColors: vec4<f32>,
+  @location(7) instanceStrokeWidths: f32
+};
+
+fn getRotationMatrix(angle: f32) -> mat2x2<f32> {
+  let s = sin(angle);
+  let c = cos(angle);
+  return mat2x2<f32>(
+    vec2<f32>(c, s),
+    vec2<f32>(-s, c)
+  );
+}
+
+fn getOffset(
+  positions: vec3<f32>,
+  strokeOffsetRatio: f32,
+  dotRadius: f32,
+  rotationMatrix: mat2x2<f32>
+) -> vec3<f32> {
+  var offset = (rotationMatrix * positions.xy * strokeOffsetRatio + column.offset) * dotRadius;
+  if (column.radiusUnits == UNIT_METERS) {
+    offset = project_size_vec2(offset);
+  } else if (column.radiusUnits == UNIT_PIXELS) {
+    offset = project_pixel_size_vec2(offset);
+  }
+  return vec3<f32>(offset, 0.0);
+}
+`;
+
+const smoothSource = /* wgsl */ `\
+${sharedSource}
+
+struct Varyings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>
+};
+
+@vertex
+fn vertexMain(attributes: Attributes) -> Varyings {
+  var varyings: Varyings;
+
+  geometry.worldPosition = attributes.instancePositions;
+  geometry.pickingColor = picking_getPickingColorFromIndex(attributes.instanceIndex);
+
+  let isStroke = column.isStroke > 0.5;
+  let baseColor = select(attributes.instanceFillColors, attributes.instanceLineColors, isStroke);
+  let rotationMatrix = getRotationMatrix(column.angle);
+
+  var elevation = 0.0;
+  var strokeOffsetRatio = 1.0;
+
+  if (column.extruded > 0.5) {
+    elevation =
+      attributes.instanceElevations * (attributes.positions.z + 1.0) / 2.0 * column.elevationScale;
+  } else if (column.stroked > 0.5) {
+    let widthPixels = clamp(
+      project_unit_size_to_pixel(attributes.instanceStrokeWidths * column.widthScale, column.widthUnits),
+      column.widthMinPixels,
+      column.widthMaxPixels
+    ) / 2.0;
+    let halfOffset =
+      project_pixel_size_float(widthPixels) /
+      project_size_float(column.edgeDistance * column.coverage * column.radius);
+    if (isStroke) {
+      strokeOffsetRatio -= sign(attributes.positions.z) * halfOffset;
+    } else {
+      strokeOffsetRatio -= halfOffset;
+    }
+  }
+
+  let shouldRender = select(0.0, 1.0, baseColor.a > 0.0 && attributes.instanceElevations >= 0.0);
+  let dotRadius = column.radius * column.coverage * shouldRender;
+  let centroidPosition =
+    vec3<f32>(
+      attributes.instancePositions.xy,
+      attributes.instancePositions.z + elevation
+    );
+  let offset = getOffset(attributes.positions, strokeOffsetRatio, dotRadius, rotationMatrix);
+  let projected = project_position_to_clipspace_and_commonspace(
+    centroidPosition,
+    attributes.instancePositions64Low,
+    offset
+  );
+
+  geometry.position = projected.commonPosition;
+  geometry.normal = project_normal(vec3<f32>(rotationMatrix * attributes.normals.xy, attributes.normals.z));
+
+  let lightColor = lighting_getLightColor2(
+    baseColor.rgb,
+    project.cameraPosition,
+    geometry.position.xyz,
+    geometry.normal
+  );
+
+  varyings.position = projected.clipPosition;
+  varyings.color = vec4<f32>(
+    select(baseColor.rgb, lightColor, column.extruded > 0.5 && !isStroke),
+    baseColor.a * layer.opacity
+  );
+
+  return varyings;
+}
+
+@fragment
+fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
+  geometry.uv = vec2<f32>(0.0);
+  return deckgl_premultiplied_alpha(varyings.color);
+}
+`;
+
+const flatSource = /* wgsl */ `\
+${sharedSource}
+
+struct Varyings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) cameraPosition: vec3<f32>,
+  @location(2) positionCommonspace: vec4<f32>
+};
+
+@vertex
+fn vertexMain(attributes: Attributes) -> Varyings {
+  var varyings: Varyings;
+
+  geometry.worldPosition = attributes.instancePositions;
+  geometry.pickingColor = picking_getPickingColorFromIndex(attributes.instanceIndex);
+
+  let isStroke = column.isStroke > 0.5;
+  let baseColor = select(attributes.instanceFillColors, attributes.instanceLineColors, isStroke);
+  let rotationMatrix = getRotationMatrix(column.angle);
+
+  var elevation = 0.0;
+  var strokeOffsetRatio = 1.0;
+
+  if (column.extruded > 0.5) {
+    elevation =
+      attributes.instanceElevations * (attributes.positions.z + 1.0) / 2.0 * column.elevationScale;
+  } else if (column.stroked > 0.5) {
+    let widthPixels = clamp(
+      project_unit_size_to_pixel(attributes.instanceStrokeWidths * column.widthScale, column.widthUnits),
+      column.widthMinPixels,
+      column.widthMaxPixels
+    ) / 2.0;
+    let halfOffset =
+      project_pixel_size_float(widthPixels) /
+      project_size_float(column.edgeDistance * column.coverage * column.radius);
+    if (isStroke) {
+      strokeOffsetRatio -= sign(attributes.positions.z) * halfOffset;
+    } else {
+      strokeOffsetRatio -= halfOffset;
+    }
+  }
+
+  let shouldRender = select(0.0, 1.0, baseColor.a > 0.0 && attributes.instanceElevations >= 0.0);
+  let dotRadius = column.radius * column.coverage * shouldRender;
+  let centroidPosition =
+    vec3<f32>(
+      attributes.instancePositions.xy,
+      attributes.instancePositions.z + elevation
+    );
+  let offset = getOffset(attributes.positions, strokeOffsetRatio, dotRadius, rotationMatrix);
+  let projected = project_position_to_clipspace_and_commonspace(
+    centroidPosition,
+    attributes.instancePositions64Low,
+    offset
+  );
+
+  geometry.position = projected.commonPosition;
+  geometry.normal = project_normal(vec3<f32>(rotationMatrix * attributes.normals.xy, attributes.normals.z));
+
+  varyings.position = projected.clipPosition;
+  varyings.color = vec4<f32>(baseColor.rgb, baseColor.a * layer.opacity);
+  varyings.cameraPosition = project.cameraPosition;
+  varyings.positionCommonspace = projected.commonPosition;
+
+  return varyings;
+}
+
+@fragment
+fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
+  geometry.uv = vec2<f32>(0.0);
+
+  var fragColor = varyings.color;
+  if (column.extruded > 0.5 && column.isStroke < 0.5) {
+    let normal = normalize(cross(dpdx(varyings.positionCommonspace.xyz), dpdy(varyings.positionCommonspace.xyz)));
+    fragColor = vec4<f32>(
+      lighting_getLightColor2(
+        varyings.color.rgb,
+        varyings.cameraPosition,
+        varyings.positionCommonspace.xyz,
+        normal
+      ),
+      varyings.color.a
+    );
+  }
+
+  return deckgl_premultiplied_alpha(fragColor);
+}
+`;
+
+export function getColumnLayerWGSL(flatShading: boolean): string {
+  return flatShading ? flatSource : smoothSource;
+}


### PR DESCRIPTION
## What changed

- Added WGSL shaders and WGSL uniform blocks for `ArcLayer`, `ColumnLayer`, and `GridCellLayer`.
- Updated the WebGPU support table for those layers.
- Corrected the shared WebGPU layer-pass blend state to use premultiplied-alpha over blending.

## Why

These are leaf layer ports that do not need new attribute layouts, interleaved buffers, aggregation fallbacks, or extension behavior. The WebGPU shader source and `color` module are selected only when `device.type === 'webgpu'`, so the WebGL shader/module path remains the same as `master`.

The blend-state correction is WebGPU-only and matches the premultiplied color emitted by the WGSL shader path; it fixes over-bright ArcLayer compositing without changing WebGL parameters.

## Impact

- `ArcLayer`, `ColumnLayer`, and `GridCellLayer` can render on WebGPU.
- Existing WebGL behavior is unchanged.
- Website device toggles are intentionally deferred: the Arc website example also instantiates GeoJsonLayer, and there is no standalone Column/GridCell website example.

## Validation

- `yarn build`
- `yarn lint` (passes with existing warnings)
- `yarn test-headless test/modules/layers/column-layer.spec.ts` (1/1)
- `yarn test-render test/render/test-cases/arc-layer.spec.ts test/render/test-cases/column-layer.spec.ts` (17/17)
- Commit hook node suite (21/21)