### PR TITLE
fix(mapbox): guard getProjection against throw when map style is not ready

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -158,7 +158,17 @@ export function drawLayerGroup(
 }
 
 export function getProjection(map: Map): 'mercator' | 'globe' {
-  const projection = map.getProjection?.();
+  let projection;
+  try {
+    projection = map.getProjection?.();
+  } catch {
+    // map.getProjection() can throw if the map's style is not yet assigned
+    // (e.g. maplibre-gl's Map.prototype.getProjection() calls
+    // this.style.getProjection() without a guard on this.style).
+    // Return 'mercator' as the safe default — callers expect this when
+    // the map is not ready yet.
+    return 'mercator';
+  }
   const type =
     // maplibre projection spec
     projection?.type ||


### PR DESCRIPTION
### Description

`getProjection()` in `@deck.gl/mapbox`'s `deck-utils.ts` can throw when the underlying map's style is not yet assigned, instead of returning `undefined` the way callers (`getDefaultView` / `MapboxOverlay#_onAddInterleaved`) expect for "not ready yet, default to mercator".

The existing optional-chaining (`map.getProjection?.()`) only guards against the method being absent, not against the call itself throwing. In maplibre-gl, `Map.prototype.getProjection()` is `return this.style.getProjection()` with no guard on `this.style`, so calling it before the style exists throws a `TypeError`.

This is reproducible under React 19 StrictMode: the dev-only double-invoke of mount effects adds, removes, and re-adds the same overlay, and the third `addControl` call hits a still-styleless map.

### Fix

Wrap the `map.getProjection?.()` call in a try/catch and return `'mercator'` as the safe default. This matches the callers' existing expectation — `getDefaultView` already treats any non-'globe' return as mercator.

### Related

- PR #9794 fixed a similar timing/undefined issue in the later `_handleStyleChange` callback path, but the fix did not cover this earlier `onAdd`-time call site.
- Fixes #10549