### PR TITLE
feat(website): enable WebGPU polygon-dependent examples

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -49,8 +49,8 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/layers` | `TextLayer` | ✅ | ❌ |
 | `@deck.gl/layers` | `SolidPolygonLayer` | ✅ | ✅ |
 | `@deck.gl/aggregation-layers` | `ScreenGridLayer` | ✅ | ✅ |
-| `@deck.gl/aggregation-layers` | `HexagonLayer` | ✅ | ❌ |
-| `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ❌ |
+| `@deck.gl/aggregation-layers` | `HexagonLayer` | ✅ | ✅ |
+| `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ✅ |
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ❌ |
 | `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ |
 | `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ❌ |

--- a/test/modules/aggregation-layers/contour-layer/contour-layer.spec.ts
+++ b/test/modules/aggregation-layers/contour-layer/contour-layer.spec.ts
@@ -8,8 +8,11 @@ import * as FIXTURES from 'deck.gl-test/data';
 
 import {testLayer, testLayerAsync, generateLayerTests, device} from '@deck.gl/test-utils/vitest';
 
+import {LayerManager, MapView} from '@deck.gl/core';
 import {PathLayer, SolidPolygonLayer} from '@deck.gl/layers';
-import {ContourLayer, ContourLayerProps} from '@deck.gl/aggregation-layers';
+import {ContourLayer, CPUAggregator} from '@deck.gl/aggregation-layers';
+import type {ContourLayerProps} from '@deck.gl/aggregation-layers';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 const webglTest = device.type === 'webgl' ? test : test.skip;
 
 const getPosition = d => d.COORDINATES;
@@ -18,6 +21,50 @@ const CONTOURS: ContourLayerProps['contours'] = [
   {threshold: 5, color: [0, 255, 0]}, // => Isoline for threshold 5
   {threshold: [6, 10], color: [0, 0, 255]} // => Isoband for threshold range [6, 10)
 ];
+
+test('ContourLayer#WebGPU renders isolines and isobands with CPU aggregation', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: -122, latitude: 38, zoom: 10}
+  });
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+
+  const layer = new ContourLayer({
+    id: 'webgpu-contours',
+    data: FIXTURES.points,
+    getPosition,
+    gpuAggregation: true,
+    contours: CONTOURS,
+    cellSize: 200
+  });
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([layer]);
+
+  expect(errors).toEqual([]);
+  expect(layer.state.aggregator).toBeInstanceOf(CPUAggregator);
+
+  const renderedLayers = layerManager.getLayers();
+  expect(renderedLayers.some(renderedLayer => renderedLayer instanceof PathLayer)).toBe(true);
+  expect(renderedLayers.some(renderedLayer => renderedLayer instanceof SolidPolygonLayer)).toBe(
+    true
+  );
+
+  await webgpuDevice.handle.queue.onSubmittedWorkDone();
+  expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+  layerManager.finalize();
+});
 
 test('ContourLayer', () => {
   const testCases = generateLayerTests({

--- a/test/modules/aggregation-layers/hexagon-layer.spec.ts
+++ b/test/modules/aggregation-layers/hexagon-layer.spec.ts
@@ -4,7 +4,9 @@
 
 import {test, expect} from 'vitest';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
 import {HexagonLayer, WebGLAggregator, CPUAggregator} from '@deck.gl/aggregation-layers';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import * as FIXTURES from 'deck.gl-test/data';
 import {device} from '@deck.gl/test-utils/vitest';
 
@@ -13,6 +15,51 @@ const SAMPLE_PROPS = {
   getPosition: d => d.COORDINATES
   // gpuAggregation: false
 };
+
+test('HexagonLayer#WebGPU renders with automatic CPU aggregation', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: -122, latitude: 38, zoom: 10}
+  });
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+
+  const layer = new HexagonLayer({
+    id: 'webgpu-hexagons',
+    ...SAMPLE_PROPS,
+    gpuAggregation: true,
+    radius: 1000,
+    extruded: true
+  });
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([layer]);
+
+  expect(errors).toEqual([]);
+  expect(layer.state.aggregator).toBeInstanceOf(CPUAggregator);
+  expect(
+    layerManager
+      .getLayers()
+      .some(
+        renderedLayer =>
+          renderedLayer.id.startsWith('webgpu-hexagons') && renderedLayer.getModels().length > 0
+      )
+  ).toBe(true);
+
+  await webgpuDevice.handle.queue.onSubmittedWorkDone();
+  expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+  layerManager.finalize();
+});
 
 test('HexagonLayer', () => {
   const testCases = generateLayerTests({

--- a/test/modules/layers/arc-layer.spec.ts
+++ b/test/modules/layers/arc-layer.spec.ts
@@ -1,0 +1,77 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
+import {ArcLayer, GeoJsonLayer, SolidPolygonLayer} from '@deck.gl/layers';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('ArcLayer#WebGPU renders arcs alongside filled GeoJSON polygons', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: -100, latitude: 40, zoom: 3}
+  });
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+
+  const counties = new GeoJsonLayer({
+    id: 'webgpu-arc-counties',
+    data: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [-101, 39],
+                [-99, 39],
+                [-99, 41],
+                [-101, 41],
+                [-101, 39]
+              ]
+            ]
+          }
+        }
+      ]
+    },
+    filled: true,
+    stroked: false,
+    getFillColor: [0, 0, 0, 0]
+  });
+  const arcs = new ArcLayer({
+    id: 'webgpu-arc-flows',
+    data: [{source: [-101, 40], target: [-99, 40]}],
+    getSourcePosition: flow => flow.source,
+    getTargetPosition: flow => flow.target,
+    getSourceColor: [0, 128, 255],
+    getTargetColor: [255, 64, 0],
+    getWidth: 2
+  });
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([counties, arcs]);
+
+  expect(errors).toEqual([]);
+  expect(arcs.state.model).toBeDefined();
+  expect(
+    layerManager.getLayers().some(renderedLayer => renderedLayer instanceof SolidPolygonLayer)
+  ).toBe(true);
+
+  await webgpuDevice.handle.queue.onSubmittedWorkDone();
+  expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+  layerManager.finalize();
+});

--- a/website/src/examples/arc-layer.js
+++ b/website/src/examples/arc-layer.js
@@ -18,6 +18,8 @@ const colorRamp = inFlowColors
 class ArcDemo extends Component {
   static title = 'United States County-to-county Migration';
 
+  static hasDeviceTabs = true;
+
   static data = {
     url: `${DATA_URI}/arc-data.txt`,
     worker: '/workers/arc-data-decoder.js'
@@ -78,6 +80,7 @@ class ArcDemo extends Component {
     return (
       <App
         {...otherProps}
+        key={this.props.device?.type}
         strokeWidth={params.lineWidth.value}
         onSelectCounty={this._onSelectCounty}
       />

--- a/website/src/examples/contour-layer.js
+++ b/website/src/examples/contour-layer.js
@@ -13,6 +13,8 @@ const MS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;
 class ContourDemo extends Component {
   static title = 'COVID-19 Cases in the United States';
 
+  static hasDeviceTabs = true;
+
   static data = {
     url: `${DATA_URI}/covid-by-county.txt`,
     worker: '/workers/contour-data-decoder.js'
@@ -126,6 +128,7 @@ class ContourDemo extends Component {
     return (
       <App
         {...this.props}
+        key={this.props.device?.type}
         data={data}
         contours={style === 'Isoband' ? BANDS : LINES}
         cellSize={cellSize}


### PR DESCRIPTION
## Summary

Enable the website device selector for examples whose previously missing polygon sublayers are now supported by WebGPU.

| Example | Polygon dependency | WebGPU behavior |
| --- | --- | --- |
| ArcLayer | Filled county GeoJsonLayer and SolidPolygonLayer | Preserves the complete original county-and-arc demo |
| ContourLayer | PathLayer isolines and SolidPolygonLayer isobands | Automatically falls back to CPU aggregation and preserves both contour types |
| HexagonLayer | Existing WebGPU HexagonCellLayer | Corrects the support matrix and verifies automatic CPU aggregation |

Key demo instances by device type so switching tabs safely finalizes existing GPU resources. Do not enable WebGPU for demos that still depend on unsupported WebGL-only features.

## Validation

- `yarn build`
- `yarn lint`
- `yarn test-website`
- Real-WebGPU headless regression tests for ArcLayer, ContourLayer, HexagonLayer, polygon-backed county geometry, and CPU aggregation fallback.
- Repository commit-hook lint and Node tests.
