### PR TITLE
fix(core): preserve WebGPU polygon side buffers

### DIFF
--- a/modules/core/src/lib/attribute/attribute-buffer-groups.ts
+++ b/modules/core/src/lib/attribute/attribute-buffer-groups.ts
@@ -270,7 +270,13 @@ export default class AttributeBufferGroups {
 
   private _getPackedBuffer(group: PackedGroup, upload: boolean): Buffer {
     const byteLength = group.rowCount * group.byteStride;
-    const layoutKey = JSON.stringify(group.layout);
+    // Step mode is pipeline metadata; it does not change the packed buffer contents. A layer may
+    // share one group across instanced and non-instanced models, as SolidPolygonLayer does for
+    // its side and top models.
+    const layoutKey = JSON.stringify({
+      byteStride: group.layout.byteStride,
+      attributes: group.layout.attributes
+    });
     let state = this.packedBuffers[group.id];
 
     if (!state || state.buffer.byteLength < byteLength || state.layoutKey !== layoutKey) {

--- a/test/modules/core/lib/attribute/attribute-buffer-groups.node.spec.ts
+++ b/test/modules/core/lib/attribute/attribute-buffer-groups.node.spec.ts
@@ -190,6 +190,36 @@ test('AttributeManager buffer groups pack IconLayer-style shader attributes', as
   expect(deleteSpy).toHaveBeenCalled();
 });
 
+test('AttributeManager buffer groups are shared across model step modes', () => {
+  const attributeManager = new AttributeManager(createWebGPUDevice());
+  attributeManager.add({
+    a: {size: 1, stepMode: 'dynamic', accessor: 'getA', bufferGroup: 'group-a'},
+    b: {size: 1, stepMode: 'dynamic', accessor: 'getB', bufferGroup: 'group-a'}
+  });
+  updateSimpleGroup(attributeManager, [
+    {a: 1, b: 2},
+    {a: 3, b: 4}
+  ]);
+
+  const attributes = attributeManager.getAttributes();
+  const instancedBindings = attributeManager.getBufferGroupBindings(attributes, {
+    isInstanced: true
+  });
+  const packedBuffer = instancedBindings.buffers['group-a'];
+  const deleteSpy = vi.spyOn(packedBuffer, 'delete');
+
+  const vertexBindings = attributeManager.getBufferGroupBindings(attributes, {
+    isInstanced: false
+  });
+
+  expect(instancedBindings.bufferLayouts[0].stepMode).toBe('instance');
+  expect(vertexBindings.bufferLayouts[0].stepMode).toBe('vertex');
+  expect(vertexBindings.buffers['group-a']).toBe(packedBuffer);
+  expect(deleteSpy).not.toHaveBeenCalled();
+
+  attributeManager.finalize();
+});
+
 test('AttributeManager buffer groups fall back for transitions and external buffers', () => {
   const testDevice = createWebGPUDevice();
   const attributeManager = new AttributeManager(testDevice);


### PR DESCRIPTION
## Goals

Restore extruded `PolygonLayer` side and wireframe rendering in WebGPU.

## Changes

- Treat vertex `stepMode` as pipeline metadata rather than packed-buffer identity.
- Reuse a packed attribute-group buffer when models consume it with different step modes.
- Add regression coverage for a buffer group shared by instanced and vertex models, matching `SolidPolygonLayer`'s side/top model usage.

## Validation

- `yarn`
- `yarn build`
- `yarn lint` (0 errors; existing warnings only)
- `yarn vitest run --project node test/modules/core/lib/attribute/attribute-buffer-groups.node.spec.ts` (7 passed)
- `yarn test-website` (passed; existing broken `TEST-STATUS` anchor warning)
- Production browser verification: WebGPU GeoJson polygon side walls render after backend switching.
- `yarn test`: 1,027 passed, 14 skipped; 6 unrelated existing WebGL golden-image mismatches remained reproducible in isolation.

## Documentation

No public API or user-facing contract changed, so no documentation or migration update is required.