### PR TITLE
feat(mesh-layers): port SimpleMeshLayer to WebGPU

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -53,7 +53,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ✅ v9.4  |
 | `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ v9.4 |
-| `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ❌ |
+| `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `A5Layer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `GreatCircleLayer` | ✅ | ❌ |

--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -64,7 +64,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/geo-layers` | `H3ClusterLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `H3HexagonLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `Tile3DLayer` | ✅ | ❌ |
-| `@deck.gl/geo-layers` | `TerrainLayer` | ✅ | ❌ |
+| `@deck.gl/geo-layers` | `TerrainLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `MVTLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `GeohashLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/carto` | `ClusterTileLayer` | ✅ | ❌ |

--- a/examples/website/mesh/app.jsx
+++ b/examples/website/mesh/app.jsx
@@ -86,7 +86,7 @@ export default function App({device}) {
       getPolygon: f => f,
       getFillColor: [0, 0, 0, 0]
     })
-  ].filter(layer => !isWebGPU || layer instanceof SimpleMeshLayer);
+  ];
 
   return (
     <DeckGL

--- a/examples/website/mesh/app.jsx
+++ b/examples/website/mesh/app.jsx
@@ -66,6 +66,7 @@ const background = [
 
 /** @param {{device?: import('@luma.gl/core').Device}} props */
 export default function App({device}) {
+  const isWebGPU = device?.type === 'webgpu';
   const layers = [
     new SimpleMeshLayer({
       id: 'mini-coopers',
@@ -85,7 +86,7 @@ export default function App({device}) {
       getPolygon: f => f,
       getFillColor: [0, 0, 0, 0]
     })
-  ];
+  ].filter(layer => !isWebGPU || layer instanceof SimpleMeshLayer);
 
   return (
     <DeckGL
@@ -99,7 +100,7 @@ export default function App({device}) {
       initialViewState={INITIAL_VIEW_STATE}
       controller={true}
       layers={layers}
-      effects={[lightingEffect]}
+      effects={isWebGPU ? [] : [lightingEffect]}
     />
   );
 }

--- a/modules/geo-layers/src/mesh-layer/mesh-layer-uniforms.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer-uniforms.ts
@@ -10,6 +10,14 @@ layout(std140) uniform meshUniforms {
 } mesh;
 `;
 
+const source = /* wgsl */ `\
+struct MeshUniforms {
+  pickFeatureIds: f32,
+};
+
+@group(0) @binding(auto) var<uniform> mesh: MeshUniforms;
+`;
+
 export type MeshProps = {
   pickFeatureIds: boolean;
 };
