### PR TITLE
feat(core): override size zoom in OrthographicView

### DIFF
--- a/docs/api-reference/core/orthographic-view.md
+++ b/docs/api-reference/core/orthographic-view.md
@@ -40,7 +40,7 @@ Distance of far clipping plane. Default `1000`.
 To render, `OrthographicView` needs to be used together with a `viewState` with the following parameters:
 
 * `target` (number[3], optional) - The world position at the center of the viewport. Default `[0, 0, 0]`.
-* `zoom` (number, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. For example `zoom: 1` is 2x the original size, `zoom: 2` is 4x, `zoom: 3` is 8x etc.. To apply independent zoom levels to the X and Y axes, use `zoomX` and `zoomY`. Default `0`.
+* `zoom` (number, optional) - The zoom level of the viewport. `zoom: 0` maps one unit distance to one pixel on screen, and increasing `zoom` by `1` scales the same object to twice as large. To apply independent zoom levels to the X and Y axes, use `zoomX` and `zoomY`. Default `0`.
 * `zoomX` (number, optional) - The zoom level along X axis. Overrides `zoom` if supplied.
 * `zoomY` (number, optional) - The zoom level along Y axis. Overrides `zoom` if supplied.
 * `minZoom` (number, optional) - The min zoom level of the viewport. Default `-Infinity`.
@@ -60,6 +60,16 @@ const view = new OrthographicView({id: '2d-scene', controller: true});
 ```
 
 Visit the [OrthographicController](./orthographic-controller.md) documentation for a full list of supported options.
+
+
+## Remarks
+
+### Common size resolution
+
+This section describes how geometry size (e.g. scatterplot radius, path width, text size) of [common units](../../developer-guide/coordinate-systems.md#common) is resolved in OrthographicView.
+
+When a uniform zoom is used, like all other view types, the `zoom` view state is used to project both position and size.
+When the X and Y axes zoom independently, it becomes ambiguous whether size should follow X or Y. By default, size is scaled to `Math.min(zoomX, zoomY)`, to provide visual stability. You may override this behavior by supplying a `zoom` value. While `zoom` is shadowed by `zoomX` and `zoomY` during position projection, it will be used to project sizes.
 
 
 ## Source

--- a/modules/core/src/viewports/orthographic-viewport.ts
+++ b/modules/core/src/viewports/orthographic-viewport.ts
@@ -105,7 +105,7 @@ export default class OrthographicViewport extends Viewport {
     } = props;
     const zoomX = props.zoomX ?? (Array.isArray(zoom) ? zoom[0] : zoom);
     const zoomY = props.zoomY ?? (Array.isArray(zoom) ? zoom[1] : zoom);
-    const zoom_ = Math.min(zoomX, zoomY);
+    const zoom_ = Number.isFinite(props.zoom) ? (props.zoom as number) : Math.min(zoomX, zoomY);
     const scale = Math.pow(2, zoom_);
 
     let distanceScales;


### PR DESCRIPTION
#### Background

While OrhographicView supports 2D zoom, `project.scale` remains a numeric value. This scaler affects the outcome of any sizeUnit: `common`, including ScatterplotLayer getRadius, TextLayer getSize, PathLayer getWidth etc.

Currently `project.scale` is calculated as `2 ** Math.min(zoomX, zoomY)`. This makes geometry sizes unpredictable when only one axis can be zoomed.

This PR allows apps to control the size zoom by supplying their own `zoom` value. The value is shadowed by `zoomX` and `zoomY` during position projection, but respected during size projection. For all other types of viewports, `zoom` is used for both position and size projections.

Alternative names considered include `sizeZoom`, and `zoomZ`. 