### PR TITLE
feat(website): pass device to example apps

### DIFF
--- a/examples/website/360-video/app.tsx
+++ b/examples/website/360-video/app.tsx
@@ -5,6 +5,7 @@
 import React, {useEffect, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {FirstPersonView} from '@deck.gl/core';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {SphereGeometry} from '@luma.gl/engine';
@@ -39,7 +40,7 @@ const INITIAL_VIEW_STATE: FirstPersonViewState = {
   bearing: 90
 };
 
-export default function App() {
+export default function App({device}: {device?: Device}) {
   const [isPlaying, setPlaying] = useState(false);
   const [video, setVideo] = useState<HTMLVideoElement>();
 
@@ -85,6 +86,7 @@ export default function App() {
 
   return (
     <DeckGL
+      device={device}
       views={new FirstPersonView()}
       initialViewState={INITIAL_VIEW_STATE}
       controller={{scrollZoom: false, doubleClickZoom: false}}

--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -6,6 +6,7 @@ import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
 import {CesiumIonLoader} from '@loaders.gl/3d-tiles';
 
@@ -29,9 +30,11 @@ const INITIAL_VIEW_STATE: MapViewState = {
 };
 
 export default function App({
+  device,
   mapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json',
   updateAttributions
 }: {
+  device?: Device;
   mapStyle?: string;
   updateAttributions?: (attributions: any) => void;
 }) {
@@ -62,7 +65,12 @@ export default function App({
   });
 
   return (
-    <DeckGL layers={[tile3DLayer]} initialViewState={initialViewState} controller={true}>
+    <DeckGL
+      device={device}
+      layers={[tile3DLayer]}
+      initialViewState={initialViewState}
+      controller={true}
+    >
       <Map reuseMaps mapStyle={mapStyle} />
     </DeckGL>
   );

--- a/examples/website/arc/app.tsx
+++ b/examples/website/arc/app.tsx
@@ -7,6 +7,7 @@ import React, {useState, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {GeoJsonLayer, ArcLayer} from '@deck.gl/layers';
 import {scaleQuantile} from 'd3-scale';
 
@@ -103,10 +104,12 @@ function getTooltip({object}: PickingInfo<County>) {
 
 /* eslint-disable react/no-deprecated */
 export default function App({
+  device,
   data,
   strokeWidth = 1,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   data?: County[];
   strokeWidth?: number;
   mapStyle?: string;
@@ -138,6 +141,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}

--- a/examples/website/brushing/app.tsx
+++ b/examples/website/brushing/app.tsx
@@ -7,6 +7,7 @@ import React, {useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {ScatterplotLayer, ArcLayer} from '@deck.gl/layers';
 import {BrushingExtension} from '@deck.gl/extensions';
 import {scaleSqrt} from 'd3-scale';
@@ -107,6 +108,7 @@ function getTooltip({object}: PickingInfo<MigrationDestination>) {
 
 /* eslint-disable react/no-deprecated */
 export default function App({
+  device,
   data,
   enableBrushing = true,
   brushRadius = 100000,
@@ -114,6 +116,7 @@ export default function App({
   opacity = 0.7,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   data?: County[];
   enableBrushing?: boolean;
   brushRadius?: number;
@@ -195,6 +198,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}

--- a/examples/website/carto-sql/app.tsx
+++ b/examples/website/carto-sql/app.tsx
@@ -6,6 +6,7 @@ import React, {useState, useCallback} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {LinearInterpolator, PickingInfo} from '@deck.gl/core';
 import {colorBins, H3TileLayer} from '@deck.gl/carto';
 import {h3QuerySource} from '@carto/api-client';
@@ -28,9 +29,15 @@ const globalOptions = {
 const transitionInterpolator = new LinearInterpolator();
 
 export default function App({
+  device,
   urbanity = 'any',
   tourism = 0,
   mapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json'
+}: {
+  device?: Device;
+  urbanity?: string;
+  tourism?: number;
+  mapStyle?: string;
 }) {
   const [viewState, updateViewState] = useState<Record<string, any>>(INITIAL_VIEW_STATE);
 
@@ -91,6 +98,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       controller={true}
       viewState={viewState}
       layers={layers}

--- a/examples/website/collision-filter/app.tsx
+++ b/examples/website/collision-filter/app.tsx
@@ -7,6 +7,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {GeoJsonLayer, TextLayer} from '@deck.gl/layers';
 import {CollisionFilterExtension, CollisionFilterExtensionProps} from '@deck.gl/extensions';
 import {calculateLabels, Label} from './calculate-labels';
@@ -31,11 +32,13 @@ type RoadProperties = {
 };
 
 export default function App({
+  device,
   mapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json',
   sizeScale = 10,
   collisionEnabled = true,
   pointSpacing = 5
 }: {
+  device?: Device;
   mapStyle?: string;
   sizeScale?: number;
   collisionEnabled?: boolean;
@@ -99,7 +102,7 @@ export default function App({
   ];
 
   return (
-    <DeckGL layers={layers} initialViewState={INITIAL_VIEW_STATE} controller={true}>
+    <DeckGL device={device} layers={layers} initialViewState={INITIAL_VIEW_STATE} controller={true}>
       <Map reuseMaps mapStyle={mapStyle} />
     </DeckGL>
   );

--- a/examples/website/contour/app.tsx
+++ b/examples/website/contour/app.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {ContourLayer} from '@deck.gl/aggregation-layers';
 
 import type {ContourLayerProps} from '@deck.gl/aggregation-layers';
@@ -51,12 +52,14 @@ type CaseReport = {
 };
 
 export default function App({
+  device,
   data = DATA_URL,
   week = 35,
   contours = BANDS,
   cellSize = 60000,
   mapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json'
 }: {
+  device?: Device;
   data?: string | CaseReport[];
   week?: number;
   contours?: ContourLayerProps['contours'];
@@ -101,6 +104,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}
       layers={layers}

--- a/examples/website/data-filter/app.tsx
+++ b/examples/website/data-filter/app.tsx
@@ -6,6 +6,7 @@ import React, {useState, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {DataFilterExtension} from '@deck.gl/extensions';
 import {MapView} from '@deck.gl/core';
@@ -89,9 +90,11 @@ function getTooltip({object}: PickingInfo<Earthquake>) {
 }
 
 export default function App({
+  device,
   data,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   data?: Earthquake[];
   mapStyle?: string;
 }) {
@@ -132,6 +135,7 @@ export default function App({
   return (
     <>
       <DeckGL
+        device={device}
         views={MAP_VIEW}
         layers={layers}
         initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/geojson/app.tsx
+++ b/examples/website/geojson/app.tsx
@@ -6,6 +6,7 @@ import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {GeoJsonLayer, PolygonLayer} from '@deck.gl/layers';
 import {LightingEffect, AmbientLight, _SunLight as SunLight} from '@deck.gl/core';
 import {scaleThreshold} from 'd3-scale';
@@ -89,9 +90,11 @@ function getTooltip({object}: PickingInfo<Feature<Geometry, BlockProperties>>) {
 }
 
 export default function App({
+  device,
   data = DATA_URL,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   data?: string | Feature<Geometry, BlockProperties>[];
   mapStyle?: string;
 }) {
@@ -127,6 +130,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       effects={effects}
       initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/globe/app.tsx
+++ b/examples/website/globe/app.tsx
@@ -8,6 +8,7 @@ import {useState, useMemo, useCallback} from 'react';
 import {createRoot} from 'react-dom/client';
 
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {
   _GlobeView as GlobeView,
   LightingEffect,
@@ -69,7 +70,7 @@ type DailyFlights = {
   flights: Flight[];
 };
 
-export default function App({data}: {data?: DailyFlights[]}) {
+export default function App({device, data}: {device?: Device; data?: DailyFlights[]}) {
   const [currentTime, setCurrentTime] = useState(0);
 
   const timeRange: [number, number] = [currentTime, currentTime + TIME_WINDOW];
@@ -126,6 +127,7 @@ export default function App({data}: {data?: DailyFlights[]}) {
   return (
     <>
       <DeckGL
+        device={device}
         views={new GlobeView()}
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}

--- a/examples/website/google-3d-tiles/app.jsx
+++ b/examples/website/google-3d-tiles/app.jsx
@@ -48,6 +48,15 @@ function getTooltip({object}) {
   );
 }
 
+/**
+ * @param {{
+ *   device?: import('@luma.gl/core').Device,
+ *   data?: string,
+ *   distance?: number,
+ *   opacity?: number,
+ *   globeView?: boolean
+ * }} props
+ */
 export default function App({
   device,
   data = TILESET_URL,

--- a/examples/website/google-3d-tiles/app.jsx
+++ b/examples/website/google-3d-tiles/app.jsx
@@ -48,7 +48,13 @@ function getTooltip({object}) {
   );
 }
 
-export default function App({data = TILESET_URL, distance = 0, opacity = 0.2, globeView = false}) {
+export default function App({
+  device,
+  data = TILESET_URL,
+  distance = 0,
+  opacity = 0.2,
+  globeView = false
+}) {
   const [credits, setCredits] = useState('');
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
   const onViewStateChange = useCallback(({viewState: vs}) => setViewState(vs), []);
@@ -107,6 +113,7 @@ export default function App({data = TILESET_URL, distance = 0, opacity = 0.2, gl
   return (
     <div>
       <DeckGL
+        device={device}
         key={globeView ? 'globe' : 'map'}
         style={{backgroundColor: '#061714'}}
         views={view}

--- a/examples/website/heatmap/app.tsx
+++ b/examples/website/heatmap/app.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';
 
 import type {MapViewState} from '@deck.gl/core';
@@ -27,12 +28,14 @@ const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-styl
 type DataPoint = [longitude: number, latitude: number, count: number];
 
 export default function App({
+  device,
   data = DATA_URL,
   intensity = 1,
   threshold = 0.03,
   radiusPixels = 30,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   data?: string | DataPoint[];
   intensity?: number;
   threshold?: number;
@@ -53,7 +56,7 @@ export default function App({
   ];
 
   return (
-    <DeckGL initialViewState={INITIAL_VIEW_STATE} controller={true} layers={layers}>
+    <DeckGL device={device} initialViewState={INITIAL_VIEW_STATE} controller={true} layers={layers}>
       <Map reuseMaps mapStyle={mapStyle} />
     </DeckGL>
   );

--- a/examples/website/highway/app.tsx
+++ b/examples/website/highway/app.tsx
@@ -6,6 +6,7 @@ import React, {useState, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {scaleLinear, scaleThreshold} from 'd3-scale';
 import {CSVLoader} from '@loaders.gl/csv';
@@ -130,11 +131,13 @@ function renderTooltip({
 }
 
 export default function App({
+  device,
   roads = DATA_URL.ROADS,
   year,
   accidents,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   roads?: string | Road[];
   accidents?: Accident[];
   year?: number;
@@ -183,6 +186,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       pickingRadius={5}
       initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/i3s/app.jsx
+++ b/examples/website/i3s/app.jsx
@@ -21,6 +21,13 @@ const INITIAL_VIEW_STATE = {
   maxZoom: 20
 };
 
+/**
+ * @param {{
+ *   device?: import('@luma.gl/core').Device,
+ *   data?: string,
+ *   mapStyle?: string
+ * }} props
+ */
 export default function App({
   device,
   data = TILESET_URL,

--- a/examples/website/i3s/app.jsx
+++ b/examples/website/i3s/app.jsx
@@ -22,6 +22,7 @@ const INITIAL_VIEW_STATE = {
 };
 
 export default function App({
+  device,
   data = TILESET_URL,
   mapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json'
 }) {
@@ -40,6 +41,7 @@ export default function App({
   return (
     <div>
       <DeckGL
+        device={device}
         style={{backgroundColor: '#061714'}}
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}

--- a/examples/website/image-tile/app.tsx
+++ b/examples/website/image-tile/app.tsx
@@ -7,6 +7,7 @@ import React, {useState, useEffect} from 'react';
 import {createRoot} from 'react-dom/client';
 
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {OrthographicView} from '@deck.gl/core';
 import {TileLayer} from '@deck.gl/geo-layers';
 import {BitmapLayer} from '@deck.gl/layers';
@@ -36,9 +37,11 @@ function getTooltip({tile, bitmap}: TileLayerPickingInfo<ImageBitmap, BitmapLaye
 }
 
 export default function App({
+  device,
   autoHighlight = true,
   onTilesLoad
 }: {
+  device?: Device;
   autoHighlight?: boolean;
   onTilesLoad?: () => void;
 }) {
@@ -111,6 +114,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       views={[new OrthographicView({id: 'ortho'})]}
       layers={[tileLayer]}
       initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/mask-extension/app.tsx
+++ b/examples/website/mask-extension/app.tsx
@@ -8,6 +8,7 @@ import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {GeoJsonLayer} from '@deck.gl/layers';
 import {MaskExtension} from '@deck.gl/extensions';
 
@@ -47,12 +48,14 @@ type Flight = {
 
 /* eslint-disable react/no-deprecated */
 export default function App({
+  device,
   data,
   mapStyle = MAP_STYLE,
   showFlights = true,
   timeWindow = 30,
   animationSpeed = 3
 }: {
+  device?: Device;
   data?: Flight[];
   mapStyle?: string;
   showFlights?: boolean;
@@ -131,6 +134,7 @@ export default function App({
   return (
     <>
       <DeckGL
+        device={device}
         initialViewState={INITIAL_VIEW_STATE}
         controller={true}
         layers={[flightPathsLayer, flightMaskLayer, citiesLayers]}

--- a/examples/website/mesh/app.jsx
+++ b/examples/website/mesh/app.jsx
@@ -64,7 +64,7 @@ const background = [
   ]
 ];
 
-export default function App() {
+export default function App({device}) {
   const layers = [
     new SimpleMeshLayer({
       id: 'mini-coopers',
@@ -88,6 +88,7 @@ export default function App() {
 
   return (
     <DeckGL
+      device={device}
       views={
         new OrbitView({
           near: 0.1,

--- a/examples/website/mesh/app.jsx
+++ b/examples/website/mesh/app.jsx
@@ -64,6 +64,7 @@ const background = [
   ]
 ];
 
+/** @param {{device?: import('@luma.gl/core').Device}} props */
 export default function App({device}) {
   const layers = [
     new SimpleMeshLayer({

--- a/examples/website/orthographic/app.tsx
+++ b/examples/website/orthographic/app.tsx
@@ -9,6 +9,7 @@ import {OrthographicView, FilterContext} from '@deck.gl/core';
 import {TextLayer, PathLayer} from '@deck.gl/layers';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {Matrix4} from '@math.gl/core';
 import {scaleLinear} from 'd3-scale';
 import {minIndex, maxIndex} from 'd3-array';
@@ -103,9 +104,11 @@ function layerFilter({viewport, layer}: FilterContext) {
 }
 
 export default function App({
+  device,
   data,
   groupBy = 'Country'
 }: {
+  device?: Device;
   data?: Station[];
   groupBy?: 'Country' | 'Latitude';
 }) {
@@ -220,6 +223,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       views={new OrthographicView()}
       initialViewState={initialViewState}
       controller={{

--- a/examples/website/plot/app.tsx
+++ b/examples/website/plot/app.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {OrbitView, OrbitViewState} from '@deck.gl/core';
 import PlotLayer, {Axes, PlotLayerPickingInfo} from './plot-layer';
 import {scaleLinear} from 'd3-scale';
@@ -52,10 +53,12 @@ function getTooltip({sample}: PlotLayerPickingInfo) {
 }
 
 export default function App({
+  device,
   resolution = 200,
   showAxis = true,
   equation = DEFAULT_EQUATION
 }: {
+  device?: Device;
   equation?: Equation;
   resolution?: number;
   showAxis?: boolean;
@@ -85,6 +88,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       views={new OrbitView({orbitAxis: 'Y'})}
       initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/radio/app.tsx
+++ b/examples/website/radio/app.tsx
@@ -10,6 +10,7 @@ import {MapView, WebMercatorViewport, FlyToInterpolator} from '@deck.gl/core';
 import {ScatterplotLayer, PathLayer} from '@deck.gl/layers';
 import {MVTLayer, H3HexagonLayer} from '@deck.gl/geo-layers';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {load} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 import {scaleSqrt, scaleLinear} from 'd3-scale';
@@ -133,10 +134,12 @@ function getTooltipText(
 
 /* eslint-disable react/no-deprecated */
 export default function App({
+  device,
   data,
   mapStyle = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
   showMinimap = true
 }: {
+  device?: Device;
   data?: Station[];
   mapStyle?: string;
   showMinimap?: boolean;
@@ -256,6 +259,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       views={showMinimap ? [mainView, minimapView] : mainView}
       viewState={viewState}

--- a/examples/website/scenegraph/app.tsx
+++ b/examples/website/scenegraph/app.tsx
@@ -7,6 +7,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
 
 import type {ScenegraphLayerProps} from '@deck.gl/mesh-layers';
@@ -110,10 +111,12 @@ export function useInterval(callback: () => unknown, delay: number) {
 }
 
 export default function App({
+  device,
   sizeScale = 25,
   onDataLoad,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   sizeScale?: number;
   onDataLoad?: (count: number) => void;
   mapStyle?: string;
@@ -178,6 +181,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={[layer]}
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}

--- a/examples/website/terrain-extension/app.tsx
+++ b/examples/website/terrain-extension/app.tsx
@@ -5,6 +5,7 @@
 import React, {useState, useEffect, useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {_GlobeView as GlobeView, MapView} from '@deck.gl/core';
 import {TerrainLayer} from '@deck.gl/geo-layers';
 import {GeoJsonLayer, IconLayer, TextLayer} from '@deck.gl/layers';
@@ -81,9 +82,11 @@ function getTooltip({object}: PickingInfo<Route>) {
 }
 
 export default function App({
+  device,
   initialViewState = INITIAL_VIEW_STATE,
   view = 'GlobeView'
 }: {
+  device?: Device;
   initialViewState?: MapViewState;
   view?: ViewType;
 }) {
@@ -165,6 +168,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       views={deckView}
       viewState={viewState}
       onViewStateChange={e => setViewState(e.viewState as MapViewState)}

--- a/examples/website/terrain/app.tsx
+++ b/examples/website/terrain/app.tsx
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import React, {useCallback, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 
@@ -35,6 +36,7 @@ const ELEVATION_DECODER: TerrainLayerProps['elevationDecoder'] = {
 };
 
 export default function App({
+  device,
   texture = SURFACE_IMAGE,
   wireframe = false,
   globeView = false,
@@ -46,6 +48,7 @@ export default function App({
   initialViewState = INITIAL_VIEW_STATE,
   onZoomChange
 }: {
+  device?: Device;
   texture?: string;
   wireframe?: boolean;
   globeView?: boolean;
@@ -84,6 +87,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       views={globeView ? new GlobeView() : new MapView()}
       viewState={viewState}
       onViewStateChange={onViewStateChange}

--- a/examples/website/text/app.tsx
+++ b/examples/website/text/app.tsx
@@ -8,6 +8,7 @@ import {useState, useCallback} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {MapView} from '@deck.gl/core';
 import {TextLayer} from '@deck.gl/layers';
 import {CollisionFilterExtension} from '@deck.gl/extensions';
@@ -51,11 +52,13 @@ const colorScale = scaleLog<Color>()
   ]);
 
 export default function App({
+  device,
   data,
   noOverlap = true,
   fontSize = 32,
   mapStyle = MAP_STYLE
 }: {
+  device?: Device;
   data?: City[];
   noOverlap?: boolean;
   fontSize?: number;
@@ -102,6 +105,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       views={new MapView({repeat: true})}
       layers={[textLayer]}
       initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/treemap/app.tsx
+++ b/examples/website/treemap/app.tsx
@@ -5,6 +5,7 @@
 import React, {useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {OrthographicView} from '@deck.gl/core';
 import type {PickingInfo, Color} from '@deck.gl/core';
 import {TextLayer} from '@deck.gl/layers';
@@ -52,10 +53,12 @@ const HEADER_SIZE = 20;
 const GAP_SIZE = 1;
 
 export default function App({
+  device,
   data,
   width = 800,
   height = 800
 }: {
+  device?: Device;
   data?: HierarchyNode<Datum>;
   width?: number;
   height?: number;
@@ -162,6 +165,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       views={new OrthographicView()}
       initialViewState={INITIAL_VIEW_STATE}

--- a/examples/website/treemap/app.tsx
+++ b/examples/website/treemap/app.tsx
@@ -5,10 +5,11 @@
 import React, {useMemo} from 'react';
 import {createRoot} from 'react-dom/client';
 import {DeckGL} from '@deck.gl/react';
-import type {Device} from '@luma.gl/core';
 import {OrthographicView} from '@deck.gl/core';
 import type {PickingInfo, Color} from '@deck.gl/core';
 import {TextLayer} from '@deck.gl/layers';
+
+import type {Device} from '@luma.gl/core';
 import {scaleOrdinal} from 'd3-scale';
 import {
   hierarchy,

--- a/examples/website/trips/app.tsx
+++ b/examples/website/trips/app.tsx
@@ -7,6 +7,7 @@ import {createRoot} from 'react-dom/client';
 import {Map} from 'react-map-gl/maplibre';
 import {AmbientLight, PointLight, LightingEffect} from '@deck.gl/core';
 import {DeckGL} from '@deck.gl/react';
+import type {Device} from '@luma.gl/core';
 import {PolygonLayer} from '@deck.gl/layers';
 import {TripsLayer} from '@deck.gl/geo-layers';
 import {animate} from 'popmotion';
@@ -85,6 +86,7 @@ type Trip = {
 };
 
 export default function App({
+  device,
   buildings = DATA_URL.BUILDINGS,
   trips = DATA_URL.TRIPS,
   trailLength = 180,
@@ -94,6 +96,7 @@ export default function App({
   loopLength = 1800, // unit corresponds to the timestamp in source data
   animationSpeed = 1
 }: {
+  device?: Device;
   buildings?: string | Building[];
   trips?: string | Trip[];
   trailLength?: number;
@@ -154,6 +157,7 @@ export default function App({
 
   return (
     <DeckGL
+      device={device}
       layers={layers}
       effects={theme.effects}
       initialViewState={initialViewState}

--- a/website/src/components/example/make-example.jsx
+++ b/website/src/components/example/make-example.jsx
@@ -57,7 +57,7 @@ export default function makeExample(DemoComponent, {isInteractive = true, style}
     const [data, setData] = useState(defaultData);
     const [params, setParams] = useState(defaultParams);
     const [meta, setMeta] = useState({});
-    const device = useStore(state => state.device)
+    const device = useStore(state => (DemoComponent.hasDeviceTabs ? state.device : undefined));
     const baseUrl = useBaseUrl('/');
 
     const useParam = useCallback(newParameters => {


### PR DESCRIPTION
## Goal

Move common device plumbing out of individual WebGPU layer-port PRs.

## Changes

- Add an optional `device` prop to the 26 standalone website demo apps that did not already have one.
- Pass that device through to each demo's `DeckGL` component.
- Keep the existing device-enabled examples unchanged.

After this PR, every standalone website example that owns a `DeckGL` instance can opt into `DeviceTabs` without changing its demo app.

Mapbox/MapLibre overlay examples are intentionally excluded: their deck instance must use the host map's rendering context rather than the website's pre-created device.

## Impact

No behavior change unless a caller supplies `device`. Layer-port PRs can now limit their example changes to enabling the device tabs.

## Validation

- `yarn build`
- `yarn test-website`
- `yarn eslint examples/website/*/app.tsx examples/website/*/app.jsx`
- `yarn prettier --check examples/website/*/app.tsx examples/website/*/app.jsx`
- Full pre-commit lint/format and Node test gate