### PR TITLE
feat(website): persist selected device tab

### DIFF
--- a/website/src/store/device-store.jsx
+++ b/website/src/store/device-store.jsx
@@ -16,10 +16,27 @@ function getStoredDeviceType() {
     return undefined;
   }
 
-  const storedDeviceType = window.localStorage.getItem(DEVICE_TYPE_STORAGE_KEY);
-  return storedDeviceType === 'webgl' || storedDeviceType === 'webgpu'
-    ? storedDeviceType
-    : undefined;
+  try {
+    const storedDeviceType = window.localStorage.getItem(DEVICE_TYPE_STORAGE_KEY);
+    return storedDeviceType === 'webgl' || storedDeviceType === 'webgpu'
+      ? storedDeviceType
+      : undefined;
+  } catch {
+    // Some browser policies block localStorage access. Persistence is best-effort.
+    return undefined;
+  }
+}
+
+function storeDeviceType(deviceType) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(DEVICE_TYPE_STORAGE_KEY, deviceType);
+  } catch {
+    // Some browser policies block localStorage access. Persistence is best-effort.
+  }
 }
 
 export async function createDevice(type) {
@@ -52,9 +69,7 @@ export const useStore = create(set => ({
     } catch (error) {
       deviceError = error.message;
     }
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(DEVICE_TYPE_STORAGE_KEY, deviceType);
-    }
+    storeDeviceType(deviceType);
     return set(state => ({deviceType, deviceError, device}));
   },
 }));

--- a/website/src/store/device-store.jsx
+++ b/website/src/store/device-store.jsx
@@ -9,6 +9,18 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 
 const cachedDevice = {};
+const DEVICE_TYPE_STORAGE_KEY = 'deck-device-type';
+
+function getStoredDeviceType() {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const storedDeviceType = window.localStorage.getItem(DEVICE_TYPE_STORAGE_KEY);
+  return storedDeviceType === 'webgl' || storedDeviceType === 'webgpu'
+    ? storedDeviceType
+    : undefined;
+}
 
 export async function createDevice(type) {
   cachedDevice[type] =
@@ -40,6 +52,14 @@ export const useStore = create(set => ({
     } catch (error) {
       deviceError = error.message;
     }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DEVICE_TYPE_STORAGE_KEY, deviceType);
+    }
     return set(state => ({deviceType, deviceError, device}));
   },
 }));
+
+const storedDeviceType = getStoredDeviceType();
+if (storedDeviceType) {
+  void useStore.getState().setDeviceType(storedDeviceType);
+}


### PR DESCRIPTION
## What changed

- match luma.gl by peristing the selected website device tab in `localStorage` under `deck-device-type`.
- Restore a validated `webgl` or `webgpu` selection when the client-side device store initializes.
- Ignore missing or unrecognized stored values and preserve the existing default behavior.

## Why

Changing an example to WebGPU and then reloading previously reset the UI to WebGL2, so reloads could hide WebGPU initialization or shader errors. Persisting the selected backend mirrors the luma.gl website behavior and makes reload-based smoke testing reliable.

## Impact

- Selecting WebGPU, then reloading or navigating to another supported example, recreates a WebGPU device automatically.
- Selecting WebGL2 persists the same way.
- Server-side rendering remains unchanged because storage is only read in the browser.

## Validation

- `yarn lint` (passes with existing warnings)
- `yarn test-website`
- Live local website check: selected WebGPU on LineLayer, reloaded, observed WebGPU restored after device creation, and found no console errors.
- Commit hook node suite (21/21)