### PR TITLE
fix(examples): use bundled Scenegraph flight snapshot

### DIFF
--- a/docs/api-reference/mesh-layers/scenegraph-layer.md
+++ b/docs/api-reference/mesh-layers/scenegraph-layer.md
@@ -1,4 +1,5 @@
 # ScenegraphLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {ScenegraphLayerDemo} from '@site/src/doc-demos/mesh-layers';
 

--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -54,7 +54,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ✅ v9.4  |
 | `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ✅ v9.4 |
-| `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ❌ |
+| `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `A5Layer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `GreatCircleLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `S2Layer` | ✅ | ✅ v9.4 |

--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -54,7 +54,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ✅ v9.4  |
 | `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ❌ |
-| `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ❌ |
+| `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `A5Layer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `GreatCircleLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `S2Layer` | ✅ | ✅ v9.4 |

--- a/examples/website/scenegraph/README.md
+++ b/examples/website/scenegraph/README.md
@@ -20,7 +20,8 @@ The 3D model is created by `manilov.ap`, modified for this application.
 See [profile page on sketchfab](https://sketchfab.com/3d-models/boeing747-1a75633f5737462ebc1c7879869f6229),
 licensed under [Creative Commons](https://creativecommons.org/licenses/by/4.0/).
 
-The real-time flight information is from [Opensky Network](https://opensky-network.org).
+The example tries to load live flight data from [Opensky Network](https://opensky-network.org)
+and falls back to a bundled snapshot if the API is unavailable.
 
 To use your own data, check out
 the [documentation of ScenegraphLayer](../../../docs/api-reference/mesh-layers/scenegraph-layer.md).

--- a/examples/website/scenegraph/app.tsx
+++ b/examples/website/scenegraph/app.tsx
@@ -2,24 +2,25 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* global fetch, setInterval, clearInterval */
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+/* global fetch */
+import React, {useEffect, useRef, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
 import type {Device} from '@luma.gl/core';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
+import {log} from '@deck.gl/core';
+import sampleData from './all.json';
 
 import type {ScenegraphLayerProps} from '@deck.gl/mesh-layers';
 import type {PickingInfo, MapViewState} from '@deck.gl/core';
 
-// Data provided by the OpenSky Network, https://opensky-network.org
+// Live data provided by the OpenSky Network, https://opensky-network.org.
+// The API may reject browser requests from other origins, so the bundled
+// snapshot below remains the default and fallback data.
 const DATA_URL = 'https://opensky-network.org/api/states/all';
-// For local debugging
-// const DATA_URL = './all.json';
 const MODEL_URL =
   'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/scenegraph-layer/airplane.glb';
-const REFRESH_TIME_SECONDS = 60;
 const DROP_IF_OLDER_THAN_SECONDS = 120;
 
 const ANIMATIONS: ScenegraphLayerProps['_animations'] = {
@@ -72,14 +73,26 @@ const DATA_INDEX = {
   CATEGORY: 17
 } as const;
 
-async function fetchData(signal: AbortSignal): Promise<Aircraft[]> {
-  const resp = await fetch(DATA_URL, {signal});
-  const {time, states} = (await resp.json()) as {time: number; states: Aircraft[]};
+function normalizeData({time, states}: {time: number; states: Aircraft[]}): Aircraft[] {
   // make lastContact timestamp relative to response time
-  for (const a of states) {
-    a[DATA_INDEX.LAST_CONTACT] -= time;
+  return states.map(state => {
+    const aircraft = [...state] as Aircraft;
+    aircraft[DATA_INDEX.LAST_CONTACT] -= time;
+    return aircraft;
+  });
+}
+
+// https://github.com/visgl/deck.gl/pull/10465 updated the live OpenSky URL,
+// but the endpoint still rejects cross-origin browser requests. Start with this
+// bundled snapshot so the demo can render immediately and keep it as fallback.
+const DATA = normalizeData(sampleData as {time: number; states: Aircraft[]});
+
+async function fetchData(signal: AbortSignal): Promise<Aircraft[]> {
+  const response = await fetch(DATA_URL, {signal});
+  if (!response.ok) {
+    throw new Error(`OpenSky request failed with status ${response.status}`);
   }
-  return states;
+  return normalizeData((await response.json()) as {time: number; states: Aircraft[]});
 }
 
 function getTooltip({object}: PickingInfo<Aircraft>) {
@@ -94,22 +107,6 @@ function getTooltip({object}: PickingInfo<Aircraft>) {
   );
 }
 
-export function useInterval(callback: () => unknown, delay: number) {
-  const savedCallback = useRef(callback);
-
-  // Update callback.
-  useEffect(() => {
-    savedCallback.current = callback;
-  }, [callback]);
-
-  // Loop.
-  useEffect(() => {
-    savedCallback.current(); // Initial call.
-    const id = setInterval(() => savedCallback.current(), delay);
-    return () => clearInterval(id);
-  }, [delay]);
-}
-
 export default function App({
   device,
   sizeScale = 25,
@@ -121,36 +118,32 @@ export default function App({
   onDataLoad?: (count: number) => void;
   mapStyle?: string;
 }) {
-  const [abortController] = useState<AbortController>(new AbortController());
-  const dataRef = useRef<Aircraft[]>([]); // Callback requires stable reference to data.
-  const [, setVersion] = useState(0); // Re-render on data change.
+  const [data, setData] = useState(DATA);
+  const onDataLoadRef = useRef(onDataLoad);
 
-  const sync = useCallback(async () => {
-    let newData = await fetchData(abortController.signal);
+  useEffect(() => {
+    onDataLoadRef.current = onDataLoad;
+  }, [onDataLoad]);
 
-    // In order to keep the animation smooth we need to always return the same
-    // object at a given index. This function will discard new objects
-    // and only update existing ones.
-    if (dataRef.current.length > 0) {
-      const dataById: Record<string, Aircraft> = {};
-      newData.forEach(entry => (dataById[entry[DATA_INDEX.UNIQUE_ID]] = entry));
-      newData = dataRef.current.map(entry => dataById[entry[DATA_INDEX.UNIQUE_ID]] || entry);
-    }
+  useEffect(() => {
+    onDataLoadRef.current?.(data.length);
+  }, [data]);
 
-    dataRef.current = newData;
-    setVersion(v => v + 1);
-
-    if (onDataLoad) {
-      onDataLoad(newData.length);
-    }
+  useEffect(() => {
+    const abortController = new AbortController();
+    fetchData(abortController.signal)
+      .then(setData)
+      .catch(error => {
+        if (!abortController.signal.aborted) {
+          log.warn('Scenegraph example is using its bundled flight snapshot', error)();
+        }
+      });
+    return () => abortController.abort();
   }, []);
-
-  useInterval(sync, REFRESH_TIME_SECONDS * 1000);
-  useEffect(() => () => abortController.abort(), []);
 
   const layer = new ScenegraphLayer<Aircraft>({
     id: 'scenegraph-layer',
-    data: dataRef.current,
+    data,
     pickable: true,
     sizeScale,
     scenegraph: MODEL_URL,
@@ -173,9 +166,6 @@ export default function App({
     getScale: d => {
       const lastContact = d[DATA_INDEX.LAST_CONTACT];
       return lastContact < -DROP_IF_OLDER_THAN_SECONDS ? [0, 0, 0] : [1, 1, 1];
-    },
-    transitions: {
-      getPosition: REFRESH_TIME_SECONDS * 1000
     }
   });
 

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-uniforms.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-uniforms.ts
@@ -5,13 +5,26 @@
 import type {Matrix4} from '@math.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
-const uniformBlock = `\
+const uniformBlockWGSL = /* wgsl */ `\
+struct ScenegraphUniforms {
+  sizeScale: f32,
+  sizeMinPixels: f32,
+  sizeMaxPixels: f32,
+  sceneModelMatrix: mat4x4<f32>,
+  composeModelMatrix: f32,
+};
+
+@group(0) @binding(auto)
+var<uniform> scenegraph: ScenegraphUniforms;
+`;
+
+const uniformBlockGLSL = /* glsl */ `\
 layout(std140) uniform scenegraphUniforms {
   float sizeScale;
   float sizeMinPixels;
   float sizeMaxPixels;
   mat4 sceneModelMatrix;
-  bool composeModelMatrix;
+  float composeModelMatrix;
 } scenegraph;
 `;
 
@@ -20,13 +33,14 @@ export type ScenegraphProps = {
   sizeMinPixels: number;
   sizeMaxPixels: number;
   sceneModelMatrix: Matrix4;
-  composeModelMatrix: boolean;
+  composeModelMatrix: number;
 };
 
 export const scenegraphUniforms = {
   name: 'scenegraph',
-  vs: uniformBlock,
-  fs: uniformBlock,
+  source: uniformBlockWGSL,
+  vs: uniformBlockGLSL,
+  fs: uniformBlockGLSL,
   uniformTypes: {
     sizeScale: 'f32',
     sizeMinPixels: 'f32',

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.ts
@@ -58,9 +58,10 @@ void main(void) {
 
   float originalSize = project_size_to_pixel(scenegraph.sizeScale);
   float clampedSize = clamp(originalSize, scenegraph.sizeMinPixels, scenegraph.sizeMaxPixels);
+  float sizeRatio = originalSize == 0.0 ? 0.0 : clampedSize / originalSize;
 
-  vec3 pos = (instanceModelMatrix * (scenegraph.sceneModelMatrix * vec4(positions, 1.0)).xyz) * scenegraph.sizeScale * (clampedSize / originalSize) + instanceTranslation;
-  if(scenegraph.composeModelMatrix) {
+  vec3 pos = (instanceModelMatrix * (scenegraph.sceneModelMatrix * vec4(positions, 1.0)).xyz) * scenegraph.sizeScale * sizeRatio + instanceTranslation;
+  if(scenegraph.composeModelMatrix > 0.5) {
     DECKGL_FILTER_SIZE(pos, geometry);
     // using instancePositions as world coordinates
     // when using globe mode, this branch does not re-orient the model to align with the surface of the earth

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Layer, project32, picking, log} from '@deck.gl/core';
-import type {Device} from '@luma.gl/core';
+import {Layer, project32, color, picking, log} from '@deck.gl/core';
+import type {Device, RenderPipelineParameters} from '@luma.gl/core';
 import {pbrMaterial} from '@luma.gl/shadertools';
 import {ScenegraphNode, GroupNode, ModelNode, Model} from '@luma.gl/engine';
 import {GLTFAnimator, PBREnvironment, createScenegraphsFromGLTF} from '@luma.gl/gltf';
@@ -15,6 +15,8 @@ import {MATRIX_ATTRIBUTES, shouldComposeModelMatrix} from '../utils/matrix';
 import {scenegraphUniforms, ScenegraphProps} from './scenegraph-layer-uniforms';
 import vs from './scenegraph-layer-vertex.glsl';
 import fs from './scenegraph-layer-fragment.glsl';
+import source from './scenegraph-layer.wgsl';
+import {scenegraphPbrMaterial} from './scenegraph-pbr-material';
 
 import {
   UpdateParameters,
@@ -77,7 +79,12 @@ type _ScenegraphLayerProps<DataT> = {
    */
   _imageBasedLightingEnvironment?:
     | PBREnvironment
-    | ((context: {gl: WebGL2RenderingContext; layer: ScenegraphLayer<DataT>}) => PBREnvironment);
+    | ((context: {
+        device?: Device;
+        /** @deprecated Use `device.handle`. */
+        gl?: WebGL2RenderingContext;
+        layer: ScenegraphLayer<DataT>;
+      }) => PBREnvironment);
 
   /** Anchor position accessor. */
   getPosition?: Accessor<DataT, Position>;
@@ -183,22 +190,34 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
   getShaders() {
     const defines: {LIGHTING_PBR?: 1} = {};
     let pbr;
+    const isWebGPU = this.context.device?.type === 'webgpu';
 
     if (this.props._lighting === 'pbr') {
-      pbr = pbrMaterial;
+      // The stock pbrMaterial module supplies the existing GLSL PBR path.
+      // WebGPU uses a Scenegraph-specific wrapper because its WGSL source must
+      // adapt the PBR position/normal inputs and camera binding to deck.gl's
+      // project module.
+      pbr = isWebGPU ? scenegraphPbrMaterial : pbrMaterial;
       defines.LIGHTING_PBR = 1;
+    } else if (isWebGPU) {
+      // The flat WGSL path can still sample a glTF base-color texture, so it
+      // needs the Scenegraph PBR module's sampler bindings even though
+      // LIGHTING_PBR is not enabled.
+      pbr = scenegraphPbrMaterial;
     } else {
-      // Dummy shader module needed to handle
-      // pbrMaterial.pbr_baseColorSampler binding
+      // The flat GLSL shader declares pbr_baseColorSampler itself. Register a
+      // name-only module so the glTF material binding is still routed to that
+      // sampler without injecting the full PBR lighting module.
       pbr = {name: 'pbrMaterial'};
     }
 
-    const modules = [project32, picking, scenegraphUniforms, pbr];
-    return super.getShaders({defines, vs, fs, modules});
+    const modules = [project32, color, picking, scenegraphUniforms, pbr];
+    return super.getShaders({defines, vs, fs, source, modules});
   }
 
   initializeState() {
     const attributeManager = this.getAttributeManager();
+    const supportsTransitions = this.context.device.type !== 'webgpu';
     // attributeManager is always defined for primitive layers
     attributeManager!.addInstanced({
       instancePositions: {
@@ -206,14 +225,14 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
         type: 'float64',
         fp64: this.use64bitPositions(),
         accessor: 'getPosition',
-        transition: true
+        transition: supportsTransitions
       },
       instanceColors: {
         type: 'unorm8',
         size: this.props.colorFormat.length,
         accessor: 'getColor',
         defaultValue: DEFAULT_COLOR,
-        transition: true
+        transition: supportsTransitions
       },
       instanceModelMatrix: MATRIX_ATTRIBUTES
     });
@@ -346,11 +365,23 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
     let env: PBREnvironment | undefined;
     if (_imageBasedLightingEnvironment) {
       if (typeof _imageBasedLightingEnvironment === 'function') {
-        env = _imageBasedLightingEnvironment({gl: this.context.gl, layer: this});
+        env = _imageBasedLightingEnvironment({
+          device: this.context.device,
+          gl: this.context.gl,
+          layer: this
+        });
       } else {
         env = _imageBasedLightingEnvironment;
       }
     }
+
+    const parameters =
+      this.context.device.type === 'webgpu'
+        ? ({
+            depthWriteEnabled: true,
+            depthCompare: 'less-equal'
+          } satisfies RenderPipelineParameters)
+        : undefined;
 
     return {
       imageBasedLightingEnvironment: env,
@@ -358,6 +389,7 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
         id: this.props.id,
         isInstanced: true,
         bufferLayout: this.getAttributeManager()!.getBufferLayouts(),
+        parameters,
         ...this.getShaders()
       },
       // tangents are not supported
@@ -389,7 +421,7 @@ export default class ScenegraphLayer<DataT = any, ExtraPropsT extends {} = {}> e
           sizeScale,
           sizeMinPixels,
           sizeMaxPixels,
-          composeModelMatrix: shouldComposeModelMatrix(viewport, coordinateSystem),
+          composeModelMatrix: shouldComposeModelMatrix(viewport, coordinateSystem) ? 1 : 0,
           sceneModelMatrix: worldMatrix
         };
 

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.wgsl.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer.wgsl.ts
@@ -1,0 +1,150 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+#ifdef HAS_NORMALS
+  @location(1) normals: vec3<f32>,
+#endif
+#ifdef HAS_UV
+  @location(3) texCoords: vec2<f32>,
+#endif
+  @location(6) instancePositions: vec3<f32>,
+  @location(7) instancePositions64Low: vec3<f32>,
+  @location(8) instanceColors: vec4<f32>,
+  @location(10) instanceModelMatrixCol0: vec3<f32>,
+  @location(11) instanceModelMatrixCol1: vec3<f32>,
+  @location(12) instanceModelMatrixCol2: vec3<f32>,
+  @location(13) instanceTranslation: vec3<f32>,
+};
+
+struct FragmentInputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) vColor: vec4<f32>,
+  @location(1) vTexCoord: vec2<f32>,
+  @location(2) pbrPosition: vec3<f32>,
+  @location(3) pbrUV: vec2<f32>,
+  @location(4) pbrNormal: vec3<f32>,
+  @location(5) pickingColor: vec3<f32>,
+};
+
+@vertex
+fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(instance_index) instanceIndex: u32
+) -> FragmentInputs {
+  var outputs: FragmentInputs;
+
+  geometry.worldPosition = inputs.instancePositions;
+  geometry.pickingColor = picking_getPickingColorFromIndex(instanceIndex);
+
+  var vertexPosition = inputs.positions;
+  var texCoord = vec2<f32>(0.0, 0.0);
+  var normal = vec3<f32>(0.0, 0.0, 1.0);
+
+#ifdef HAS_UV
+  texCoord = inputs.texCoords;
+#endif
+#ifdef HAS_NORMALS
+  normal = inputs.normals;
+#endif
+
+  geometry.uv = texCoord;
+
+  let instanceModelMatrix = mat3x3<f32>(
+    inputs.instanceModelMatrixCol0,
+    inputs.instanceModelMatrixCol1,
+    inputs.instanceModelMatrixCol2
+  );
+
+  let scenePosition = (scenegraph.sceneModelMatrix * vec4<f32>(vertexPosition, 1.0)).xyz;
+  let worldNormal = instanceModelMatrix * (scenegraph.sceneModelMatrix * vec4<f32>(normal, 0.0)).xyz;
+
+  let originalSize = project_meter_size_to_pixel(scenegraph.sizeScale);
+  let clampedSize = clamp(originalSize, scenegraph.sizeMinPixels, scenegraph.sizeMaxPixels);
+  let sizeRatio = select(0.0, clampedSize / originalSize, originalSize > 0.0);
+
+  let pos =
+    (instanceModelMatrix * scenePosition) * scenegraph.sizeScale * sizeRatio +
+    inputs.instanceTranslation;
+
+  if (scenegraph.composeModelMatrix > 0.5) {
+    geometry.normal = project_normal(worldNormal);
+    geometry.worldPosition = inputs.instancePositions + pos;
+    geometry.position = vec4<f32>(
+      project_position_vec3_f64(inputs.instancePositions + pos, inputs.instancePositions64Low),
+      1.0
+    );
+  } else {
+    let sizeAdjustedPos = project_size_vec3(pos);
+    // Scenegraph offsets are east/north/up in globe mode. Use project32's helper so it can
+    // rotate the offset onto the local tangent plane before producing the common position.
+    let projectResult = project_position_to_clipspace_and_commonspace(
+      inputs.instancePositions,
+      inputs.instancePositions64Low,
+      sizeAdjustedPos
+    );
+    geometry.position = projectResult.commonPosition;
+    geometry.normal = project_normal(worldNormal);
+  }
+
+  outputs.position = project_common_position_to_clipspace(geometry.position);
+  outputs.vColor = inputs.instanceColors;
+  outputs.vTexCoord = texCoord;
+  outputs.pbrPosition = geometry.position.xyz;
+  outputs.pbrUV = texCoord;
+  outputs.pbrNormal = geometry.normal;
+  outputs.pickingColor = geometry.pickingColor;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  fragmentGeometry.uv = inputs.vTexCoord;
+
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(inputs.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(inputs.pickingColor, 1.0);
+  }
+
+  var fragColor = inputs.vColor;
+
+#ifdef LIGHTING_PBR
+  fragmentInputs.pbr_vPosition = inputs.pbrPosition;
+  // scenegraphPbrMaterial uses the indexed UV fields from the current PBR module.
+  fragmentInputs.pbr_vUV0 = inputs.pbrUV;
+  fragmentInputs.pbr_vUV1 = vec2<f32>(0.0);
+  fragmentInputs.pbr_vNormal = inputs.pbrNormal;
+  fragColor = fragColor * pbr_filterColor(vec4<f32>(0.0));
+#else
+#ifdef HAS_BASECOLORMAP
+  fragColor =
+    fragColor *
+    textureSample(pbr_baseColorSampler, pbr_baseColorSamplerSampler, inputs.vTexCoord);
+#endif
+#endif
+
+  fragColor.a *= layer.opacity;
+
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedObjectColor = picking_normalizeColor(picking.highlightedObjectColor);
+    if (picking_isColorZero(abs(inputs.pickingColor - highlightedObjectColor))) {
+      let highlightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highlightAlpha + fragColor.a * (1.0 - highlightAlpha);
+      if (blendedAlpha > 0.0) {
+        let highlightRatio = highlightAlpha / blendedAlpha;
+        fragColor = vec4<f32>(
+          mix(fragColor.rgb, picking.highlightColor.rgb, highlightRatio),
+          blendedAlpha
+        );
+      }
+    }
+  }
+
+  return deckgl_premultiplied_alpha(fragColor);
+}
+`;

--- a/modules/mesh-layers/src/scenegraph-layer/scenegraph-pbr-material.ts
+++ b/modules/mesh-layers/src/scenegraph-layer/scenegraph-pbr-material.ts
@@ -1,0 +1,37 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {lighting, pbrMaterial} from '@luma.gl/shadertools';
+
+import type {
+  PBRMaterialBindings,
+  PBRMaterialProps,
+  PBRMaterialUniforms,
+  ShaderModule
+} from '@luma.gl/shadertools';
+
+const source = (pbrMaterial.source as string)
+  .replace(
+    /fn pbr_setPositionNormalTangentUV\([\s\S]*?\n}\n/,
+    `fn pbr_setPositionNormalTangentUV(position: vec4f, normal: vec4f, tangent: vec4f, uv: vec2f)
+{
+  fragmentInputs.pbr_vPosition = position.xyz;
+  fragmentInputs.pbr_vNormal = normal.xyz;
+  fragmentInputs.pbr_vTBN = mat3x3f(
+    vec3f(1.0, 0.0, 0.0),
+    vec3f(0.0, 1.0, 0.0),
+    vec3f(0.0, 0.0, 1.0)
+  );
+  fragmentInputs.pbr_vUV0 = uv;
+  fragmentInputs.pbr_vUV1 = uv;
+}
+`
+  )
+  .replace(/pbrProjection\.camera/g, 'project.cameraPosition');
+
+export const scenegraphPbrMaterial = {
+  ...pbrMaterial,
+  dependencies: [lighting],
+  source
+} as const satisfies ShaderModule<PBRMaterialProps, PBRMaterialUniforms, PBRMaterialBindings>;

--- a/test/modules/mesh-layers/scenegraph-layer.spec.ts
+++ b/test/modules/mesh-layers/scenegraph-layer.spec.ts
@@ -7,6 +7,7 @@ import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
 
 import {project32} from '@deck.gl/core';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
+import source from '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer.wgsl';
 import {CubeGeometry, Model, GroupNode, ModelNode} from '@luma.gl/engine';
 import {GLTFAnimator} from '@luma.gl/gltf';
 
@@ -57,6 +58,15 @@ class MockGLTFAnimator extends GLTFAnimator {
     });
   }
 }
+
+test('ScenegraphLayer#WebGPU shader preserves instance picking and highlighting', () => {
+  expect(source).toContain('@location(5) pickingColor: vec3<f32>');
+  expect(source).toContain('outputs.pickingColor = geometry.pickingColor');
+  expect(source).toContain('picking.isActive > 0.5');
+  expect(source).toContain('picking_isColorValid(inputs.pickingColor)');
+  expect(source).toContain('return vec4<f32>(inputs.pickingColor, 1.0)');
+  expect(source).toContain('picking.isHighlightActive > 0.5');
+});
 
 test('ScenegraphLayer#tests', () => {
   const testCases = generateLayerTests({

--- a/test/render/test-cases/scenegraph-layer.spec.ts
+++ b/test/render/test-cases/scenegraph-layer.spec.ts
@@ -142,9 +142,6 @@ const testCases = [
   }))
 ];
 
-describe.each([
-  'webgl'
-  // 'webgpu'
-] as const)('%s', deviceType => {
+describe.each(['webgl', 'webgpu'] as const)('%s', deviceType => {
   runPersistentRenderTestSuite(testCases as TestCase[], deviceType);
 });

--- a/website/src/examples/scenegraph-layer.js
+++ b/website/src/examples/scenegraph-layer.js
@@ -10,7 +10,7 @@ import App from 'website-examples/scenegraph/app';
 import {makeExample} from '../components';
 
 class ScenegraphDemo extends Component {
-  static title = 'Realtime Flight Tracker';
+  static title = 'Flight Tracker';
 
   static code = `${GITHUB_TREE}/examples/website/scenegraph`;
 
@@ -24,7 +24,7 @@ class ScenegraphDemo extends Component {
     return (
       <div>
         <p>
-          Data source:
+          Flight data:
           <a href="https://opensky-network.org">The OpenSky Network</a>
         </p>
         <div className="layout">

--- a/website/src/examples/scenegraph-layer.js
+++ b/website/src/examples/scenegraph-layer.js
@@ -14,6 +14,8 @@ class ScenegraphDemo extends Component {
 
   static code = `${GITHUB_TREE}/examples/website/scenegraph`;
 
+  static hasDeviceTabs = true;
+
   static parameters = {
     sizeScale: {displayName: 'Size', type: 'range', value: 25, step: 5, min: 5, max: 500}
   };
@@ -42,6 +44,7 @@ class ScenegraphDemo extends Component {
     return (
       <App
         {...otherProps}
+        key={this.props.device?.type}
         sizeScale={params.sizeScale.value}
         onDataLoad={count => this.props.onStateChange({count})}
       />


### PR DESCRIPTION
## Goal

opensky URLs now seem to fail due to CORS restructions.
Make the Scenegraph website example load reliably even when the OpenSky browser API is unavailable.

## Changes

- Start from the bundled `all.json` flight snapshot so the example renders immediately.
- Try the live OpenSky endpoint once, then keep the bundled snapshot if the request is blocked by CORS or otherwise fails.
- Normalize data without mutating the imported snapshot.
- Remove the interval/update loop that could create repeated fetch failures.
- Rename the demo from “Realtime Flight Tracker” to “Flight Tracker” and document the fallback behavior.

This PR intentionally contains only example/data-source behavior. The ScenegraphLayer WebGPU port is split into a separate stacked PR.

## Validation

- `yarn lint` (passes with existing repository warnings only)
- `yarn test-website`
