### PR TITLE
docs: document WebGPU support in v9.4

### DIFF
--- a/docs/api-reference/aggregation-layers/contour-layer.md
+++ b/docs/api-reference/aggregation-layers/contour-layer.md
@@ -1,4 +1,5 @@
 # ContourLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {ContourLayerDemo} from '@site/src/doc-demos/aggregation-layers';
 

--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -1,4 +1,5 @@
 # HeatmapLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {HeatmapLayerDemo} from '@site/src/doc-demos/aggregation-layers';
 

--- a/docs/api-reference/aggregation-layers/hexagon-layer.md
+++ b/docs/api-reference/aggregation-layers/hexagon-layer.md
@@ -1,4 +1,5 @@
 # HexagonLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {HexagonLayerDemo} from '@site/src/doc-demos/aggregation-layers';
 

--- a/docs/api-reference/aggregation-layers/screen-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/screen-grid-layer.md
@@ -1,4 +1,5 @@
 # ScreenGridLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {ScreenGridLayerDemo} from '@site/src/doc-demos/aggregation-layers';
 

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -1,4 +1,5 @@
 # TileLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {TileLayerDemo} from '@site/src/doc-demos/geo-layers';
 

--- a/docs/api-reference/layers/arc-layer.md
+++ b/docs/api-reference/layers/arc-layer.md
@@ -1,4 +1,5 @@
 # ArcLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {ArcLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/column-layer.md
+++ b/docs/api-reference/layers/column-layer.md
@@ -1,4 +1,5 @@
 # ColumnLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {ColumnLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/grid-cell-layer.md
+++ b/docs/api-reference/layers/grid-cell-layer.md
@@ -1,4 +1,5 @@
 # GridCellLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {GridCellLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/icon-layer.md
+++ b/docs/api-reference/layers/icon-layer.md
@@ -1,4 +1,5 @@
 # IconLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {IconLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/path-layer.md
+++ b/docs/api-reference/layers/path-layer.md
@@ -1,4 +1,5 @@
 # PathLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {PathLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/point-cloud-layer.md
+++ b/docs/api-reference/layers/point-cloud-layer.md
@@ -1,5 +1,5 @@
 # PointCloudLayer
