### PR TITLE
feat(geo-layers): enable TerrainLayer on WebGPU

### DIFF
--- a/docs/developer-guide/webgpu.md
+++ b/docs/developer-guide/webgpu.md
@@ -64,7 +64,7 @@ The table below covers the public layer exports from the layer packages. It is d
 | `@deck.gl/geo-layers` | `H3ClusterLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `H3HexagonLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `Tile3DLayer` | ✅ | ❌ |
-| `@deck.gl/geo-layers` | `TerrainLayer` | ✅ | ❌ |
+| `@deck.gl/geo-layers` | `TerrainLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/geo-layers` | `MVTLayer` | ✅ | ❌ |
 | `@deck.gl/geo-layers` | `GeohashLayer` | ✅ | ✅ v9.4 |
 | `@deck.gl/carto` | `ClusterTileLayer` | ✅ | ❌ |

--- a/test/modules/geo-layers/terrain-layer.spec.ts
+++ b/test/modules/geo-layers/terrain-layer.spec.ts
@@ -4,9 +4,76 @@
 
 import {test, expect} from 'vitest';
 import {generateLayerTests, testLayerAsync} from '@deck.gl/test-utils/vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
 import {TerrainLayer, TileLayer} from '@deck.gl/geo-layers';
 import {SimpleMeshLayer} from '@deck.gl/mesh-layers';
 import {TerrainLoader} from '@loaders.gl/terrain';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+const TEST_TERRAIN_MESH = {
+  attributes: {
+    positions: {
+      size: 3,
+      value: new Float32Array([-1, -1, 0, 1, -1, 0, 0, 1, 1])
+    },
+    normals: {
+      size: 3,
+      value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    },
+    texCoords: {
+      size: 2,
+      value: new Float32Array([0, 0, 1, 0, 0.5, 1])
+    }
+  }
+};
+
+class TestTerrainLayer extends TerrainLayer {
+  static layerName = 'TestTerrainLayer';
+
+  loadTerrain() {
+    return TEST_TERRAIN_MESH as any;
+  }
+}
+
+test('TerrainLayer#initializes its mesh sublayer with a WebGPU device', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const texture = webgpuDevice.createTexture({
+    data: new Uint8Array([255, 128, 64, 255]),
+    width: 1,
+    height: 1
+  });
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+  const layer = new TestTerrainLayer({
+    id: 'webgpu-terrain',
+    elevationData: 'terrain.png',
+    bounds: [-1, -1, 1, 1],
+    texture: texture as any
+  });
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([layer]);
+
+  const meshLayer = layer.getSubLayers()[0] as SimpleMeshLayer;
+  expect(errors).toEqual([]);
+  expect(meshLayer).toBeInstanceOf(SimpleMeshLayer);
+  expect(meshLayer.state.model).toBeDefined();
+  expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+  layerManager.finalize();
+  texture.delete();
+});
 
 test('TerrainLayer', async () => {
   const testCases = generateLayerTests({

--- a/website/src/examples/terrain-layer.js
+++ b/website/src/examples/terrain-layer.js
@@ -59,6 +59,8 @@ const SURFACE_IMAGES = {
 class TerrainDemo extends Component {
   static title = 'Terrains';
 
+  static hasDeviceTabs = true;
+
   static code = `${GITHUB_TREE}/examples/website/terrain`;
 
   static parameters = {


### PR DESCRIPTION
## Goal

Enable `TerrainLayer` on WebGPU with the smallest possible review surface.

This PR is stacked on #10485. `TerrainLayer` already delegates its rendering to `SimpleMeshLayer`, so no terrain production code or WebGL behavior changes are needed once the textured, non-instanced SimpleMesh path is available.

## Changes

- expose the WebGPU device tab on the TerrainLayer website example
- mark TerrainLayer supported in the WebGPU support table
- add a real WebGPU regression that initializes the actual `TerrainLayer`-generated textured mesh sublayer

## Validation

- `yarn lint` (passes; existing repository warnings only)
- `yarn test-headless test/modules/geo-layers/terrain-layer.spec.ts` with Chromium WebGPU enabled (2 tests passed)
- commit hooks: 21 node tests passed

## Stack

- Base: #10485 (`SimpleMeshLayer` WebGPU port)
- This PR contains only the TerrainLayer enablement and regression coverage.