### PR TITLE
fix(core): clipspace depth in wgsl

### DIFF
--- a/modules/core/src/shaderlib/project/project.wgsl.ts
+++ b/modules/core/src/shaderlib/project/project.wgsl.ts
@@ -280,7 +280,10 @@ fn project_position_vec2_f32(position: vec2<f32>) -> vec2<f32> {
 
 // Transforms a common space position to clip space.
 fn project_common_position_to_clipspace_with_projection(position: vec4<f32>, viewProjectionMatrix: mat4x4<f32>, center: vec4<f32>) -> vec4<f32> {
-  return viewProjectionMatrix * position + center;
+  var clipPosition = viewProjectionMatrix * position + center;
+  // deck.gl projection matrices use WebGL's [-w, w] depth range; WebGPU clips z to [0, w].
+  clipPosition.z = (clipPosition.z + clipPosition.w) * 0.5;
+  return clipPosition;
 }
 
 // Uses the project viewProjectionMatrix and center.


### PR DESCRIPTION
#### Background

In WebGPU, normalized device coordinates (NDC) for the depth (z-value) is [0, 1], instead of WebGL's [-1, 1]. This results in some geometries being clipped unexpectedly under the existing viewports' projection matrices.

Discussion: should getUniforms generate different matrices depending on the target device?

#### Change List
- Remap `clipPosition` in wgsl's `project_common_position_to_clipspace`
