### PR TITLE
fix(core): read texture dimensions from the plain object image form

### DIFF
--- a/modules/core/src/utils/texture.ts
+++ b/modules/core/src/utils/texture.ts
@@ -47,7 +47,10 @@ export function createTexture(
     };
   }
 
-  const {width, height} = image.data;
+  // Browser objects are wrapped as `{data: browserImage}` above, so their dimensions live on
+  // `data`. The plain object form `{data: <Uint8Array>, width, height}` carries them on the object
+  // itself - reading `image.data` there yields `undefined` and an invalid `mipLevels` count.
+  const {width, height} = image.data.width === undefined ? image : image.data;
   const texture = device.createTexture({
     ...image,
     sampler: {

--- a/test/modules/core/utils/index.ts
+++ b/test/modules/core/utils/index.ts
@@ -15,3 +15,4 @@ import './math-utils.spec';
 import './shader.spec';
 import './typed-array-manager.spec';
 import './apply-styles.spec';
+import './texture.spec';

--- a/test/modules/core/utils/texture.spec.ts
+++ b/test/modules/core/utils/texture.spec.ts
@@ -1,0 +1,48 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+
+import {createTexture, destroyTexture} from '@deck.gl/core/utils/texture';
+import {device} from '@deck.gl/test-utils/vitest';
+
+const SIZE = 64;
+// 1 + floor(log2(64))
+const EXPECTED_MIP_LEVELS = 7;
+
+test('createTexture#plain object image', () => {
+  // The documented `{data, width, height}` form carries its dimensions on the object itself, not on
+  // `data`. Reading them from the wrong level produced `mipLevels: NaN`, which rendered as opaque
+  // black. See issue #10371
+  const texture = createTexture(
+    'test-owner',
+    device,
+    {data: new Uint8Array(SIZE * SIZE * 4).fill(200), width: SIZE, height: SIZE},
+    {}
+  );
+
+  expect(texture, 'creates a texture').toBeTruthy();
+  expect(texture!.width, 'reads width from the plain object').toBe(SIZE);
+  expect(texture!.height, 'reads height from the plain object').toBe(SIZE);
+  expect(texture!.mipLevels, 'derives a valid mip level count').toBe(EXPECTED_MIP_LEVELS);
+
+  destroyTexture('test-owner', texture!);
+});
+
+test('createTexture#browser image object', () => {
+  // Browser objects are wrapped as `{data: browserImage}`, so their dimensions live on `data`
+  const texture = createTexture(
+    'test-owner',
+    device,
+    new ImageData(new Uint8ClampedArray(SIZE * SIZE * 4).fill(200), SIZE, SIZE),
+    {}
+  );
+
+  expect(texture, 'creates a texture').toBeTruthy();
+  expect(texture!.width, 'reads width from the wrapped image').toBe(SIZE);
+  expect(texture!.height, 'reads height from the wrapped image').toBe(SIZE);
+  expect(texture!.mipLevels, 'derives a valid mip level count').toBe(EXPECTED_MIP_LEVELS);
+
+  destroyTexture('test-owner', texture!);
+});


### PR DESCRIPTION
## Goal

Fixes #10371 — the documented plain object `image` form renders as **opaque black**, painting black over everything beneath the layer's bounds.

`BitmapLayer`'s docs list `{data: <Uint8Array>, width, height}` as a supported `image` value ([bitmap-layer.md](https://github.com/visgl/deck.gl/blob/master/docs/api-reference/layers/bitmap-layer.md#image)), but in 9.x it does not render.

## Root cause

`createTexture()` in `modules/core/src/utils/texture.ts` reads the dimensions off `image.data`:

```ts
const {width, height} = image.data;
```

Browser image objects (`ImageData`, `ImageBitmap`, canvas, …) hit the branch above that wraps them as `image = {data: browserImage}`, so `image.data.width/height` exist and everything works. The plain object form has `constructor.name === 'Object'`, so it is **not** wrapped — it stays `{data, width, height}`, where `data` is the raw typed array. Both dimensions come back `undefined`, so:

```ts
device.getMipLevelCount(undefined, undefined)
// -> 1 + Math.floor(Math.log2(Math.max(undefined, undefined, 1)))  ->  NaN
```

The texture is created with `mipLevels: NaN`. Combined with the default `mipmapFilter: 'linear'` in `DEFAULT_TEXTURE_PARAMETERS`, the texture is incomplete and samples as `(0, 0, 0, 1)`.

This runs through the shared `image` prop type in `modules/core/src/lifecycle/prop-types.ts`, so it affects every `image`-typed prop (`BitmapLayer.image`, `IconLayer.iconAtlas`, `TextLayer`, …), not just `BitmapLayer`.

## Changes

`modules/core/src/utils/texture.ts` — read the dimensions from whichever level actually carries them:

```ts
const {width, height} = image.data.width === undefined ? image : image.data;
```

One-line behavioral change; the browser-object path is untouched.

## Validation

New `test/modules/core/utils/texture.spec.ts` covering both forms, asserting `width`, `height`, and a valid `mipLevels`. Confirmed it actually catches the bug — with the fix reverted:

```
AssertionError: derives a valid mip level count: expected NaN to be 7
```

Also verified end-to-end by pixel readback, rendering a solid-yellow bitmap through both forms and sampling the canvas centre:

| | plain object | equivalent `ImageData` |
|---|---|---|
| before | `[0, 0, 0, 255]` — black | `[255, 255, 0, 255]` |
| after | `[255, 255, 0, 255]` | `[255, 255, 0, 255]` |

This matches the reporter's measurements. That probe was a throwaway and is not included — the committed test asserts the root cause (`mipLevels`) instead, since the repo keeps visual checks in `test/render` with golden images.

Suites run: `core` + `layers` headless — 84 files, 360 tests, all passing. `biome check` clean on all three files.

**Not run locally:** `yarn test-render`. The render project needs headed chromium, and the Playwright build this checkout pins (1217) currently 400s on every CDN mirror, so I could not install it. No existing golden image exercises the plain-object path — all `bitmap-layer` render cases load images by URL — so none should shift, but that is worth confirming in CI.

Also note the full headless suite is flaky on my machine independently of this change: repeated runs on unmodified `master` fail a varying 2–3 tests (`LoadingWidget` consistently, plus rotating `WebGLAggregator`/`MapboxOverlay`/react-mount failures). None are in `core` or `layers`.
