### PR TITLE
fix(mesh-layers): SimpleMeshLayer matrix constant

### DIFF
--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -231,7 +231,11 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
         if (this.constant) {
           // Route constant updater output through the same path used by constant accessors
           // so WebGPU can materialize a real buffer while WebGL keeps a constant attribute.
-          this.setConstantValue(context, this.value);
+          const constantValue = this.value;
+          // The updater replaced the allocated CPU array without uploading it. Clear the
+          // cached value so WebGPU cannot mistake it for an already materialized buffer.
+          this.value = null;
+          this.setConstantValue(context, constantValue);
         } else {
           this.setData({
             value: this.value,

--- a/test/modules/core/lib/attribute/attribute.spec.ts
+++ b/test/modules/core/lib/attribute/attribute.spec.ts
@@ -242,6 +242,41 @@ test('Attribute#setConstantBufferValue - webgpu', async ({skip}) => {
   attribute.delete();
 });
 
+test('Attribute#updateBuffer uploads a one-instance constant updater - webgpu', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+  }
+  const matrix = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]);
+  const attribute = new Attribute(webgpuDevice, {
+    id: 'instanceModelMatrix',
+    size: 12,
+    update: target => {
+      // Matrix attributes use this legacy constant-updater path when all transforms are static.
+      target.constant = true;
+      target.value = new Float32Array(matrix);
+    }
+  });
+
+  attribute.allocate(1);
+  attribute.updateBuffer({
+    numInstances: 1,
+    data: [0],
+    props: {},
+    context: null
+  });
+
+  const buffer = attribute.getValue().instanceModelMatrix as Buffer;
+  expect(buffer, 'constant updater is exposed as a buffer').toBeInstanceOf(Buffer);
+  const bytes = await buffer.readAsync();
+  expect(
+    new Float32Array(bytes.buffer).slice(0, matrix.length),
+    'constant matrix is uploaded'
+  ).toEqual(matrix);
+
+  attribute.delete();
+});
+
 test('Attribute#allocate - partial', async () => {
   let positions = new Attribute(device, {
     id: 'positions',


### PR DESCRIPTION
#### Background

In WebGPU, a single-instance `SimpleMeshLayer` could render nothing when its transform was constant. The attribute updater replaced the allocated CPU array with the constant transform, but the caching logic mistook that value for an already-uploaded GPU buffer and skipped the actual upload. Consequently, the mesh had no valid transform data. This affected the flat- and smooth-shaded mesh tests, `TerrainLayer`, and another lighting test using a single mesh instance. The fix clears the stale cached value before materializing the WebGPU buffer, with a regression test verifying the transform is uploaded.

#### Change List
- Clear updater-populated `attribute.value` before calling `setConstantValue`
- Tests
