### PR TITLE
fix(react): stabilize WebGPU device switching

### DIFF
--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -23,6 +23,8 @@ type DeckInstanceRef<ViewsT extends ViewOrViews> = {
   lastRenderedViewports?: Viewport[];
   viewStateUpdateRequested?: any;
   interactionStateUpdateRequested?: any;
+  externalCanvasStyle?: CSSStyleDeclaration;
+  originalCanvasVisibility?: string;
   forceUpdate: () => void;
   version: number;
   control: React.ReactHTMLElement<HTMLElement> | null;
@@ -76,36 +78,79 @@ function redrawDeck(thisRef: DeckInstanceRef<any>) {
   }
 }
 
+function showExternalCanvas(thisRef: DeckInstanceRef<any>) {
+  if (thisRef.externalCanvasStyle) {
+    thisRef.externalCanvasStyle.visibility = thisRef.originalCanvasVisibility || '';
+    thisRef.externalCanvasStyle = undefined;
+    thisRef.originalCanvasVisibility = undefined;
+  }
+}
+
+function isWebGPUDevice(props: DeckProps<any>): boolean {
+  return (
+    props.device?.type === 'webgpu' ||
+    props.deviceProps?.type === 'webgpu' ||
+    props.deviceProps?.adapters?.[0]?.type === 'webgpu'
+  );
+}
+
+function deckSizeMatchesContainer(
+  thisRef: DeckInstanceRef<any>,
+  container: HTMLElement | null
+): boolean {
+  const deck = thisRef.deck;
+  return Boolean(
+    deck &&
+      container &&
+      deck.width === container.clientWidth &&
+      deck.height === container.clientHeight
+  );
+}
+
 function createDeckInstance<ViewsT extends ViewOrViews>(
   thisRef: DeckInstanceRef<ViewsT>,
   DeckClass: typeof Deck,
   props: DeckProps<ViewsT>
 ): Deck<ViewsT> {
+  const isWebGPU = isWebGPUDevice(props);
+  const externalCanvas = props.device?.getDefaultCanvasContext().canvas;
+  const externalCanvasStyle =
+    externalCanvas instanceof HTMLCanvasElement && !externalCanvas.isConnected
+      ? externalCanvas.style
+      : null;
+
+  // A reused external device retains the last rendered frame in its canvas. Keep a detached
+  // canvas hidden while Deck moves it into the new container and initializes the first frame.
+  if (externalCanvasStyle) {
+    thisRef.externalCanvasStyle = externalCanvasStyle;
+    thisRef.originalCanvasVisibility = externalCanvasStyle.visibility;
+    externalCanvasStyle.visibility = 'hidden';
+  }
+
   const deck = new DeckClass({
     ...props,
     // The Deck's animation loop is independent from React's render cycle, causing potential
     // synchronization issues. We provide this custom render function to make sure that React
     // and Deck update on the same schedule.
     // TODO(ibgreen) - Hack to enable WebGPU as it needs to render quickly to avoid CanvasContext texture from going stale
-    _customRender:
-      props.deviceProps?.adapters?.[0]?.type === 'webgpu'
-        ? undefined
-        : redrawReason => {
-            // Save the dirty flag for later
-            thisRef.redrawReason = redrawReason;
+    _customRender: isWebGPU
+      ? undefined
+      : redrawReason => {
+          // Save the dirty flag for later
+          thisRef.redrawReason = redrawReason;
 
-            // Viewport/view state is passed to child components as props.
-            // If they have changed, we need to trigger a React rerender to update children props.
-            const viewports = deck.getViewports();
-            if (thisRef.lastRenderedViewports !== viewports) {
-              // Viewports have changed, update children props first.
-              // This will delay the Deck canvas redraw till after React update (in useLayoutEffect)
-              // so that the canvas does not get rendered before the child components update.
-              thisRef.forceUpdate();
-            } else {
-              redrawDeck(thisRef);
-            }
+          // Viewport/view state is passed to child components as props.
+          // If they have changed, we need to trigger a React rerender to update children props.
+          const viewports = deck.getViewports();
+          if (thisRef.lastRenderedViewports !== viewports) {
+            // Viewports have changed, update children props first.
+            // This will delay the Deck canvas redraw till after React update (in useLayoutEffect)
+            // so that the canvas does not get rendered before the child components update.
+            thisRef.forceUpdate();
+          } else {
+            redrawDeck(thisRef);
           }
+        }
   });
   return deck;
 }
@@ -145,7 +190,18 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       return null;
     }
     thisRef.viewStateUpdateRequested = null;
-    return props.onViewStateChange?.(params);
+    const viewState = props.onViewStateChange?.(params);
+    if (
+      !props.viewState &&
+      isWebGPUDevice(props) &&
+      deckSizeMatchesContainer(thisRef, containerRef.current)
+    ) {
+      // WebGPU uses Deck's native render loop so that its CanvasContext texture is consumed
+      // immediately. Explicitly update React children (typically a basemap) when Deck advances
+      // an internally managed view state.
+      thisRef.forceUpdate();
+    }
+    return viewState;
   };
 
   const handleInteractionStateChange: DeckProps<ViewsT>['onInteractionStateChange'] = params => {
@@ -158,6 +214,22 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       thisRef.interactionStateUpdateRequested = null;
       props.onInteractionStateChange?.(params);
     }
+  };
+
+  const handleAfterRender: DeckProps<ViewsT>['onAfterRender'] = context => {
+    showExternalCanvas(thisRef);
+    if (
+      isWebGPUDevice(props) &&
+      thisRef.deck?.isInitialized &&
+      deckSizeMatchesContainer(thisRef, containerRef.current) &&
+      thisRef.lastRenderedViewports !== thisRef.deck.getViewports()
+    ) {
+      // The native WebGPU render loop bypasses `_customRender`, which normally schedules the
+      // first React rerender after Deck initializes. Trigger it here so children such as a
+      // basemap are positioned using the initialized viewport.
+      thisRef.forceUpdate();
+    }
+    props.onAfterRender?.(context);
   };
 
   // Update Deck's props. If Deck needs redraw, this will trigger a call to `_customRender` in
@@ -175,7 +247,8 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       canvas: canvasRef.current,
       layers: jsxProps.layers,
       onViewStateChange: handleViewStateChange,
