### PR TITLE
feat(aggregation-layers): port HeatmapLayer to WebGPU

### DIFF
--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -231,7 +231,7 @@ Method called to retrieve weight of each point. By default each point will use a
 
 ## Limitations
 
-The `HeatmapLayer` performs aggregation on the GPU. This feature is fully supported in evergreen desktop browsers, but limited in the following platforms due to partial WebGL support:
+The `HeatmapLayer` performs aggregation on the GPU. On WebGPU, it uses instanced quads and a 16-bit floating-point render target to preserve Gaussian kernel density estimation without requiring WebGL point sprites. On WebGL, this feature is fully supported in evergreen desktop browsers, but limited in the following platforms due to partial WebGL support:
 
 - iOS Safari: WebGL context does not support rendering to a float texture. The layer therefore falls back to an 8-bit low-precision mode, where weights must be integers and the accumulated weights in any pixel cannot exceed 255.
 

--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -52,7 +52,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/aggregation-layers` | `HexagonLayer` | ✅ | ❌ |
 | `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ❌ |
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ❌ |
-| `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ❌ |
+| `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ |
 | `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ❌ |
 | `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `A5Layer` | ✅ | ❌ |

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer-uniforms.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer-uniforms.ts
@@ -5,6 +5,17 @@
 import {Texture} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
