### PR TITLE
fix(core): position widgets relative to their canvas

### DIFF
--- a/docs/api-reference/core/widget.md
+++ b/docs/api-reference/core/widget.md
@@ -41,10 +41,11 @@ Additional CSS classnames on the top HTML element.
 
 #### `_container` (string | HTMLDivElement, optional) {#_container}
 
-Experimental. The container that this widget is being attached to. Default to `viewId`.
-- If set to `'root'`, the widget is placed relative to the whole deck.gl canvas.
+Experimental. Selects the DOM container used for this widget. Defaults to `viewId`.
+
+- If set to `'root'`, the widget is placed relative to the shared widget root.
 - If set to a valid view id, the widget is placed relative to that view.
-- If set to a HTMLElement, `placement` is ignored and the widget is appended into the given element.
+- If set to an HTMLElement, `placement` is ignored and the widget is appended into the given element.
 
 
 ### Additional `WidgetProps` on UI Widgets
@@ -53,19 +54,13 @@ Experimental. The container that this widget is being attached to. Default to `v
 
 * Default: `null`
 
-The `viewId` prop controls how a widget interacts with views. If `viewId` is defined, the widget is placed in that view and interacts exclusively with it; otherwise, it is placed in the root widget container and affects all views.
-
-When a widget instance is added to Deck, the user can optionally specify a `viewId` that it is attached to (default `null`). If assigned, this widget will only respond to events occurred inside the specific view that matches this id.
-
-The id of the view that the widget is attached to. If `null`, the widget receives events from all views. Otherwise, it only receives events from the view that matches this id.
+The `viewId` prop controls both positioning and event scope. If defined, the widget is positioned relative to the matching view and only responds to events inside that view. If `null`, the widget is positioned in the shared root widget container and receives events from all views.
 
 #### `placement` (string, optional) {#placement}
 
 * Default: `'top-left'`
 
-Widget position within the view relative to the map container.
-
-Widget positioning within the view. One of:
+Widget positioning within the selected view, or within the shared widget root when `viewId` is `null`. One of:
 
 - `'top-left'`
 - `'top-right'`

--- a/docs/api-reference/widgets/overview.md
+++ b/docs/api-reference/widgets/overview.md
@@ -133,7 +133,7 @@ new Deck({
 
 Widgets with UI (e.g. a button or panel) can be positioned relative to the deck.gl view they are controlling, via the `viewId` and `placement` props. See [WidgetProps](../core/widget.md#widgetprops).
 
-The `viewId` controls which HTML container will mount to, and the `placement` prop will position it relative to the container it is in, like so:
+The `viewId` selects a deck-managed view container under the shared widget root, and the `placement` prop positions the widget within that container:
 
 ```ts
 new Deck({

--- a/modules/core/src/lib/tooltip-widget.ts
+++ b/modules/core/src/lib/tooltip-widget.ts
@@ -80,7 +80,10 @@ export class TooltipWidget extends Widget<TooltipWidgetProps> {
       return;
     }
     const displayInfo = getTooltip(info);
-    this.setTooltip(displayInfo, info.x, info.y);
+    const canvasBounds = this.widgetManager?.getCanvasBounds(info.viewport);
+    const x = info.x + (canvasBounds?.x || 0);
+    const y = info.y + (canvasBounds?.y || 0);
+    this.setTooltip(displayInfo, x, y);
   }
 
   setTooltip(displayInfo: TooltipContent, x?: number, y?: number): void {

--- a/modules/core/src/lib/widget-manager.ts
+++ b/modules/core/src/lib/widget-manager.ts
@@ -25,13 +25,28 @@ export type WidgetPlacement = keyof typeof PLACEMENTS;
 
 const ROOT_CONTAINER_ID = 'root';
 
+/** CSS-pixel bounds of a canvas relative to the shared widget root. */
+type WidgetCanvasBounds = {
+  /** Horizontal offset from the widget root. */
+  x: number;
+  /** Vertical offset from the widget root. */
+  y: number;
+  /** Canvas width in CSS pixels. */
+  width: number;
+  /** Canvas height in CSS pixels. */
+  height: number;
+};
+
 export type WidgetManagerProps = {
   deck: Deck<any>;
   parentElement?: HTMLElement | null;
+  /** Optional resolver for a viewport's canvas bounds relative to the widget root. */
+  getCanvasBounds?: (viewport?: Viewport | null) => WidgetCanvasBounds;
 };
 export class WidgetManager {
   deck: Deck<any>;
   parentElement?: HTMLElement | null;
+  private _resolveCanvasBounds?: (viewport?: Viewport | null) => WidgetCanvasBounds;
 
   /** Widgets added via the imperative API */
   private defaultWidgets: Widget[] = [];
@@ -45,10 +60,11 @@ export class WidgetManager {
   /** Viewport provided to widget on redraw */
   private lastViewports: {[id: string]: Viewport} = {};
 
-  constructor({deck, parentElement}: WidgetManagerProps) {
+  constructor({deck, parentElement, getCanvasBounds}: WidgetManagerProps) {
     this.deck = deck;
     parentElement?.classList.add('deck-widget-container');
     this.parentElement = parentElement;
+    this._resolveCanvasBounds = getCanvasBounds;
   }
 
   getWidgets(): Widget[] {
@@ -123,6 +139,23 @@ export class WidgetManager {
         widget.onHover?.(info, event);
       }
     }
+  }
+
+  /** Resolves a viewport's canvas bounds relative to the shared widget root. */
+  getCanvasBounds(viewport?: Viewport | null): WidgetCanvasBounds {
+    if (this._resolveCanvasBounds) {
+      return this._resolveCanvasBounds(viewport);
+    }
+
+    const canvas = this.deck?.getCanvas?.();
+    const canvasBounds = canvas?.getBoundingClientRect();
+    const parentBounds = this.parentElement?.getBoundingClientRect();
+    return {
+      x: canvasBounds && parentBounds ? canvasBounds.left - parentBounds.left : 0,
+      y: canvasBounds && parentBounds ? canvasBounds.top - parentBounds.top : 0,
+      width: canvasBounds?.width || this.deck?.width || 0,
+      height: canvasBounds?.height || this.deck?.height || 0
+    };
   }
 
   onEvent(info: PickingInfo, event: MjolnirGestureEvent) {
@@ -253,23 +286,42 @@ export class WidgetManager {
   }
 
   private _updateContainers() {
-    const canvasWidth = this.deck.width;
-    const canvasHeight = this.deck.height;
     for (const id in this.containers) {
       const viewport = this.lastViewports[id] || null;
       const visible = id === ROOT_CONTAINER_ID || viewport;
 
       const container = this.containers[id];
       if (visible) {
+        const bounds = this._getContainerBounds(viewport);
         container.style.display = 'block';
         // Align the container with the view
-        container.style.left = `${viewport ? viewport.x : 0}px`;
-        container.style.top = `${viewport ? viewport.y : 0}px`;
-        container.style.width = `${viewport ? viewport.width : canvasWidth}px`;
-        container.style.height = `${viewport ? viewport.height : canvasHeight}px`;
+        container.style.left = `${bounds.x}px`;
+        container.style.top = `${bounds.y}px`;
+        container.style.width = `${bounds.width}px`;
+        container.style.height = `${bounds.height}px`;
       } else {
         container.style.display = 'none';
       }
     }
+  }
+
+  /** Resolves a root container or view container in the shared widget coordinate system. */
+  private _getContainerBounds(viewport: Viewport | null): WidgetCanvasBounds {
+    if (!viewport) {
+      return {
+        x: 0,
+        y: 0,
+        width: this.parentElement?.clientWidth || this.deck.width,
+        height: this.parentElement?.clientHeight || this.deck.height
+      };
+    }
+
+    const canvasBounds = this.getCanvasBounds(viewport);
+    return {
+      x: canvasBounds.x + viewport.x,
+      y: canvasBounds.y + viewport.y,
+      width: viewport.width,
+      height: viewport.height
+    };
   }
 }

--- a/modules/core/src/lib/widget.ts
+++ b/modules/core/src/lib/widget.ts
@@ -19,10 +19,11 @@ export type WidgetProps = {
   /** Additional CSS class. */
   className?: string;
   /**
-   * The container that this widget is being attached to. Default to `viewId`.
-   * If set to `'root'`, the widget is placed relative to the whole deck.gl canvas.
+   * Selects the DOM container used for this widget. Defaults to `viewId`.
+   * If set to `'root'`, the widget is placed relative to the shared widget root.
    * If set to a valid view id, the widget is placed relative to that view.
-   * If set to a HTMLElement, `placement` is ignored and the widget is appended into the given element.
+   * If set to an HTMLElement, `placement` is ignored and the widget is appended into the
+   * given element.
    */
   _container?: string | HTMLDivElement | null;
 };
@@ -43,8 +44,8 @@ export abstract class Widget<
   /** Widget props, with defaults applied */
   props: Required<PropsT>;
   /**
-   * The view id that this widget controls. Default `null`.
-   * If assigned, this widget will only respond to events occurred inside the specific view that matches this id.
+   * The view id that this widget controls and is positioned relative to. Default `null`.
+   * If assigned, this widget only responds to events inside the matching view.
    */
   viewId?: string | null = null;
 

--- a/test/modules/core/lib/tooltip.spec.ts
+++ b/test/modules/core/lib/tooltip.spec.ts
@@ -139,3 +139,28 @@ test('TooltipWidget#onViewportChange', () => {
 
   widgetManager.finalize();
 });
+
+test('TooltipWidget#onHover accounts for canvas offset', () => {
+  const container = document.createElement('div');
+  const deck = {
+    props: {getTooltip: () => 'Test tooltip'}
+  };
+  const widgetManager = new WidgetManager({
+    deck,
+    parentElement: container,
+    getCanvasBounds: () => ({x: 100, y: 200, width: 0, height: 0})
+  });
+  const tooltip = new TooltipWidget();
+  widgetManager.addDefault(tooltip);
+
+  tooltip.onHover({
+    object: {elevationValue: 10},
+    viewport: new WebMercatorViewport({id: 'right-view'}),
+    x: 5,
+    y: 7
+  });
+
+  expect(tooltip.rootElement?.style.transform).toBe('translate(105px, 207px)');
+
+  widgetManager.finalize();
+});

--- a/test/modules/core/lib/widget-manager.spec.ts
+++ b/test/modules/core/lib/widget-manager.spec.ts
@@ -220,6 +220,61 @@ test('WidgetManager#onRedraw#without viewId', () => {
   widgetManager.finalize();
 });
 
+test('WidgetManager#onRedraw#without viewId uses parent size', () => {
+  const parentElement = document.createElement('div');
+  Object.defineProperty(parentElement, 'clientWidth', {value: 1200});
+  Object.defineProperty(parentElement, 'clientHeight', {value: 800});
+  const widgetManager = new WidgetManager({
+    deck: mockDeckInstance,
+    parentElement
+  });
+
+  const widget = new TestWidget({id: 'A'});
+  widgetManager.addDefault(widget);
+  widgetManager.onRedraw({viewports: [], layers: []});
+
+  const container = widgetManager.containers['root'];
+  expect(container.style.width, 'root container width uses parent size').toBe('1200px');
+  expect(container.style.height, 'root container height uses parent size').toBe('800px');
+
+  widgetManager.finalize();
+});
+
+test('WidgetManager#onRedraw#viewId uses canvas offset', () => {
+  const parentElement = document.createElement('div');
+  const widgetManager = new WidgetManager({
+    deck: mockDeckInstance,
+    parentElement,
+    getCanvasBounds: () => ({x: 300, y: 200, width: 400, height: 300})
+  });
+
+  const widget = new TestWidget({id: 'A', viewId: 'minimap'});
+  widgetManager.addDefault(widget);
+  widgetManager.onRedraw({
+    viewports: [
+      new WebMercatorViewport({
+        id: 'minimap',
+        x: 7,
+        y: 8,
+        width: 100,
+        height: 80,
+        longitude: 0,
+        latitude: 0,
+        zoom: 0
+      })
+    ],
+    layers: []
+  });
+
+  const container = widgetManager.containers['minimap'];
+  expect(container.style.left, 'view container includes canvas x offset').toBe('307px');
+  expect(container.style.top, 'view container includes canvas y offset').toBe('208px');
+  expect(container.style.width, 'view container width uses viewport width').toBe('100px');
+  expect(container.style.height, 'view container height uses viewport height').toBe('80px');
+
+  widgetManager.finalize();
+});
+
 test('WidgetManager#onRedraw#viewId', () => {
   const parentElement = document.createElement('div');
   const widgetManager = new WidgetManager({deck: mockDeckInstance, parentElement});


### PR DESCRIPTION
## Goal
Position existing Deck widgets and tooltips correctly when their rendering canvas is offset from the shared widget root.

## Changes
- Resolve canvas bounds relative to the shared widget root, with an optional internal bounds resolver for alternate presentation surfaces.
- Size root-level widget containers from their actual parent, and offset view-specific containers by their canvas position.
- Apply the same canvas offset to built-in hover tooltips.
- Clarify widget root, `viewId`, and placement documentation and TSDoc.
- Add focused regressions for root sizing, view-container offsets, and tooltip placement.

## Scope
Seven widget implementation, documentation, and test files only. No `Deck` API changes, multi-canvas props, presentation contexts, event-manager lifecycle changes, or example applications.

## Validation
- `./node_modules/.bin/tsc -p modules/core/tsconfig.json --noEmit --pretty false`
- `yarn test-headless test/modules/core/lib/widget-manager.spec.ts test/modules/core/lib/tooltip.spec.ts test/modules/core/lib/deck.spec.ts --retry 1 --silent` — 39 tests passed.
- Repository lint/format checks and 21 node smoke tests passed through the pre-commit hook.

## Stack
1. This PR: independent widget-root geometry and tooltip positioning.
2. #10229: multi-canvas presentation and interaction, stacked on this preparation.
3. #10492: standalone multi-canvas cities example, stacked on #10229.