-[webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {PointCloudLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/polygon-layer.md
+++ b/docs/api-reference/layers/polygon-layer.md
@@ -1,4 +1,5 @@
 # PolygonLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {PolygonLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/api-reference/layers/solid-polygon-layer.md
+++ b/docs/api-reference/layers/solid-polygon-layer.md
@@ -1,4 +1,5 @@
 # SolidPolygonLayer
+![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 
 import {SolidPolygonLayerDemo} from '@site/src/doc-demos/layers';
 

--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -8,7 +8,7 @@ deck.gl is gradually adding support for running on WebGPU. Support is landing la
 
 This page is conservative and source-based:
 
-- `✅` means the current tree contains an explicit WebGPU/WGSL implementation, or the API is a thin wrapper over one.
+- `✅ vX.Y` means the current tree contains an explicit WebGPU/WGSL implementation, or the API is a thin wrapper over one. The version identifies the first deck.gl minor release with full WebGPU support.
 - `🚧` means some code paths work, but the full API surface is not yet ported.
 - `❌` means there is no in-tree WebGPU implementation yet.
 
@@ -35,31 +35,31 @@ The table below covers the public layer exports from the layer packages. It is d
 
 | Module | Layer | WebGL | WebGPU |
 | --- | --- | --- | --- |
-| `@deck.gl/layers` | `ArcLayer` | ✅ | ✅ |
+| `@deck.gl/layers` | `ArcLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/layers` | `BitmapLayer` | ✅ | 🚧 |
-| `@deck.gl/layers` | `IconLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `LineLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `PointCloudLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `ScatterplotLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `ColumnLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `GridCellLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `PathLayer` | ✅ | ✅ |
-| `@deck.gl/layers` | `PolygonLayer` | ✅ | ✅ |
+| `@deck.gl/layers` | `IconLayer` | ✅ | ✅ v9.3 |
+| `@deck.gl/layers` | `LineLayer` | ✅ | ✅ v9.2 |
+| `@deck.gl/layers` | `PointCloudLayer` | ✅ | ✅ v9.2 |
+| `@deck.gl/layers` | `ScatterplotLayer` | ✅ | ✅ v9.2 |
+| `@deck.gl/layers` | `ColumnLayer` | ✅ | ✅ v9.4 |
+| `@deck.gl/layers` | `GridCellLayer` | ✅ | ✅ v9.4 |
+| `@deck.gl/layers` | `PathLayer` | ✅ | ✅ v9.4 |
+| `@deck.gl/layers` | `PolygonLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/layers` | `GeoJsonLayer` | ✅ | 🚧 |
 | `@deck.gl/layers` | `TextLayer` | ✅ | ❌ |
-| `@deck.gl/layers` | `SolidPolygonLayer` | ✅ | ✅ |
-| `@deck.gl/aggregation-layers` | `ScreenGridLayer` | ✅ | ✅ |
-| `@deck.gl/aggregation-layers` | `HexagonLayer` | ✅ | ✅ |
-| `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ✅ |
+| `@deck.gl/layers` | `SolidPolygonLayer` | ✅ | ✅ v9.4 |
+| `@deck.gl/aggregation-layers` | `ScreenGridLayer` | ✅ | ✅ v9.4 |
+| `@deck.gl/aggregation-layers` | `HexagonLayer` | ✅ | ✅ v9.4 |
+| `@deck.gl/aggregation-layers` | `ContourLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/aggregation-layers` | `GridLayer` | ✅ | ❌ |
-| `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ |
+| `@deck.gl/aggregation-layers` | `HeatmapLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/mesh-layers` | `SimpleMeshLayer` | ✅ | ❌ |
 | `@deck.gl/mesh-layers` | `ScenegraphLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `A5Layer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `GreatCircleLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `S2Layer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `QuadkeyLayer` | ✅ | ❌ |
-| `@deck.gl/geo-layers` | `TileLayer` | ✅ | ✅ |
+| `@deck.gl/geo-layers` | `TileLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `TripsLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `H3ClusterLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `H3HexagonLayer` | ✅ | ❌ |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -14,6 +14,14 @@ Looking ahead, deck.gl v10 is expected to introduce larger architectural changes
 
 - Picking has been optimized. Most layers now use shader builtins (`instance_index`) instead of picking color buffers, reducing GPU memory usage and layer initialization costs.
 
+### WebGPU
+
+deck.gl v9.4 substantially expands its experimental WebGPU support. Newly supported layers include [`ArcLayer`](./api-reference/layers/arc-layer.md), [`ColumnLayer`](./api-reference/layers/column-layer.md), [`GridCellLayer`](./api-reference/layers/grid-cell-layer.md), [`PathLayer`](./api-reference/layers/path-layer.md), [`PolygonLayer`](./api-reference/layers/polygon-layer.md), [`SolidPolygonLayer`](./api-reference/layers/solid-polygon-layer.md), and [`TileLayer`](./api-reference/geo-layers/tile-layer.md), together with [`ScreenGridLayer`](./api-reference/aggregation-layers/screen-grid-layer.md), [`HexagonLayer`](./api-reference/aggregation-layers/hexagon-layer.md), [`ContourLayer`](./api-reference/aggregation-layers/contour-layer.md), and [`HeatmapLayer`](./api-reference/aggregation-layers/heatmap-layer.md). [`BitmapLayer`](./api-reference/layers/bitmap-layer.md) and [`GeoJsonLayer`](./api-reference/layers/geojson-layer.md) also gain partial WebGPU support.
+
+This release improves WebGPU attribute-buffer handling, adds WebGPU render-test coverage, and makes switching between WebGL2 and WebGPU more reliable in React and across website examples.
+
+WebGPU support remains experimental and is not yet recommended for production. Some layers and features remain unavailable or only partially supported. See the [WebGPU guide](./developer-guide/webgpu.md) for setup instructions, current limitations, and the complete compatibility matrix.
+
 ### Views and Controllers
 
 deck.gl v9.4 brings additional view and controller improvements on top of the substantial changes in v9.3.


### PR DESCRIPTION
## Goal

Document the WebGPU support added in deck.gl v9.4 and make the current compatibility level easier to discover.

## Changes

- add a WebGPU section to the v9.4 release notes with links to every referenced layer
- annotate fully supported layers in the WebGPU compatibility matrix with the first supporting deck.gl minor release
- add the existing WebGPU support badge to all fully supported layer API pages and fix the PointCloudLayer badge rendering
- keep partially supported layers unbadged

## Validation

- `git diff --check`
- verified all 14 links in the new release-note section resolve to local documentation pages
- commit hooks passed formatting, lockfile validation, and 21 focused Node tests
- commit hooks reported existing lint warnings only, with no lint errors
- `yarn test-website` did not complete because the repository package-build orchestration exits with `lerna undefined`; a direct Docusaurus build subsequently reached bundling but could not resolve the generated widgets stylesheet because that package build had not completed