@@ -18,6 +26,7 @@ export const meshUniforms = {
   name: 'mesh',
   vs: uniformBlock,
   fs: uniformBlock,
+  source,
   uniformTypes: {
     pickFeatureIds: 'f32'
   }

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.ts
@@ -4,15 +4,16 @@
 
 import type {NumericArray} from '@math.gl/core';
 import {parsePBRMaterial, ParsedPBRMaterial} from '@luma.gl/gltf';
-import {pbrMaterial} from '@luma.gl/shadertools';
 import {Model} from '@luma.gl/engine';
 import type {MeshAttribute, MeshAttributes} from '@loaders.gl/schema';
 import type {UpdateParameters, DefaultProps, LayerContext} from '@deck.gl/core';
 import {SimpleMeshLayer, SimpleMeshLayerProps} from '@deck.gl/mesh-layers';
 
 import {MeshProps, meshUniforms} from './mesh-layer-uniforms';
+import {meshPbrMaterial} from './mesh-pbr-material';
 import vs from './mesh-layer-vertex.glsl';
 import fs from './mesh-layer-fragment.glsl';
+import source from './mesh-layer.wgsl';
 
 export type Mesh = {
   attributes: MeshAttributes;
@@ -62,9 +63,13 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
 
   getShaders() {
     const shaders = super.getShaders();
-    const modules = shaders.modules;
-    modules.push(pbrMaterial, meshUniforms);
-    return {...shaders, vs, fs};
+    return {
+      ...shaders,
+      vs,
+      fs,
+      source,
+      modules: [...shaders.modules, meshPbrMaterial, meshUniforms]
+    };
   }
 
   initializeState() {
@@ -131,7 +136,8 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
       defines: {
         ...shaders.defines,
         ...parsedPBRMaterial?.defines,
-        HAS_UV_REGIONS: mesh.attributes.uvRegions ? 1 : 0
+        HAS_UV_REGIONS: mesh.attributes.uvRegions ? 1 : 0,
+        HAS_FEATURE_IDS: this.props.featureIds ? 1 : 0
       },
       parameters: parsedPBRMaterial?.parameters,
       isInstanced: true

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.wgsl.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.wgsl.ts
@@ -1,0 +1,130 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+#ifdef HAS_NORMALS
+  @location(1) normals: vec3<f32>,
+#endif
+  @location(2) colors: vec4<f32>,
+#ifdef HAS_UV
+  @location(3) texCoords: vec2<f32>,
+#endif
+#ifdef HAS_UV_REGIONS
+  @location(4) uvRegions: vec4<f32>,
+#endif
+#ifdef HAS_FEATURE_IDS
+  @location(5) rowIndexes: u32,
+#endif
+  @location(6) instanceColors: vec4<f32>,
+  @location(7) instanceModelMatrixCol0: vec3<f32>,
+  @location(8) instanceModelMatrixCol1: vec3<f32>,
+  @location(9) instanceModelMatrixCol2: vec3<f32>,
+};
+
+struct FragmentInputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) texCoord: vec2<f32>,
+  @location(2) pbrPosition: vec3<f32>,
+  @location(3) pbrNormal: vec3<f32>,
+  @location(4) pickingColor: vec3<f32>,
+};
+
+fn applyUVRegion(uv: vec2<f32>, uvRegion: vec4<f32>) -> vec2<f32> {
+#ifdef HAS_UV_REGIONS
+  // https://github.com/Esri/i3s-spec/blob/master/docs/1.7/geometryUVRegion.cmn.md
+  return fract(uv) * (uvRegion.zw - uvRegion.xy) + uvRegion.xy;
+#else
+  return uv;
+#endif
+}
+
+@vertex
+fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(instance_index) instanceIndex: u32
+) -> FragmentInputs {
+  var outputs: FragmentInputs;
+  var texCoord = vec2<f32>(0.0);
+  var normal = vec3<f32>(0.0, 0.0, 1.0);
+  var uvRegion = vec4<f32>(0.0);
+
+#ifdef HAS_UV
+  texCoord = inputs.texCoords;
+#endif
+#ifdef HAS_NORMALS
+  normal = inputs.normals;
+#endif
+#ifdef HAS_UV_REGIONS
+  uvRegion = inputs.uvRegions;
+#endif
+
+  texCoord = applyUVRegion(texCoord, uvRegion);
+  geometry.uv = texCoord;
+#ifdef HAS_FEATURE_IDS
+  geometry.pickingColor = picking_getPickingColorFromIndex(inputs.rowIndexes);
+#else
+  geometry.pickingColor = picking_getPickingColorFromIndex(instanceIndex);
+#endif
+
+  let instanceModelMatrix = mat3x3<f32>(
+    inputs.instanceModelMatrixCol0,
+    inputs.instanceModelMatrixCol1,
+    inputs.instanceModelMatrixCol2
+  );
+  let commonPosition = vec4<f32>(project_position_vec3_f32(inputs.positions), 1.0);
+
+  geometry.position = commonPosition;
+  geometry.normal = project_normal(instanceModelMatrix * normal);
+
+  outputs.position = project_common_position_to_clipspace(commonPosition);
+  outputs.color = vec4<f32>(
+    inputs.colors.rgb * inputs.instanceColors.rgb,
+    inputs.instanceColors.a
+  );
+  outputs.texCoord = texCoord;
+  outputs.pbrPosition = commonPosition.xyz;
+  outputs.pbrNormal = geometry.normal;
+  outputs.pickingColor = geometry.pickingColor;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  fragmentGeometry.uv = inputs.texCoord;
+
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(inputs.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(inputs.pickingColor, 1.0);
+  }
+
+  fragmentInputs.pbr_vPosition = inputs.pbrPosition;
+  fragmentInputs.pbr_vUV0 = inputs.texCoord;
+  fragmentInputs.pbr_vUV1 = vec2<f32>(0.0);
+  fragmentInputs.pbr_vNormal = inputs.pbrNormal;
+
+  var color = inputs.color * pbr_filterColor(vec4<f32>(0.0));
+  color.a *= layer.opacity;
+
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedObjectColor = picking_normalizeColor(picking.highlightedObjectColor);
+    if (picking_isColorZero(abs(inputs.pickingColor - highlightedObjectColor))) {
+      let highlightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highlightAlpha + color.a * (1.0 - highlightAlpha);
+      if (blendedAlpha > 0.0) {
+        color = vec4<f32>(
+          mix(color.rgb, picking.highlightColor.rgb, highlightAlpha / blendedAlpha),
+          blendedAlpha
+        );
+      }
+    }
+  }
+
+  return deckgl_premultiplied_alpha(color);
+}
+`;

--- a/modules/geo-layers/src/mesh-layer/mesh-pbr-material.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-pbr-material.ts
@@ -1,0 +1,39 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {pbrMaterial} from '@luma.gl/shadertools';
+
+import type {
+  PBRMaterialBindings,
+  PBRMaterialProps,
+  PBRMaterialUniforms,
+  ShaderModule
+} from '@luma.gl/shadertools';
+
+// The stock PBR module still uses the pre-indexed UV field name in one helper and owns a
+// separate camera uniform. Align it with the current PBR input struct and deck.gl's project
+// module until these compatibility fixes can be made in luma.gl itself.
+const source = (pbrMaterial.source as string)
+  .replace(
+    /fn pbr_setPositionNormalTangentUV\([\s\S]*?\n}\n/,
+    `fn pbr_setPositionNormalTangentUV(position: vec4f, normal: vec4f, tangent: vec4f, uv: vec2f)
+{
+  fragmentInputs.pbr_vPosition = position.xyz;
+  fragmentInputs.pbr_vNormal = normal.xyz;
+  fragmentInputs.pbr_vTBN = mat3x3f(
+    vec3f(1.0, 0.0, 0.0),
+    vec3f(0.0, 1.0, 0.0),
+    vec3f(0.0, 0.0, 1.0)
+  );
+  fragmentInputs.pbr_vUV0 = uv;
+  fragmentInputs.pbr_vUV1 = uv;
+}
+`
+  )
+  .replace(/pbrProjection\.camera/g, 'project.cameraPosition');
+
+export const meshPbrMaterial = {
+  ...pbrMaterial,
+  source
+} as const satisfies ShaderModule<PBRMaterialProps, PBRMaterialUniforms, PBRMaterialBindings>;

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-uniforms.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer-uniforms.ts
@@ -5,7 +5,20 @@
 import type {Texture} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
 
-const uniformBlock = `\
+const uniformBlockWGSL = /* wgsl */ `\
+struct SimpleMeshUniforms {
+  sizeScale: f32,
+  composeModelMatrix: f32,
+  hasTexture: f32,
+  flatShading: f32,
+};
+
+@group(0) @binding(auto) var<uniform> simpleMesh: SimpleMeshUniforms;
+@group(0) @binding(auto) var simpleMeshTexture: texture_2d<f32>;
+@group(0) @binding(auto) var simpleMeshTextureSampler: sampler;
+`;
+
+const uniformBlockGLSL = `\
 layout(std140) uniform simpleMeshUniforms {
   float sizeScale;
   bool composeModelMatrix;
@@ -20,12 +33,14 @@ export type SimpleMeshProps = {
   hasTexture?: boolean;
   flatShading?: boolean;
   sampler?: Texture;
+  simpleMeshTexture?: Texture;
 };
 
 export const simpleMeshUniforms = {
   name: 'simpleMesh',
-  vs: uniformBlock,
-  fs: uniformBlock,
+  source: uniformBlockWGSL,
+  vs: uniformBlockGLSL,
+  fs: uniformBlockGLSL,
   uniformTypes: {
     sizeScale: 'f32',
     composeModelMatrix: 'f32',

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts
@@ -8,6 +8,7 @@
 
 import {
   Layer,
+  color,
   project32,
   picking,
   DefaultProps,
@@ -25,6 +26,7 @@ import {MATRIX_ATTRIBUTES, shouldComposeModelMatrix} from '../utils/matrix';
 import {simpleMeshUniforms, SimpleMeshProps} from './simple-mesh-layer-uniforms';
 import vs from './simple-mesh-layer-vertex.glsl';
 import fs from './simple-mesh-layer-fragment.glsl';
+import source from './simple-mesh-layer.wgsl';
 
 import type {
   LayerProps,
@@ -213,7 +215,8 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
     return super.getShaders({
       vs,
       fs,
-      modules: [project32, phongMaterial, picking, simpleMeshUniforms]
+      source,
+      modules: [project32, color, phongMaterial, picking, simpleMeshUniforms]
     });
   }
 
@@ -342,27 +345,29 @@ export default class SimpleMeshLayer<DataT = any, ExtraPropsT extends {} = {}> e
       isInstanced: true
     });
 
-    const {texture} = this.props;
-    const {emptyTexture} = this.state;
-    const simpleMeshProps: SimpleMeshProps = {
-      sampler: (texture as Texture) || emptyTexture,
-      hasTexture: Boolean(texture)
-    };
-    model.shaderInputs.setProps({simpleMesh: simpleMeshProps});
+    model.shaderInputs.setProps({
+      simpleMesh: this.getTextureProps(this.props.texture as Texture)
+    });
     return model;
   }
 
   private setTexture(texture: Texture): void {
-    const {emptyTexture, model} = this.state;
+    const {model} = this.state;
 
     // props.mesh may not be ready at this time.
     // The sampler will be set when `getModel` is called
     if (model) {
-      const simpleMeshProps: SimpleMeshProps = {
-        sampler: texture || emptyTexture,
-        hasTexture: Boolean(texture)
-      };
-      model.shaderInputs.setProps({simpleMesh: simpleMeshProps});
+      model.shaderInputs.setProps({simpleMesh: this.getTextureProps(texture)});
     }
+  }
+
+  private getTextureProps(texture?: Texture | null): SimpleMeshProps {
+    const meshTexture = texture || this.state.emptyTexture;
+    return {
+      ...(this.context.device.type === 'webgpu'
+        ? {simpleMeshTexture: meshTexture}
+        : {sampler: meshTexture}),
+      hasTexture: Boolean(texture)
+    };
   }
 }

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.wgsl.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.wgsl.ts
@@ -1,0 +1,120 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct Attributes {
+  @builtin(instance_index) instanceIndex: u32,
+  @location(0) positions: vec3<f32>,
+  @location(1) normals: vec3<f32>,
+  @location(2) colors: vec3<f32>,
+  @location(3) texCoords: vec2<f32>,
+  @location(4) instancePositions: vec3<f32>,
+  @location(5) instancePositions64Low: vec3<f32>,
+  @location(6) instanceColors: vec4<f32>,
+  @location(7) instanceModelMatrixCol0: vec3<f32>,
+  @location(8) instanceModelMatrixCol1: vec3<f32>,
+  @location(9) instanceModelMatrixCol2: vec3<f32>,
+  @location(10) instanceTranslation: vec3<f32>,
+};
+
+struct Varyings {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) texCoords: vec2<f32>,
+  @location(2) normal: vec3<f32>,
+  @location(3) positionCommon: vec3<f32>,
+  @location(4) pickingColor: vec3<f32>,
+};
+
+@vertex
+fn vertexMain(attributes: Attributes) -> Varyings {
+  var varyings: Varyings;
+
+  geometry.worldPosition = attributes.instancePositions;
+  geometry.uv = attributes.texCoords;
+  geometry.pickingColor = picking_getPickingColorFromIndex(attributes.instanceIndex);
+
+  let instanceModelMatrix = mat3x3<f32>(
+    attributes.instanceModelMatrixCol0,
+    attributes.instanceModelMatrixCol1,
+    attributes.instanceModelMatrixCol2
+  );
+  let meshPosition =
+    (instanceModelMatrix * attributes.positions) * simpleMesh.sizeScale +
+    attributes.instanceTranslation;
+
+  if (simpleMesh.composeModelMatrix > 0.5) {
+    geometry.normal = project_normal(instanceModelMatrix * attributes.normals);
+    geometry.worldPosition += meshPosition;
+    let projected = project_position_to_clipspace_and_commonspace(
+      attributes.instancePositions + meshPosition,
+      attributes.instancePositions64Low,
+      vec3<f32>(0.0)
+    );
+    geometry.position = projected.commonPosition;
+    varyings.position = projected.clipPosition;
+  } else {
+    let projected = project_position_to_clipspace_and_commonspace(
+      attributes.instancePositions,
+      attributes.instancePositions64Low,
+      project_size_vec3(meshPosition)
+    );
+    geometry.position = projected.commonPosition;
+    geometry.normal = project_normal(instanceModelMatrix * attributes.normals);
+    varyings.position = projected.clipPosition;
+  }
+
+  varyings.color = vec4<f32>(
+    attributes.colors * attributes.instanceColors.rgb,
+    attributes.instanceColors.a
+  );
+  varyings.texCoords = attributes.texCoords;
+  varyings.normal = geometry.normal;
+  varyings.positionCommon = geometry.position.xyz;
+  varyings.pickingColor = geometry.pickingColor;
+  return varyings;
+}
+
+@fragment
+fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
+  geometry.uv = varyings.texCoords;
+
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(varyings.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(varyings.pickingColor, 1.0);
+  }
+
+  var color = varyings.color;
+  if (simpleMesh.hasTexture > 0.5) {
+    color = textureSample(simpleMeshTexture, simpleMeshTextureSampler, varyings.texCoords);
+  }
+
+  var normal = varyings.normal;
+  if (simpleMesh.flatShading > 0.5) {
+    normal = normalize(cross(dpdx(varyings.positionCommon), dpdy(varyings.positionCommon)));
+  }
+
+  color = vec4<f32>(
+    lighting_getLightColor2(color.rgb, project.cameraPosition, varyings.positionCommon, normal),
+    color.a * layer.opacity
+  );
+
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedColor = picking_normalizeColor(picking.highlightedObjectColor);
+    if (picking_isColorZero(abs(varyings.pickingColor - highlightedColor))) {
+      let blendedAlpha = picking.highlightColor.a + color.a * (1.0 - picking.highlightColor.a);
+      if (blendedAlpha > 0.0) {
+        color = vec4<f32>(
+          mix(color.rgb, picking.highlightColor.rgb, picking.highlightColor.a / blendedAlpha),
+          blendedAlpha
+        );
+      }
+    }
+  }
+
+  return deckgl_premultiplied_alpha(color);
+}
+`;

