### PR TITLE
feat(geo-layers): port A5Layer to WebGPU

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -55,7 +55,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ |
 | `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ❌ |
 | `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ❌ |
-| `@deck.gl/geo-layers` | `A5Layer` | ✅ | ❌ |
+| `@deck.gl/geo-layers` | `A5Layer` | ✅ | ✅ |
 | `@deck.gl/geo-layers` | `GreatCircleLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `S2Layer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `QuadkeyLayer` | ✅ | ❌ |
@@ -76,6 +76,8 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/carto` | `VectorTileLayer` | ✅ | ❌ |
 
 `GeoJsonLayer` supports polygon and line rendering on WebGPU; text point rendering still depends on `TextLayer` support.
+
+`A5Layer` inherits its WebGPU rendering from `PolygonLayer` and supports both bigint and hexadecimal A5 cell identifiers.
 
 ## Extensions
 

--- a/test/modules/geo-layers/a5-layer-webgpu.spec.ts
+++ b/test/modules/geo-layers/a5-layer-webgpu.spec.ts
@@ -1,0 +1,92 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
+import {A5Layer} from '@deck.gl/geo-layers';
+import {PathLayer, PolygonLayer, SolidPolygonLayer} from '@deck.gl/layers';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+const A5_CELLS = [7160826761612099584n, 7160839955751632896n, 7160980693239988224n];
+
+const TEST_CASES = [
+  {name: 'bigint cell identifiers', data: A5_CELLS},
+  {
+    name: 'hexadecimal cell identifiers',
+    data: A5_CELLS.map(cell => cell.toString(16))
+  }
+];
+
+const GEOMETRY_MODES = [
+  {name: 'extruded wireframe cells', extruded: true},
+  {name: 'flat stroked cells', extruded: false}
+];
+
+for (const {name, data} of TEST_CASES) {
+  for (const geometry of GEOMETRY_MODES) {
+    test(`A5Layer#WebGPU ${name} and ${geometry.name}`, async ({skip}) => {
+      const webgpuDevice = await getWebGPUTestDevice();
+      if (!webgpuDevice) {
+        skip();
+        return;
+      }
+
+      const viewport = new MapView().makeViewport({
+        width: 100,
+        height: 100,
+        viewState: {longitude: -122.4, latitude: 37.8, zoom: 2}
+      });
+      const errors: Error[] = [];
+      const layerManager = new LayerManager(webgpuDevice, {viewport});
+      layerManager.setProps({onError: error => errors.push(error)});
+
+      const layer = new A5Layer<bigint | string>({
+        id: 'webgpu-a5-cells',
+        data,
+        getPentagon: cell => cell,
+        extruded: geometry.extruded,
+        wireframe: geometry.extruded,
+        stroked: !geometry.extruded,
+        getElevation: 100
+      });
+
+      webgpuDevice.handle.pushErrorScope('validation');
+      layerManager.setLayers([layer]);
+
+      const polygonLayer = layerManager.layers.find(
+        currentLayer => currentLayer instanceof PolygonLayer
+      );
+      const solidPolygonLayer = layerManager.layers.find(
+        currentLayer => currentLayer instanceof SolidPolygonLayer
+      ) as SolidPolygonLayer | undefined;
+      const pathLayer = layerManager.layers.find(
+        currentLayer => currentLayer instanceof PathLayer
+      ) as PathLayer | undefined;
+
+      expect(errors, 'A5 polygon sublayers initialize').toEqual([]);
+      expect(polygonLayer, 'creates the inherited polygon sublayer').toBeDefined();
+      expect(solidPolygonLayer?.state.topModel, 'creates the pentagon top pipeline').toBeDefined();
+      if (geometry.extruded) {
+        expect(
+          solidPolygonLayer?.state.sideModel,
+          'creates the extruded side pipeline'
+        ).toBeDefined();
+        expect(
+          solidPolygonLayer?.state.wireframeModel,
+          'creates the pentagon wireframe pipeline'
+        ).toBeDefined();
+      } else {
+        expect(pathLayer?.state.model, 'creates the stroked outline pipeline').toBeDefined();
+      }
+
+      await webgpuDevice.handle.queue.onSubmittedWorkDone();
+      expect(
+        await webgpuDevice.handle.popErrorScope(),
+        'A5 tops, sides, wireframes, and outlines have valid WebGPU pipelines'
+      ).toBeNull();
+
+      layerManager.finalize();
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Enable and validate `A5Layer` on WebGPU using its inherited `PolygonLayer` renderer.

| A5 cell identifier | Flat stroked cells | Extruded wireframe cells |
| --- | --- | --- |
| `bigint` | Tested on WebGPU | Tested on WebGPU |
| hexadecimal `string` | Tested on WebGPU | Tested on WebGPU |

Verify pentagon generation, polygon tops, extrusion, wireframes, and path outlines against a real WebGPU device. Update the WebGPU support matrix without changing production A5 code, shaders, or WebGL behavior.

## Validation

- `yarn build`
- `yarn lint`
- Real-WebGPU `yarn test-headless` regression coverage, including the existing `SolidPolygonLayer` validation.
- Repository commit-hook lint and Node smoke tests.
- Existing A5 layer tests.