### PR TITLE
fix(core): isolate shader assemblers per Deck instance

### DIFF
--- a/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregator.ts
+++ b/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-aggregator.ts
@@ -8,7 +8,7 @@ import {_deepEqual as deepEqual, log, BinaryAttribute} from '@deck.gl/core';
 
 import type {Aggregator, AggregationProps, AggregatedBin} from '../aggregator';
 import type {Device, Buffer, BufferLayout, TypedArray} from '@luma.gl/core';
-import type {ShaderModule} from '@luma.gl/shadertools';
+import type {ShaderAssembler, ShaderModule} from '@luma.gl/shadertools';
 
 /** Options used to construct a new WebGLAggregator */
 export type WebGLAggregatorProps = {
@@ -31,6 +31,8 @@ export type WebGLAggregatorProps = {
    * Required to support certain layer extensions (e.g. data filter)
    */
   modules?: ShaderModule[];
+  /** Shader assembler configured for the owning layer and rendering device. */
+  shaderAssembler?: ShaderAssembler;
   /** Shadertool module defines */
   defines?: Record<string, string | number | boolean>;
 } & Partial<WebGLAggregationProps>;

--- a/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-bin-sorter.ts
+++ b/modules/aggregation-layers/src/common/aggregator/gpu-aggregator/webgl-bin-sorter.ts
@@ -247,6 +247,7 @@ void main() {
 `;
   const model = new Model(device, {
     bufferLayout: props.bufferLayout,
+    ...(props.shaderAssembler ? {shaderAssembler: props.shaderAssembler} : {}),
     modules: [...(props.modules || []), binSorterUniforms],
     defines: {...props.defines, NON_INSTANCED_MODEL: 1, NUM_CHANNELS: props.channelCount},
     isInstanced: false,

--- a/modules/core/src/lib/layer.ts
+++ b/modules/core/src/lib/layer.ts
@@ -469,7 +469,10 @@ export default abstract class Layer<PropsT extends {} = {}> extends Component<
   getShaders(shaders: any): any {
     shaders = mergeShaders(shaders, {
       disableWarnings: true,
-      modules: this.context.defaultShaderModules
+      modules: this.context.defaultShaderModules,
+      ...(this.context.shaderAssembler
+        ? {shaderAssembler: shaders.shaderAssembler ?? this.context.shaderAssembler}
+        : {})
     });
     for (const extension of this.props.extensions) {
       shaders = mergeShaders(shaders, extension.getShaders.call(this, extension));

--- a/modules/core/src/shaderlib/index.ts
+++ b/modules/core/src/shaderlib/index.ts
@@ -25,16 +25,11 @@ const SHADER_HOOKS_WGSL = [
 ];
 
 export function getShaderAssembler(language: 'glsl' | 'wgsl'): ShaderAssembler {
-  const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+  const shaderAssembler = new ShaderAssembler();
 
   for (const shaderModule of DEFAULT_MODULES) {
     shaderAssembler.addDefaultModule(shaderModule);
   }
-
-  // if we're recreating the device we may have changed language
-  // and must not inject hooks for the wrong language
-  // shaderAssembler.resetShaderHooks();
-  (shaderAssembler as any)._hookFunctions.length = 0;
 
   // Add shader hooks based on language
   // TODO(ibgreen) - should the luma shader assembler support both sets of hooks?

--- a/modules/extensions/src/data-filter/data-filter-extension.ts
+++ b/modules/extensions/src/data-filter/data-filter-extension.ts
@@ -219,7 +219,10 @@ export default class DataFilterExtension extends LayerExtension<
       const filterModel = aggregator.getModel(
         device,
         attributeManager.getBufferLayouts({isInstanced: false}),
-        extension.getShaders.call(this, extension),
+        {
+          ...extension.getShaders.call(this, extension),
+          ...(this.context.shaderAssembler ? {shaderAssembler: this.context.shaderAssembler} : {})
+        },
         useFloatTarget
       );
       this.setState({filterFBO, filterModel});

--- a/test/modules/core/shaderlib/shader-assembler.node.spec.ts
+++ b/test/modules/core/shaderlib/shader-assembler.node.spec.ts
@@ -1,0 +1,89 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {getShaderAssembler, Layer} from '@deck.gl/core';
+import {LineLayer} from '@deck.gl/layers';
+import {ShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
+import {expect, test} from 'vitest';
+
+const WEBGL_PLATFORM_INFO: PlatformInfo = {
+  type: 'webgl',
+  gpu: 'test-gpu',
+  shaderLanguage: 'glsl',
+  shaderLanguageVersion: 300,
+  features: new Set()
+};
+
+const VERTEX_SHADER = /* glsl */ `\
+#version 300 es
+in vec4 positions;
+void main(void) {
+  gl_Position = positions;
+}
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+out vec4 fragmentColor;
+void main(void) {
+  fragmentColor = vec4(1.0);
+}
+`;
+
+function assembleGLSLShaderPair(shaderAssembler: ShaderAssembler) {
+  return shaderAssembler.assembleGLSLShaderPair({
+    platformInfo: WEBGL_PLATFORM_INFO,
+    vs: VERTEX_SHADER,
+    fs: FRAGMENT_SHADER
+  });
+}
+
+test('getShaderAssembler preserves WebGL hooks when a WebGPU assembler is created', () => {
+  const webglShaderAssembler = getShaderAssembler('glsl');
+  const initialShaders = assembleGLSLShaderPair(webglShaderAssembler);
+
+  expect(initialShaders.vs).toContain('DECKGL_FILTER_GL_POSITION');
+  expect(initialShaders.fs).toContain('DECKGL_FILTER_COLOR');
+  expect(initialShaders.modules.map(shaderModule => shaderModule.name)).toContain('geometry');
+
+  const webgpuShaderAssembler = getShaderAssembler('wgsl');
+  const secondWebglShaderAssembler = getShaderAssembler('glsl');
+  const retainedShaders = assembleGLSLShaderPair(webglShaderAssembler);
+
+  expect(webgpuShaderAssembler).not.toBe(webglShaderAssembler);
+  expect(secondWebglShaderAssembler).not.toBe(webglShaderAssembler);
+  expect(secondWebglShaderAssembler).not.toBe(webgpuShaderAssembler);
+  expect(assembleGLSLShaderPair(secondWebglShaderAssembler).vs).toBe(initialShaders.vs);
+  expect(retainedShaders.vs).toBe(initialShaders.vs);
+  expect(retainedShaders.fs).toBe(initialShaders.fs);
+});
+
+test('getShaderAssembler does not mutate the shared luma.gl shader assembler', () => {
+  const defaultShaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+  const initialShaders = assembleGLSLShaderPair(defaultShaderAssembler);
+  const webglShaderAssembler = getShaderAssembler('glsl');
+  const webgpuShaderAssembler = getShaderAssembler('wgsl');
+  const retainedShaders = assembleGLSLShaderPair(defaultShaderAssembler);
+
+  expect(webglShaderAssembler).not.toBe(defaultShaderAssembler);
+  expect(webgpuShaderAssembler).not.toBe(defaultShaderAssembler);
+  expect(retainedShaders.vs).toBe(initialShaders.vs);
+  expect(retainedShaders.fs).toBe(initialShaders.fs);
+  expect(retainedShaders.modules).toEqual(initialShaders.modules);
+});
+
+test('Layer#getShaders passes its context shader assembler to luma.gl models', () => {
+  const shaderAssembler = getShaderAssembler('glsl');
+  const overrideShaderAssembler = getShaderAssembler('wgsl');
+  const layer = new LineLayer({id: 'shader-assembler-test', data: []});
+
+  Object.assign(layer, {context: {defaultShaderModules: [], shaderAssembler}});
+
+  expect(layer.getShaders().shaderAssembler).toBe(shaderAssembler);
+  expect(
+    Layer.prototype.getShaders.call(layer, {shaderAssembler: overrideShaderAssembler})
+      .shaderAssembler
+  ).toBe(overrideShaderAssembler);
+});

--- a/test/modules/react/deckgl.spec.ts
+++ b/test/modules/react/deckgl.spec.ts
@@ -183,9 +183,7 @@ test('DeckGL#custom render uses the initialized device type', () => {
   container.remove();
 });
 
-test.skip('DeckGL#real WebGPU device draws through the React custom render loop', async ({
-  skip
-}) => {
+test('DeckGL#real WebGPU device draws through the React custom render loop', async ({skip}) => {
   const webgpuDevice = await getWebGPUTestDevice();
   if (!webgpuDevice) {
     skip();


### PR DESCRIPTION
## Summary

- Give each Deck layer manager its own shader assembler instead of clearing hooks on luma.gl's shared default assembler.
- Propagate the owning assembler through layer shaders, WebGL aggregation, and data-filter models while preserving explicit assembler overrides.
- Add regression coverage for concurrent WebGL/WebGPU assemblers and an untouched luma.gl singleton.
- Re-enable the real-WebGPU React rendering test that was temporarily skipped in #10521.

## Why

Initializing a WebGPU Deck after a WebGL Deck previously cleared the same global assembler's GLSL hooks, corrupting the existing Deck instance and making browser tests race.

## Validation

- `yarn vitest run --project node` — 25 tests passed.
- Repository pre-commit lint and Node checks.
- `yarn tsc --build modules/core/tsconfig.json modules/layers/tsconfig.json modules/aggregation-layers/tsconfig.json modules/extensions/tsconfig.json --pretty false`.
- `yarn prettier --config .prettierrc --check test/modules/react/deckgl.spec.ts test/modules/core/shaderlib/shader-assembler.node.spec.ts`.