--- a/test/modules/geo-layers/mesh-layer.spec.ts
+++ b/test/modules/geo-layers/mesh-layer.spec.ts
@@ -1,0 +1,85 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
+import {Geometry} from '@luma.gl/engine';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+import MeshLayer from '../../../modules/geo-layers/src/mesh-layer/mesh-layer';
+
+const TEST_MATERIAL = {
+  pbrMetallicRoughness: {
+    baseColorFactor: [1, 1, 1, 1],
+    metallicFactor: 0,
+    roughnessFactor: 1
+  }
+};
+
+test('Tile3DLayer mesh sublayer initializes with a WebGPU device', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+
+  for (const featureIds of [null, new Uint32Array([0, 1, 1])]) {
+    const errors: Error[] = [];
+    const layerManager = new LayerManager(webgpuDevice, {viewport});
+    layerManager.setProps({onError: error => errors.push(error)});
+    const layer = new MeshLayer({
+      id: featureIds ? 'webgpu-tile3d-feature-mesh' : 'webgpu-tile3d-mesh',
+      data: [0],
+      mesh: new Geometry({
+        topology: 'triangle-list',
+        attributes: {
+          positions: {
+            size: 3,
+            value: new Float32Array([-1, -1, 0, 1, -1, 0, 0, 1, 0])
+          },
+          normals: {
+            size: 3,
+            value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+          },
+          colors: {
+            size: 4,
+            value: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255]),
+            normalized: true
+          },
+          texCoords: {
+            size: 2,
+            value: new Float32Array([0, 0, 1, 0, 0.5, 1])
+          },
+          ...(featureIds
+            ? {
+                uvRegions: {
+                  size: 4,
+                  value: new Float32Array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1])
+                }
+              }
+            : {})
+        }
+      }),
+      pbrMaterial: TEST_MATERIAL,
+      featureIds,
+      getPosition: [0, 0, 0],
+      getColor: [255, 255, 255, 255]
+    });
+
+    webgpuDevice.handle.pushErrorScope('validation');
+    layerManager.setLayers([layer]);
+
+    expect(errors).toEqual([]);
+    expect(layer.state.model).toBeDefined();
+    expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+    layerManager.finalize();
+  }
+});

