### PR TITLE
fix(layers): WebGPU derivative-based normal calculation

### DIFF
--- a/modules/layers/src/column-layer/column-layer.wgsl.ts
+++ b/modules/layers/src/column-layer/column-layer.wgsl.ts
@@ -195,7 +195,8 @@ fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
 
   var fragColor = varyings.color;
   if (column.extruded > 0.5 && column.isStroke < 0.5) {
-    let normal = normalize(cross(dpdx(varyings.positionCommonspace.xyz), dpdy(varyings.positionCommonspace.xyz)));
+    // WebGPU's screen-space Y axis reverses the derivative orientation used by GLSL flat shading.
+    let normal = normalize(cross(dpdy(varyings.positionCommonspace.xyz), dpdx(varyings.positionCommonspace.xyz)));
     fragColor = vec4<f32>(
       lighting_getLightColor2(
         varyings.color.rgb,

--- a/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.wgsl.ts
+++ b/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.wgsl.ts
@@ -94,7 +94,8 @@ fn fragmentMain(varyings: Varyings) -> @location(0) vec4<f32> {
 
   var normal = varyings.normal;
   if (simpleMesh.flatShading > 0.5) {
-    normal = normalize(cross(dpdx(varyings.positionCommon), dpdy(varyings.positionCommon)));
+    // WebGPU's screen-space Y axis reverses the derivative orientation used by GLSL flat shading.
+    normal = normalize(cross(dpdy(varyings.positionCommon), dpdx(varyings.positionCommon)));
   }
 
   color = vec4<f32>(


### PR DESCRIPTION
#### Background

WebGL and WebGPU use opposite screen-space Y-axis orientations, which reverses the direction of the Y derivative. In GLSL, `cross(dFdx(position), dFdy(position))` reconstructs the expected outward-facing surface normal, but applying the same operand order to WGSL’s `dpdx` and `dpdy` produces its inverse. Reversing the operands to `cross(dpdy(position), dpdx(position))` compensates for that coordinate-system difference, restoring outward-facing normals and therefore the correct diffuse and specular lighting. Geometry with supplied normals is unaffected; this only corrects normals reconstructed from screen-space derivatives.

#### Change List
- ColumnLayer
- SimpleMeshLayer