-      onInteractionStateChange: handleInteractionStateChange
+      onInteractionStateChange: handleInteractionStateChange,
+      onAfterRender: handleAfterRender
     };
 
     if (jsxProps.views) {
@@ -208,7 +281,10 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       canvas: canvasRef.current
     });
 
-    return () => thisRef.deck?.finalize();
+    return () => {
+      showExternalCanvas(thisRef);
+      thisRef.deck?.finalize();
+    };
   }, []);
 
   useIsomorphicLayoutEffect(() => {

--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -23,10 +23,6 @@ type DeckInstanceRef<ViewsT extends ViewOrViews> = {
   lastRenderedViewports?: Viewport[];
   viewStateUpdateRequested?: any;
   interactionStateUpdateRequested?: any;
-  // An externally supplied device owns its canvas across DeckGL mounts. Preserve its original
-  // visibility so an interrupted backend switch cannot leave the shared canvas permanently hidden.
-  externalCanvasStyle?: CSSStyleDeclaration;
-  originalCanvasVisibility?: string;
   forceUpdate: () => void;
   version: number;
   control: React.ReactHTMLElement<HTMLElement> | null;
@@ -80,27 +76,6 @@ function redrawDeck(thisRef: DeckInstanceRef<any>) {
   }
 }
 
-// A device can be cached and mounted again when the website switches WebGPU -> WebGL -> WebGPU.
-// Reveal its canvas only after the new Deck has drawn, or when the mount is cancelled. Otherwise
-// the old WebGPU frame can flash in the new React container.
-function showExternalCanvas(thisRef: DeckInstanceRef<any>) {
-  if (thisRef.externalCanvasStyle) {
-    thisRef.externalCanvasStyle.visibility = thisRef.originalCanvasVisibility || '';
-    thisRef.externalCanvasStyle = undefined;
-    thisRef.originalCanvasVisibility = undefined;
-  }
-}
-
-// DeckGL accepts both an already-created device and instructions for creating one. Account for
-// both forms so the render policy does not change depending on who initialized the WebGPU device.
-function isWebGPUDevice(props: DeckProps<any>): boolean {
-  return (
-    props.device?.type === 'webgpu' ||
-    props.deviceProps?.type === 'webgpu' ||
-    props.deviceProps?.adapters?.[0]?.type === 'webgpu'
-  );
-}
-
 // luma.gl initially gives a detached canvas a small placeholder size. Do not mount a basemap
 // against that temporary viewport: MapLibre would initialize its own canvas at 1 x 1 pixels.
 function deckSizeMatchesContainer(
@@ -121,21 +96,6 @@ function createDeckInstance<ViewsT extends ViewOrViews>(
   DeckClass: typeof Deck,
   props: DeckProps<ViewsT>
 ): Deck<ViewsT> {
-  const isWebGPU = isWebGPUDevice(props);
-  const externalCanvas = props.device?.getDefaultCanvasContext().canvas;
-  const externalCanvasStyle =
-    externalCanvas instanceof HTMLCanvasElement && !externalCanvas.isConnected
-      ? externalCanvas.style
-      : null;
-
-  // The website reuses one device per backend. Its canvas can therefore still contain the previous
-  // example's frame when Deck moves it from a detached container into this React wrapper.
-  if (externalCanvasStyle) {
-    thisRef.externalCanvasStyle = externalCanvasStyle;
-    thisRef.originalCanvasVisibility = externalCanvasStyle.visibility;
-    externalCanvasStyle.visibility = 'hidden';
-  }
-
   const deck = new DeckClass({
     ...props,
     // Keep one authoritative render callback for both backends. Deck calls `_customRender` from
@@ -143,6 +103,11 @@ function createDeckInstance<ViewsT extends ViewOrViews>(
     // where React children must be synchronized with the viewport used to draw those layers.
     _customRender: redrawReason => {
       thisRef.redrawReason = redrawReason;
+      // `deviceProps` describes the requested adapter, not necessarily the adapter that was
+      // initialized. Read the resolved device here, after Deck's animation loop has initialized
+      // it, so fallback from WebGPU to WebGL keeps the WebGL synchronization path.
+      // @ts-expect-error accessing protected device
+      const isWebGPU = deck.device?.type === 'webgpu';
 
       const viewports = deck.getViewports();
       if (thisRef.lastRenderedViewports !== viewports) {
@@ -221,14 +186,6 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
     }
   };
 
-  const handleAfterRender: DeckProps<ViewsT>['onAfterRender'] = context => {
-    // `_customRender` has already submitted the first frame. It is now safe to reveal a reused
-    // external canvas without displaying the previous DeckGL instance's contents.
-    showExternalCanvas(thisRef);
-    // Preserve the public callback: canvas ownership is internal to the React wrapper.
-    props.onAfterRender?.(context);
-  };
-
   // Update Deck's props. If Deck needs redraw, this will trigger a call to `_customRender` in
   // the next animation frame.
   // Needs to be called both from initial mount, and when new props are received
@@ -244,8 +201,7 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       canvas: canvasRef.current,
       layers: jsxProps.layers,
       onViewStateChange: handleViewStateChange,
-      onInteractionStateChange: handleInteractionStateChange,
-      onAfterRender: handleAfterRender
+      onInteractionStateChange: handleInteractionStateChange
     };
 
     if (jsxProps.views) {
@@ -278,12 +234,7 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       canvas: canvasRef.current
     });
 
-    return () => {
-      // Device switching can unmount an example before its first frame. Restore the canvas even
-      // when `onAfterRender` never ran so the cached device remains usable on its next mount.
-      showExternalCanvas(thisRef);
-      thisRef.deck?.finalize();
-    };
+    return () => thisRef.deck?.finalize();
   }, []);
 
   useIsomorphicLayoutEffect(() => {

--- a/modules/react/src/deckgl.ts
+++ b/modules/react/src/deckgl.ts
@@ -23,6 +23,8 @@ type DeckInstanceRef<ViewsT extends ViewOrViews> = {
   lastRenderedViewports?: Viewport[];
   viewStateUpdateRequested?: any;
   interactionStateUpdateRequested?: any;
+  // An externally supplied device owns its canvas across DeckGL mounts. Preserve its original
+  // visibility so an interrupted backend switch cannot leave the shared canvas permanently hidden.
   externalCanvasStyle?: CSSStyleDeclaration;
   originalCanvasVisibility?: string;
   forceUpdate: () => void;
@@ -78,6 +80,9 @@ function redrawDeck(thisRef: DeckInstanceRef<any>) {
   }
 }
 
+// A device can be cached and mounted again when the website switches WebGPU -> WebGL -> WebGPU.
+// Reveal its canvas only after the new Deck has drawn, or when the mount is cancelled. Otherwise
+// the old WebGPU frame can flash in the new React container.
 function showExternalCanvas(thisRef: DeckInstanceRef<any>) {
   if (thisRef.externalCanvasStyle) {
     thisRef.externalCanvasStyle.visibility = thisRef.originalCanvasVisibility || '';
@@ -86,6 +91,8 @@ function showExternalCanvas(thisRef: DeckInstanceRef<any>) {
   }
 }
 
+// DeckGL accepts both an already-created device and instructions for creating one. Account for
+// both forms so the render policy does not change depending on who initialized the WebGPU device.
 function isWebGPUDevice(props: DeckProps<any>): boolean {
   return (
     props.device?.type === 'webgpu' ||
@@ -94,6 +101,8 @@ function isWebGPUDevice(props: DeckProps<any>): boolean {
   );
 }
 
+// luma.gl initially gives a detached canvas a small placeholder size. Do not mount a basemap
+// against that temporary viewport: MapLibre would initialize its own canvas at 1 x 1 pixels.
 function deckSizeMatchesContainer(
   thisRef: DeckInstanceRef<any>,
   container: HTMLElement | null
@@ -119,8 +128,8 @@ function createDeckInstance<ViewsT extends ViewOrViews>(
       ? externalCanvas.style
       : null;
 
-  // A reused external device retains the last rendered frame in its canvas. Keep a detached
-  // canvas hidden while Deck moves it into the new container and initializes the first frame.
+  // The website reuses one device per backend. Its canvas can therefore still contain the previous
+  // example's frame when Deck moves it from a detached container into this React wrapper.
   if (externalCanvasStyle) {
     thisRef.externalCanvasStyle = externalCanvasStyle;
     thisRef.originalCanvasVisibility = externalCanvasStyle.visibility;
@@ -129,28 +138,32 @@ function createDeckInstance<ViewsT extends ViewOrViews>(
 
   const deck = new DeckClass({
     ...props,
-    // The Deck's animation loop is independent from React's render cycle, causing potential
-    // synchronization issues. We provide this custom render function to make sure that React
-    // and Deck update on the same schedule.
-    // TODO(ibgreen) - Hack to enable WebGPU as it needs to render quickly to avoid CanvasContext texture from going stale
-    _customRender: isWebGPU
-      ? undefined
-      : redrawReason => {
-          // Save the dirty flag for later
-          thisRef.redrawReason = redrawReason;
+    // Keep one authoritative render callback for both backends. Deck calls `_customRender` from
+    // its animation loop whenever its viewport or layers become dirty; this is also the point
+    // where React children must be synchronized with the viewport used to draw those layers.
+    _customRender: redrawReason => {
+      thisRef.redrawReason = redrawReason;
 
-          // Viewport/view state is passed to child components as props.
-          // If they have changed, we need to trigger a React rerender to update children props.
-          const viewports = deck.getViewports();
-          if (thisRef.lastRenderedViewports !== viewports) {
-            // Viewports have changed, update children props first.
-            // This will delay the Deck canvas redraw till after React update (in useLayoutEffect)
-            // so that the canvas does not get rendered before the child components update.
-            thisRef.forceUpdate();
-          } else {
-            redrawDeck(thisRef);
-          }
+      const viewports = deck.getViewports();
+      if (thisRef.lastRenderedViewports !== viewports) {
+        // Do not initialize a map against the detached WebGPU canvas's temporary 1 x 1 viewport.
+        // The next resize invalidates Deck again and repeats this callback with the final size.
+        if (!isWebGPU || deckSizeMatchesContainer(thisRef, props.parent || null)) {
+          thisRef.forceUpdate();
         }
+
+        if (!isWebGPU) {
+          // WebGL may defer drawing until React's layout effect so its DOM children and canvas
+          // appear in the same frame. Keep master behavior unchanged for the existing backend.
+          return;
+        }
+      }
+
+      // WebGPU's current canvas texture is valid only for this animation frame. Draw now, even
+      // when React still has a pending viewport update; waiting for a layout effect would reuse
+      // an expired texture. React children catch up through the forceUpdate scheduled above.
+      redrawDeck(thisRef);
+    }
   });
   return deck;
 }
@@ -190,18 +203,10 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
       return null;
     }
     thisRef.viewStateUpdateRequested = null;
-    const viewState = props.onViewStateChange?.(params);
-    if (
-      !props.viewState &&
-      isWebGPUDevice(props) &&
-      deckSizeMatchesContainer(thisRef, containerRef.current)
-    ) {
-      // WebGPU uses Deck's native render loop so that its CanvasContext texture is consumed
-      // immediately. Explicitly update React children (typically a basemap) when Deck advances
-      // an internally managed view state.
-      thisRef.forceUpdate();
-    }
-    return viewState;
+    // Deck marks the new viewport dirty and schedules `_customRender`; do not start a competing
+    // React update here. Keeping redraw ownership in one callback handles both controlled and
+    // uncontrolled view state without making WebGPU a separate synchronization path.
+    return props.onViewStateChange?.(params);
   };
 
   const handleInteractionStateChange: DeckProps<ViewsT>['onInteractionStateChange'] = params => {
@@ -217,18 +222,10 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
   };
 
   const handleAfterRender: DeckProps<ViewsT>['onAfterRender'] = context => {
+    // `_customRender` has already submitted the first frame. It is now safe to reveal a reused
+    // external canvas without displaying the previous DeckGL instance's contents.
     showExternalCanvas(thisRef);
-    if (
-      isWebGPUDevice(props) &&
-      thisRef.deck?.isInitialized &&
-      deckSizeMatchesContainer(thisRef, containerRef.current) &&
-      thisRef.lastRenderedViewports !== thisRef.deck.getViewports()
-    ) {
-      // The native WebGPU render loop bypasses `_customRender`, which normally schedules the
-      // first React rerender after Deck initializes. Trigger it here so children such as a
-      // basemap are positioned using the initialized viewport.
-      thisRef.forceUpdate();
-    }
+    // Preserve the public callback: canvas ownership is internal to the React wrapper.
     props.onAfterRender?.(context);
   };
 
@@ -282,6 +279,8 @@ function DeckGLWithRef<ViewsT extends ViewOrViews = null>(
     });
 
     return () => {
+      // Device switching can unmount an example before its first frame. Restore the canvas even
+      // when `onAfterRender` never ran so the cached device remains usable on its next mount.
       showExternalCanvas(thisRef);
       thisRef.deck?.finalize();
     };

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -19,6 +19,7 @@ import {createRoot} from 'react-dom/client';
 import {Deck, Layer, Widget, type WebMercatorViewport, type MapViewState} from '@deck.gl/core';
 import DeckGL, {type DeckGLRef} from '@deck.gl/react';
 import {type WidgetProps, type WidgetPlacement} from '@deck.gl/core';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 // Required by React 19
 // @ts-expect-error undefined global flag
@@ -85,7 +86,7 @@ test('DeckGL#mount/unmount', async () => {
   container.remove();
 });
 
-test('DeckGL#external WebGPU device uses the native render loop', () => {
+test('DeckGL#external WebGPU device preserves the React custom render loop', () => {
   let capturedProps: Record<string, any> | undefined;
   const externalCanvas = document.createElement('canvas');
   const onAfterRender = vi.fn();
@@ -117,12 +118,50 @@ test('DeckGL#external WebGPU device uses the native render loop', () => {
     );
   });
 
-  expect(capturedProps?._customRender).toBeUndefined();
+  expect(capturedProps?._customRender).toEqual(expect.any(Function));
   expect(externalCanvas.style.visibility).toBe('hidden');
 
   capturedProps?.onAfterRender({});
   expect(externalCanvas.style.visibility).toBe('');
   expect(onAfterRender).toHaveBeenCalledOnce();
+
+  act(() => {
+    root.render(null);
+  });
+  container.remove();
+});
+
+test('DeckGL#real WebGPU device draws through the React custom render loop', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const ref = createRef<DeckGLRef>();
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  const {onAfterRender, waitUntilReady} = createRenderTracker();
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        device: webgpuDevice,
+        initialViewState: TEST_VIEW_STATE,
+        ref,
+        width: 100,
+        height: 100,
+        onAfterRender
+      })
+    );
+  });
+  await waitUntilReady(ref);
+
+  const {deck} = ref.current!;
+  expect(deck?.device).toBe(webgpuDevice);
+  expect(deck?.props._customRender).toEqual(expect.any(Function));
+  expect(webgpuDevice.getDefaultCanvasContext().canvas.isConnected).toBe(true);
 
   act(() => {
     root.render(null);
@@ -155,6 +194,7 @@ test('DeckGL#external WebGPU device waits for its final size before mounting Rea
       getViewport: () => this.viewports[0],
       getViewState: () => ({})
     };
+    drawReasons: string[] = [];
 
     constructor(props: Record<string, any>) {
       capturedProps = props;
@@ -164,6 +204,10 @@ test('DeckGL#external WebGPU device waits for its final size before mounting Rea
 
     getViewports() {
       return this.viewports;
+    }
+
+    _drawLayers(reason: string) {
+      this.drawReasons.push(reason);
     }
 
     finalize() {}
@@ -193,9 +237,10 @@ test('DeckGL#external WebGPU device waits for its final size before mounting Rea
   });
 
   act(() => {
-    capturedProps?.onAfterRender({});
+    capturedProps?._customRender('placeholder WebGPU viewport');
   });
   expect(container.querySelector('#map-child')).toBeNull();
+  expect(deckInstance!.drawReasons).toEqual(['placeholder WebGPU viewport']);
 
   deckInstance!.width = 100;
   deckInstance!.height = 50;
@@ -210,9 +255,13 @@ test('DeckGL#external WebGPU device waits for its final size before mounting Rea
     }
   ];
   act(() => {
-    capturedProps?.onAfterRender({});
+    capturedProps?._customRender('resized WebGPU viewport');
   });
   expect(container.querySelector('#map-child')).toBeTruthy();
+  expect(deckInstance!.drawReasons).toEqual([
+    'placeholder WebGPU viewport',
+    'resized WebGPU viewport'
+  ]);
 
   act(() => {
     root.render(null);
@@ -220,7 +269,7 @@ test('DeckGL#external WebGPU device waits for its final size before mounting Rea
   container.remove();
 });
 
-test('DeckGL#external WebGPU device synchronizes React children after view state changes', () => {
+test('DeckGL#external WebGPU device synchronizes view changes through custom render', () => {
   let capturedProps: Record<string, any> | undefined;
   let deckInstance: TestDeck;
   let viewportReadCount = 0;
@@ -229,6 +278,7 @@ test('DeckGL#external WebGPU device synchronizes React children after view state
     isInitialized = true;
     width = 0;
     height = 0;
+    drawReasons: string[] = [];
 
     constructor(props: Record<string, any>) {
       capturedProps = props;
@@ -238,6 +288,10 @@ test('DeckGL#external WebGPU device synchronizes React children after view state
     getViewports() {
       viewportReadCount++;
       return [];
+    }
+
+    _drawLayers(reason: string) {
+      this.drawReasons.push(reason);
     }
 
     finalize() {}
@@ -275,9 +329,11 @@ test('DeckGL#external WebGPU device synchronizes React children after view state
       viewState: {...TEST_VIEW_STATE, longitude: 0},
       interactionState: {}
     });
+    capturedProps?._customRender('WebGPU view state changed');
   });
 
   expect(viewportReadCount).toBeGreaterThan(viewportReadCountBeforeChange);
+  expect(deckInstance!.drawReasons).toEqual(['WebGPU view state changed']);
 
   act(() => {
     root.render(null);

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -88,11 +88,11 @@ test('DeckGL#mount/unmount', async () => {
 
 test('DeckGL#external WebGPU device preserves the React custom render loop', () => {
   let capturedProps: Record<string, any> | undefined;
-  const externalCanvas = document.createElement('canvas');
   const onAfterRender = vi.fn();
 
   class TestDeck {
     isInitialized = false;
+    device = {type: 'webgpu'};
 
     constructor(props: Record<string, any>) {
       capturedProps = props;
@@ -111,7 +111,7 @@ test('DeckGL#external WebGPU device preserves the React custom render loop', () 
         Deck: TestDeck as unknown as typeof Deck,
         device: {
           type: 'webgpu',
-          getDefaultCanvasContext: () => ({canvas: externalCanvas})
+          getDefaultCanvasContext: () => ({canvas: document.createElement('canvas')})
         } as any,
         onAfterRender
       })
@@ -119,11 +119,63 @@ test('DeckGL#external WebGPU device preserves the React custom render loop', () 
   });
 
   expect(capturedProps?._customRender).toEqual(expect.any(Function));
-  expect(externalCanvas.style.visibility).toBe('hidden');
+  expect(capturedProps?.onAfterRender).toBe(onAfterRender);
 
-  capturedProps?.onAfterRender({});
-  expect(externalCanvas.style.visibility).toBe('');
-  expect(onAfterRender).toHaveBeenCalledOnce();
+  act(() => {
+    root.render(null);
+  });
+  container.remove();
+});
+
+test('DeckGL#custom render uses the initialized device type', () => {
+  let capturedProps: Record<string, any> | undefined;
+  let deckInstance: TestDeck;
+
+  class TestDeck {
+    isInitialized = true;
+    // Simulate a requested WebGPU adapter falling back to WebGL.
+    device = {type: 'webgl'};
+    drawReasons: string[] = [];
+
+    constructor(props: Record<string, any>) {
+      capturedProps = props;
+      deckInstance = this;
+    }
+
+    getViewports() {
+      return [];
+    }
+
+    _drawLayers(reason: string) {
+      this.drawReasons.push(reason);
+    }
+
+    finalize() {}
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        Deck: TestDeck as unknown as typeof Deck,
+        deviceProps: {type: 'webgpu'}
+      })
+    );
+  });
+
+  let drawCountDuringCustomRender = -1;
+  act(() => {
+    capturedProps?._customRender('adapter fallback');
+    drawCountDuringCustomRender = deckInstance!.drawReasons.length;
+  });
+
+  // WebGL defers the draw until React has synchronized its children. If deviceProps were used,
+  // this would incorrectly take the WebGPU path and draw synchronously inside _customRender.
+  expect(drawCountDuringCustomRender).toBe(0);
+  expect(deckInstance!.drawReasons).toEqual(['adapter fallback']);
 
   act(() => {
     root.render(null);
@@ -175,6 +227,7 @@ test('DeckGL#external WebGPU device waits for its final size before mounting Rea
 
   class TestDeck {
     isInitialized = true;
+    device = {type: 'webgpu'};
     width = 1;
     height = 1;
     canvas: HTMLCanvasElement;
@@ -276,6 +329,7 @@ test('DeckGL#external WebGPU device synchronizes view changes through custom ren
 
   class TestDeck {
     isInitialized = true;
+    device = {type: 'webgpu'};
     width = 0;
     height = 0;
     drawReasons: string[] = [];

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -85,6 +85,206 @@ test('DeckGL#mount/unmount', async () => {
   container.remove();
 });
 
+test('DeckGL#external WebGPU device uses the native render loop', () => {
+  let capturedProps: Record<string, any> | undefined;
+  const externalCanvas = document.createElement('canvas');
+  const onAfterRender = vi.fn();
+
+  class TestDeck {
+    isInitialized = false;
+
+    constructor(props: Record<string, any>) {
+      capturedProps = props;
+    }
+
+    finalize() {}
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        Deck: TestDeck as unknown as typeof Deck,
+        device: {
+          type: 'webgpu',
+          getDefaultCanvasContext: () => ({canvas: externalCanvas})
+        } as any,
+        onAfterRender
+      })
+    );
+  });
+
+  expect(capturedProps?._customRender).toBeUndefined();
+  expect(externalCanvas.style.visibility).toBe('hidden');
+
+  capturedProps?.onAfterRender({});
+  expect(externalCanvas.style.visibility).toBe('');
+  expect(onAfterRender).toHaveBeenCalledOnce();
+
+  act(() => {
+    root.render(null);
+  });
+  container.remove();
+});
+
+test('DeckGL#external WebGPU device waits for its final size before mounting React children', () => {
+  let capturedProps: Record<string, any> | undefined;
+  let deckInstance: TestDeck;
+
+  class TestDeck {
+    isInitialized = true;
+    width = 1;
+    height = 1;
+    canvas: HTMLCanvasElement;
+    eventManager = {};
+    viewports = [
+      {
+        id: 'default-view',
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+        padding: null
+      }
+    ];
+    viewManager = {
+      views: [{id: 'default-view'}],
+      getViewport: () => this.viewports[0],
+      getViewState: () => ({})
+    };
+
+    constructor(props: Record<string, any>) {
+      capturedProps = props;
+      this.canvas = props.canvas;
+      deckInstance = this;
+    }
+
+    getViewports() {
+      return this.viewports;
+    }
+
+    finalize() {}
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        Deck: TestDeck as unknown as typeof Deck,
+        device: {
+          type: 'webgpu',
+          getDefaultCanvasContext: () => ({canvas: document.createElement('canvas')})
+        } as any,
+        children: createElement('div', {id: 'map-child'})
+      })
+    );
+  });
+
+  const wrapper = container.querySelector('#deckgl-wrapper')!;
+  Object.defineProperties(wrapper, {
+    clientWidth: {value: 100},
+    clientHeight: {value: 50}
+  });
+
+  act(() => {
+    capturedProps?.onAfterRender({});
+  });
+  expect(container.querySelector('#map-child')).toBeNull();
+
+  deckInstance!.width = 100;
+  deckInstance!.height = 50;
+  deckInstance!.viewports = [
+    {
+      id: 'default-view',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+      padding: null
+    }
+  ];
+  act(() => {
+    capturedProps?.onAfterRender({});
+  });
+  expect(container.querySelector('#map-child')).toBeTruthy();
+
+  act(() => {
+    root.render(null);
+  });
+  container.remove();
+});
+
+test('DeckGL#external WebGPU device synchronizes React children after view state changes', () => {
+  let capturedProps: Record<string, any> | undefined;
+  let deckInstance: TestDeck;
+  let viewportReadCount = 0;
+
+  class TestDeck {
+    isInitialized = true;
+    width = 0;
+    height = 0;
+
+    constructor(props: Record<string, any>) {
+      capturedProps = props;
+      deckInstance = this;
+    }
+
+    getViewports() {
+      viewportReadCount++;
+      return [];
+    }
+
+    finalize() {}
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      createElement(DeckGL, {
+        Deck: TestDeck as unknown as typeof Deck,
+        device: {
+          type: 'webgpu',
+          getDefaultCanvasContext: () => ({canvas: document.createElement('canvas')})
+        } as any,
+        initialViewState: TEST_VIEW_STATE
+      })
+    );
+  });
+
+  const wrapper = container.querySelector('#deckgl-wrapper')!;
+  Object.defineProperties(wrapper, {
+    clientWidth: {value: 100},
+    clientHeight: {value: 50}
+  });
+  deckInstance!.width = 100;
+  deckInstance!.height = 50;
+
+  const viewportReadCountBeforeChange = viewportReadCount;
+  act(() => {
+    capturedProps?.onViewStateChange({
+      viewId: 'default-view',
+      viewState: {...TEST_VIEW_STATE, longitude: 0},
+      interactionState: {}
+    });
+  });
+
+  expect(viewportReadCount).toBeGreaterThan(viewportReadCountBeforeChange);
+
+  act(() => {
+    root.render(null);
+  });
+  container.remove();
+});
+
 test('DeckGL#render', async () => {
   const ref = createRef<DeckGLRef>();
   const container = document.createElement('div');

--- a/test/modules/website/device-store.spec.ts
+++ b/test/modules/website/device-store.spec.ts
@@ -34,12 +34,15 @@ test('device store suspends rendering and ignores a stale device request', async
   await state.setDeviceType('webgl');
   expect(state.device).toBe(webglDevice);
 
+  // Starting a switch must unmount the current demo before its replacement device resolves.
   const pendingWebGPUSwitch = state.setDeviceType('webgpu');
   expect(state).toMatchObject({
     deviceType: 'webgpu',
     device: undefined
   });
 
+  // Resolve the newer WebGL selection first, then complete the stale WebGPU request. The older
+  // promise must not take ownership of the canvas or overwrite the persisted WebGL preference.
   await state.setDeviceType('webgl');
   resolveWebGPUDevice?.(webgpuDevice);
   await pendingWebGPUSwitch;

--- a/test/modules/website/device-store.spec.ts
+++ b/test/modules/website/device-store.spec.ts
@@ -1,0 +1,52 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {createDeviceStoreState} from '../../../website/src/store/device-store-state';
+
+test('device store suspends rendering and ignores a stale device request', async () => {
+  const webglDevice = {id: 'webgl-device', type: 'webgl'};
+  const webgpuDevice = {id: 'webgpu-device', type: 'webgpu'};
+  const persistedDeviceTypes: string[] = [];
+  let resolveWebGPUDevice: ((device: typeof webgpuDevice) => void) | undefined;
+  const webgpuDevicePromise = new Promise<typeof webgpuDevice>(resolve => {
+    resolveWebGPUDevice = resolve;
+  });
+
+  const requestDevice = (type: string) =>
+    type === 'webgpu' ? webgpuDevicePromise : Promise.resolve(webglDevice);
+  type DeviceState = {
+    deviceType?: string;
+    deviceError?: string;
+    device?: typeof webglDevice | typeof webgpuDevice;
+    setDeviceType: (type: string) => Promise<void>;
+  };
+  const initializeStore = createDeviceStoreState(requestDevice, (type: string) =>
+    persistedDeviceTypes.push(type)
+  );
+  let state: DeviceState;
+  const setState = (partialState: Partial<DeviceState>) => {
+    state = {...state, ...partialState};
+  };
+  state = initializeStore(setState);
+
+  await state.setDeviceType('webgl');
+  expect(state.device).toBe(webglDevice);
+
+  const pendingWebGPUSwitch = state.setDeviceType('webgpu');
+  expect(state).toMatchObject({
+    deviceType: 'webgpu',
+    device: undefined
+  });
+
+  await state.setDeviceType('webgl');
+  resolveWebGPUDevice?.(webgpuDevice);
+  await pendingWebGPUSwitch;
+
+  expect(state).toMatchObject({
+    deviceType: 'webgl',
+    device: webglDevice
+  });
+  expect(persistedDeviceTypes).toEqual(['webgl', 'webgl']);
+});

--- a/website/ocular-docusaurus-plugin/index.js
+++ b/website/ocular-docusaurus-plugin/index.js
@@ -44,8 +44,10 @@ module.exports = function (
       // Load existing source maps
       _config.module.rules.push({
         test: /\/dist\/.+\.js$/,
-        enforce: "pre",
-        use: ["source-map-loader"],
+        // arc@0.2.0 publishes source maps without the referenced TypeScript sources
+        exclude: /node_modules\/arc\/dist\//,
+        enforce: 'pre',
+        use: ['source-map-loader']
       });
 
       const devtool = debug ? 'source-map' : false;

--- a/website/ocular-docusaurus-plugin/index.js
+++ b/website/ocular-docusaurus-plugin/index.js
@@ -44,10 +44,8 @@ module.exports = function (
       // Load existing source maps
       _config.module.rules.push({
         test: /\/dist\/.+\.js$/,
-        // arc@0.2.0 publishes source maps without the referenced TypeScript sources
-        exclude: /node_modules\/arc\/dist\//,
-        enforce: 'pre',
-        use: ['source-map-loader']
+        enforce: "pre",
+        use: ["source-map-loader"],
       });
 
       const devtool = debug ? 'source-map' : false;

--- a/website/src/components/example/make-example.jsx
+++ b/website/src/components/example/make-example.jsx
@@ -51,6 +51,37 @@ const MapTip = styled.div`
   }
 `;
 
+// The website caches one device per backend, and each device owns a canvas that is reused across
+// examples. Remember the website-owned canvas style so switching away and back does not reveal the
+// previous example's last frame or leave a reused canvas permanently hidden.
+const originalCanvasVisibility = new WeakMap();
+
+function useSharedDeviceCanvas(device) {
+  useEffect(() => {
+    const canvas = device?.getDefaultCanvasContext().canvas;
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      return;
+    }
+
+    if (!originalCanvasVisibility.has(canvas)) {
+      originalCanvasVisibility.set(canvas, canvas.style.visibility);
+    }
+    canvas.style.visibility = 'hidden';
+
+    // DeckGL mounts the device's existing canvas and schedules its first draw in a child effect.
+    // Reveal it on the next frame, after that setup, so a cached frame from another example cannot
+    // flash while the canvas is moved into the new wrapper.
+    const animationFrame = requestAnimationFrame(() => {
+      canvas.style.visibility = originalCanvasVisibility.get(canvas) ?? '';
+    });
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      canvas.style.visibility = 'hidden';
+    };
+  }, [device]);
+}
+
 export default function makeExample(DemoComponent, {isInteractive = true, style} = {}) {
   const {parameters = {}, mapStyle} = DemoComponent;
   const defaultParams = Object.keys(parameters).reduce((acc, name) => {
@@ -68,6 +99,7 @@ export default function makeExample(DemoComponent, {isInteractive = true, style}
     // their existing, independently initialized WebGL path.
     const device = useStore(state => (DemoComponent.hasDeviceTabs ? state.device : undefined));
     const baseUrl = useBaseUrl('/');
+    useSharedDeviceCanvas(device);
 
     const useParam = useCallback(newParameters => {
       const newParams = Object.keys(newParameters).reduce((acc, name) => {

--- a/website/src/components/example/make-example.jsx
+++ b/website/src/components/example/make-example.jsx
@@ -64,6 +64,8 @@ export default function makeExample(DemoComponent, {isInteractive = true, style}
     const [data, setData] = useState(defaultData);
     const [params, setParams] = useState(defaultParams);
     const [meta, setMeta] = useState({});
+    // Only demos that expose device tabs receive the shared device. Unsupported examples keep
+    // their existing, independently initialized WebGL path.
     const device = useStore(state => (DemoComponent.hasDeviceTabs ? state.device : undefined));
     const baseUrl = useBaseUrl('/');
 
@@ -128,6 +130,12 @@ export default function makeExample(DemoComponent, {isInteractive = true, style}
       <>
         {DemoComponent.hasDeviceTabs && <DeviceTabs />}
         <DemoContainer style={style}>
+          {/*
+            Device creation is asynchronous. Unmount the current demo while a switch is pending;
+            otherwise two Deck instances can temporarily try to render into the same canvas.
+            The device key makes a completed switch create a fresh DeckGL lifecycle instead of
+            replacing a GPU backend inside an already initialized Deck.
+          */}
           {(!DemoComponent.hasDeviceTabs || device) && (
             <DemoComponent
               key={device?.id}

--- a/website/src/components/example/make-example.jsx
+++ b/website/src/components/example/make-example.jsx
@@ -2,15 +2,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import React, {useState, useEffect, useCallback, Children, isValidElement, cloneElement} from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  Children,
+  isValidElement,
+  cloneElement
+} from 'react';
 import styled from 'styled-components';
 import InfoPanel from '../info-panel';
 import {loadData, joinPath} from '../../utils/data-utils';
 import {normalizeParam} from '../../utils/format-utils';
 import {MAPBOX_STYLES} from '../../constants/defaults';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import { DeviceTabs } from '../device-tabs';
-import { useStore } from '../../store/device-store';
+import {DeviceTabs} from '../device-tabs';
+import {useStore} from '../../store/device-store';
 
 const DemoContainer = styled.div`
   height: 100%;
@@ -121,14 +128,17 @@ export default function makeExample(DemoComponent, {isInteractive = true, style}
       <>
         {DemoComponent.hasDeviceTabs && <DeviceTabs />}
         <DemoContainer style={style}>
-          <DemoComponent
-            device={device}
-            data={data}
-            mapStyle={mapStyle || MAPBOX_STYLES.BLANK}
-            params={params}
-            useParam={useParam}
-            onStateChange={updateMeta}
-          />
+          {(!DemoComponent.hasDeviceTabs || device) && (
+            <DemoComponent
+              key={device?.id}
+              device={device}
+              data={data}
+              mapStyle={mapStyle || MAPBOX_STYLES.BLANK}
+              params={params}
+              useParam={useParam}
+              onStateChange={updateMeta}
+            />
+          )}
           {isInteractive && (
             <InfoPanel
               title={DemoComponent.title}

--- a/website/src/store/device-store-state.js
+++ b/website/src/store/device-store-state.js
@@ -1,0 +1,32 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export function createDeviceStoreState(requestDevice, persistDeviceType) {
+  let deviceRequestGeneration = 0;
+
+  return set => ({
+    deviceType: undefined,
+    deviceError: undefined,
+    device: undefined,
+    setDeviceType: async deviceType => {
+      const requestGeneration = ++deviceRequestGeneration;
+      set({deviceType, deviceError: undefined, device: undefined});
+
+      let deviceError;
+      let device;
+      try {
+        device = await requestDevice(deviceType);
+      } catch (error) {
+        deviceError = error.message;
+      }
+
+      if (requestGeneration !== deviceRequestGeneration) {
+        return;
+      }
+
+      persistDeviceType(deviceType);
+      return set({deviceType, deviceError, device});
+    }
+  });
+}

--- a/website/src/store/device-store-state.js
+++ b/website/src/store/device-store-state.js
@@ -3,6 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 export function createDeviceStoreState(requestDevice, persistDeviceType) {
+  // Device creation is asynchronous. A monotonically increasing request identifier makes the
+  // most recently selected tab authoritative, even when an earlier WebGPU request finishes last.
   let deviceRequestGeneration = 0;
 
   return set => ({
@@ -11,6 +13,9 @@ export function createDeviceStoreState(requestDevice, persistDeviceType) {
     device: undefined,
     setDeviceType: async deviceType => {
       const requestGeneration = ++deviceRequestGeneration;
+
+      // Clear the old device immediately. makeExample unmounts the old DeckGL before mounting
+      // a replacement, so WebGL and WebGPU never try to own the same canvas at the same time.
       set({deviceType, deviceError: undefined, device: undefined});
 
       let deviceError;
@@ -21,10 +26,13 @@ export function createDeviceStoreState(requestDevice, persistDeviceType) {
         deviceError = error.message;
       }
 
+      // A newer tab selection wins. In particular, a slow WebGPU request must not replace a
+      // subsequently selected WebGL device or overwrite the persisted device preference.
       if (requestGeneration !== deviceRequestGeneration) {
         return;
       }
 
+      // Persist only the request that actually became current; stale completions are ignored.
       persistDeviceType(deviceType);
       return set({deviceType, deviceError, device});
     }

--- a/website/src/store/device-store.jsx
+++ b/website/src/store/device-store.jsx
@@ -7,6 +7,7 @@ import {create} from 'zustand';
 import {luma, Device} from '@luma.gl/core';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
+import {createDeviceStoreState} from './device-store-state';
 
 const cachedDevice = {};
 const DEVICE_TYPE_STORAGE_KEY = 'deck-device-type';
@@ -42,39 +43,31 @@ function storeDeviceType(deviceType) {
 export async function createDevice(type) {
   cachedDevice[type] =
     cachedDevice[type] ||
-    luma.createDevice({
-      adapters: [webgl2Adapter, webgpuAdapter],
-      type,
-      createCanvasContext: {
-        container: 'deckgl-wrapper',
-        alphaMode: 'premultiplied',
-        useDevicePixels: true,
-        autoResize: true,
-        width: undefined,
-        height: undefined,
-      },
-    });
+    luma
+      .createDevice({
+        adapters: [webgl2Adapter, webgpuAdapter],
+        type,
+        createCanvasContext: {
+          // Deck moves a detached external-device canvas into its React wrapper on initialization.
+          // Creating it in a detached container avoids depending on a wrapper that may not be
+          // mounted yet while a device switch is pending.
+          container: document.createElement('div'),
+          alphaMode: 'premultiplied',
+          useDevicePixels: true,
+          autoResize: true,
+          width: undefined,
+          height: undefined
+        }
+      })
+      .catch(error => {
+        delete cachedDevice[type];
+        throw error;
+      });
   return await cachedDevice[type];
 }
 
-export const useStore = create(set => ({
-  deviceType: undefined,
-  deviceError: undefined,
-  device: undefined,
-  setDeviceType: async (deviceType) => {
-    let deviceError;
-    let device;
-    try {
-      device = await createDevice(deviceType);
-    } catch (error) {
-      deviceError = error.message;
-    }
-    storeDeviceType(deviceType);
-    return set(state => ({deviceType, deviceError, device}));
-  },
-}));
+export const useStore = create(createDeviceStoreState(createDevice, storeDeviceType));
 
-const storedDeviceType = getStoredDeviceType();
-if (storedDeviceType) {
-  void useStore.getState().setDeviceType(storedDeviceType);
+if (typeof window !== 'undefined') {
+  void useStore.getState().setDeviceType(getStoredDeviceType() || 'webgl');
 }

--- a/website/src/store/device-store.jsx
+++ b/website/src/store/device-store.jsx
@@ -9,6 +9,8 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {createDeviceStoreState} from './device-store-state';
 
+// A backend's canvas and GPU resources belong to its Device. Reuse the same pending/resolved
+// device when navigating examples or switching WebGPU -> WebGL -> WebGPU.
 const cachedDevice = {};
 const DEVICE_TYPE_STORAGE_KEY = 'deck-device-type';
 
@@ -41,6 +43,8 @@ function storeDeviceType(deviceType) {
 }
 
 export async function createDevice(type) {
+  // Cache the promise, rather than only the resolved device, so concurrent requests for the
+  // same backend cannot initialize two devices against the same canvas.
   cachedDevice[type] =
     cachedDevice[type] ||
     luma
@@ -48,9 +52,10 @@ export async function createDevice(type) {
         adapters: [webgl2Adapter, webgpuAdapter],
         type,
         createCanvasContext: {
-          // Deck moves a detached external-device canvas into its React wrapper on initialization.
-          // Creating it in a detached container avoids depending on a wrapper that may not be
-          // mounted yet while a device switch is pending.
+          // A switch deliberately unmounts the previous demo before the next one exists. The
+          // target `deckgl-wrapper` therefore may not be in the DOM when the device is created.
+          // Create the canvas in a detached container; Deck inserts that existing canvas into
+          // the newly mounted React wrapper after the device has initialized.
           container: document.createElement('div'),
           alphaMode: 'premultiplied',
           useDevicePixels: true,
@@ -60,6 +65,8 @@ export async function createDevice(type) {
         }
       })
       .catch(error => {
+        // A failed initialization must not poison the cache: selecting the same tab again
+        // should attempt to create a fresh device rather than replaying a rejected promise.
         delete cachedDevice[type];
         throw error;
       });
@@ -69,5 +76,7 @@ export async function createDevice(type) {
 export const useStore = create(createDeviceStoreState(createDevice, storeDeviceType));
 
 if (typeof window !== 'undefined') {
+  // Browser-only initialization keeps Docusaurus server-side rendering free of document/GPU
+  // access. WebGL is the initial fallback when the user has no persisted backend preference.
   void useStore.getState().setDeviceType(getStoredDeviceType() || 'webgl');
 }


### PR DESCRIPTION
## Goal

Make React device switching reliable and understandable without introducing a second WebGPU render loop or changing existing WebGL behavior.

## Render lifecycle

`_customRender` remains the single source of truth for both backends:

1. Deck calls `_customRender` whenever its layers or viewport need a redraw.
2. If the viewport changed, the callback schedules the React update that keeps basemaps and other children synchronized.
3. WebGL preserves the existing behavior: React updates its children first, then its layout effect redraws Deck.
4. WebGPU redraws during the same animation frame because the current canvas texture cannot safely be saved for a later React layout effect.
5. React children are not mounted against a detached WebGPU canvas's temporary 1 × 1 viewport; the next resize schedules the final-sized update.

There are no duplicate render or viewport synchronization paths in `onViewStateChange` or `onAfterRender`.

## Device switching and canvas ownership

- Only examples that expose device tabs receive the shared device; unsupported demos retain their existing WebGL behavior.
- Unmount the current example while the requested device initializes so two Deck instances cannot contend for one canvas.
- Remount the example by device identity to give each backend a clean Deck lifecycle.
- Reuse one device-creation promise per backend; discard rejected promises so device initialization can be retried.
- Ignore stale asynchronous switch completions; the user's latest tab selection always wins.
- Create device-owned canvases in a detached container because the next React wrapper does not yet exist during a switch.
- Hide a reused canvas until its replacement Deck renders its first frame, and restore its visibility if initialization is interrupted.
- Explain each non-obvious lifecycle and canvas-ownership boundary with inline comments.
- Remove the unrelated webpack/source-map change from the PR.

## Validation

- `yarn build` — passed.
- `yarn lint` — passed; only pre-existing repository warnings.
- `yarn test-headless test/modules/react/deckgl.spec.ts test/modules/website/device-store.spec.ts` — 11 passed, including an actual headless WebGPU adapter.
- Commit-hook Node smoke tests — 21 passed.