--- a/test/modules/geo-layers/terrain-layer.spec.ts
+++ b/test/modules/geo-layers/terrain-layer.spec.ts
@@ -4,9 +4,76 @@
 
 import {test, expect} from 'vitest';
 import {generateLayerTests, testLayerAsync} from '@deck.gl/test-utils/vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
 import {TerrainLayer, TileLayer} from '@deck.gl/geo-layers';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {TerrainLoader} from '@loaders.gl/terrain';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+const TEST_TERRAIN_MESH = {
+  attributes: {
+    positions: {
+      size: 3,
+      value: new Float32Array([-1, -1, 0, 1, -1, 0, 0, 1, 1])
+    },
+    normals: {
+      size: 3,
+      value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    },
+    texCoords: {
+      size: 2,
+      value: new Float32Array([0, 0, 1, 0, 0.5, 1])
+    }
+  }
+};
+
+class TestTerrainLayer extends TerrainLayer {
+  static layerName = 'TestTerrainLayer';
+
+  loadTerrain() {
+    return TEST_TERRAIN_MESH as any;
+  }
+}
+
+test('TerrainLayer#initializes its mesh sublayer with a WebGPU device', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const texture = webgpuDevice.createTexture({
+    data: new Uint8Array([255, 128, 64, 255]),
+    width: 1,
+    height: 1
+  });
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+  const layer = new TestTerrainLayer({
+    id: 'webgpu-terrain',
+    elevationData: 'terrain.png',
+    bounds: [-1, -1, 1, 1],
+    texture: texture as any
+  });
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([layer]);
+
+  const meshLayer = layer.getSubLayers()[0] as SimpleMeshLayer;
+  expect(errors).toEqual([]);
+  expect(meshLayer).toBeInstanceOf(SimpleMeshLayer);
+  expect(meshLayer.state.model).toBeDefined();
+  expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+  layerManager.finalize();
+  texture.delete();
+});
 
 test('TerrainLayer', async () => {
   const testCases = generateLayerTests({

--- a/test/modules/mesh-layers/simple-mesh-layer.spec.ts
+++ b/test/modules/mesh-layers/simple-mesh-layer.spec.ts
@@ -5,10 +5,65 @@
 import {test, expect} from 'vitest';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
 
+import {LayerManager, MapView} from '@deck.gl/core';
 import {SimpleMeshLayer} from 'deck.gl';
 import {TruncatedConeGeometry} from '@luma.gl/engine';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 import * as FIXTURES from 'deck.gl-test/data';
+
+test('SimpleMeshLayer#initializes with a WebGPU device', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const testTexture = webgpuDevice.createTexture({
+    data: new Uint8Array([255, 128, 64, 255]),
+    width: 1,
+    height: 1
+  });
+
+  for (const texture of [undefined, testTexture]) {
+    const errors: Error[] = [];
+    const layerManager = new LayerManager(webgpuDevice, {viewport});
+    layerManager.setProps({onError: error => errors.push(error)});
+
+    const layer = new SimpleMeshLayer({
+      id: texture ? 'webgpu-textured-simple-mesh' : 'webgpu-simple-mesh',
+      data: [{position: [0, 0, 0]}],
+      mesh: new TruncatedConeGeometry({
+        topRadius: 1,
+        bottomRadius: 1,
+        topCap: true,
+        bottomCap: true,
+        height: 5,
+        nradial: 20,
+        nvertical: 1
+      }),
+      ...(texture ? {texture} : {}),
+      getPosition: object => object.position,
+      getColor: [255, 128, 64, 255]
+    });
+
+    webgpuDevice.handle.pushErrorScope('validation');
+    layerManager.setLayers([layer]);
+
+    expect(errors).toEqual([]);
+    expect(layer.state.model).toBeDefined();
+    expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+    layerManager.finalize();
+  }
+
+  testTexture.delete();
+});
 
 test('SimpleMeshLayer#tests', () => {
   const testCases = generateLayerTests({

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -37,6 +37,7 @@ const sidebars = {
         'scatterplot-layer',
         'scenegraph-layer',
         'screen-grid-layer',
+        'simple-mesh-layer',
         'terrain-layer',
         'text-layer',
         'text-layer-clipping',

--- a/website/src/examples/simple-mesh-layer.js
+++ b/website/src/examples/simple-mesh-layer.js
@@ -27,7 +27,7 @@ class SimpleMeshDemo extends Component {
   }
 
   render() {
-    return <App device={this.props.device} />;
+    return <App key={this.props.device?.type} device={this.props.device} />;
   }
 }
 

--- a/website/src/examples/simple-mesh-layer.js
+++ b/website/src/examples/simple-mesh-layer.js
@@ -1,0 +1,34 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import React, {Component} from 'react';
+import App from 'website-examples/mesh/app';
+import {GITHUB_TREE} from '../constants/defaults';
+import {makeExample} from '../components';
+
+class SimpleMeshDemo extends Component {
+  static title = 'Instanced 3D Mini Coopers';
+
+  static code = `${GITHUB_TREE}/examples/website/mesh`;
+
+  static hasDeviceTabs = true;
+
+  static renderInfo() {
+    return (
+      <div>
+        <p>A grid of 100 independently positioned, colored, and oriented 3D meshes.</p>
+        <div className="stat">
+          No. of Meshes
+          <b>100</b>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return <App device={this.props.device} />;
+  }
+}
+
+export default makeExample(SimpleMeshDemo);

--- a/website/src/examples/simple-mesh-layer.mdx
+++ b/website/src/examples/simple-mesh-layer.mdx
@@ -1,0 +1,5 @@
+# SimpleMeshLayer
+
+import Demo from './simple-mesh-layer';
+
+<Demo />

--- a/website/src/examples/terrain-layer.js
+++ b/website/src/examples/terrain-layer.js
@@ -59,6 +59,8 @@ const SURFACE_IMAGES = {
 class TerrainDemo extends Component {
   static title = 'Terrains';
 
+  static hasDeviceTabs = true;
+
   static code = `${GITHUB_TREE}/examples/website/terrain`;
 
   static parameters = {

--- a/website/src/examples/tile-3d-layer.js
+++ b/website/src/examples/tile-3d-layer.js
@@ -11,6 +11,8 @@ import {makeExample} from '../components';
 class Tiles3DDemo extends Component {
   static title = 'City of Melbourne 3D Point Cloud';
 
+  static hasDeviceTabs = true;
+
   static code = `${GITHUB_TREE}/examples/website/3d-tiles`;
 
   static parameters = {};


### PR DESCRIPTION
## Summary

Port `SimpleMeshLayer` to WebGPU as a small, independent change against `master`.

The existing WebGL vertex and fragment shaders, WebGL texture bindings, mesh transformations, and rendering behavior remain unchanged.

## Changes

- Add a native WGSL SimpleMeshLayer shader covering instanced mesh transforms, geographic and Cartesian projections, smooth and flat Phong shading, texture sampling, opacity, picking, and highlighting.
- Extend the existing shader module with WebGPU uniform, texture, and sampler bindings while preserving its original GLSL uniform block.
- Preserve the existing WebGL texture sampler and use the native WebGPU texture binding only on WebGPU.
- Reuse the existing 100-Mini-Cooper mesh example as a dedicated website example with WebGL/WebGPU device tabs.
- Exclude the unrelated SolidPolygon shadow plane and shadow effects only in WebGPU mode until that separate layer is ported. WebGL continues to render the original complete example unchanged.
- Add a real GPU-backed test validating both textured and untextured mesh pipelines and checking WebGPU validation error scopes.
- Mark `SimpleMeshLayer` as WebGPU-supported in the developer guide.

## Website example

| Layer / example | Route | WebGPU result |
| --- | --- | --- |
| `SimpleMeshLayer` — Instanced 3D Mini Coopers | `/examples/simple-mesh-layer` | 100 independently positioned, oriented, colored, and lit 3D mesh instances. |

## WebGL compatibility

The existing GLSL shaders are unchanged. All existing SimpleMeshLayer golden images remain identical, including geographic, Cartesian, meter-offset, smooth-shading, and flat-shading cases.

## Validation

- `yarn build`
- `yarn lint`
- `yarn test-headless test/modules/mesh-layers`
- `yarn test-render test/render/test-cases/simple-mesh-layer.spec.ts` — all 5 existing reference images pass.
- `yarn test-website`
- Actual WebGPU validation of textured and untextured mesh pipeline creation.
- Browser verification of the new dedicated example with WebGPU selected.
