### PR TITLE
feat(geo-layers): port Tile3DLayer mesh content to WebGPU

### DIFF
--- a/modules/geo-layers/src/mesh-layer/mesh-layer-uniforms.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer-uniforms.ts
@@ -10,6 +10,14 @@ layout(std140) uniform meshUniforms {
 } mesh;
 `;
 
+const source = /* wgsl */ `\
+struct MeshUniforms {
+  pickFeatureIds: f32,
+};
+
+@group(0) @binding(auto) var<uniform> mesh: MeshUniforms;
+`;
+
 export type MeshProps = {
   pickFeatureIds: boolean;
 };
@@ -18,6 +26,7 @@ export const meshUniforms = {
   name: 'mesh',
   vs: uniformBlock,
   fs: uniformBlock,
+  source,
   uniformTypes: {
     pickFeatureIds: 'f32'
   }

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.ts
@@ -4,15 +4,16 @@
 
 import type {NumericArray} from '@math.gl/core';
 import {parsePBRMaterial, ParsedPBRMaterial} from '@luma.gl/gltf';
-import {pbrMaterial} from '@luma.gl/shadertools';
 import {Model} from '@luma.gl/engine';
 import type {MeshAttribute, MeshAttributes} from '@loaders.gl/schema';
 import type {UpdateParameters, DefaultProps, LayerContext} from '@deck.gl/core';
 import {SimpleMeshLayer, SimpleMeshLayerProps} from '@deck.gl/mesh-layers';
 
 import {MeshProps, meshUniforms} from './mesh-layer-uniforms';
+import {meshPbrMaterial} from './mesh-pbr-material';
 import vs from './mesh-layer-vertex.glsl';
 import fs from './mesh-layer-fragment.glsl';
+import source from './mesh-layer.wgsl';
 
 export type Mesh = {
   attributes: MeshAttributes;
@@ -62,9 +63,13 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
 
   getShaders() {
     const shaders = super.getShaders();
-    const modules = shaders.modules;
-    modules.push(pbrMaterial, meshUniforms);
-    return {...shaders, vs, fs};
+    return {
+      ...shaders,
+      vs,
+      fs,
+      source,
+      modules: [...shaders.modules, meshPbrMaterial, meshUniforms]
+    };
   }
 
   initializeState() {
@@ -131,7 +136,8 @@ export default class MeshLayer<DataT = any, ExtraProps extends {} = {}> extends 
       defines: {
         ...shaders.defines,
         ...parsedPBRMaterial?.defines,
-        HAS_UV_REGIONS: mesh.attributes.uvRegions ? 1 : 0
+        HAS_UV_REGIONS: mesh.attributes.uvRegions ? 1 : 0,
+        HAS_FEATURE_IDS: this.props.featureIds ? 1 : 0
       },
       parameters: parsedPBRMaterial?.parameters,
       isInstanced: true

--- a/modules/geo-layers/src/mesh-layer/mesh-layer.wgsl.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-layer.wgsl.ts
@@ -1,0 +1,130 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export default /* wgsl */ `\
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+#ifdef HAS_NORMALS
+  @location(1) normals: vec3<f32>,
+#endif
+  @location(2) colors: vec4<f32>,
+#ifdef HAS_UV
+  @location(3) texCoords: vec2<f32>,
+#endif
+#ifdef HAS_UV_REGIONS
+  @location(4) uvRegions: vec4<f32>,
+#endif
+#ifdef HAS_FEATURE_IDS
+  @location(5) rowIndexes: u32,
+#endif
+  @location(6) instanceColors: vec4<f32>,
+  @location(7) instanceModelMatrixCol0: vec3<f32>,
+  @location(8) instanceModelMatrixCol1: vec3<f32>,
+  @location(9) instanceModelMatrixCol2: vec3<f32>,
+};
+
+struct FragmentInputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) texCoord: vec2<f32>,
+  @location(2) pbrPosition: vec3<f32>,
+  @location(3) pbrNormal: vec3<f32>,
+  @location(4) pickingColor: vec3<f32>,
+};
+
+fn applyUVRegion(uv: vec2<f32>, uvRegion: vec4<f32>) -> vec2<f32> {
+#ifdef HAS_UV_REGIONS
+  // https://github.com/Esri/i3s-spec/blob/master/docs/1.7/geometryUVRegion.cmn.md
+  return fract(uv) * (uvRegion.zw - uvRegion.xy) + uvRegion.xy;
+#else
+  return uv;
+#endif
+}
+
+@vertex
+fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(instance_index) instanceIndex: u32
+) -> FragmentInputs {
+  var outputs: FragmentInputs;
+  var texCoord = vec2<f32>(0.0);
+  var normal = vec3<f32>(0.0, 0.0, 1.0);
+  var uvRegion = vec4<f32>(0.0);
+
+#ifdef HAS_UV
+  texCoord = inputs.texCoords;
+#endif
+#ifdef HAS_NORMALS
+  normal = inputs.normals;
+#endif
+#ifdef HAS_UV_REGIONS
+  uvRegion = inputs.uvRegions;
+#endif
+
+  texCoord = applyUVRegion(texCoord, uvRegion);
+  geometry.uv = texCoord;
+#ifdef HAS_FEATURE_IDS
+  geometry.pickingColor = picking_getPickingColorFromIndex(inputs.rowIndexes);
+#else
+  geometry.pickingColor = picking_getPickingColorFromIndex(instanceIndex);
+#endif
+
+  let instanceModelMatrix = mat3x3<f32>(
+    inputs.instanceModelMatrixCol0,
+    inputs.instanceModelMatrixCol1,
+    inputs.instanceModelMatrixCol2
+  );
+  let commonPosition = vec4<f32>(project_position_vec3_f32(inputs.positions), 1.0);
+
+  geometry.position = commonPosition;
+  geometry.normal = project_normal(instanceModelMatrix * normal);
+
+  outputs.position = project_common_position_to_clipspace(commonPosition);
+  outputs.color = vec4<f32>(
+    inputs.colors.rgb * inputs.instanceColors.rgb,
+    inputs.instanceColors.a
+  );
+  outputs.texCoord = texCoord;
+  outputs.pbrPosition = commonPosition.xyz;
+  outputs.pbrNormal = geometry.normal;
+  outputs.pickingColor = geometry.pickingColor;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  fragmentGeometry.uv = inputs.texCoord;
+
+  if (picking.isActive > 0.5) {
+    if (!picking_isColorValid(inputs.pickingColor)) {
+      discard;
+    }
+    return vec4<f32>(inputs.pickingColor, 1.0);
+  }
+
+  fragmentInputs.pbr_vPosition = inputs.pbrPosition;
+  fragmentInputs.pbr_vUV0 = inputs.texCoord;
+  fragmentInputs.pbr_vUV1 = vec2<f32>(0.0);
+  fragmentInputs.pbr_vNormal = inputs.pbrNormal;
+
+  var color = inputs.color * pbr_filterColor(vec4<f32>(0.0));
+  color.a *= layer.opacity;
+
+  if (picking.isHighlightActive > 0.5) {
+    let highlightedObjectColor = picking_normalizeColor(picking.highlightedObjectColor);
+    if (picking_isColorZero(abs(inputs.pickingColor - highlightedObjectColor))) {
+      let highlightAlpha = picking.highlightColor.a;
+      let blendedAlpha = highlightAlpha + color.a * (1.0 - highlightAlpha);
+      if (blendedAlpha > 0.0) {
+        color = vec4<f32>(
+          mix(color.rgb, picking.highlightColor.rgb, highlightAlpha / blendedAlpha),
+          blendedAlpha
+        );
+      }
+    }
+  }
+
+  return deckgl_premultiplied_alpha(color);
+}
+`;

--- a/modules/geo-layers/src/mesh-layer/mesh-pbr-material.ts
+++ b/modules/geo-layers/src/mesh-layer/mesh-pbr-material.ts
@@ -1,0 +1,39 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {pbrMaterial} from '@luma.gl/shadertools';
+
+import type {
+  PBRMaterialBindings,
+  PBRMaterialProps,
+  PBRMaterialUniforms,
+  ShaderModule
+} from '@luma.gl/shadertools';
+
+// The stock PBR module still uses the pre-indexed UV field name in one helper and owns a
+// separate camera uniform. Align it with the current PBR input struct and deck.gl's project
+// module until these compatibility fixes can be made in luma.gl itself.
+const source = (pbrMaterial.source as string)
+  .replace(
+    /fn pbr_setPositionNormalTangentUV\([\s\S]*?\n}\n/,
+    `fn pbr_setPositionNormalTangentUV(position: vec4f, normal: vec4f, tangent: vec4f, uv: vec2f)
+{
+  fragmentInputs.pbr_vPosition = position.xyz;
+  fragmentInputs.pbr_vNormal = normal.xyz;
+  fragmentInputs.pbr_vTBN = mat3x3f(
+    vec3f(1.0, 0.0, 0.0),
+    vec3f(0.0, 1.0, 0.0),
+    vec3f(0.0, 0.0, 1.0)
+  );
+  fragmentInputs.pbr_vUV0 = uv;
+  fragmentInputs.pbr_vUV1 = uv;
+}
+`
+  )
+  .replace(/pbrProjection\.camera/g, 'project.cameraPosition');
+
+export const meshPbrMaterial = {
+  ...pbrMaterial,
+  source
+} as const satisfies ShaderModule<PBRMaterialProps, PBRMaterialUniforms, PBRMaterialBindings>;

--- a/test/modules/geo-layers/mesh-layer.spec.ts
+++ b/test/modules/geo-layers/mesh-layer.spec.ts
@@ -1,0 +1,85 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
+import {Geometry} from '@luma.gl/engine';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+import MeshLayer from '../../../modules/geo-layers/src/mesh-layer/mesh-layer';
+
+const TEST_MATERIAL = {
+  pbrMetallicRoughness: {
+    baseColorFactor: [1, 1, 1, 1],
+    metallicFactor: 0,
+    roughnessFactor: 1
+  }
+};
+
+test('Tile3DLayer mesh sublayer initializes with a WebGPU device', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+
+  for (const featureIds of [null, new Uint32Array([0, 1, 1])]) {
+    const errors: Error[] = [];
+    const layerManager = new LayerManager(webgpuDevice, {viewport});
+    layerManager.setProps({onError: error => errors.push(error)});
+    const layer = new MeshLayer({
+      id: featureIds ? 'webgpu-tile3d-feature-mesh' : 'webgpu-tile3d-mesh',
+      data: [0],
+      mesh: new Geometry({
+        topology: 'triangle-list',
+        attributes: {
+          positions: {
+            size: 3,
+            value: new Float32Array([-1, -1, 0, 1, -1, 0, 0, 1, 0])
+          },
+          normals: {
+            size: 3,
+            value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+          },
+          colors: {
+            size: 4,
+            value: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255]),
+            normalized: true
+          },
+          texCoords: {
+            size: 2,
+            value: new Float32Array([0, 0, 1, 0, 0.5, 1])
+          },
+          ...(featureIds
+            ? {
+                uvRegions: {
+                  size: 4,
+                  value: new Float32Array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1])
+                }
+              }
+            : {})
+        }
+      }),
+      pbrMaterial: TEST_MATERIAL,
+      featureIds,
+      getPosition: [0, 0, 0],
+      getColor: [255, 255, 255, 255]
+    });
+
+    webgpuDevice.handle.pushErrorScope('validation');
+    layerManager.setLayers([layer]);
+
+    expect(errors).toEqual([]);
+    expect(layer.state.model).toBeDefined();
+    expect(await webgpuDevice.handle.popErrorScope()).toBeNull();
+
+    layerManager.finalize();
+  }
+});

--- a/website/src/examples/tile-3d-layer.js
+++ b/website/src/examples/tile-3d-layer.js
@@ -11,6 +11,8 @@ import {makeExample} from '../components';
 class Tiles3DDemo extends Component {
   static title = 'City of Melbourne 3D Point Cloud';
 
+  static hasDeviceTabs = true;
+
   static code = `${GITHUB_TREE}/examples/website/3d-tiles`;
 
   static parameters = {};


### PR DESCRIPTION
## Goal

Port Tile3DLayer's remaining private mesh renderer to WebGPU without changing its WebGL shader path.

This PR is stacked on #10485. Point-cloud tile content already inherits the WebGPU-capable `PointCloudLayer`; scenegraph tile content is covered separately by #10477.

## Changes

- add a focused WGSL shader for Tile3DLayer's internal PBR mesh sublayer
- support normals, UVs, I3S UV regions, per-feature picking IDs, PBR lighting, highlighting, and premultiplied alpha
- add a backend-neutral PBR compatibility module; its WGSL source is ignored on WebGL, while the existing GLSL and dependency behavior is preserved
- avoid `isWebGPU` branching in shader setup
- expose the WebGPU device tab on the Melbourne point-cloud Tile3DLayer example
- add real WebGPU coverage with and without per-feature IDs/UV regions

The global support-table row remains unchanged until the ScenegraphLayer dependency (#10477) lands.

## Validation

- `yarn lint` (passes; existing repository warnings only)
- `yarn test-headless test/modules/geo-layers/mesh-layer.spec.ts test/modules/geo-layers/tile-3d-layer/tile-3d-layer.spec.ts` with Chromium WebGPU enabled (2 tests passed)
- commit hooks: 21 node tests passed
- `yarn build` was attempted and stops in unchanged stacked-base code at `modules/core/src/transitions/gpu-interpolation-transition.ts:205` because an existing `@ts-expect-error` is unused with the local luma 9.4 types

## Stack

- Base: #10485 (`SimpleMeshLayer` WebGPU port)
- Related dependency for scenegraph tile content: #10477