### PR TITLE
fix(mapbox): ignore useDevicePixels in interleaved mode

### DIFF
--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -113,7 +113,7 @@ new MapboxOverlay(props: MapboxOverlayProps);
 - `parent` / `canvas` / `device` - context creation is managed internally.
 - `viewState` / `initialViewState` - camera state is managed internally.
 - `controller` - always disabled (to use Mapbox's interaction handlers).
-- `useDevicePixels` - ignored in interleaved mode. To control pixel ratio in interleaved mode, use MapLibre's [`pixelRatio`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/#pixelratio) constructor option on the Map instance. Mapbox GL JS does not expose an equivalent option.
+- `useDevicePixels` - ignored in interleaved mode, where the base map owns the WebGL context and the canvas drawing buffer size. To control pixel ratio in interleaved mode, use MapLibre's [`pixelRatio`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/#pixelratio) constructor option on the Map instance. Mapbox GL JS does not expose an equivalent option.
 
 The constructor additionally accepts the following options:
 

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -113,6 +113,7 @@ new MapboxOverlay(props: MapboxOverlayProps);
 - `parent` / `canvas` / `device` - context creation is managed internally.
 - `viewState` / `initialViewState` - camera state is managed internally.
 - `controller` - always disabled (to use Mapbox's interaction handlers).
+- `useDevicePixels` - ignored in interleaved mode. To control pixel ratio in interleaved mode, use MapLibre's [`pixelRatio`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/#pixelratio) constructor option on the Map instance. Mapbox GL JS does not expose an equivalent option.
 
 The constructor additionally accepts the following options:
 

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -57,9 +57,14 @@ export default class MapboxOverlay implements IControl {
 
   /** Filter out props to pass to Deck **/
   filterProps(props: MapboxOverlayProps): MapboxOverlayProps {
-    const {interleaved = false, useDevicePixels, ...deckProps} = props;
-    if (!interleaved && useDevicePixels !== undefined) {
-      // useDevicePixels cannot be used in interleaved mode
+    const {interleaved, useDevicePixels, ...deckProps} = props;
+    if (this._interleaved) {
+      if (useDevicePixels !== undefined && useDevicePixels !== true) {
+        log.warn(
+          'useDevicePixels has no effect in interleaved mode. The basemap controls the drawing buffer resolution. Use MapLibre pixelRatio option instead.'
+        )();
+      }
+    } else if (useDevicePixels !== undefined) {
       (deckProps as MapboxOverlayProps).useDevicePixels = useDevicePixels;
     }
     return deckProps;

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -57,7 +57,7 @@ export default class MapboxOverlay implements IControl {
 
   /** Filter out props to pass to Deck **/
   filterProps(props: MapboxOverlayProps): MapboxOverlayProps {
-    const {interleaved, useDevicePixels, ...deckProps} = props;
+    const {interleaved: _, useDevicePixels, ...deckProps} = props;
     if (this._interleaved) {
       if (useDevicePixels !== undefined && useDevicePixels !== true) {
         log.warn(

--- a/modules/mapbox/src/mapbox-overlay.ts
+++ b/modules/mapbox/src/mapbox-overlay.ts
@@ -58,13 +58,10 @@ export default class MapboxOverlay implements IControl {
   /** Filter out props to pass to Deck **/
   filterProps(props: MapboxOverlayProps): MapboxOverlayProps {
     const {interleaved: _, useDevicePixels, ...deckProps} = props;
-    if (this._interleaved) {
-      if (useDevicePixels !== undefined && useDevicePixels !== true) {
-        log.warn(
-          'useDevicePixels has no effect in interleaved mode. The basemap controls the drawing buffer resolution. Use MapLibre pixelRatio option instead.'
-        )();
-      }
-    } else if (useDevicePixels !== undefined) {
+    // In interleaved mode the base map owns the WebGL context and the canvas drawing buffer size,
+    // so useDevicePixels cannot be applied and is dropped here. Use MapLibre's `pixelRatio` map
+    // option instead. Mapbox GL JS has no equivalent option.
+    if (!this._interleaved && useDevicePixels !== undefined) {
       (deckProps as MapboxOverlayProps).useDevicePixels = useDevicePixels;
     }
     return deckProps;

--- a/test/modules/mapbox/mapbox-overlay.spec.ts
+++ b/test/modules/mapbox/mapbox-overlay.spec.ts
@@ -366,6 +366,25 @@ webglTest('MapboxOverlay#interleaved', async () => {
   await renderPromise;
 });
 
+test('MapboxOverlay#interleaved drops useDevicePixels', () => {
+  // The base map owns the drawing buffer size in interleaved mode, so useDevicePixels cannot apply
+  const interleaved = new MapboxOverlay({interleaved: true, useDevicePixels: 1.5});
+  expect(
+    'useDevicePixels' in interleaved._props,
+    'useDevicePixels is dropped in interleaved mode'
+  ).toBeFalsy();
+
+  // setProps must drop it too, even though `interleaved` is not in the partial props
+  interleaved.setProps({useDevicePixels: 1.5});
+  expect(
+    'useDevicePixels' in interleaved._props,
+    'useDevicePixels is dropped by setProps in interleaved mode'
+  ).toBeFalsy();
+
+  const overlaid = new MapboxOverlay({useDevicePixels: 1.5});
+  expect(overlaid._props.useDevicePixels, 'useDevicePixels is kept in overlaid mode').toBe(1.5);
+});
+
 webglTest('MapboxOverlay#interleaved#remove and add', () => {
   const map = new MockMapboxMap({
     center: {lng: -122.45, lat: 37.78},


### PR DESCRIPTION
Closes #10509

#### Change List
- Drop `useDevicePixels` in interleaved mode instead of forwarding it to Deck. The base map owns the WebGL context and the canvas drawing buffer size, so the prop has never had any effect there. The reason is recorded in a code comment rather than a runtime warning, to avoid bundling a string for a development-only case.
- Fix `filterProps` reading `interleaved` off the incoming props (defaulting to `false`) instead of `this._interleaved`. Since `setProps` receives partial props, `setProps({useDevicePixels})` on an interleaved overlay was forwarding the value.
- Document `useDevicePixels` as ignored in interleaved mode in the MapboxOverlay API reference, pointing to MapLibre's `pixelRatio` map option (Mapbox GL JS has no equivalent).
- Add a test covering the constructor path, the `setProps` path, and that overlaid mode still passes the prop through.

Not a breaking change: `useDevicePixels` had no effect in interleaved mode in any tested version (9.1, 9.2, 9.3), so nothing that worked before stops working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized prop filtering and documentation for MapboxOverlay; no auth, security, or broad rendering pipeline changes beyond avoiding a mistaken useDevicePixels forward in interleaved mode.
> 
> **Overview**
> **`MapboxOverlay`** now **strips `useDevicePixels`** when **`interleaved: true`**, because the basemap owns the WebGL context and canvas buffer size. **`filterProps`** uses **`this._interleaved`** instead of the incoming **`interleaved`** prop (which defaulted to **`false`**), so **`setProps({ useDevicePixels })`** no longer incorrectly forwards that value in interleaved mode. Overlaid mode still passes **`useDevicePixels`** through to Deck.
> 
> The **MapboxOverlay API docs** document that **`useDevicePixels`** is ignored in interleaved mode and point users to MapLibre’s **`pixelRatio`** map option (no Mapbox GL JS equivalent). Tests cover constructor and **`setProps`** behavior for interleaved vs overlaid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c4cc1bcc783334152d9cb33c530fec91e83c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
