### PR TITLE
fix(geo-layers): normalize legacy numeric coordinateSystem in Tile3DLayer

### DIFF
--- a/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
+++ b/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts
@@ -10,6 +10,7 @@ import {
   CompositeLayer,
   CompositeLayerProps,
   COORDINATE_SYSTEM,
+  CoordinateSystem,
   FilterContext,
   GetPickingInfoParams,
   Layer,
@@ -31,6 +32,30 @@ import {Tileset3D, Tile3D, TILE_TYPE} from '@loaders.gl/tiles';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 
 const SINGLE_DATA = [0];
+
+/**
+ * Numeric `COORDINATE_SYSTEM` values used by deck.gl before v9.3, still emitted on tile content by
+ * released versions of loaders such as `@loaders.gl/i3s`. Mapped back to the string constants that
+ * the layers understand.
+ */
+const LEGACY_COORDINATE_SYSTEMS: Record<number, CoordinateSystem> = {
+  [-1]: COORDINATE_SYSTEM.DEFAULT,
+  0: COORDINATE_SYSTEM.CARTESIAN,
+  1: COORDINATE_SYSTEM.LNGLAT,
+  2: COORDINATE_SYSTEM.METER_OFFSETS,
+  3: COORDINATE_SYSTEM.LNGLAT_OFFSETS
+};
+
+/** @internal Exported for testing. */
+export function normalizeCoordinateSystem(
+  coordinateSystem: CoordinateSystem | number
+): CoordinateSystem | number {
+  if (typeof coordinateSystem === 'number') {
+    // Unrecognized values are passed through so that the core reports `Invalid coordinateSystem`
+    return LEGACY_COORDINATE_SYSTEMS[coordinateSystem] ?? coordinateSystem;
+  }
+  return coordinateSystem;
+}
 
 const defaultProps: DefaultProps<Tile3DLayerProps> = {
   getPointColor: {type: 'accessor', value: [0, 0, 0, 255]},
@@ -419,7 +444,7 @@ export default class Tile3DLayer<DataT = any, ExtraPropsT extends {} = {}> exten
         pbrMaterial: material,
         modelMatrix,
         coordinateOrigin: cartographicOrigin,
-        coordinateSystem,
+        coordinateSystem: normalizeCoordinateSystem(coordinateSystem),
         featureIds,
         _offset: 0
       }

--- a/test/modules/geo-layers/tile-3d-layer/tile-3d-layer.spec.ts
+++ b/test/modules/geo-layers/tile-3d-layer/tile-3d-layer.spec.ts
@@ -6,7 +6,26 @@ import {test, expect} from 'vitest';
 
 import {LayerTestCase, testLayerAsync} from '@deck.gl/test-utils/vitest';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
-import {WebMercatorViewport} from '@deck.gl/core';
+import {normalizeCoordinateSystem} from '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer';
+import {COORDINATE_SYSTEM, WebMercatorViewport} from '@deck.gl/core';
+
+test('Tile3DLayer#normalizeCoordinateSystem', () => {
+  // Loaders that predate the v9.3 string constants report numeric values, see issue #10368
+  expect(normalizeCoordinateSystem(-1)).toBe(COORDINATE_SYSTEM.DEFAULT);
+  expect(normalizeCoordinateSystem(0)).toBe(COORDINATE_SYSTEM.CARTESIAN);
+  expect(normalizeCoordinateSystem(1)).toBe(COORDINATE_SYSTEM.LNGLAT);
+  expect(normalizeCoordinateSystem(2)).toBe(COORDINATE_SYSTEM.METER_OFFSETS);
+  expect(normalizeCoordinateSystem(3)).toBe(COORDINATE_SYSTEM.LNGLAT_OFFSETS);
+
+  // String constants pass through untouched
+  expect(normalizeCoordinateSystem(COORDINATE_SYSTEM.METER_OFFSETS)).toBe(
+    COORDINATE_SYSTEM.METER_OFFSETS
+  );
+  expect(normalizeCoordinateSystem(COORDINATE_SYSTEM.LNGLAT)).toBe(COORDINATE_SYSTEM.LNGLAT);
+
+  // Unknown numeric values are passed through so that the core validation reports them
+  expect(normalizeCoordinateSystem(42)).toBe(42);
+});
 
 test('Tile3DLayer', async () => {
   const testCases: LayerTestCase<Tile3DLayer>[] = [


### PR DESCRIPTION
## Goal

Fixes #10368 — `Tile3DLayer` throws `Invalid coordinateSystem: 2` when rendering i3s tiles.

deck.gl v9.3 migrated `coordinateSystem` from numeric enums to string constants (#10140). Released tile loaders still emit the old numeric value on parsed tile content — `@loaders.gl/i3s` sets `METER_OFFSETS = 2`. `Tile3DLayer._makeSimpleMeshLayer()` reads `coordinateSystem` straight off `tileHeader.content` and forwards it to the sublayer, so the numeric `2` reaches `getShaderCoordinateSystem()`, which rejects it:

```
deck: drawing MeshLayer({id: 'tile-3d-layer-mesh-49639-default-view'}) to screen: Invalid coordinateSystem: 2
    at getShaderCoordinateSystem (viewport-uniforms.ts:39:11)
```

Upstream fixed this in loaders.gl master (visgl/loaders.gl#3449), but the numeric values are still present in released `4.4.x` builds, and `Tile3DLayer` accepts tile content from any loader — including third-party ones. Normalizing at that boundary keeps deck.gl working regardless of which loader version is installed.

## Changes

`modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts`

- Add `LEGACY_COORDINATE_SYSTEMS`, mapping the pre-9.3 numeric values (`-1`, `0`, `1`, `2`, `3`) to their string constants.
- Add `normalizeCoordinateSystem()` and apply it to the `coordinateSystem` read from tile content in `_makeSimpleMeshLayer()`.
- Unrecognized numeric values are passed through unchanged, so the core `Invalid coordinateSystem` validation still reports genuinely bad input rather than this shim masking it.

The public API is untouched: this only translates loader-provided values, so raw numeric `coordinateSystem` **props** remain unsupported as documented in the v9.3 upgrade guide. `normalizeCoordinateSystem` is exported for the test only and is not re-exported from `modules/geo-layers/src/index.ts`.

## Validation

- `test/modules/geo-layers/tile-3d-layer/tile-3d-layer.spec.ts` — new `Tile3DLayer#normalizeCoordinateSystem` case covering each legacy numeric value, string pass-through, and unknown-value pass-through.
- geo-layers headless suite: 20 files, 98 passed / 1 skipped.
- node smoke tests: 15 passed.
- `biome check` on both changed files reports no new findings (4 pre-existing `noUnusedVariables` warnings in the untouched `defaultProps` block are left alone to keep the diff focused).

Not run locally: `yarn test-render` (golden images) and the full `yarn build`.
