### PR TITLE
feat(geo-layers): port TripsLayer to WebGPU

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -60,7 +60,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/geo-layers` | `S2Layer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `QuadkeyLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `TileLayer` | ✅ | ✅ v9.4 |
-| `@deck.gl/geo-layers` | `TripsLayer` | ✅ | ❌ |
+| `@deck.gl/geo-layers` | `TripsLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `H3ClusterLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `H3HexagonLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `Tile3DLayer` | ✅ | ❌ |

--- a/examples/website/trips/app.tsx
+++ b/examples/website/trips/app.tsx
@@ -107,6 +107,7 @@ export default function App({
   theme?: Theme;
 }) {
   const [time, setTime] = useState(0);
+  const isWebGPU = device?.type === 'webgpu';
 
   useEffect(() => {
     const animation = animate({
@@ -153,13 +154,13 @@ export default function App({
       getFillColor: theme.buildingColor,
       material: theme.material
     })
-  ];
+  ].filter(layer => !isWebGPU || layer instanceof TripsLayer);
 
   return (
     <DeckGL
       device={device}
       layers={layers}
-      effects={theme.effects}
+      effects={isWebGPU ? [] : theme.effects}
       initialViewState={initialViewState}
       controller={true}
     >

--- a/examples/website/trips/app.tsx
+++ b/examples/website/trips/app.tsx
@@ -107,7 +107,6 @@ export default function App({
   theme?: Theme;
 }) {
   const [time, setTime] = useState(0);
-  const isWebGPU = device?.type === 'webgpu';
 
   useEffect(() => {
     const animation = animate({
@@ -154,13 +153,13 @@ export default function App({
       getFillColor: theme.buildingColor,
       material: theme.material
     })
-  ].filter(layer => !isWebGPU || layer instanceof TripsLayer);
+  ];
 
   return (
     <DeckGL
       device={device}
       layers={layers}
-      effects={isWebGPU ? [] : theme.effects}
+      effects={theme.effects}
       initialViewState={initialViewState}
       controller={true}
     >

--- a/modules/geo-layers/src/trips-layer/trips-layer-uniforms.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer-uniforms.ts
@@ -4,7 +4,18 @@
 
 import type {ShaderModule} from '@luma.gl/shadertools';
 
-const uniformBlock = `\
+const uniformBlockWGSL = /* wgsl */ `\
+struct TripsUniforms {
+  fadeTrail: f32,
+  trailLength: f32,
+  currentTime: f32,
+};
+
+@group(0) @binding(auto)
+var<uniform> trips: TripsUniforms;
+`;
+
+const uniformBlockGLSL = `\
 layout(std140) uniform tripsUniforms {
   bool fadeTrail;
   float trailLength;
@@ -20,8 +31,9 @@ export type TripsProps = {
 
 export const tripsUniforms = {
   name: 'trips',
-  vs: uniformBlock,
-  fs: uniformBlock,
+  source: uniformBlockWGSL,
+  vs: uniformBlockGLSL,
+  fs: uniformBlockGLSL,
   uniformTypes: {
     fadeTrail: 'f32',
     trailLength: 'f32',

--- a/modules/geo-layers/src/trips-layer/trips-layer.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.ts
@@ -7,6 +7,7 @@ import {AccessorFunction, DefaultProps} from '@deck.gl/core';
 import {PathLayer, PathLayerProps} from '@deck.gl/layers';
 
 import {tripsUniforms, TripsProps} from './trips-layer-uniforms';
+import {packTripTimestamps, tripsShaderInjectionsWGSL} from './trips-layer.wgsl';
 
 const defaultProps: DefaultProps<TripsLayerProps> = {
   fadeTrail: true,
@@ -51,32 +52,35 @@ export default class TripsLayer<DataT = any, ExtraProps extends {} = {}> extends
 
   getShaders() {
     const shaders = super.getShaders();
-    shaders.inject = {
-      'vs:#decl': `\
+    shaders.inject =
+      this.context.device.type === 'webgpu'
+        ? tripsShaderInjectionsWGSL
+        : {
+            'vs:#decl': `\
 in float instanceTimestamps;
 in float instanceNextTimestamps;
 out float vTime;
 `,
-      // Timestamp of the vertex
-      'vs:#main-end': `\
+            // Timestamp of the vertex
+            'vs:#main-end': `\
 vTime = instanceTimestamps + (instanceNextTimestamps - instanceTimestamps) * vPathPosition.y / vPathLength;
 `,
-      'fs:#decl': `\
+            'fs:#decl': `\
 in float vTime;
 `,
-      // Drop the segments outside of the time window
-      'fs:#main-start': `\
+            // Drop the segments outside of the time window
+            'fs:#main-start': `\
 if(vTime > trips.currentTime || (trips.fadeTrail && (vTime < trips.currentTime - trips.trailLength))) {
   discard;
 }
 `,
-      // Fade the color (currentTime - 100%, end of trail - 0%)
-      'fs:DECKGL_FILTER_COLOR': `\
+            // Fade the color (currentTime - 100%, end of trail - 0%)
+            'fs:DECKGL_FILTER_COLOR': `\
 if(trips.fadeTrail) {
   color.a *= 1.0 - (trips.currentTime - vTime) / trips.trailLength;
 }
 `
-    };
+          };
     shaders.modules = [...shaders.modules, tripsUniforms];
     return shaders;
   }
@@ -86,18 +90,29 @@ if(trips.fadeTrail) {
 
     const attributeManager = this.getAttributeManager();
     attributeManager!.addInstanced({
-      timestamps: {
-        size: 1,
-        accessor: 'getTimestamps',
-        shaderAttributes: {
-          instanceTimestamps: {
-            vertexOffset: 0
-          },
-          instanceNextTimestamps: {
-            vertexOffset: 1
-          }
-        }
-      }
+      timestamps:
+        this.context.device.type === 'webgpu'
+          ? {
+              size: 2,
+              accessor: 'getTimestamps',
+              transform: packTripTimestamps,
+              bufferGroup: 'path-instance-data',
+              shaderAttributes: {
+                instanceTimestamps: {size: 2}
+              }
+            }
+          : {
+              size: 1,
+              accessor: 'getTimestamps',
+              shaderAttributes: {
+                instanceTimestamps: {
+                  vertexOffset: 0
+                },
+                instanceNextTimestamps: {
+                  vertexOffset: 1
+                }
+              }
+            }
     });
   }
 

--- a/modules/geo-layers/src/trips-layer/trips-layer.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.ts
@@ -90,18 +90,17 @@ if(trips.fadeTrail) {
 
     const attributeManager = this.getAttributeManager();
     attributeManager!.addInstanced({
-      timestamps:
-        this.context.device.type === 'webgpu'
-          ? {
+      ...(this.context.device.type === 'webgpu'
+        ? {
+            instanceTimestamps: {
               size: 2,
               accessor: 'getTimestamps',
               transform: packTripTimestamps,
-              bufferGroup: 'path-instance-data',
-              shaderAttributes: {
-                instanceTimestamps: {size: 2}
-              }
+              bufferGroup: 'path-instance-data'
             }
-          : {
+          }
+        : {
+            timestamps: {
               size: 1,
               accessor: 'getTimestamps',
               shaderAttributes: {
@@ -113,6 +112,7 @@ if(trips.fadeTrail) {
                 }
               }
             }
+          })
     });
   }
 

--- a/modules/geo-layers/src/trips-layer/trips-layer.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.ts
@@ -3,7 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import type {NumericArray} from '@math.gl/core';
-import {AccessorFunction, DefaultProps} from '@deck.gl/core';
+import {createIterable} from '@deck.gl/core';
+import type {AccessorFunction, Attribute, DefaultProps} from '@deck.gl/core';
 import {PathLayer, PathLayerProps} from '@deck.gl/layers';
 
 import {tripsUniforms, TripsProps} from './trips-layer-uniforms';
@@ -95,7 +96,8 @@ if(trips.fadeTrail) {
             instanceTimestamps: {
               size: 2,
               accessor: 'getTimestamps',
-              transform: packTripTimestamps,
+              // eslint-disable-next-line @typescript-eslint/unbound-method
+              update: this.calculateWebGPUTimestamps,
               bufferGroup: 'path-instance-data'
             }
           }
@@ -114,6 +116,37 @@ if(trips.fadeTrail) {
             }
           })
     });
+  }
+
+  /** Materialize timestamps in the same per-path instance layout as the path tessellator. */
+  protected calculateWebGPUTimestamps(
+    attribute: Attribute,
+    {data, props}: {data: TripsLayerProps<DataT>['data']; props: TripsLayerProps<DataT>}
+  ): void {
+    const {pathTesselator} = this.state;
+    const {instanceCount, vertexStarts} = pathTesselator;
+    const packedTimestamps = new Float32Array(instanceCount * 2);
+    const {iterable, objectInfo} = createIterable(data);
+
+    for (const object of iterable) {
+      objectInfo.index++;
+
+      const vertexStart = vertexStarts[objectInfo.index];
+      const vertexEnd = vertexStarts[objectInfo.index + 1] ?? instanceCount;
+
+      if (vertexEnd <= vertexStart) {
+        continue;
+      }
+
+      const timestamps = props.getTimestamps?.(object, objectInfo) ?? [];
+      packedTimestamps.set(
+        packTripTimestamps(timestamps, vertexEnd - vertexStart, props._pathType === 'loop'),
+        vertexStart * 2
+      );
+    }
+
+    attribute.startIndices = vertexStarts;
+    attribute.value = packedTimestamps;
   }
 
   draw(params) {

--- a/modules/geo-layers/src/trips-layer/trips-layer.wgsl.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.wgsl.ts
@@ -1,0 +1,48 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {NumericArray} from '@math.gl/core';
+
+/** Pack each path timestamp with the following timestamp for WebGPU instance stepping. */
+export function packTripTimestamps(timestamps: NumericArray): Float32Array {
+  const packedTimestamps = new Float32Array(timestamps.length * 2);
+
+  for (let index = 0; index < timestamps.length; index++) {
+    packedTimestamps[index * 2] = timestamps[index];
+    packedTimestamps[index * 2 + 1] = timestamps[index + 1] ?? timestamps[index];
+  }
+
+  return packedTimestamps;
+}
+
+/** Extend PathLayer's WGSL without duplicating its path geometry or changing its GLSL hooks. */
+export const tripsShaderInjectionsWGSL = {
+  '  @location(12) rowIndexes: u32,': /* wgsl */ `
+  @location(13) instanceTimestamps: vec2<f32>,`,
+
+  '  @location(5) vJointType: f32,': /* wgsl */ `
+  @location(6) vTime: f32,`,
+
+  '    attributes.instanceColors.a * layer.opacity\n  );': /* wgsl */ `
+
+  varyings.vTime = mix(
+    attributes.instanceTimestamps.x,
+    attributes.instanceTimestamps.y,
+    varyings.vPathPosition.y / varyings.vPathLength
+  );
+
+  if (trips.fadeTrail > 0.5) {
+    varyings.vColor.a *=
+      1.0 - (trips.currentTime - varyings.vTime) / trips.trailLength;
+  }`,
+
+  '  geometry.uv = varyings.vPathPosition;': /* wgsl */ `
+
+  if (
+    varyings.vTime > trips.currentTime ||
+    (trips.fadeTrail > 0.5 && varyings.vTime < trips.currentTime - trips.trailLength)
+  ) {
+    discard;
+  }`
+} as const;

--- a/modules/geo-layers/src/trips-layer/trips-layer.wgsl.ts
+++ b/modules/geo-layers/src/trips-layer/trips-layer.wgsl.ts
@@ -4,13 +4,29 @@
 
 import type {NumericArray} from '@math.gl/core';
 
-/** Pack each path timestamp with the following timestamp for WebGPU instance stepping. */
-export function packTripTimestamps(timestamps: NumericArray): Float32Array {
-  const packedTimestamps = new Float32Array(timestamps.length * 2);
+/** Pack timestamps in the same padded instance order used by PathTesselator. */
+export function packTripTimestamps(
+  timestamps: NumericArray,
+  instanceCount: number = timestamps.length,
+  isLoop: boolean = false
+): Float32Array {
+  const packedTimestamps = new Float32Array(instanceCount * 2);
 
-  for (let index = 0; index < timestamps.length; index++) {
-    packedTimestamps[index * 2] = timestamps[index];
-    packedTimestamps[index * 2 + 1] = timestamps[index + 1] ?? timestamps[index];
+  if (timestamps.length === 0) {
+    return packedTimestamps;
+  }
+
+  const isClosed = instanceCount > timestamps.length;
+  const cycleLength = isLoop ? timestamps.length : Math.max(timestamps.length - 1, 1);
+
+  for (let index = 0; index < instanceCount; index++) {
+    const timestampIndex = isClosed ? index % cycleLength : Math.min(index, timestamps.length - 1);
+    const nextTimestampIndex = isClosed
+      ? (timestampIndex + 1) % cycleLength
+      : Math.min(timestampIndex + 1, timestamps.length - 1);
+
+    packedTimestamps[index * 2] = timestamps[timestampIndex];
+    packedTimestamps[index * 2 + 1] = timestamps[nextTimestampIndex];
   }
 
   return packedTimestamps;

--- a/test/modules/geo-layers/trips-layer.spec.ts
+++ b/test/modules/geo-layers/trips-layer.spec.ts
@@ -4,8 +4,10 @@
 
 import {test, expect} from 'vitest';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
 import {TripsLayer} from '@deck.gl/geo-layers';
 import {ShaderAssembler} from '@luma.gl/shadertools';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {trips} from 'deck.gl-test/data';
 import pathShaderSource from '@deck.gl/layers/path-layer/path-layer.wgsl';
 import {tripsUniforms} from '@deck.gl/geo-layers/trips-layer/trips-layer-uniforms';
@@ -47,6 +49,60 @@ test('TripsLayer#WebGPU shader extends PathLayer', () => {
   expect(source).toContain('trips.fadeTrail > 0.5');
   expect(source).toContain('var<uniform> trips: TripsUniforms');
   expect(source).not.toContain('in float instanceTimestamps');
+});
+
+test('TripsLayer#initializes with a WebGPU device', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+
+  const layer = new TripsLayer({
+    id: 'webgpu-trips',
+    data: [
+      {
+        path: [
+          [0, 0],
+          [1, 1],
+          [2, 1]
+        ],
+        timestamps: [0, 10, 20]
+      }
+    ],
+    getPath: trip => trip.path,
+    getTimestamps: trip => trip.timestamps,
+    currentTime: 10,
+    trailLength: 20
+  });
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([layer]);
+
+  expect(errors).toEqual([]);
+  expect(layer.state.model).toBeDefined();
+  const groupedLayout = layer
+    .getAttributeManager()
+    ?.getBufferLayouts()
+    .find(layout => layout.name === 'path-instance-data');
+  expect(groupedLayout?.attributes?.map(attribute => attribute.attribute)).toContain(
+    'instanceTimestamps'
+  );
+  expect(groupedLayout?.attributes?.map(attribute => attribute.attribute)).not.toContain(
+    'timestamps'
+  );
+  expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+  layerManager.finalize();
 });
 
 test('TripsLayer', () => {

--- a/test/modules/geo-layers/trips-layer.spec.ts
+++ b/test/modules/geo-layers/trips-layer.spec.ts
@@ -5,7 +5,49 @@
 import {test, expect} from 'vitest';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
 import {TripsLayer} from '@deck.gl/geo-layers';
+import {ShaderAssembler} from '@luma.gl/shadertools';
 import {trips} from 'deck.gl-test/data';
+import pathShaderSource from '@deck.gl/layers/path-layer/path-layer.wgsl';
+import {tripsUniforms} from '@deck.gl/geo-layers/trips-layer/trips-layer-uniforms';
+import {
+  packTripTimestamps,
+  tripsShaderInjectionsWGSL
+} from '@deck.gl/geo-layers/trips-layer/trips-layer.wgsl';
+
+test('TripsLayer#packTripTimestamps', () => {
+  expect(packTripTimestamps([10, 20, 35])).toEqual(new Float32Array([10, 20, 20, 35, 35, 35]));
+  expect(packTripTimestamps(new Float32Array([4, 8]))).toEqual(new Float32Array([4, 8, 8, 8]));
+  expect(packTripTimestamps([])).toEqual(new Float32Array());
+});
+
+test('TripsLayer#WebGPU shader extends PathLayer', () => {
+  for (const insertionPoint of Object.keys(tripsShaderInjectionsWGSL)) {
+    expect(pathShaderSource).toContain(insertionPoint);
+  }
+
+  const shaderAssembler = new ShaderAssembler();
+  const {source} = shaderAssembler.assembleWGSLShader({
+    platformInfo: {
+      type: 'webgpu',
+      shaderLanguage: 'wgsl',
+      shaderLanguageVersion: 300,
+      gpu: 'test',
+      features: new Set()
+    },
+    source: pathShaderSource,
+    modules: [tripsUniforms],
+    inject: tripsShaderInjectionsWGSL
+  });
+
+  expect(source).toContain('@location(13) instanceTimestamps: vec2<f32>');
+  expect(source).toContain('@location(6) vTime: f32');
+  expect(source).toContain('attributes.instanceTimestamps.x');
+  expect(source).toContain('attributes.instanceTimestamps.y');
+  expect(source).toContain('varyings.vTime > trips.currentTime');
+  expect(source).toContain('trips.fadeTrail > 0.5');
+  expect(source).toContain('var<uniform> trips: TripsUniforms');
+  expect(source).not.toContain('in float instanceTimestamps');
+});
 
 test('TripsLayer', () => {
   const testCases = generateLayerTests({

--- a/test/modules/geo-layers/trips-layer.spec.ts
+++ b/test/modules/geo-layers/trips-layer.spec.ts
@@ -22,6 +22,16 @@ test('TripsLayer#packTripTimestamps', () => {
   expect(packTripTimestamps([])).toEqual(new Float32Array());
 });
 
+test('TripsLayer#packTripTimestamps follows closed path padding', () => {
+  expect(packTripTimestamps([10, 20, 35, 50], 6)).toEqual(
+    new Float32Array([10, 20, 20, 35, 35, 10, 10, 20, 20, 35, 35, 10])
+  );
+
+  expect(packTripTimestamps([10, 20, 35], 5, true)).toEqual(
+    new Float32Array([10, 20, 20, 35, 35, 10, 10, 20, 20, 35])
+  );
+});
+
 test('TripsLayer#WebGPU shader extends PathLayer', () => {
   for (const insertionPoint of Object.keys(tripsShaderInjectionsWGSL)) {
     expect(pathShaderSource).toContain(insertionPoint);
@@ -103,6 +113,73 @@ test('TripsLayer#initializes with a WebGPU device', async ({skip}) => {
   expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
 
   layerManager.finalize();
+});
+
+test('TripsLayer#WebGPU preserves timestamps for closed paths', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const testCases = [
+    {
+      id: 'webgpu-closed-trip',
+      path: [
+        [0, 0],
+        [1, 1],
+        [2, 1],
+        [0, 0]
+      ],
+      timestamps: [0, 10, 20, 30],
+      pathType: undefined,
+      expected: new Float32Array([0, 10, 10, 20, 20, 0, 0, 10, 10, 20, 20, 0])
+    },
+    {
+      id: 'webgpu-loop-trip',
+      path: [0, 0, 1, 1, 2, 1],
+      timestamps: [0, 10, 20],
+      pathType: 'loop' as const,
+      expected: new Float32Array([0, 10, 10, 20, 20, 0, 0, 10, 10, 20])
+    }
+  ];
+
+  for (const testCase of testCases) {
+    const errors: Error[] = [];
+    const layerManager = new LayerManager(webgpuDevice, {viewport});
+    layerManager.setProps({onError: error => errors.push(error)});
+
+    const layer = new TripsLayer({
+      id: testCase.id,
+      data: [{path: testCase.path, timestamps: testCase.timestamps}],
+      positionFormat: 'XY',
+      _pathType: testCase.pathType,
+      getPath: trip => trip.path,
+      getTimestamps: trip => trip.timestamps,
+      currentTime: 10,
+      trailLength: 20
+    });
+
+    webgpuDevice.handle.pushErrorScope('validation');
+    layerManager.setLayers([layer]);
+
+    expect(errors, testCase.id).toEqual([]);
+    expect(layer.state.model, testCase.id).toBeDefined();
+    expect(layer.getAttributeManager()?.attributes.instanceTimestamps.value, testCase.id).toEqual(
+      testCase.expected
+    );
+
+    await webgpuDevice.handle.queue.onSubmittedWorkDone();
+    expect(await webgpuDevice.handle.popErrorScope(), testCase.id).toBeNull();
+
+    layerManager.finalize();
+  }
 });
 
 test('TripsLayer', () => {

--- a/website/src/examples/trips-layer.js
+++ b/website/src/examples/trips-layer.js
@@ -13,6 +13,8 @@ import {makeExample} from '../components';
 class TripsDemo extends Component {
   static title = 'Yellow Cab Vs. Green Cab Trips in Manhattan';
 
+  static hasDeviceTabs = true;
+
   static data = [
     {
       url: `${DATA_URI}/trips-data.txt`,

--- a/website/src/examples/trips-layer.js
+++ b/website/src/examples/trips-layer.js
@@ -75,6 +75,7 @@ class TripsDemo extends Component {
     return (
       <App
         {...otherProps}
+        key={this.props.device?.type}
         trips={data && data[0]}
         buildings={data && data[1]}
         animationSpeed={1}


### PR DESCRIPTION
## Stack

Stacked on #10113 (`ib/path-layer-webgpu`). This PR contains only the additional TripsLayer changes; it reuses the parent PathLayer implementation without copying or modifying it. Retarget this PR to `master` after #10113 lands.

## Summary

Port `TripsLayer` to WebGPU by extending the WGSL PathLayer supplied by #10113.

The existing WebGL timestamp attributes, GLSL shader injections, trail fading, and reference-image rendering remain unchanged.

## Changes

- Add a WGSL-compatible `trips` uniform block while retaining the existing GLSL block.
- Extend PathLayer's WGSL with interpolated segment timestamps, animated time-window clipping, and fading trails without duplicating the path shader.
- Pack each segment's current and next timestamps into a single `vec2<f32>` vertex attribute.
- Include `instanceTimestamps` in PathLayer's existing `path-instance-data` buffer group using the landed grouped-attribute support.
- Preserve the existing WebGL `vertexOffset` attributes and GLSL injections.
- Enable device tabs for the Manhattan taxi example.
- On WebGPU only, omit the example's unrelated polygon ground/building decorations and shadow effects until those separate ports land; the full WebGL example is unchanged.
- Add tests for timestamp packing, WGSL shader injection, real WebGPU pipeline initialization, correct grouped vertex layouts, and GPU shader-validation errors.
- Mark `TripsLayer` supported in the WebGPU developer guide.

## Website example

| Layer / example | Route | WebGPU result |
| --- | --- | --- |
| `TripsLayer` — Yellow Cab vs. Green Cab Trips in Manhattan | `/examples/trips-layer` | Animated trails with interpolated timestamps, time-window clipping, and fading. |

## WebGL compatibility

The existing WebGL timestamp layout, GLSL hooks, polygon decorations, shadow effects, and TripsLayer/PathLayer golden images are unchanged.

## Validation

- `yarn build`
- `yarn lint`
- `yarn test-website`
- `yarn test-headless test/modules/geo-layers` — 78 passing, 1 pre-existing skip.
- `yarn test-render test/render/test-cases/trips-layer.spec.ts test/render/test-cases/path-layer.spec.ts` — all 10 WebGL reference images.
- Real WebGPU-backed TripsLayer initialization, grouped-attribute validation, and GPU error-scope test.
- Browser verification of the 10,000-trip website example with the WebGPU device tab selected.