+const uniformBlockWGSL = /* wgsl */ `\
+struct weightUniforms {
+  commonBounds: vec4<f32>,
+  radiusPixels: f32,
+  textureWidth: f32,
+  weightsScale: f32,
+};
+
+@group(0) @binding(auto) var<uniform> weight: weightUniforms;
+`;
+
 const uniformBlock = `\
 layout(std140) uniform weightUniforms {
   vec4 commonBounds;
@@ -23,6 +34,7 @@ export type WeightProps = {
 
 export const weightUniforms = {
   name: 'weight',
+  source: uniformBlockWGSL,
   vs: uniformBlock,
   uniformTypes: {
     commonBounds: 'vec4<f32>',
@@ -39,6 +51,14 @@ export type MaxWeightProps = {
 
 export const maxWeightUniforms = {
   name: 'maxWeight',
+  source: /* wgsl */ `\
+struct maxWeightUniforms {
+  textureSize: f32,
+};
+
+@group(0) @binding(auto) var<uniform> maxWeight: maxWeightUniforms;
+@group(0) @binding(auto) var inTexture: texture_2d<f32>;
+`,
   vs: `\
 layout(std140) uniform maxWeightUniforms {
   float textureSize;

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -389,7 +389,13 @@ export default class HeatmapLayer<
 
     if (this.context.device.type === 'webgpu') {
       attributeManager.addInstanced({
-        instancePositions: {size: 3, type: 'float64', accessor: 'getPosition'},
+        instancePositions: {
+          size: 3,
+          type: 'float64',
+          accessor: 'getPosition',
+          // Normalize binary XY positions into the packed XYZ high/low layout WebGPU requires.
+          transform: (position: Position) => [position[0], position[1], position[2] ?? 0]
+        },
         instanceWeights: {size: 1, accessor: 'getWeight'}
       });
       this.setState({positionAttributeName: 'instancePositions'});

--- a/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/heatmap-layer.ts
@@ -10,7 +10,14 @@ import {
   scaleToAspectRatio,
   getTextureCoordinates
 } from './heatmap-layer-utils';
-import {Buffer, DeviceFeature, Texture, TextureProps, TextureFormat} from '@luma.gl/core';
+import {
+  Buffer,
+  DeviceFeature,
+  Texture,
+  TextureProps,
+  TextureFormat,
+  TextureFormatColor
+} from '@luma.gl/core';
 import {TextureTransform, TextureTransformProps} from '@luma.gl/engine';
 import {
   Accessor,
@@ -34,6 +41,8 @@ import weightsVs from './weights-vs.glsl';
 import weightsFs from './weights-fs.glsl';
 import maxVs from './max-vs.glsl';
 import maxFs from './max-fs.glsl';
+import maxSource from './max.wgsl';
+import weightsSource from './weights.wgsl';
 import {
   MaxWeightProps,
   maxWeightUniforms,
@@ -42,6 +51,7 @@ import {
 } from './heatmap-layer-uniforms';
 
 const RESOLUTION = 2; // (number of common space pixels) / (number texels)
+const MAX_WEIGHT_REDUCTION_SIZE = 16;
 const TEXTURE_PROPS: TextureProps = {
   format: 'rgba8unorm',
   dimension: '2d',
@@ -376,11 +386,20 @@ export default class HeatmapLayer<
 
   _setupAttributes() {
     const attributeManager = this.getAttributeManager()!;
-    attributeManager.add({
-      positions: {size: 3, type: 'float64', accessor: 'getPosition'},
-      weights: {size: 1, accessor: 'getWeight'}
-    });
-    this.setState({positionAttributeName: 'positions'});
+
+    if (this.context.device.type === 'webgpu') {
+      attributeManager.addInstanced({
+        instancePositions: {size: 3, type: 'float64', accessor: 'getPosition'},
+        instanceWeights: {size: 1, accessor: 'getWeight'}
+      });
+      this.setState({positionAttributeName: 'instancePositions'});
+    } else {
+      attributeManager.add({
+        positions: {size: 3, type: 'float64', accessor: 'getPosition'},
+        weights: {size: 1, accessor: 'getWeight'}
+      });
+      this.setState({positionAttributeName: 'positions'});
+    }
   }
 
   _setupTextureParams() {
@@ -388,8 +407,15 @@ export default class HeatmapLayer<
     const {weightsTextureSize} = this.props;
 
     const textureSize = Math.min(weightsTextureSize, device.limits.maxTextureDimension2D);
-    const floatTargetSupport = FLOAT_TARGET_FEATURES.every(feature => device.features.has(feature));
-    const format: TextureFormat = floatTargetSupport ? 'rgba32float' : 'rgba8unorm';
+    const isWebGPU = device.type === 'webgpu';
+    const floatTargetSupport = isWebGPU
+      ? device.getTextureFormatCapabilities('rgba16float').blend
+      : FLOAT_TARGET_FEATURES.every(feature => device.features.has(feature));
+    const format: TextureFormat = floatTargetSupport
+      ? isWebGPU
+        ? 'rgba16float'
+        : 'rgba32float'
+      : 'rgba8unorm';
     const weightsScale = floatTargetSupport ? 1 : 1 / 255;
     this.setState({textureSize, format, weightsScale});
     if (!floatTargetSupport) {
@@ -402,14 +428,23 @@ export default class HeatmapLayer<
   _createWeightsTransform(shaders: {vs: string; fs?: string; modules: any[]}) {
     let {weightsTransform} = this.state;
     const {weightsTexture} = this.state;
+    const isWebGPU = this.context.device.type === 'webgpu';
     const attributeManager = this.getAttributeManager()!;
 
     weightsTransform?.destroy();
     weightsTransform = new TextureTransform(this.context.device, {
       id: `${this.id}-weights-transform`,
       ...shaders,
-      bufferLayout: attributeManager.getBufferLayouts(),
-      vertexCount: 1,
+      source: weightsSource,
+      bufferLayout: attributeManager.getBufferLayouts({isInstanced: isWebGPU}),
+      vertexCount: isWebGPU ? 6 : 1,
+      ...(isWebGPU
+        ? {
+            colorAttachmentFormats: [weightsTexture!.format as TextureFormatColor],
+            isInstanced: true,
+            instanceCount: this.getNumInstances()
+          }
+        : {}),
       targetTexture: weightsTexture!,
       parameters: {
         depthWriteEnabled: false,
@@ -420,7 +455,7 @@ export default class HeatmapLayer<
         blendAlphaSrcFactor: 'one',
         blendAlphaDstFactor: 'one'
       },
-      topology: 'point-list',
+      topology: isWebGPU ? 'triangle-list' : 'point-list',
       modules: [...shaders.modules, weightUniforms]
     } as TextureTransformProps);
 
@@ -439,6 +474,7 @@ export default class HeatmapLayer<
     this._createWeightsTransform(weightsTransformShaders);
 
     const maxWeightsTransformShaders = this.getShaders({
+      source: maxSource,
       vs: maxVs,
       fs: maxFs,
       modules: [maxWeightUniforms]
@@ -447,7 +483,13 @@ export default class HeatmapLayer<
       id: `${this.id}-max-weights-transform`,
       targetTexture: maxWeightsTexture!,
       ...maxWeightsTransformShaders,
-      vertexCount: textureSize * textureSize,
+      ...(device.type === 'webgpu'
+        ? {colorAttachmentFormats: [maxWeightsTexture!.format as TextureFormatColor]}
+        : {}),
+      vertexCount:
+        device.type === 'webgpu'
+          ? Math.ceil(textureSize / MAX_WEIGHT_REDUCTION_SIZE) ** 2
+          : textureSize * textureSize,
       topology: 'point-list',
       parameters: {
         depthWriteEnabled: false,
@@ -605,7 +647,13 @@ export default class HeatmapLayer<
     const attributes = attributeManager.getAttributes();
     const moduleSettings = this.getModuleSettings();
     this._setModelAttributes(weightsTransform.model, attributes);
-    weightsTransform.model.setVertexCount(this.getNumInstances());
+    if (this.context.device.type === 'webgpu') {
+      const instanceCount = this.getNumInstances();
+      weightsTransform.model.setVertexCount(instanceCount > 0 ? 6 : 0);
+      weightsTransform.model.setInstanceCount(instanceCount);
+    } else {
+      weightsTransform.model.setVertexCount(this.getNumInstances());
+    }
 
     const weightProps: WeightProps = {
       radiusPixels,

--- a/modules/aggregation-layers/src/heatmap-layer/max.wgsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/max.wgsl.ts
@@ -1,0 +1,48 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct MaxWeightVaryings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) weights: vec4<f32>,
+};
+
+const MAX_WEIGHT_REDUCTION_SIZE: u32 = 16u;
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> MaxWeightVaryings {
+  var output: MaxWeightVaryings;
+  let textureSize = u32(maxWeight.textureSize);
+  let reducedTextureSize =
+    (textureSize + MAX_WEIGHT_REDUCTION_SIZE - 1u) / MAX_WEIGHT_REDUCTION_SIZE;
+  let blockCoordinates = vec2<u32>(
+    vertexIndex % reducedTextureSize,
+    vertexIndex / reducedTextureSize
+  );
+  var maximumWeights = vec4<f32>(0.0);
+
+  for (var y = 0u; y < MAX_WEIGHT_REDUCTION_SIZE; y++) {
+    for (var x = 0u; x < MAX_WEIGHT_REDUCTION_SIZE; x++) {
+      let textureCoordinates = blockCoordinates * MAX_WEIGHT_REDUCTION_SIZE + vec2<u32>(x, y);
+
+      if (textureCoordinates.x < textureSize && textureCoordinates.y < textureSize) {
+        let weights = textureLoad(inTexture, vec2<i32>(textureCoordinates), 0);
+        maximumWeights.r = max(maximumWeights.r, weights.r);
+        maximumWeights.g = max(maximumWeights.g, weights.r / max(1.0, weights.a));
+        maximumWeights.b = max(maximumWeights.b, weights.b);
+        maximumWeights.a = max(maximumWeights.a, weights.a);
+      }
+    }
+  }
+
+  output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  output.weights = maximumWeights;
+  return output;
+}
+
+@fragment
+fn fragmentMain(varyings: MaxWeightVaryings) -> @location(0) vec4<f32> {
+  return varyings.weights;
+}
+`;

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer-uniforms.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer-uniforms.ts
@@ -5,6 +5,22 @@
 import {Texture} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
+const uniformBlockWGSL = /* wgsl */ `\
+struct triangleUniforms {
+  aggregationMode: f32,
+  colorDomain: vec2<f32>,
+  intensity: f32,
+  threshold: f32,
+};
+
+@group(0) @binding(auto) var<uniform> triangle: triangleUniforms;
+@group(0) @binding(auto) var colorTexture: texture_2d<f32>;
+@group(0) @binding(auto) var colorTextureSampler: sampler;
+@group(0) @binding(auto) var maxTexture: texture_2d<f32>;
+@group(0) @binding(auto) var weightsTexture: texture_2d<f32>;
+@group(0) @binding(auto) var weightsTextureSampler: sampler;
+`;
+
 const uniformBlock = `\
 layout(std140) uniform triangleUniforms {
   float aggregationMode;
@@ -26,6 +42,7 @@ export type TriangleProps = {
 
 export const triangleUniforms = {
   name: 'triangle',
+  source: uniformBlockWGSL,
   vs: uniformBlock,
   fs: uniformBlock,
   uniformTypes: {

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.ts
@@ -4,7 +4,8 @@
 
 import type {Buffer, Device, Texture} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
-import {Layer, LayerContext, project32} from '@deck.gl/core';
+import {Layer, LayerContext, color, project32} from '@deck.gl/core';
+import source from './triangle-layer.wgsl';
 import vs from './triangle-layer-vertex.glsl';
 import fs from './triangle-layer-fragment.glsl';
 import {TriangleProps, triangleUniforms} from './triangle-layer-uniforms';
@@ -31,7 +32,7 @@ export default class TriangleLayer extends Layer<_TriangleLayerProps> {
   };
 
   getShaders() {
-    return super.getShaders({vs, fs, modules: [project32, triangleUniforms]});
+    return super.getShaders({source, vs, fs, modules: [project32, color, triangleUniforms]});
   }
 
   initializeState({device}: LayerContext): void {

--- a/modules/aggregation-layers/src/heatmap-layer/triangle-layer.wgsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/triangle-layer.wgsl.ts
@@ -1,0 +1,65 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct TriangleAttributes {
+  @location(0) positions: vec3<f32>,
+  @location(1) texCoords: vec2<f32>,
+};
+
+struct TriangleVaryings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) textureCoordinates: vec2<f32>,
+  @location(1) intensityMinimum: f32,
+  @location(2) intensityMaximum: f32,
+};
+
+@vertex
+fn vertexMain(attributes: TriangleAttributes) -> TriangleVaryings {
+  var output: TriangleVaryings;
+  output.position = project_position_to_clipspace(
+    attributes.positions,
+    vec3<f32>(0.0),
+    vec3<f32>(0.0)
+  );
+  // WebGPU render-target textures use a top-left origin.
+  output.textureCoordinates = vec2<f32>(attributes.texCoords.x, 1.0 - attributes.texCoords.y);
+
+  let maxWeights = textureLoad(maxTexture, vec2<i32>(0), 0);
+  var maximumValue = select(maxWeights.r, maxWeights.g, triangle.aggregationMode > 0.5);
+  var minimumValue = maximumValue * triangle.threshold;
+
+  if (triangle.colorDomain.y > 0.0) {
+    maximumValue = triangle.colorDomain.y;
+    minimumValue = triangle.colorDomain.x;
+  }
+
+  output.intensityMaximum = triangle.intensity / maximumValue;
+  output.intensityMinimum = triangle.intensity / minimumValue;
+  return output;
+}
+
+@fragment
+fn fragmentMain(varyings: TriangleVaryings) -> @location(0) vec4<f32> {
+  let weights = textureSample(weightsTexture, weightsTextureSampler, varyings.textureCoordinates);
+  var weight = weights.r;
+
+  if (triangle.aggregationMode > 0.5) {
+    weight /= max(1.0, weights.a);
+  }
+
+  let colorCoordinates = vec2<f32>(
+    clamp(weight * varyings.intensityMaximum, 0.0, 1.0),
+    0.5
+  );
+  var color = textureSample(colorTexture, colorTextureSampler, colorCoordinates);
+
+  if (weight <= 0.0) {
+    discard;
+  }
+
+  color.a *= min(weight * varyings.intensityMinimum, 1.0) * layer.opacity;
+  return deckgl_premultiplied_alpha(color);
+}
+`;

--- a/modules/aggregation-layers/src/heatmap-layer/weights.wgsl.ts
+++ b/modules/aggregation-layers/src/heatmap-layer/weights.wgsl.ts
@@ -1,0 +1,64 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct WeightAttributes {
+  @builtin(vertex_index) vertexIndex: u32,
+  @location(0) instancePositions: vec3<f32>,
+  @location(1) instancePositions64Low: vec3<f32>,
+  @location(2) instanceWeights: f32,
+};
+
+struct WeightVaryings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) pointCoordinates: vec2<f32>,
+  @location(1) weights: vec4<f32>,
+};
+
+const WEIGHT_QUAD_POSITIONS = array<vec2<f32>, 6>(
+  vec2<f32>(-1.0, -1.0),
+  vec2<f32>(1.0, -1.0),
+  vec2<f32>(-1.0, 1.0),
+  vec2<f32>(-1.0, 1.0),
+  vec2<f32>(1.0, -1.0),
+  vec2<f32>(1.0, 1.0)
+);
+
+@vertex
+fn vertexMain(attributes: WeightAttributes) -> WeightVaryings {
+  var output: WeightVaryings;
+  let commonPosition = project_position_vec3_f64(
+    attributes.instancePositions,
+    attributes.instancePositions64Low
+  );
+  let clipPosition =
+    (commonPosition.xy - weight.commonBounds.xy) /
+    (weight.commonBounds.zw - weight.commonBounds.xy) * 2.0 - vec2<f32>(1.0);
+  let radiusTexels =
+    project_pixel_size_float(weight.radiusPixels) * weight.textureWidth /
+    (weight.commonBounds.z - weight.commonBounds.x);
+  let offset = WEIGHT_QUAD_POSITIONS[attributes.vertexIndex];
+
+  output.position = vec4<f32>(
+    clipPosition + offset * radiusTexels * 2.0 / weight.textureWidth,
+    0.0,
+    1.0
+  );
+  output.pointCoordinates = (offset + vec2<f32>(1.0)) * 0.5;
+  output.weights = vec4<f32>(attributes.instanceWeights * weight.weightsScale, 0.0, 0.0, 1.0);
+  return output;
+}
+
+@fragment
+fn fragmentMain(varyings: WeightVaryings) -> @location(0) vec4<f32> {
+  let distanceFromCenter = length(varyings.pointCoordinates - vec2<f32>(0.5));
+  if (distanceFromCenter > 0.5) {
+    discard;
+  }
+
+  let gaussian = exp(-pow(2.0 * distanceFromCenter, 2.0) / 0.05555) /
+    (1.77245385 * 0.166666);
+  return varyings.weights * gaussian;
+}
+`;

--- a/test/modules/aggregation-layers/heatmap-layer/heatmap-layer.spec.ts
+++ b/test/modules/aggregation-layers/heatmap-layer/heatmap-layer.spec.ts
@@ -5,7 +5,7 @@
 import {test, expect} from 'vitest';
 import * as FIXTURES from 'deck.gl-test/data';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
-import {MapView} from '@deck.gl/core';
+import {LayerManager, MapView} from '@deck.gl/core';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';
 import {default as TriangleLayer} from '@deck.gl/aggregation-layers/heatmap-layer/triangle-layer';
 import {
@@ -20,6 +20,7 @@ import {
   getShaderModuleSource,
   getShaderModuleUniformLayoutValidationResult
 } from '@luma.gl/shadertools';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 const getPosition = d => d.COORDINATES;
 
@@ -337,4 +338,54 @@ test('HeatmapLayer#binaryData', () => {
       }
     ]
   });
+});
+
+test('HeatmapLayer#WebGPU binary positions', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  for (const positionSize of [2, 3]) {
+    const errors: Error[] = [];
+    const layerManager = new LayerManager(webgpuDevice, {viewport: viewport0});
+    layerManager.setProps({onError: error => errors.push(error)});
+
+    const positions =
+      positionSize === 2
+        ? new Float32Array([-122.4, 37.8, -122.3, 37.7])
+        : new Float32Array([-122.4, 37.8, 0, -122.3, 37.7, 0]);
+    const layer = new HeatmapLayer({
+      id: `webgpu-binary-heatmap-${positionSize}`,
+      data: {
+        length: 2,
+        attributes: {
+          getPosition: {value: positions, size: positionSize},
+          getWeight: {value: new Float32Array([100, 50]), size: 1}
+        }
+      },
+      radiusPixels: 30
+    });
+
+    webgpuDevice.handle.pushErrorScope('validation');
+    layerManager.setLayers([layer]);
+
+    expect(errors, `${positionSize}-component binary positions initialize`).toEqual([]);
+    expect(layer.state.weightsTransform, 'creates the weights transform').toBeDefined();
+    const positionLayout = layer.state.weightsTransform?.model.bufferLayout.find(
+      layout => layout.name === 'instancePositions'
+    );
+    expect(positionLayout?.byteStride, 'packs high and low XYZ positions').toBe(24);
+    expect(positionLayout?.attributes, 'declares compatible WebGPU vertex attributes').toEqual([
+      {attribute: 'instancePositions', format: 'float32x3', byteOffset: 0},
+      {attribute: 'instancePositions64Low', format: 'float32x3', byteOffset: 12}
+    ]);
+    expect(
+      await webgpuDevice.handle.popErrorScope(),
+      `${positionSize}-component binary positions create a valid WebGPU pipeline`
+    ).toBeNull();
+
+    layerManager.finalize();
+  }
 });

--- a/test/modules/aggregation-layers/heatmap-layer/heatmap-layer.spec.ts
+++ b/test/modules/aggregation-layers/heatmap-layer/heatmap-layer.spec.ts
@@ -8,8 +8,75 @@ import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
 import {MapView} from '@deck.gl/core';
 import {HeatmapLayer} from '@deck.gl/aggregation-layers';
 import {default as TriangleLayer} from '@deck.gl/aggregation-layers/heatmap-layer/triangle-layer';
+import {
+  maxWeightUniforms,
+  weightUniforms
+} from '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer-uniforms';
+import {triangleUniforms} from '@deck.gl/aggregation-layers/heatmap-layer/triangle-layer-uniforms';
+import triangleSource from '@deck.gl/aggregation-layers/heatmap-layer/triangle-layer.wgsl';
+import maxWeightSource from '@deck.gl/aggregation-layers/heatmap-layer/max.wgsl';
+import weightSource from '@deck.gl/aggregation-layers/heatmap-layer/weights.wgsl';
+import {
+  getShaderModuleSource,
+  getShaderModuleUniformLayoutValidationResult
+} from '@luma.gl/shadertools';
 
 const getPosition = d => d.COORDINATES;
+
+test('HeatmapLayer#WGSL uniform layouts', () => {
+  const modules = [
+    {
+      module: weightUniforms,
+      uniformNames: ['commonBounds', 'radiusPixels', 'textureWidth', 'weightsScale']
+    },
+    {module: maxWeightUniforms, uniformNames: ['textureSize']},
+    {
+      module: triangleUniforms,
+      uniformNames: ['aggregationMode', 'colorDomain', 'intensity', 'threshold']
+    }
+  ];
+
+  for (const {module, uniformNames} of modules) {
+    const validation = getShaderModuleUniformLayoutValidationResult(module, 'wgsl');
+
+    expect(validation, `${module.name} declares a WGSL uniform block`).toBeTruthy();
+    expect(validation?.matches, `${module.name} matches its uniform types`).toBe(true);
+    expect(validation?.expectedUniformNames, `${module.name} preserves uniform order`).toEqual(
+      uniformNames
+    );
+  }
+});
+
+test('HeatmapLayer#WGSL texture bindings', () => {
+  const maxModuleSource = getShaderModuleSource(maxWeightUniforms, 'wgsl');
+  const triangleModuleSource = getShaderModuleSource(triangleUniforms, 'wgsl');
+
+  expect(maxModuleSource).toContain('var inTexture: texture_2d<f32>');
+  expect(triangleModuleSource).toContain('var colorTexture: texture_2d<f32>');
+  expect(triangleModuleSource).toContain('var colorTextureSampler: sampler');
+  expect(triangleModuleSource).toContain('var maxTexture: texture_2d<f32>');
+  expect(triangleModuleSource).toContain('var weightsTexture: texture_2d<f32>');
+  expect(triangleModuleSource).toContain('var weightsTextureSampler: sampler');
+});
+
+test('HeatmapLayer#WGSL kernel uses instanced quads', () => {
+  expect(weightSource).toContain('@builtin(vertex_index) vertexIndex: u32');
+  expect(weightSource).toContain('array<vec2<f32>, 6>');
+  expect(weightSource).toContain('instancePositions: vec3<f32>');
+  expect(weightSource).toContain('instancePositions64Low: vec3<f32>');
+  expect(weightSource).toContain('instanceWeights: f32');
+  expect(weightSource).not.toContain('gl_PointCoord');
+});
+
+test('HeatmapLayer#WGSL maximum reduction uses bounded blocks', () => {
+  expect(maxWeightSource).toContain('MAX_WEIGHT_REDUCTION_SIZE: u32 = 16u');
+  expect(maxWeightSource).toContain('textureCoordinates.x < textureSize');
+  expect(maxWeightSource).toContain('textureCoordinates.y < textureSize');
+});
+
+test('HeatmapLayer#WGSL presentation corrects render-target origin', () => {
+  expect(triangleSource).toContain('1.0 - attributes.texCoords.y');
+});
 
 const viewport0 = new MapView().makeViewport({
   width: 100,

--- a/website/src/examples/heatmap-layer.js
+++ b/website/src/examples/heatmap-layer.js
@@ -12,6 +12,8 @@ import {makeExample} from '../components';
 class HeatmapDemo extends Component {
   static title = 'Uber Pickup Locations In NewYork City';
 
+  static hasDeviceTabs = true;
+
   static data = {
     url: `${DATA_URI}/screen-grid-data-uber-pickups-nyc.txt`,
     worker: '/workers/screen-grid-data-decoder.js'


### PR DESCRIPTION
## Summary

Ports `HeatmapLayer` to WebGPU while preserving its existing WebGL shaders, point-sprite aggregation, precision fallbacks, and golden-image output.

Unlike the CPU-backed aggregation layers, `HeatmapLayer` requires three GPU rendering passes. WebGPU does not support WebGL's programmable point sprites, so the density pass renders one six-vertex instanced Gaussian-kernel quad for each pickup. The maximum-density pass then reduces 16×16 texture blocks before performing max blending, avoiding four million contending writes to a single pixel.

## Changes

- Add WGSL density, maximum-density, and heatmap presentation shaders.
- Register WebGPU density inputs as `instancePositions`, `instancePositions64Low`, and `instanceWeights` so luma.gl correctly applies per-instance stepping and the landed `AttributeManager` buffer layouts work as intended.
- Keep the WebGL `positions`/`weights` attributes and point-list path unchanged.
- Use blendable `rgba16float` render targets on WebGPU while preserving WebGL's existing float extension detection and `rgba32float`/`rgba8unorm` fallback behavior.
- Set the offscreen WebGPU pipeline attachment formats explicitly.
- Handle asynchronously loaded empty input without issuing an invalid instanced draw.
- Reduce maximum-density texture blocks 16×16 before max blending.
- Correct the top-left WebGPU render-target texture origin in the presentation shader.
- Add tests for uniform layouts, texture bindings, instanced attribute names, bounded maximum reduction, and render-target origin.
- Enable the already-landed persisted device tabs on the existing website example without adding app-level device plumbing.
- Update the HeatmapLayer documentation and WebGPU layer support table.

## Website example

| Layer / example | Route | WebGPU result |
| --- | --- | --- |
| HeatmapLayer — NYC Uber pickup locations | `/examples/heatmap-layer` | 574,558 pickup samples; Gaussian density aggregation, 16×16 maximum reduction, color-ramp presentation, and correct geographic placement; verified with the WebGPU tab selected and no WebGPU validation errors. |

## WebGL compatibility

The existing GLSL shaders, non-instanced WebGL attributes, point-sprite topology, floating-point extension checks, precision fallback, and existing `getPosition`/`getWeight` binary accessor path are unchanged. All five existing WebGL reference images pass unchanged: SUM, MEAN, high zoom, high precision, and coordinate offsets.

## Validation

- `yarn build`
- `yarn lint`
- `yarn test-headless test/modules/aggregation-layers` — 44 passing, 2 existing skips
- `yarn test-render test/render/test-cases/heatmap-layer.spec.ts` — 5/5 golden images passing
- `yarn test-website`
- Real-browser production smoke test: selected persisted WebGPU, loaded all 574,558 samples, visually compared NYC hotspots with WebGL, and checked the console for WebGPU shader, pipeline, and validation errors.

The existing `Binding weightsTexture not set: Not found in shader layout` warning also appears on the unchanged WebGL golden-image baseline and is not introduced by this port.