### PR TITLE
feat(aggregation-layers): port ScreenGridLayer to WebGPU

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -48,7 +48,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/layers` | `GeoJsonLayer` | ✅ | ❌ |
 | `@deck.gl/layers` | `TextLayer` | ✅ | ❌ |
 | `@deck.gl/layers` | `SolidPolygonLayer` | ✅ | ❌ |
-| `@deck.gl/aggregation-layers` | `ScreenGridLayer` | ✅ | ❌ |
+| `@deck.gl/aggregation-layers` | `ScreenGridLayer` | ✅ | ✅ |
 | `@deck.gl/aggregation-layers` | `HexagonLayer` | ✅ | ❌ |
 | `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ❌ |
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ❌ |

--- a/examples/website/screen-grid/app.tsx
+++ b/examples/website/screen-grid/app.tsx
@@ -9,6 +9,7 @@ import {DeckGL} from '@deck.gl/react';
 import {ScreenGridLayer} from '@deck.gl/aggregation-layers';
 
 import type {Color, MapViewState} from '@deck.gl/core';
+import type {Device} from '@luma.gl/core';
 
 // Source data CSV
 const DATA_URL =
@@ -41,13 +42,15 @@ export default function App({
   cellSize = 20,
   gpuAggregation = true,
   aggregation = 'SUM',
-  mapStyle = MAP_STYLE
+  mapStyle = MAP_STYLE,
+  device
 }: {
   data?: string | DataPoint[];
   cellSize?: number;
   gpuAggregation?: boolean;
   aggregation?: 'SUM' | 'MEAN' | 'MIN' | 'MAX';
   mapStyle?: string;
+  device?: Device;
 }) {
   const layers = [
     new ScreenGridLayer<DataPoint>({
@@ -64,7 +67,7 @@ export default function App({
   ];
 
   return (
-    <DeckGL layers={layers} initialViewState={INITIAL_VIEW_STATE} controller={true}>
+    <DeckGL device={device} layers={layers} initialViewState={INITIAL_VIEW_STATE} controller={true}>
       <Map reuseMaps mapStyle={mapStyle} />
     </DeckGL>
   );

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
@@ -4,12 +4,12 @@
 
 import {Texture} from '@luma.gl/core';
 import {Model, Geometry} from '@luma.gl/engine';
-import {Layer, picking, UpdateParameters, Color} from '@deck.gl/core';
+import {Layer, color, picking, UpdateParameters, Color} from '@deck.gl/core';
 import {createColorRangeTexture, updateColorRangeTexture} from '../common/utils/color-utils';
+import source from './screen-grid-cell-layer.wgsl';
 import vs from './screen-grid-layer-vertex.glsl';
 import fs from './screen-grid-layer-fragment.glsl';
 import {ScreenGridProps, screenGridUniforms} from './screen-grid-layer-uniforms';
-import {ShaderModule} from '@luma.gl/shadertools';
 import type {ScaleType} from '../common/types';
 
 /** Proprties added by ScreenGridCellLayer. */
@@ -31,7 +31,10 @@ export default class ScreenGridCellLayer<ExtraPropsT extends {} = {}> extends La
     colorTexture: Texture;
   };
 
-  getShaders(): {vs: string; fs: string; modules: ShaderModule[]} {
+  getShaders() {
+    if (this.context.device.type === 'webgpu') {
+      return super.getShaders({source, vs, fs, modules: [color, picking, screenGridUniforms]});
+    }
     return super.getShaders({vs, fs, modules: [picking, screenGridUniforms]});
   }
 

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.wgsl.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.wgsl.ts
@@ -52,6 +52,25 @@ fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
     }
     return vec4<f32>(varyings.pickingColor, 1.0);
   }
-  return deckgl_premultiplied_alpha(varyings.color);
+
+  var color = varyings.color;
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedObjectColor = picking_normalizeColor(picking.highlightedObjectColor);
+    if (picking_isColorZero(abs(varyings.pickingColor - highlightedObjectColor))) {
+      let highLightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highLightAlpha + color.a * (1.0 - highLightAlpha);
+      if (blendedAlpha > 0.0) {
+        let highLightRatio = highLightAlpha / blendedAlpha;
+        color = vec4<f32>(
+          mix(color.rgb, picking.highlightColor.rgb, highLightRatio),
+          blendedAlpha
+        );
+      } else {
+        color = vec4<f32>(color.rgb, 0.0);
+      }
+    }
+  }
+
+  return deckgl_premultiplied_alpha(color);
 }
 `;

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.wgsl.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.wgsl.ts
@@ -1,0 +1,57 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `
+struct Attributes {
+  @builtin(instance_index) instanceIndex: u32,
+  @location(0) positions: vec2<f32>,
+  @location(1) instancePositions: vec2<f32>,
+  @location(2) instanceWeights: f32,
+};
+
+struct Varyings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) pickingColor: vec3<f32>,
+};
+
+fn sampleColorRange(value: f32, domain: vec2<f32>) -> vec4<f32> {
+  let ratio = (value - domain.x) / (domain.y - domain.x);
+  return textureSampleLevel(colorRange, colorRangeSampler, vec2<f32>(ratio, 0.5), 0.0);
+}
+
+@vertex
+fn vertexMain(attributes: Attributes) -> Varyings {
+  var output: Varyings;
+  output.pickingColor = picking_getPickingColorFromIndex(attributes.instanceIndex);
+
+  if (attributes.instanceWeights != attributes.instanceWeights) {
+    output.position = vec4<f32>(0.0);
+    output.color = vec4<f32>(0.0);
+    return output;
+  }
+
+  var position =
+    attributes.instancePositions * screenGrid.gridSizeClipspace +
+    attributes.positions * screenGrid.cellSizeClipspace;
+  position.x -= 1.0;
+  position.y = 1.0 - position.y;
+
+  output.position = vec4<f32>(position, 0.0, 1.0);
+  let colorValue = sampleColorRange(attributes.instanceWeights, screenGrid.colorDomain);
+  output.color = vec4<f32>(colorValue.rgb, colorValue.a * layer.opacity);
+  return output;
+}
+
+@fragment
+fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(varyings.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(varyings.pickingColor, 1.0);
+  }
+  return deckgl_premultiplied_alpha(varyings.color);
+}
+`;

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer-uniforms.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-layer-uniforms.ts
@@ -5,6 +5,18 @@
 import {Texture} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
+const uniformBlockWGSL = /* wgsl */ `
+struct ScreenGridUniforms {
+  cellSizeClipspace: vec2<f32>,
+  gridSizeClipspace: vec2<f32>,
+  colorDomain: vec2<f32>,
+};
+
+@group(0) @binding(auto) var<uniform> screenGrid: ScreenGridUniforms;
+@group(0) @binding(auto) var colorRange: texture_2d<f32>;
+@group(0) @binding(auto) var colorRangeSampler: sampler;
+`;
+
 const uniformBlock = /* glsl */ `\
 layout(std140) uniform screenGridUniforms {
   vec2 cellSizeClipspace;
@@ -22,6 +34,7 @@ export type ScreenGridProps = {
 
 export const screenGridUniforms = {
   name: 'screenGrid',
+  source: uniformBlockWGSL,
   vs: uniformBlock,
   uniformTypes: {
     cellSizeClipspace: 'vec2<f32>',

--- a/website/src/examples/screen-grid-layer.js
+++ b/website/src/examples/screen-grid-layer.js
@@ -12,6 +12,8 @@ import {makeExample} from '../components';
 class ScreenGridDemo extends Component {
   static title = 'Uber Pickup Locations In NewYork City';
 
+  static hasDeviceTabs = true;
+
   static code = `${GITHUB_TREE}/examples/website/screen-grid`;
 
   static data = {
@@ -95,6 +97,8 @@ class ScreenGridDemo extends Component {
     return (
       <App
         {...this.props}
+        key={this.props.device?.type}
+        device={this.props.device}
         data={this.state.dataSample || data}
         cellSize={cellSize}
         gpuAggregation={gpuAggregation}


### PR DESCRIPTION
## Goal

Port ScreenGridLayer's cell renderer to WebGPU as a small extraction from #10450, and expose the website example through the device tabs.

## Changes

- Added WGSL vertex/fragment shader support for `ScreenGridCellLayer`.
- Added WGSL declarations for the screen-grid uniforms and color-range texture bindings.
- Kept WebGL behavior aligned with `master`: WebGL still calls the same `super.getShaders({vs, fs, modules: [picking, screenGridUniforms]})`; only WebGPU receives the WGSL source and `color` shader module.
- Passed the selected device into the ScreenGrid example and enabled its WebGL2/WebGPU tabs.

## Website examples

| Layer / example | WebGPU aggregation | WebGPU render path | Status |
| --- | --- | --- | --- |
| ScreenGridLayer / Uber pickups | Existing CPU fallback when `WebGLAggregator` is unavailable | `ScreenGridCellLayer` WGSL shader | ✅ Works |

The aggregation behavior is unchanged: WebGPU selects the existing CPU aggregator because `WebGLAggregator.isSupported(device)` is false. This PR only ports the cell rendering path.

## Validation

- `yarn build`
- `yarn lint` (passes; repository's existing warnings remain)
- `yarn test-headless test/modules/aggregation-layers/screen-grid-layer.spec.ts test/modules/aggregation-layers/screengrid-cell-layer.spec.ts`
- `yarn test-website`
- Manual website check: selected the WebGPU tab on `/examples/screen-grid-layer`; the example rendered and the browser console had no errors.
