### PR TITLE
refactor(core): honor canvas contexts throughout render passes

### DIFF
--- a/modules/core/src/lib/deck-picker.ts
+++ b/modules/core/src/lib/deck-picker.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Buffer, Texture} from '@luma.gl/core';
-import type {CanvasContext, Device} from '@luma.gl/core';
+import type {CanvasContext, Device, PresentationContext} from '@luma.gl/core';
 import PickLayersPass, {PickingColorDecoder} from '../passes/pick-layers-pass';
 import log from '../utils/log';
 import {getClosestObject, getUniqueObjects, PickedPixel} from './picking/query-object';
@@ -44,7 +44,7 @@ type PickOperationContext = {
   layers: Layer[];
   views: Record<string, View>;
   viewports: Viewport[];
-  canvasContext?: CanvasContext;
+  canvasContext?: CanvasContext | PresentationContext;
   onViewportActive: (viewport: Viewport) => void;
   effects: Effect[];
 };
@@ -158,7 +158,9 @@ export default class DeckPicker {
   // Private
 
   /** Ensures that picking framebuffer exists and matches the canvas size */
-  _resizeBuffer(canvasContext: CanvasContext = this.device.getDefaultCanvasContext()) {
+  _resizeBuffer(
+    canvasContext: CanvasContext | PresentationContext = this.device.getDefaultCanvasContext()
+  ) {
     // Create a frame buffer if not already available
     if (!this.pickingFBO) {
       const pickingColorTexture = this.device.createTexture({
@@ -282,7 +284,8 @@ export default class DeckPicker {
           deviceRect,
           cullRect,
           effects,
-          pass: `picking:${mode}`
+          pass: `picking:${mode}`,
+          canvasContext
         });
 
         pickInfo = getClosestObject({
@@ -316,7 +319,8 @@ export default class DeckPicker {
             },
             cullRect,
             effects,
-            pass: `picking:${mode}:z`
+            pass: `picking:${mode}:z`,
+            canvasContext
           },
           true
         );
@@ -446,7 +450,8 @@ export default class DeckPicker {
           deviceRect,
           cullRect,
           effects,
-          pass: `picking:${mode}`
+          pass: `picking:${mode}`,
+          canvasContext
         });
 
         pickInfo = getClosestObject({
@@ -480,7 +485,8 @@ export default class DeckPicker {
             },
             cullRect,
             effects,
-            pass: `picking:${mode}:z`
+            pass: `picking:${mode}:z`,
+            canvasContext
           },
           true
         );
@@ -588,7 +594,8 @@ export default class DeckPicker {
       deviceRect,
       cullRect: {x, y, width, height},
       effects,
-      pass: `picking:${mode}`
+      pass: `picking:${mode}`,
+      canvasContext
     });
 
     const pickInfos = getUniqueObjects(pickedResult);
@@ -693,7 +700,8 @@ export default class DeckPicker {
       deviceRect,
       cullRect: {x, y, width, height},
       effects,
-      pass: `picking:${mode}`
+      pass: `picking:${mode}`,
+      canvasContext
     });
 
     const pickInfos = getUniqueObjects(pickedResult);
@@ -751,6 +759,7 @@ export default class DeckPicker {
     onViewportActive: (viewport: Viewport) => void;
     cullRect?: Rect;
     effects: Effect[];
+    canvasContext?: CanvasContext | PresentationContext;
   }): Promise<{
     pickedColors: Uint8Array;
     decodePickingColor: PickingColorDecoder;
@@ -767,6 +776,7 @@ export default class DeckPicker {
       onViewportActive: (viewport: Viewport) => void;
       cullRect?: Rect;
       effects: Effect[];
+      canvasContext?: CanvasContext | PresentationContext;
     },
     pickZ: true
   ): Promise<{
@@ -784,7 +794,8 @@ export default class DeckPicker {
       deviceRect,
       cullRect,
       effects,
-      pass
+      pass,
+      canvasContext
     }: {
       deviceRect: Rect;
       pass: string;
@@ -794,6 +805,7 @@ export default class DeckPicker {
       onViewportActive: (viewport: Viewport) => void;
       cullRect?: Rect;
       effects: Effect[];
+      canvasContext?: CanvasContext | PresentationContext;
     },
     pickZ: boolean = false
   ): Promise<{
@@ -812,6 +824,7 @@ export default class DeckPicker {
       cullRect,
       effects,
       pass,
+      canvasContext,
       pickZ,
       preRenderStats: {},
       isPicking: true
@@ -921,6 +934,7 @@ export default class DeckPicker {
     onViewportActive: (viewport: Viewport) => void;
     cullRect?: Rect;
     effects: Effect[];
+    canvasContext?: CanvasContext | PresentationContext;
   }): {
     pickedColors: Uint8Array;
     decodePickingColor: PickingColorDecoder;
@@ -940,6 +954,7 @@ export default class DeckPicker {
       onViewportActive: (viewport: Viewport) => void;
       cullRect?: Rect;
       effects: Effect[];
+      canvasContext?: CanvasContext | PresentationContext;
     },
     pickZ: true
   ): {
@@ -957,7 +972,8 @@ export default class DeckPicker {
       deviceRect,
       cullRect,
       effects,
-      pass
+      pass,
+      canvasContext
     }: {
       deviceRect: Rect;
       pass: string;
@@ -967,6 +983,7 @@ export default class DeckPicker {
       onViewportActive: (viewport: Viewport) => void;
       cullRect?: Rect;
       effects: Effect[];
+      canvasContext?: CanvasContext | PresentationContext;
     },
     pickZ: boolean = false
   ): {
@@ -985,6 +1002,7 @@ export default class DeckPicker {
       cullRect,
       effects,
       pass,
+      canvasContext,
       pickZ,
       preRenderStats: {},
       isPicking: true

--- a/modules/core/src/lib/deck-renderer.ts
+++ b/modules/core/src/lib/deck-renderer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Device} from '@luma.gl/core';
+import type {CanvasContext, Device, PresentationContext} from '@luma.gl/core';
 import {Framebuffer} from '@luma.gl/core';
 import debug from '../debug/index';
 import DrawLayersPass from '../passes/draw-layers-pass';
@@ -65,6 +65,7 @@ export default class DeckRenderer {
     onViewportActive: (viewport: Viewport) => void;
     effects: Effect[];
     target?: Framebuffer | null;
+    canvasContext?: CanvasContext | PresentationContext;
     layerFilter?: LayerFilter;
     clearStack?: boolean;
     clearCanvas?: boolean;
@@ -146,13 +147,13 @@ export default class DeckRenderer {
     }
 
     if (this.lastPostProcessEffect) {
-      this._resizeRenderBuffers();
+      this._resizeRenderBuffers(opts.canvasContext);
     }
   }
 
-  private _resizeRenderBuffers() {
+  private _resizeRenderBuffers(canvasContext = this.device.canvasContext!) {
     const {renderBuffers} = this;
-    const size = this.device.canvasContext!.getDrawingBufferSize();
+    const size = canvasContext.getDrawingBufferSize();
     const [width, height] = size;
     if (renderBuffers.length === 0) {
       [0, 1].map(i => {

--- a/modules/core/src/lib/deck-renderer.ts
+++ b/modules/core/src/lib/deck-renderer.ts
@@ -177,6 +177,7 @@ export default class DeckRenderer {
 
   private _postRender(effects: Effect[], opts: LayersPassRenderOptions) {
     const {renderBuffers} = this;
+    const target = opts.target ?? opts.canvasContext?.getCurrentFramebuffer() ?? opts.target;
     const params: PostRenderOptions = {
       ...opts,
       inputBuffer: renderBuffers[0],
@@ -186,7 +187,7 @@ export default class DeckRenderer {
       if (effect.postRender) {
         // If not the last post processing effect, unset the target so that
         // it only renders between the swap buffers
-        params.target = effect.id === this.lastPostProcessEffect ? opts.target : undefined;
+        params.target = effect.id === this.lastPostProcessEffect ? target : undefined;
         const buffer = effect.postRender(params);
         // Buffer cannot be null if target is unset
         params.inputBuffer = buffer!;

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -10,6 +10,7 @@ import type Controller from '../controllers/controller';
 import type {ViewStateChangeParameters, InteractionState} from '../controllers/controller';
 import type Viewport from '../viewports/viewport';
 import type View from '../views/view';
+import type {CanvasContext, PresentationContext} from '@luma.gl/core';
 import type {Timeline} from '@luma.gl/engine';
 import type {EventManager} from 'mjolnir.js';
 import type {ConstructorOf} from '../types/types';
@@ -45,7 +46,44 @@ type ViewEventManager = {
   eventManager: EventManager;
 };
 
-/** ViewManager props directly supplied by the user */
+/**
+ * Looks up an existing canvas context without duplicating its resize or pixel-size bookkeeping.
+ * @param canvasId - Presentation canvas to resolve, or undefined to select the default canvas.
+ * @returns The existing render or presentation context, or null when no canvas matches.
+ */
+type CanvasContextResolver = (canvasId?: string) => CanvasContext | PresentationContext | null;
+
+/**
+ * Restricts viewport selection to one presentation canvas, optionally at a CSS-pixel location.
+ * Canvas-only filters intentionally omit coordinates so they return every matching viewport.
+ */
+type ViewportFilter =
+  | {
+      /** Presentation canvas whose viewports should be returned. */
+      canvasId: string;
+    }
+  | {
+      /** Horizontal CSS-pixel coordinate to match. */
+      x: number;
+      /** Vertical CSS-pixel coordinate to match. */
+      y: number;
+      /** Optional width of the CSS-pixel query rectangle. */
+      width?: number;
+      /** Optional height of the CSS-pixel query rectangle. */
+      height?: number;
+      /** Optional presentation canvas that further restricts the pixel query. */
+      canvasId?: string;
+    };
+
+/** CSS-pixel dimensions read directly from an existing canvas context. */
+type CanvasDimensions = {
+  /** Canvas width in CSS pixels. */
+  width: number;
+  /** Canvas height in CSS pixels. */
+  height: number;
+};
+
+/** Internal view, controller, and canvas-routing properties supplied by Deck. */
 type ViewManagerProps<ViewsT extends ViewOrViews> = {
   views: ViewsT;
   viewState: ViewStateObject<ViewsT> | null;
@@ -54,10 +92,13 @@ type ViewManagerProps<ViewsT extends ViewOrViews> = {
   pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
   width?: number;
   height?: number;
+  /** Resolve existing luma contexts, which own all canvas resize and pixel-size tracking. */
+  getCanvasContext?: CanvasContextResolver;
   /** Event managers keyed by presentation canvas id. */
   eventManagers?: Record<string, EventManager>;
 };
 
+/** Builds viewports and routes controllers using their assigned canvas coordinate systems. */
 export default class ViewManager<ViewsT extends View[]> {
   width: number;
   height: number;
@@ -79,7 +120,13 @@ export default class ViewManager<ViewsT extends View[]> {
     onInteractionStateChange?: (state: InteractionState) => void;
   };
   private _pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
+  /** Context lookup supplied by Deck; context dimensions remain owned and observed by luma. */
+  private _getCanvasContext?: CanvasContextResolver;
 
+  /**
+   * Initializes the viewport layout, controller routing, and optional canvas-context lookup.
+   * @param props - Initial views, view state, event managers, dimensions, and context resolver.
+   */
   constructor(
     props: ViewManagerProps<ViewsT> & {
       // Initial options
@@ -109,6 +156,7 @@ export default class ViewManager<ViewsT extends View[]> {
       onInteractionStateChange: props.onInteractionStateChange
     };
     this._pickPosition = props.pickPosition;
+    this._getCanvasContext = props.getCanvasContext;
 
     Object.seal(this);
 
@@ -157,16 +205,21 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
-  /** Get a set of viewports for a given width and height
-   * TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
-   * @param rect (object, optional) - filter the viewports
-   *   + not provided - return all viewports
-   *   + {x, y} - only return viewports that contain this pixel
-   *   + {x, y, width, height} - only return viewports that overlap with this rectangle
+  /**
+   * Returns active viewports, optionally restricted by canvas and/or CSS-pixel coordinates.
+   * @param filter - A canvas-only selection or a point/rectangle with an optional canvas id.
+   * @returns Matching viewports in their original rendering order.
    */
-  getViewports(rect?: {x: number; y: number; width?: number; height?: number}): Viewport[] {
-    if (rect) {
-      return this._viewports.filter(viewport => viewport.containsPixel(rect));
+  getViewports(filter?: ViewportFilter): Viewport[] {
+    if (filter) {
+      return this._viewports.filter(viewport => {
+        // Different canvases can contain the same CSS coordinates. First select the requested
+        // canvas, then test pixel containment only when coordinates were actually supplied;
+        // canvas-only queries must retain every viewport on that canvas.
+        const matchesCanvas = !filter.canvasId || this.getCanvasId(viewport.id) === filter.canvasId;
+        const matchesPixel = !('x' in filter) || viewport.containsPixel(filter);
+        return matchesCanvas && matchesPixel;
+      });
     }
     return this._viewports;
   }
@@ -202,11 +255,15 @@ export default class ViewManager<ViewsT extends View[]> {
     return this._viewportMap[viewId];
   }
 
-  /** Return the presentation canvas id assigned to a view. */
+  /**
+   * Resolves the presentation canvas associated with an existing or supplied view.
+   * @param viewOrViewId - View instance or id whose canvas association should be resolved.
+   * @returns The assigned canvas id, or undefined when the view does not exist.
+   */
   getCanvasId(viewOrViewId: string | View): string | undefined {
     const view = typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
     return view
-      ? this._viewEventManagers[view.id]?.canvasId || view.props.canvasId || DEFAULT_CANVAS_ID
+      ? this._viewEventManagers[view.id]?.canvasId || this._getCanvasIdFromView(view)
       : undefined;
   }
 
@@ -331,6 +388,28 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
+  /**
+   * Resolves a view's explicit canvas id, falling back to the existing default canvas context.
+   * @param view - View whose presentation canvas is being determined.
+   * @returns The explicit, default-context, or legacy default canvas id.
+   */
+  private _getCanvasIdFromView(view: View): string {
+    return view.props.canvasId || this._getCanvasContext?.()?.id || DEFAULT_CANVAS_ID;
+  }
+
+  /**
+   * Reads the CSS dimensions used to lay out a view and its controller viewport.
+   * @param view - View whose assigned canvas provides the layout coordinate space.
+   * @returns Context-owned CSS dimensions, or the manager dimensions without a canvas context.
+   */
+  private _getCanvasDimensions(view: View): CanvasDimensions {
+    // Viewport layout uses CSS pixels, not framebuffer pixels. Read them directly from the
+    // observed luma context instead of maintaining a second per-canvas size snapshot.
+    const canvasContext = this._getCanvasContext?.(this._getCanvasIdFromView(view));
+    const [width, height] = canvasContext?.getCSSSize() || [this.width, this.height];
+    return {width, height};
+  }
+
   private _getViewEventManager(view: View): ViewEventManager {
     const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
     return {
@@ -367,6 +446,12 @@ export default class ViewManager<ViewsT extends View[]> {
     return controller;
   }
 
+  /**
+   * Creates a controller that resolves its viewport against the view's assigned canvas.
+   * @param view - View receiving the controller.
+   * @param props - Controller identity and implementation class.
+   * @returns The initialized controller for the view.
+   */
   private _createController(
     view: View,
     props: {id: string; type: ConstructorOf<Controller<any>>}
@@ -382,8 +467,7 @@ export default class ViewManager<ViewsT extends View[]> {
       makeViewport: viewState =>
         this.getView(view.id)?.makeViewport({
           viewState,
-          width: this.width,
-          height: this.height
+          ...this._getCanvasDimensions(view)
         }),
       pickPosition: this._pickPosition
     });
@@ -422,7 +506,7 @@ export default class ViewManager<ViewsT extends View[]> {
     return null;
   }
 
-  // Rebuilds viewports from descriptors towards a certain window size
+  /** Rebuilds each viewport and controller using its presentation canvas's CSS dimensions. */
   private _rebuildViewports(): void {
     const {views} = this;
 
@@ -432,10 +516,11 @@ export default class ViewManager<ViewsT extends View[]> {
     // Create controllers in reverse order, so that views on top receive events first
     for (let i = views.length; i--; ) {
       const view = views[i];
+      const {width, height} = this._getCanvasDimensions(view);
       const viewEventManager = this._getViewEventManager(view);
       this._viewEventManagers[view.id] = viewEventManager;
       const viewState = this.getViewState(view);
-      const viewport = view.makeViewport({viewState, width: this.width, height: this.height});
+      const viewport = view.makeViewport({viewState, width, height});
 
       let oldController = this._getReusableController(
         oldControllers[view.id],

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -3,8 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import type {
+  CanvasContext,
   Device,
   Parameters,
+  PresentationContext,
   RenderPassParameters,
   RenderPipelineParameters
 } from '@luma.gl/core';
@@ -36,6 +38,8 @@ const WEBGPU_DEFAULT_DRAW_PARAMETERS: RenderPipelineParameters = {
 export type LayersPassRenderOptions = {
   /** @deprecated TODO v9 recommend we rename this to framebuffer to minimize confusion */
   target?: Framebuffer | null;
+  /** Canvas context that provides framebuffer dimensions and pixel conversion. */
+  canvasContext?: CanvasContext | PresentationContext;
   isPicking?: boolean;
   pass: string;
   layers: Layer[];
@@ -87,7 +91,7 @@ export default class LayersPass extends Pass {
   }
 
   protected _render(options: LayersPassRenderOptions): RenderStats[] {
-    const canvasContext = this.device.canvasContext!;
+    const {canvasContext = this.device.canvasContext!} = options;
     const framebuffer = options.target ?? canvasContext.getCurrentFramebuffer();
     const [width, height] = canvasContext.getDrawingBufferSize();
 
@@ -126,6 +130,7 @@ export default class LayersPass extends Pass {
   /** Draw a list of layers in a list of viewports */
   private _drawLayers(renderPass: RenderPass, options: LayersPassRenderOptions) {
     const {
+      canvasContext = this.device.canvasContext!,
       target,
       shaderModuleProps,
       viewports,
@@ -156,6 +161,7 @@ export default class LayersPass extends Pass {
           renderPass,
           {
             target,
+            canvasContext,
             shaderModuleProps,
             viewport: subViewport,
             view,
@@ -184,6 +190,7 @@ export default class LayersPass extends Pass {
       cullRect,
       views,
       effects,
+      canvasContext = this.device.canvasContext!,
       shaderModuleProps
     }: LayersPassRenderOptions,
     /** Internal flag, true if only used to determine whether each layer should be drawn */
@@ -223,6 +230,7 @@ export default class LayersPass extends Pass {
           layer,
           effects,
           pass,
+          canvasContext,
           shaderModuleProps
         );
         const defaultParams =
@@ -251,6 +259,7 @@ export default class LayersPass extends Pass {
       shaderModuleProps: globalModuleParameters,
       pass,
       target,
+      canvasContext,
       viewport,
       view,
       isPicking
@@ -259,6 +268,7 @@ export default class LayersPass extends Pass {
       shaderModuleProps: Record<string, any>;
       pass: string;
       target?: Framebuffer | null;
+      canvasContext: CanvasContext | PresentationContext;
       viewport: Viewport;
       view?: View;
       isPicking?: boolean;
@@ -266,6 +276,7 @@ export default class LayersPass extends Pass {
     drawLayerParams: DrawLayerParameters[]
   ): RenderStats {
     const glViewport = getGLViewport(this.device, {
+      canvasContext,
       shaderModuleProps: globalModuleParameters,
       target,
       viewport
@@ -431,10 +442,10 @@ export default class LayersPass extends Pass {
     layer: Layer,
     effects: Effect[] | undefined,
     pass: string,
+    canvasContext: CanvasContext | PresentationContext,
     overrides: any
   ): any {
-    // @ts-expect-error TODO - assuming WebGL context
-    const devicePixelRatio = this.device.canvasContext.cssToDeviceRatio();
+    const devicePixelRatio = canvasContext.cssToDeviceRatio();
     const layerProps = layer.internalState?.propsInTransition || layer.props;
 
     const shaderModuleProps = {
@@ -530,23 +541,22 @@ export function layerIndexResolver(
 function getGLViewport(
   device: Device,
   {
+    canvasContext = device.canvasContext!,
     shaderModuleProps,
     target,
     viewport
   }: {
+    canvasContext?: CanvasContext | PresentationContext;
     shaderModuleProps: any;
     target?: Framebuffer | null;
     viewport: Viewport;
   }
 ): [number, number, number, number] {
   const pixelRatio =
-    shaderModuleProps?.project?.devicePixelRatio ??
-    // @ts-expect-error TODO - assuming WebGL context
-    device.canvasContext.cssToDeviceRatio();
+    shaderModuleProps?.project?.devicePixelRatio ?? canvasContext.cssToDeviceRatio();
 
   // Default framebuffer is used when writing to canvas
-  // @ts-expect-error TODO - assuming WebGL context
-  const [, drawingBufferHeight] = device.canvasContext.getDrawingBufferSize();
+  const [, drawingBufferHeight] = canvasContext.getDrawingBufferSize();
   const height = target ? target.height : drawingBufferHeight;
 
   // Convert viewport top-left CSS coordinates to bottom up WebGL coordinates

--- a/modules/core/src/passes/layers-pass.ts
+++ b/modules/core/src/passes/layers-pass.ts
@@ -119,7 +119,7 @@ export default class LayersPass extends Pass {
     });
 
     try {
-      return this._drawLayers(renderPass, options);
+      return this._drawLayers(renderPass, {...options, target: framebuffer});
     } finally {
       renderPass.end();
       // TODO(ibgreen): WebGPU - submit may not be needed here but initial port had issues with out of render loop rendering

--- a/modules/core/src/passes/pick-layers-pass.ts
+++ b/modules/core/src/passes/pick-layers-pass.ts
@@ -74,6 +74,7 @@ export default class PickLayersPass extends LayersPass {
     effects,
     pass = 'picking',
     pickZ,
+    canvasContext,
     shaderModuleProps,
     clearColor
   }: PickLayersPassRenderOptions): {
@@ -99,6 +100,7 @@ export default class PickLayersPass extends LayersPass {
       cullRect,
       effects: effects?.filter(e => e.useInPicking),
       pass,
+      canvasContext,
       isPicking: true,
       shaderModuleProps,
       clearColor: clearColor ?? [0, 0, 0, 0],

--- a/test/modules/core/lib/deck-picker.spec.ts
+++ b/test/modules/core/lib/deck-picker.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {test, expect} from 'vitest';
+import {test, expect, vi} from 'vitest';
 import {LayerManager, MapView} from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import DeckPicker from '@deck.gl/core/lib/deck-picker';
@@ -90,6 +90,7 @@ test('DeckPicker#pick empty', () => {
     viewState: {longitude: 0, latitude: 0, zoom: 1}
   });
   const layerManager = new LayerManager(device, {viewport});
+  const drawAndSample = vi.spyOn(deckPicker, '_drawAndSample');
 
   const opts = {
     layers: [],
@@ -128,6 +129,12 @@ test('DeckPicker#pick empty', () => {
   deckPicker.setProps({_pickable: true});
   output = deckPicker.pickObject(opts);
   expect(output.result[0].layer, 'Layer is picked').toBe(layer);
+  expect(
+    drawAndSample,
+    'the active canvas context reaches synchronous picking'
+  ).toHaveBeenCalledWith(
+    expect.objectContaining({canvasContext: device.getDefaultCanvasContext()})
+  );
 
   expect(deckPicker.pickingFBO, 'pickingFBO is generated').toBeTruthy();
 
@@ -145,6 +152,7 @@ test('DeckPicker#pick async empty', async () => {
     viewState: {longitude: 0, latitude: 0, zoom: 1}
   });
   const layerManager = new LayerManager(device, {viewport});
+  const drawAndSampleAsync = vi.spyOn(deckPicker, '_drawAndSampleAsync');
 
   const opts = {
     layers: [],
@@ -174,6 +182,12 @@ test('DeckPicker#pick async empty', async () => {
   deckPicker.setProps({_pickable: true});
   output = await deckPicker.pickObjectAsync(opts);
   expect(output.result[0].layer, 'Layer is picked (async)').toBe(layer);
+  expect(
+    drawAndSampleAsync,
+    'the active canvas context reaches asynchronous picking'
+  ).toHaveBeenCalledWith(
+    expect.objectContaining({canvasContext: device.getDefaultCanvasContext()})
+  );
 
   expect(deckPicker.pickingFBO, 'pickingFBO is generated (async)').toBeTruthy();
 

--- a/test/modules/core/lib/deck-renderer.spec.ts
+++ b/test/modules/core/lib/deck-renderer.spec.ts
@@ -1,0 +1,52 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {Viewport} from '@deck.gl/core';
+import DeckRenderer from '@deck.gl/core/lib/deck-renderer';
+import {device} from '@deck.gl/test-utils/vitest';
+import type {CanvasContext, Framebuffer} from '@luma.gl/core';
+import type {Effect, PostRenderOptions} from '@deck.gl/core/lib/effect';
+
+test('DeckRenderer#post processing renders to the supplied canvas framebuffer', () => {
+  const framebuffer = device.createFramebuffer({
+    width: 60,
+    height: 40,
+    colorAttachments: ['rgba8unorm']
+  });
+  const canvasContext = {
+    getCurrentFramebuffer: () => framebuffer,
+    getDrawingBufferSize: () => [60, 40],
+    cssToDeviceRatio: () => 1
+  } as CanvasContext;
+  const postRenderTargets: (Framebuffer | null | undefined)[] = [];
+  const createEffect = (id: string): Effect => ({
+    id,
+    props: {},
+    setup() {},
+    cleanup() {},
+    preRender() {},
+    postRender({target, swapBuffer}: PostRenderOptions) {
+      postRenderTargets.push(target);
+      return target || swapBuffer;
+    }
+  });
+  const deckRenderer = new DeckRenderer(device);
+
+  deckRenderer.renderLayers({
+    pass: 'screen',
+    layers: [],
+    viewports: [new Viewport({id: 'canvas-context-view', width: 60, height: 40})],
+    views: {},
+    onViewportActive: () => {},
+    effects: [createEffect('first-effect'), createEffect('last-effect')],
+    target: null,
+    canvasContext
+  });
+
+  expect(postRenderTargets).toEqual([undefined, framebuffer]);
+
+  deckRenderer.finalize();
+  framebuffer.destroy();
+});

--- a/test/modules/core/lib/view-manager.spec.ts
+++ b/test/modules/core/lib/view-manager.spec.ts
@@ -7,6 +7,7 @@ import {MapView} from '@deck.gl/core';
 import ViewManager from '@deck.gl/core/lib/view-manager';
 import {equals} from '@math.gl/core';
 import {EventManager} from 'mjolnir.js';
+import type {CanvasContext} from '@luma.gl/core';
 
 test('ViewManager#constructor', () => {
   const viewManager = new ViewManager({
@@ -287,6 +288,93 @@ test('ViewManager#routes controllers by canvas event manager', () => {
 });
 
 /* eslint-disable max-statements */
+test('ViewManager#layouts and filters views by canvas', () => {
+  const leftEventManager = new EventManager(document.createElement('div'));
+  const rightEventManager = new EventManager(document.createElement('div'));
+  const leftView = new MapView({id: 'left', canvasId: 'left-canvas'});
+  const rightView = new MapView({id: 'right', canvasId: 'right-canvas'});
+  const canvasSizes: Record<string, [number, number]> = {
+    'left-canvas': [200, 100],
+    'right-canvas': [120, 180]
+  };
+  const canvasContexts = Object.fromEntries(
+    Object.keys(canvasSizes).map(canvasId => [
+      canvasId,
+      {id: canvasId, getCSSSize: () => canvasSizes[canvasId]} as CanvasContext
+    ])
+  );
+
+  const viewManager = new ViewManager({
+    views: [leftView, rightView],
+    viewState: {
+      left: {longitude: -122, latitude: 38, zoom: 10},
+      right: {longitude: -74, latitude: 40.7, zoom: 11}
+    },
+    width: 1,
+    height: 1,
+    getCanvasContext: canvasId => canvasContexts[canvasId || 'left-canvas'] || null,
+    eventManager: leftEventManager,
+    eventManagers: {
+      'left-canvas': leftEventManager,
+      'right-canvas': rightEventManager
+    }
+  });
+
+  expect(viewManager.getViewport('left')?.width).toBe(200);
+  expect(viewManager.getViewport('right')?.height).toBe(180);
+  expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'left-canvas'})).toEqual([
+    viewManager.getViewport('left')
+  ]);
+  expect(viewManager.getViewports({canvasId: 'left-canvas'})).toEqual([
+    viewManager.getViewport('left')
+  ]);
+  expect(viewManager.getViewports({canvasId: 'right-canvas'})).toEqual([
+    viewManager.getViewport('right')
+  ]);
+  expect(viewManager.getViewports({canvasId: 'unknown-canvas'})).toEqual([]);
+  expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'unknown-canvas'})).toEqual([]);
+
+  const viewports = viewManager.getViewports();
+  viewManager.setProps({});
+  expect(viewManager.getViewports(), 'unchanged canvas dimensions preserve viewports').toBe(
+    viewports
+  );
+
+  canvasSizes['left-canvas'] = [240, 140];
+  viewManager.setNeedsUpdate('Canvas resized');
+  viewManager.setProps({});
+  expect(viewManager.getViewport('left')?.width, 'updated dimensions rebuild the viewport').toBe(
+    240
+  );
+
+  viewManager.finalize();
+  leftEventManager.destroy();
+  rightEventManager.destroy();
+});
+
+test('ViewManager#uses the first canvas for views without an explicit canvas id', () => {
+  const eventManager = new EventManager(document.createElement('div'));
+  const canvasContext = {
+    id: 'first-canvas',
+    getCSSSize: () => [160, 90]
+  } as CanvasContext;
+  const viewManager = new ViewManager({
+    views: [new MapView({id: 'main'})],
+    viewState: {longitude: -122, latitude: 38, zoom: 10},
+    width: 1,
+    height: 1,
+    getCanvasContext: () => canvasContext,
+    eventManager
+  });
+
+  expect(viewManager.getCanvasId('main')).toBe('first-canvas');
+  expect(viewManager.getViewport('main')?.width).toBe(160);
+  expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'first-canvas'})).toHaveLength(1);
+
+  viewManager.finalize();
+  eventManager.destroy();
+});
+
 test('ViewManager#zero-size', () => {
   const mainView = new MapView({id: 'main', controller: true});
 

--- a/test/modules/core/passes/layers-pass.spec.ts
+++ b/test/modules/core/passes/layers-pass.spec.ts
@@ -10,6 +10,7 @@ import DrawLayersPass from '@deck.gl/core/passes/draw-layers-pass';
 import {device} from '@deck.gl/test-utils/vitest';
 import {getGLParameters} from '@luma.gl/webgl';
 import {GL} from '@luma.gl/webgl/constants';
+import type {CanvasContext} from '@luma.gl/core';
 
 class TestLayer extends Layer {
   initializeState() {}
@@ -344,6 +345,41 @@ test('LayersPass#viewParameters', () => {
     blendColorSrcFactor: 'src-alpha',
     cullMode: 'none'
   });
+});
+
+test('LayersPass#uses the supplied canvas context', () => {
+  const layer = new TestLayer({id: 'canvas-context-layer'});
+  const layerManager = new LayerManager(device, {});
+  const layersPass = new DrawLayersPass(device);
+  const framebuffer = device.createFramebuffer({
+    width: 60,
+    height: 40,
+    colorAttachments: ['rgba8unorm']
+  });
+  const canvasContext = {
+    getCurrentFramebuffer: () => framebuffer,
+    getDrawingBufferSize: () => [60, 40],
+    cssToDeviceRatio: () => 2
+  } as CanvasContext;
+  const viewport = new Viewport({id: 'canvas-context-view', x: 2, y: 3, width: 10, height: 8});
+
+  layerManager.setLayers([layer]);
+  layersPass.render({
+    canvasContext,
+    target: framebuffer,
+    viewports: [viewport],
+    layers: layerManager.getLayers(),
+    onViewportActive: layerManager.activateViewport
+  });
+
+  expect(
+    // @ts-expect-error glParameters not exposed
+    layerManager.context.renderPass.glParameters.viewport,
+    'viewport uses the supplied drawing-buffer height and pixel ratio'
+  ).toEqual([4, 18, 20, 16]);
+
+  layerManager.finalize();
+  framebuffer.destroy();
 });
 
 test('LayersPass#GLViewport', () => {

--- a/test/modules/core/passes/layers-pass.spec.ts
+++ b/test/modules/core/passes/layers-pass.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {test, expect} from 'vitest';
+import {test, expect, vi} from 'vitest';
 
 import {Layer, CompositeLayer, LayerManager, Viewport, MapView} from '@deck.gl/core';
 import {layerIndexResolver} from '@deck.gl/core/passes/layers-pass';
@@ -347,7 +347,7 @@ test('LayersPass#viewParameters', () => {
   });
 });
 
-test('LayersPass#uses the supplied canvas context', () => {
+test('LayersPass#uses the supplied canvas context for viewport and clear passes', () => {
   const layer = new TestLayer({id: 'canvas-context-layer'});
   const layerManager = new LayerManager(device, {});
   const layersPass = new DrawLayersPass(device);
@@ -364,9 +364,10 @@ test('LayersPass#uses the supplied canvas context', () => {
   const viewport = new Viewport({id: 'canvas-context-view', x: 2, y: 3, width: 10, height: 8});
 
   layerManager.setLayers([layer]);
+  const beginRenderPass = vi.spyOn(device, 'beginRenderPass');
   layersPass.render({
     canvasContext,
-    target: framebuffer,
+    views: {[viewport.id]: new MapView({id: viewport.id, clear: true})},
     viewports: [viewport],
     layers: layerManager.getLayers(),
     onViewportActive: layerManager.activateViewport
@@ -377,7 +378,11 @@ test('LayersPass#uses the supplied canvas context', () => {
     layerManager.context.renderPass.glParameters.viewport,
     'viewport uses the supplied drawing-buffer height and pixel ratio'
   ).toEqual([4, 18, 20, 16]);
+  expect(beginRenderPass).toHaveBeenCalledTimes(2);
+  expect(beginRenderPass.mock.calls[0][0].framebuffer).toBe(framebuffer);
+  expect(beginRenderPass.mock.calls[1][0].framebuffer).toBe(framebuffer);
 
+  beginRenderPass.mockRestore();
   layerManager.finalize();
   framebuffer.destroy();
 });

--- a/test/modules/core/passes/pick-layers-pass.spec.ts
+++ b/test/modules/core/passes/pick-layers-pass.spec.ts
@@ -8,6 +8,7 @@ import {LayerManager, MapView, PolygonLayer, ScatterplotLayer} from 'deck.gl';
 import PickLayersPass from '@deck.gl/core/passes/pick-layers-pass';
 import * as FIXTURES from 'deck.gl-test/data';
 import {device, getLayerUniforms} from '@deck.gl/test-utils/vitest';
+import type {CanvasContext} from '@luma.gl/core';
 
 test('PickLayersPass#drawPickingBuffer', () => {
   const pickingFBO = device.createFramebuffer({colorAttachments: ['rgba8unorm']});
@@ -47,6 +48,51 @@ test('PickLayersPass#drawPickingBuffer', () => {
     getLayerUniforms(subLayers[0], 'lighting').enabled,
     `PickLayersPass lighting disabled correctly`
   ).toBe(0);
+});
+
+test('PickLayersPass#forwards the supplied canvas context', () => {
+  const pickingFBO = device.createFramebuffer({colorAttachments: ['rgba8unorm']});
+  pickingFBO.resize({width: 64, height: 64});
+
+  const view = new MapView();
+  const viewport = view.makeViewport({
+    width: 10,
+    height: 8,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const layer = new ScatterplotLayer({
+    data: [{position: [0, 0]}],
+    getPosition: datum => datum.position,
+    radiusMinPixels: 2,
+    pickable: true
+  });
+  const canvasContext = {
+    getCurrentFramebuffer: () => pickingFBO,
+    getDrawingBufferSize: () => [64, 64],
+    cssToDeviceRatio: () => 2
+  } as CanvasContext;
+  const layerManager = new LayerManager(device, {viewport});
+  const pickLayersPass = new PickLayersPass(device);
+
+  layerManager.setLayers([layer]);
+  pickLayersPass.render({
+    canvasContext,
+    viewports: [viewport],
+    views: {[view.id]: view},
+    layers: layerManager.getLayers(),
+    onViewportActive: layerManager.activateViewport,
+    pickingFBO,
+    deviceRect: {x: 0, y: 0, width: 64, height: 64}
+  });
+
+  expect(
+    // @ts-expect-error glParameters not exposed
+    layerManager.context.renderPass.glParameters.viewport,
+    'picking pass preserves the supplied canvas pixel ratio'
+  ).toEqual([0, 48, 20, 16]);
+
+  layerManager.finalize();
+  pickingFBO.destroy();
 });
 
 test('PickLayersPass#view clearColor does not corrupt the picking buffer', () => {


### PR DESCRIPTION
## Goal
Make rendering, picking, and viewport layout consistently honor the active luma canvas context while preserving existing single-canvas behavior.

## Changes
- Accept `CanvasContext` or `PresentationContext` in internal rendering and picking options.
- Propagate the selected context through synchronous/asynchronous point and rectangle picking, including the picking render pass.
- Derive framebuffer dimensions, viewport coordinates, device-pixel ratio, and post-processing buffer sizes from the selected context.
- Ensure per-view clear passes and final post-processing output use the selected canvas framebuffer.
- Include the already-merged #10475 viewport-layout preparation: read each view’s CSS dimensions directly from its existing canvas context, avoiding a separate canvas-size map or duplicated resize bookkeeping.
- Support canvas-only and canvas-plus-pixel viewport filters, with inline documentation explaining why both canvas identity and pixel containment are checked.
- Add focused regression coverage for canvas-aware picking, rendering, clear passes, post-processing output, and independent per-canvas viewport layout.

## Review scope
Ten core source/test files. No new public `Deck` multi-canvas props, canvas lifecycle ownership, widgets, or application examples; omitted contexts preserve existing defaults.

## Validation
- Rebased onto current `master` (`dd9b4047d6`).
- `./node_modules/.bin/tsc -p modules/core/tsconfig.json --noEmit --pretty false`
- `yarn lint` — passed; existing repository lint warnings remain.
- Focused headless browser regressions: **70 tests passed across 7 files**.
- Downstream stacked feature regressions: **90 tests passed across 9 files**.

## Stack
1. This PR contains context-aware rendering/picking plus the already-merged #10475 canvas-aware viewport-layout preparation.
2. #10229 builds the multi-canvas presentation and interaction feature on top.