### PR TITLE
chore(core): remove trivial WebGPU conditional checks in layers

### DIFF
--- a/modules/aggregation-layers/src/hexagon-layer/hexagon-cell-layer.ts
+++ b/modules/aggregation-layers/src/hexagon-layer/hexagon-cell-layer.ts
@@ -36,7 +36,7 @@ export default class HexagonCellLayer<ExtraPropsT extends {} = {}> extends Colum
   getShaders() {
     const shaders = super.getShaders();
     shaders.modules.push(hexagonUniforms);
-    return this.context.device.type === 'webgpu' ? {...shaders, source, vs} : {...shaders, vs};
+    return {...shaders, source, vs};
   }
 
   initializeState() {

--- a/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
+++ b/modules/aggregation-layers/src/screen-grid-layer/screen-grid-cell-layer.ts
@@ -32,10 +32,7 @@ export default class ScreenGridCellLayer<ExtraPropsT extends {} = {}> extends La
   };
 
   getShaders() {
-    if (this.context.device.type === 'webgpu') {
-      return super.getShaders({source, vs, fs, modules: [color, picking, screenGridUniforms]});
-    }
-    return super.getShaders({vs, fs, modules: [picking, screenGridUniforms]});
+    return super.getShaders({source, vs, fs, modules: [color, picking, screenGridUniforms]});
   }
 
   initializeState() {

--- a/modules/core/src/shaderlib/color/color.ts
+++ b/modules/core/src/shaderlib/color/color.ts
@@ -27,6 +27,8 @@ export type ColorUniforms = {
 export default {
   name: 'color',
   dependencies: [],
+  // Intentionally WGSL-only. Layers can include this module unconditionally because
+  // the GLSL assembler treats modules without vs/fs source as no-ops.
   source: colorWGSL,
   getUniforms: (_props: Partial<ColorProps>) => {
     // TODO (kaapp) Handle layer opacity

--- a/modules/layers/src/arc-layer/arc-layer.ts
+++ b/modules/layers/src/arc-layer/arc-layer.ts
@@ -150,13 +150,11 @@ export default class ArcLayer<DataT = any, ExtraPropsT extends {} = {}> extends 
   }
 
   getShaders() {
-    const isWebGPU = this.context.device.type === 'webgpu';
-
     return super.getShaders({
       vs,
       fs,
-      ...(isWebGPU ? {source} : {}),
-      modules: [project32, ...(isWebGPU ? [color] : []), picking, arcUniforms]
+      source,
+      modules: [project32, color, picking, arcUniforms]
     }); // 'project' module added by default.
   }
 

--- a/modules/layers/src/bitmap-layer/bitmap-layer.ts
+++ b/modules/layers/src/bitmap-layer/bitmap-layer.ts
@@ -131,15 +131,11 @@ export default class BitmapLayer<ExtraPropsT extends {} = {}> extends Layer<
   };
 
   getShaders() {
-    const isWebGPU = this.context.device.type === 'webgpu';
-
     return super.getShaders({
-      ...(isWebGPU && {source}),
       vs,
       fs,
-      modules: isWebGPU
-        ? [colorModule, project32, picking, bitmapUniforms]
-        : [project32, picking, bitmapUniforms]
+      source,
+      modules: [colorModule, project32, picking, bitmapUniforms]
     });
   }
 

--- a/modules/layers/src/column-layer/column-layer.ts
+++ b/modules/layers/src/column-layer/column-layer.ts
@@ -233,18 +233,17 @@ export default class ColumnLayer<DataT = any, ExtraPropsT extends {} = {}> exten
     const defines: Record<string, any> = {};
 
     const {flatShading} = this.props;
-    const isWebGPU = this.context.device.type === 'webgpu';
     if (flatShading) {
       defines.FLAT_SHADING = 1;
     }
     return super.getShaders({
-      ...(isWebGPU ? {source: source(flatShading)} : {}),
       vs,
       fs,
+      source: source(flatShading),
       defines,
       modules: [
         project32,
-        ...(isWebGPU ? [color] : []),
+        color,
         flatShading ? phongMaterial : gouraudMaterial,
         picking,
         columnUniforms


### PR DESCRIPTION
## Goal

Remove trivial `isWebGPU` checks from shader setup so WebGPU layer ports can use the same `getShaders()` shape on both backends.

## Changes

- Document that the `color` shader module is intentionally WGSL-only and a no-op for GLSL assembly.
- Always supply WGSL `source` alongside `vs`/`fs`; luma.gl selects the source for the active backend.
- Always include the `color` module in ArcLayer, BitmapLayer, ColumnLayer, HexagonCellLayer, and ScreenGridCellLayer.
- Leave real backend-specific branches such as buffer layouts, picking blend state, mipmaps, and constant attributes unchanged.

This follows the existing unconditional `source`/`color` pattern already used by IconLayer, ScatterplotLayer, and PointCloudLayer.

## Impact

No intended rendering change. WebGL still assembles `vs`/`fs`, while WebGPU still assembles WGSL `source`. The color module has no GLSL source, uniforms, or injections.

## Validation

- `yarn build`
- Full pre-commit lint/format and Node test gate
- `yarn vitest run test/render/test-cases/arc-layer.spec.ts test/render/test-cases/column-layer.spec.ts test/render/test-cases/hexagon-layer.spec.ts test/render/test-cases/screen-grid-layer.spec.ts --project render` (23 passed)
- `yarn vitest run test/modules/layers/bitmap-layer.spec.ts --project headless` (4 passed)