### PR TITLE
refactor(core): size and filter viewports by canvas

### DIFF
--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -54,6 +54,8 @@ type ViewManagerProps<ViewsT extends ViewOrViews> = {
   pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
   width?: number;
   height?: number;
+  /** CSS pixel dimensions for each presentation canvas, keyed by canvas id. */
+  canvasMetrics?: Record<string, {width: number; height: number}>;
   /** Event managers keyed by presentation canvas id. */
   eventManagers?: Record<string, EventManager>;
 };
@@ -79,6 +81,7 @@ export default class ViewManager<ViewsT extends View[]> {
     onInteractionStateChange?: (state: InteractionState) => void;
   };
   private _pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
+  private _canvasMetrics: Record<string, {width: number; height: number}>;
 
   constructor(
     props: ViewManagerProps<ViewsT> & {
@@ -109,6 +112,7 @@ export default class ViewManager<ViewsT extends View[]> {
       onInteractionStateChange: props.onInteractionStateChange
     };
     this._pickPosition = props.pickPosition;
+    this._canvasMetrics = props.canvasMetrics || {};
 
     Object.seal(this);
 
@@ -163,10 +167,21 @@ export default class ViewManager<ViewsT extends View[]> {
    *   + not provided - return all viewports
    *   + {x, y} - only return viewports that contain this pixel
    *   + {x, y, width, height} - only return viewports that overlap with this rectangle
+   *   + {canvasId} - only return viewports associated with this canvas
    */
-  getViewports(rect?: {x: number; y: number; width?: number; height?: number}): Viewport[] {
+  getViewports(rect?: {
+    x: number;
+    y: number;
+    width?: number;
+    height?: number;
+    canvasId?: string;
+  }): Viewport[] {
     if (rect) {
-      return this._viewports.filter(viewport => viewport.containsPixel(rect));
+      return this._viewports.filter(
+        viewport =>
+          (!rect.canvasId || this.getCanvasId(viewport.id) === rect.canvasId) &&
+          viewport.containsPixel(rect)
+      );
     }
     return this._viewports;
   }
@@ -206,7 +221,7 @@ export default class ViewManager<ViewsT extends View[]> {
   getCanvasId(viewOrViewId: string | View): string | undefined {
     const view = typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
     return view
-      ? this._viewEventManagers[view.id]?.canvasId || view.props.canvasId || DEFAULT_CANVAS_ID
+      ? this._viewEventManagers[view.id]?.canvasId || this._resolveCanvasId(view)
       : undefined;
   }
 
@@ -251,6 +266,10 @@ export default class ViewManager<ViewsT extends View[]> {
 
     if ('pickPosition' in props) {
       this._pickPosition = props.pickPosition;
+    }
+
+    if ('canvasMetrics' in props) {
+      this._setCanvasMetrics(props.canvasMetrics || {});
     }
 
     if ('eventManagers' in props) {
@@ -331,6 +350,27 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
+  private _setCanvasMetrics(canvasMetrics: Record<string, {width: number; height: number}>): void {
+    if (!deepEqual(canvasMetrics, this._canvasMetrics, 2)) {
+      this._canvasMetrics = canvasMetrics;
+      this.setNeedsUpdate('canvasMetrics changed');
+    }
+  }
+
+  private _resolveCanvasId(view: View): string {
+    const canvasIds = Object.keys(this._canvasMetrics);
+    return view.props.canvasId || canvasIds[0] || DEFAULT_CANVAS_ID;
+  }
+
+  private _getCanvasMetrics(view: View): {width: number; height: number} {
+    const canvasId = this._resolveCanvasId(view);
+    const metrics = this._canvasMetrics[canvasId];
+    return {
+      width: metrics?.width ?? this.width,
+      height: metrics?.height ?? this.height
+    };
+  }
+
   private _getViewEventManager(view: View): ViewEventManager {
     const canvasId = this.getCanvasId(view) || DEFAULT_CANVAS_ID;
     return {
@@ -382,8 +422,8 @@ export default class ViewManager<ViewsT extends View[]> {
       makeViewport: viewState =>
         this.getView(view.id)?.makeViewport({
           viewState,
-          width: this.width,
-          height: this.height
+          width: this._getCanvasMetrics(view).width,
+          height: this._getCanvasMetrics(view).height
         }),
       pickPosition: this._pickPosition
     });
@@ -432,10 +472,11 @@ export default class ViewManager<ViewsT extends View[]> {
     // Create controllers in reverse order, so that views on top receive events first
     for (let i = views.length; i--; ) {
       const view = views[i];
+      const {width, height} = this._getCanvasMetrics(view);
       const viewEventManager = this._getViewEventManager(view);
       this._viewEventManagers[view.id] = viewEventManager;
       const viewState = this.getViewState(view);
-      const viewport = view.makeViewport({viewState, width: this.width, height: this.height});
+      const viewport = view.makeViewport({viewState, width, height});
 
       let oldController = this._getReusableController(
         oldControllers[view.id],

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -263,7 +263,7 @@ export default class ViewManager<ViewsT extends View[]> {
   getCanvasId(viewOrViewId: string | View): string | undefined {
     const view = typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
     return view
-      ? this._viewEventManagers[view.id]?.canvasId || this._resolveCanvasId(view)
+      ? this._viewEventManagers[view.id]?.canvasId || this._getCanvasIdFromView(view)
       : undefined;
   }
 
@@ -393,7 +393,7 @@ export default class ViewManager<ViewsT extends View[]> {
    * @param view - View whose presentation canvas is being determined.
    * @returns The explicit, default-context, or legacy default canvas id.
    */
-  private _resolveCanvasId(view: View): string {
+  private _getCanvasIdFromView(view: View): string {
     return view.props.canvasId || this._getCanvasContext?.()?.id || DEFAULT_CANVAS_ID;
   }
 
@@ -405,7 +405,7 @@ export default class ViewManager<ViewsT extends View[]> {
   private _getCanvasDimensions(view: View): CanvasDimensions {
     // Viewport layout uses CSS pixels, not framebuffer pixels. Read them directly from the
     // observed luma context instead of maintaining a second per-canvas size snapshot.
-    const canvasContext = this._getCanvasContext?.(this._resolveCanvasId(view));
+    const canvasContext = this._getCanvasContext?.(this._getCanvasIdFromView(view));
     const [width, height] = canvasContext?.getCSSSize() || [this.width, this.height];
     return {width, height};
   }

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -46,7 +46,44 @@ type ViewEventManager = {
   eventManager: EventManager;
 };
 
-/** ViewManager props directly supplied by the user */
+/**
+ * Looks up an existing canvas context without duplicating its resize or pixel-size bookkeeping.
+ * @param canvasId - Presentation canvas to resolve, or undefined to select the default canvas.
+ * @returns The existing render or presentation context, or null when no canvas matches.
+ */
+type CanvasContextResolver = (canvasId?: string) => CanvasContext | PresentationContext | null;
+
+/**
+ * Restricts viewport selection to one presentation canvas, optionally at a CSS-pixel location.
+ * Canvas-only filters intentionally omit coordinates so they return every matching viewport.
+ */
+type ViewportFilter =
+  | {
+      /** Presentation canvas whose viewports should be returned. */
+      canvasId: string;
+    }
+  | {
+      /** Horizontal CSS-pixel coordinate to match. */
+      x: number;
+      /** Vertical CSS-pixel coordinate to match. */
+      y: number;
+      /** Optional width of the CSS-pixel query rectangle. */
+      width?: number;
+      /** Optional height of the CSS-pixel query rectangle. */
+      height?: number;
+      /** Optional presentation canvas that further restricts the pixel query. */
+      canvasId?: string;
+    };
+
+/** CSS-pixel dimensions read directly from an existing canvas context. */
+type CanvasDimensions = {
+  /** Canvas width in CSS pixels. */
+  width: number;
+  /** Canvas height in CSS pixels. */
+  height: number;
+};
+
+/** Internal view, controller, and canvas-routing properties supplied by Deck. */
 type ViewManagerProps<ViewsT extends ViewOrViews> = {
   views: ViewsT;
   viewState: ViewStateObject<ViewsT> | null;
@@ -55,12 +92,13 @@ type ViewManagerProps<ViewsT extends ViewOrViews> = {
   pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
   width?: number;
   height?: number;
-  /** Look up existing canvas contexts; luma owns their observed CSS and drawing-buffer sizes. */
-  getCanvasContext?: (canvasId?: string) => CanvasContext | PresentationContext | null;
+  /** Resolve existing luma contexts, which own all canvas resize and pixel-size tracking. */
+  getCanvasContext?: CanvasContextResolver;
   /** Event managers keyed by presentation canvas id. */
   eventManagers?: Record<string, EventManager>;
 };
 
+/** Builds viewports and routes controllers using their assigned canvas coordinate systems. */
 export default class ViewManager<ViewsT extends View[]> {
   width: number;
   height: number;
@@ -82,8 +120,13 @@ export default class ViewManager<ViewsT extends View[]> {
     onInteractionStateChange?: (state: InteractionState) => void;
   };
   private _pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
-  private _getCanvasContext?: (canvasId?: string) => CanvasContext | PresentationContext | null;
+  /** Context lookup supplied by Deck; context dimensions remain owned and observed by luma. */
+  private _getCanvasContext?: CanvasContextResolver;
 
+  /**
+   * Initializes the viewport layout, controller routing, and optional canvas-context lookup.
+   * @param props - Initial views, view state, event managers, dimensions, and context resolver.
+   */
   constructor(
     props: ViewManagerProps<ViewsT> & {
       // Initial options
@@ -162,25 +205,21 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
-  /** Get a set of viewports for a given width and height
-   * TODO - Intention is for deck.gl to autodeduce width and height and drop the need for props
-   * @param rect (object, optional) - filter the viewports
-   *   + not provided - return all viewports
-   *   + {x, y} - only return viewports that contain this pixel
-   *   + {x, y, width, height} - only return viewports that overlap with this rectangle
-   *   + {canvasId} - only return viewports associated with this canvas
+  /**
+   * Returns active viewports, optionally restricted by canvas and/or CSS-pixel coordinates.
+   * @param filter - A canvas-only selection or a point/rectangle with an optional canvas id.
+   * @returns Matching viewports in their original rendering order.
    */
-  getViewports(
-    rect?:
-      | {canvasId: string}
-      | {x: number; y: number; width?: number; height?: number; canvasId?: string}
-  ): Viewport[] {
-    if (rect) {
-      return this._viewports.filter(
-        viewport =>
-          (!rect.canvasId || this.getCanvasId(viewport.id) === rect.canvasId) &&
-          (!('x' in rect) || viewport.containsPixel(rect))
-      );
+  getViewports(filter?: ViewportFilter): Viewport[] {
+    if (filter) {
+      return this._viewports.filter(viewport => {
+        // Different canvases can contain the same CSS coordinates. First select the requested
+        // canvas, then test pixel containment only when coordinates were actually supplied;
+        // canvas-only queries must retain every viewport on that canvas.
+        const matchesCanvas = !filter.canvasId || this.getCanvasId(viewport.id) === filter.canvasId;
+        const matchesPixel = !('x' in filter) || viewport.containsPixel(filter);
+        return matchesCanvas && matchesPixel;
+      });
     }
     return this._viewports;
   }
@@ -216,7 +255,11 @@ export default class ViewManager<ViewsT extends View[]> {
     return this._viewportMap[viewId];
   }
 
-  /** Return the presentation canvas id assigned to a view. */
+  /**
+   * Resolves the presentation canvas associated with an existing or supplied view.
+   * @param viewOrViewId - View instance or id whose canvas association should be resolved.
+   * @returns The assigned canvas id, or undefined when the view does not exist.
+   */
   getCanvasId(viewOrViewId: string | View): string | undefined {
     const view = typeof viewOrViewId === 'string' ? this.getView(viewOrViewId) : viewOrViewId;
     return view
@@ -345,11 +388,21 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
+  /**
+   * Resolves a view's explicit canvas id, falling back to the existing default canvas context.
+   * @param view - View whose presentation canvas is being determined.
+   * @returns The explicit, default-context, or legacy default canvas id.
+   */
   private _resolveCanvasId(view: View): string {
     return view.props.canvasId || this._getCanvasContext?.()?.id || DEFAULT_CANVAS_ID;
   }
 
-  private _getCanvasDimensions(view: View): {width: number; height: number} {
+  /**
+   * Reads the CSS dimensions used to lay out a view and its controller viewport.
+   * @param view - View whose assigned canvas provides the layout coordinate space.
+   * @returns Context-owned CSS dimensions, or the manager dimensions without a canvas context.
+   */
+  private _getCanvasDimensions(view: View): CanvasDimensions {
     // Viewport layout uses CSS pixels, not framebuffer pixels. Read them directly from the
     // observed luma context instead of maintaining a second per-canvas size snapshot.
     const canvasContext = this._getCanvasContext?.(this._resolveCanvasId(view));
@@ -393,6 +446,12 @@ export default class ViewManager<ViewsT extends View[]> {
     return controller;
   }
 
+  /**
+   * Creates a controller that resolves its viewport against the view's assigned canvas.
+   * @param view - View receiving the controller.
+   * @param props - Controller identity and implementation class.
+   * @returns The initialized controller for the view.
+   */
   private _createController(
     view: View,
     props: {id: string; type: ConstructorOf<Controller<any>>}
@@ -447,7 +506,7 @@ export default class ViewManager<ViewsT extends View[]> {
     return null;
   }
 
-  // Rebuilds viewports from descriptors towards a certain window size
+  /** Rebuilds each viewport and controller using its presentation canvas's CSS dimensions. */
   private _rebuildViewports(): void {
     const {views} = this;
 

--- a/modules/core/src/lib/view-manager.ts
+++ b/modules/core/src/lib/view-manager.ts
@@ -10,6 +10,7 @@ import type Controller from '../controllers/controller';
 import type {ViewStateChangeParameters, InteractionState} from '../controllers/controller';
 import type Viewport from '../viewports/viewport';
 import type View from '../views/view';
+import type {CanvasContext, PresentationContext} from '@luma.gl/core';
 import type {Timeline} from '@luma.gl/engine';
 import type {EventManager} from 'mjolnir.js';
 import type {ConstructorOf} from '../types/types';
@@ -54,8 +55,8 @@ type ViewManagerProps<ViewsT extends ViewOrViews> = {
   pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
   width?: number;
   height?: number;
-  /** CSS pixel dimensions for each presentation canvas, keyed by canvas id. */
-  canvasMetrics?: Record<string, {width: number; height: number}>;
+  /** Look up existing canvas contexts; luma owns their observed CSS and drawing-buffer sizes. */
+  getCanvasContext?: (canvasId?: string) => CanvasContext | PresentationContext | null;
   /** Event managers keyed by presentation canvas id. */
   eventManagers?: Record<string, EventManager>;
 };
@@ -81,7 +82,7 @@ export default class ViewManager<ViewsT extends View[]> {
     onInteractionStateChange?: (state: InteractionState) => void;
   };
   private _pickPosition?: (x: number, y: number) => {coordinate?: number[]} | null;
-  private _canvasMetrics: Record<string, {width: number; height: number}>;
+  private _getCanvasContext?: (canvasId?: string) => CanvasContext | PresentationContext | null;
 
   constructor(
     props: ViewManagerProps<ViewsT> & {
@@ -112,7 +113,7 @@ export default class ViewManager<ViewsT extends View[]> {
       onInteractionStateChange: props.onInteractionStateChange
     };
     this._pickPosition = props.pickPosition;
-    this._canvasMetrics = props.canvasMetrics || {};
+    this._getCanvasContext = props.getCanvasContext;
 
     Object.seal(this);
 
@@ -169,18 +170,16 @@ export default class ViewManager<ViewsT extends View[]> {
    *   + {x, y, width, height} - only return viewports that overlap with this rectangle
    *   + {canvasId} - only return viewports associated with this canvas
    */
-  getViewports(rect?: {
-    x: number;
-    y: number;
-    width?: number;
-    height?: number;
-    canvasId?: string;
-  }): Viewport[] {
+  getViewports(
+    rect?:
+      | {canvasId: string}
+      | {x: number; y: number; width?: number; height?: number; canvasId?: string}
+  ): Viewport[] {
     if (rect) {
       return this._viewports.filter(
         viewport =>
           (!rect.canvasId || this.getCanvasId(viewport.id) === rect.canvasId) &&
-          viewport.containsPixel(rect)
+          (!('x' in rect) || viewport.containsPixel(rect))
       );
     }
     return this._viewports;
@@ -268,10 +267,6 @@ export default class ViewManager<ViewsT extends View[]> {
       this._pickPosition = props.pickPosition;
     }
 
-    if ('canvasMetrics' in props) {
-      this._setCanvasMetrics(props.canvasMetrics || {});
-    }
-
     if ('eventManagers' in props) {
       this._setEventManagers(props.eventManagers || {});
     }
@@ -350,25 +345,16 @@ export default class ViewManager<ViewsT extends View[]> {
     }
   }
 
-  private _setCanvasMetrics(canvasMetrics: Record<string, {width: number; height: number}>): void {
-    if (!deepEqual(canvasMetrics, this._canvasMetrics, 2)) {
-      this._canvasMetrics = canvasMetrics;
-      this.setNeedsUpdate('canvasMetrics changed');
-    }
-  }
-
   private _resolveCanvasId(view: View): string {
-    const canvasIds = Object.keys(this._canvasMetrics);
-    return view.props.canvasId || canvasIds[0] || DEFAULT_CANVAS_ID;
+    return view.props.canvasId || this._getCanvasContext?.()?.id || DEFAULT_CANVAS_ID;
   }
 
-  private _getCanvasMetrics(view: View): {width: number; height: number} {
-    const canvasId = this._resolveCanvasId(view);
-    const metrics = this._canvasMetrics[canvasId];
-    return {
-      width: metrics?.width ?? this.width,
-      height: metrics?.height ?? this.height
-    };
+  private _getCanvasDimensions(view: View): {width: number; height: number} {
+    // Viewport layout uses CSS pixels, not framebuffer pixels. Read them directly from the
+    // observed luma context instead of maintaining a second per-canvas size snapshot.
+    const canvasContext = this._getCanvasContext?.(this._resolveCanvasId(view));
+    const [width, height] = canvasContext?.getCSSSize() || [this.width, this.height];
+    return {width, height};
   }
 
   private _getViewEventManager(view: View): ViewEventManager {
@@ -422,8 +408,7 @@ export default class ViewManager<ViewsT extends View[]> {
       makeViewport: viewState =>
         this.getView(view.id)?.makeViewport({
           viewState,
-          width: this._getCanvasMetrics(view).width,
-          height: this._getCanvasMetrics(view).height
+          ...this._getCanvasDimensions(view)
         }),
       pickPosition: this._pickPosition
     });
@@ -472,7 +457,7 @@ export default class ViewManager<ViewsT extends View[]> {
     // Create controllers in reverse order, so that views on top receive events first
     for (let i = views.length; i--; ) {
       const view = views[i];
-      const {width, height} = this._getCanvasMetrics(view);
+      const {width, height} = this._getCanvasDimensions(view);
       const viewEventManager = this._getViewEventManager(view);
       this._viewEventManagers[view.id] = viewEventManager;
       const viewState = this.getViewState(view);

--- a/test/modules/core/lib/view-manager.spec.ts
+++ b/test/modules/core/lib/view-manager.spec.ts
@@ -287,6 +287,83 @@ test('ViewManager#routes controllers by canvas event manager', () => {
 });
 
 /* eslint-disable max-statements */
+test('ViewManager#layouts and filters views by canvas', () => {
+  const leftEventManager = new EventManager(document.createElement('div'));
+  const rightEventManager = new EventManager(document.createElement('div'));
+  const leftView = new MapView({id: 'left', canvasId: 'left-canvas'});
+  const rightView = new MapView({id: 'right', canvasId: 'right-canvas'});
+
+  const viewManager = new ViewManager({
+    views: [leftView, rightView],
+    viewState: {
+      left: {longitude: -122, latitude: 38, zoom: 10},
+      right: {longitude: -74, latitude: 40.7, zoom: 11}
+    },
+    width: 1,
+    height: 1,
+    canvasMetrics: {
+      'left-canvas': {width: 200, height: 100},
+      'right-canvas': {width: 120, height: 180}
+    },
+    eventManager: leftEventManager,
+    eventManagers: {
+      'left-canvas': leftEventManager,
+      'right-canvas': rightEventManager
+    }
+  });
+
+  expect(viewManager.getViewport('left')?.width).toBe(200);
+  expect(viewManager.getViewport('right')?.height).toBe(180);
+  expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'left-canvas'})).toEqual([
+    viewManager.getViewport('left')
+  ]);
+  expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'unknown-canvas'})).toEqual([]);
+
+  const viewports = viewManager.getViewports();
+  viewManager.setProps({
+    canvasMetrics: {
+      'left-canvas': {width: 200, height: 100},
+      'right-canvas': {width: 120, height: 180}
+    }
+  });
+  expect(viewManager.getViewports(), 'unchanged canvas dimensions preserve viewports').toBe(
+    viewports
+  );
+
+  viewManager.setProps({
+    canvasMetrics: {
+      'left-canvas': {width: 240, height: 140},
+      'right-canvas': {width: 120, height: 180}
+    }
+  });
+  expect(viewManager.getViewport('left')?.width, 'updated dimensions rebuild the viewport').toBe(
+    240
+  );
+
+  viewManager.finalize();
+  leftEventManager.destroy();
+  rightEventManager.destroy();
+});
+
+test('ViewManager#uses the first canvas for views without an explicit canvas id', () => {
+  const eventManager = new EventManager(document.createElement('div'));
+  const viewManager = new ViewManager({
+    views: [new MapView({id: 'main'})],
+    viewState: {longitude: -122, latitude: 38, zoom: 10},
+    width: 1,
+    height: 1,
+    canvasMetrics: {'first-canvas': {width: 160, height: 90}},
+    eventManager
+  });
+
+  expect(viewManager.getCanvasId('main')).toBe('first-canvas');
+  expect(viewManager.getViewport('main')?.width).toBe(160);
+  expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'first-canvas'})).toHaveLength(1);
+
+  viewManager.finalize();
+  eventManager.destroy();
+});
+
 test('ViewManager#zero-size', () => {
   const mainView = new MapView({id: 'main', controller: true});
 

--- a/test/modules/core/lib/view-manager.spec.ts
+++ b/test/modules/core/lib/view-manager.spec.ts
@@ -7,6 +7,7 @@ import {MapView} from '@deck.gl/core';
 import ViewManager from '@deck.gl/core/lib/view-manager';
 import {equals} from '@math.gl/core';
 import {EventManager} from 'mjolnir.js';
+import type {CanvasContext} from '@luma.gl/core';
 
 test('ViewManager#constructor', () => {
   const viewManager = new ViewManager({
@@ -292,6 +293,16 @@ test('ViewManager#layouts and filters views by canvas', () => {
   const rightEventManager = new EventManager(document.createElement('div'));
   const leftView = new MapView({id: 'left', canvasId: 'left-canvas'});
   const rightView = new MapView({id: 'right', canvasId: 'right-canvas'});
+  const canvasSizes: Record<string, [number, number]> = {
+    'left-canvas': [200, 100],
+    'right-canvas': [120, 180]
+  };
+  const canvasContexts = Object.fromEntries(
+    Object.keys(canvasSizes).map(canvasId => [
+      canvasId,
+      {id: canvasId, getCSSSize: () => canvasSizes[canvasId]} as CanvasContext
+    ])
+  );
 
   const viewManager = new ViewManager({
     views: [leftView, rightView],
@@ -301,10 +312,7 @@ test('ViewManager#layouts and filters views by canvas', () => {
     },
     width: 1,
     height: 1,
-    canvasMetrics: {
-      'left-canvas': {width: 200, height: 100},
-      'right-canvas': {width: 120, height: 180}
-    },
+    getCanvasContext: canvasId => canvasContexts[canvasId || 'left-canvas'] || null,
     eventManager: leftEventManager,
     eventManagers: {
       'left-canvas': leftEventManager,
@@ -317,25 +325,24 @@ test('ViewManager#layouts and filters views by canvas', () => {
   expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'left-canvas'})).toEqual([
     viewManager.getViewport('left')
   ]);
+  expect(viewManager.getViewports({canvasId: 'left-canvas'})).toEqual([
+    viewManager.getViewport('left')
+  ]);
+  expect(viewManager.getViewports({canvasId: 'right-canvas'})).toEqual([
+    viewManager.getViewport('right')
+  ]);
+  expect(viewManager.getViewports({canvasId: 'unknown-canvas'})).toEqual([]);
   expect(viewManager.getViewports({x: 1, y: 1, canvasId: 'unknown-canvas'})).toEqual([]);
 
   const viewports = viewManager.getViewports();
-  viewManager.setProps({
-    canvasMetrics: {
-      'left-canvas': {width: 200, height: 100},
-      'right-canvas': {width: 120, height: 180}
-    }
-  });
+  viewManager.setProps({});
   expect(viewManager.getViewports(), 'unchanged canvas dimensions preserve viewports').toBe(
     viewports
   );
 
-  viewManager.setProps({
-    canvasMetrics: {
-      'left-canvas': {width: 240, height: 140},
-      'right-canvas': {width: 120, height: 180}
-    }
-  });
+  canvasSizes['left-canvas'] = [240, 140];
+  viewManager.setNeedsUpdate('Canvas resized');
+  viewManager.setProps({});
   expect(viewManager.getViewport('left')?.width, 'updated dimensions rebuild the viewport').toBe(
     240
   );
@@ -347,12 +354,16 @@ test('ViewManager#layouts and filters views by canvas', () => {
 
 test('ViewManager#uses the first canvas for views without an explicit canvas id', () => {
   const eventManager = new EventManager(document.createElement('div'));
+  const canvasContext = {
+    id: 'first-canvas',
+    getCSSSize: () => [160, 90]
+  } as CanvasContext;
   const viewManager = new ViewManager({
     views: [new MapView({id: 'main'})],
     viewState: {longitude: -122, latitude: 38, zoom: 10},
     width: 1,
     height: 1,
-    canvasMetrics: {'first-canvas': {width: 160, height: 90}},
+    getCanvasContext: () => canvasContext,
     eventManager
   });
 


### PR DESCRIPTION
## Goal
Teach the existing `ViewManager` to lay out and select views by presentation canvas without introducing a second canvas-size tracking system.

## Why this is needed
`Deck.width` and `Deck.height` describe the default canvas, but views assigned to different presentation canvases must use each canvas's own **CSS-pixel** dimensions. luma's existing `CanvasContext` / `PresentationContext` already owns resize observation, CSS dimensions, device-pixel ratio, and drawing-buffer dimensions.

This PR therefore adds only an optional internal `getCanvasContext(canvasId)` callback. `ViewManager` reads `context.getCSSSize()` when constructing viewports and controller viewports; it does not maintain a size map, size cache, resize observer, or duplicate drawing-buffer bookkeeping. The follow-up feature PR invalidates the existing viewport layout when luma reports a presentation-canvas resize.

## Changes
- Resolve a view's canvas and read its authoritative CSS dimensions directly from the existing luma context.
- Fall back to existing `ViewManager.width` / `height` when no context lookup is supplied.
- Support both whole-canvas viewport queries (`{canvasId}`) and combined canvas/pixel queries (`{x, y, canvasId}`).
- Preserve first-canvas defaults, unknown-canvas filtering, unchanged viewport identity, and explicit resize invalidation.
- Add focused coverage for independent canvas dimensions, context-owned resize updates, whole-canvas filtering, and first-canvas fallback.

## Review scope
Only `modules/core/src/lib/view-manager.ts` and its existing unit test file. No new public Deck props, canvas lifecycle changes, widgets, presentation code, or parallel size tracking.

## Validation
- `yarn test-headless test/modules/core/lib/view-manager.spec.ts test/modules/core/lib/deck.spec.ts --retry 1 --silent` — 32 passed.
- Core TypeScript check passed.
- Repository lint, formatting, and 21 node smoke tests passed through the pre-commit hook.
- Downstream feature validation: 90 affected rendering, picking, widget, resize, and integration tests passed.

## Stack
1. #10474: context-aware render/picking plumbing.
2. This PR: context-derived viewport sizing and canvas filtering.
3. #10229: multi-canvas presentation and interaction.