### PR TITLE
fix(mapbox): catch error in getProjection before style is loaded

### DIFF
--- a/modules/mapbox/src/deck-utils.ts
+++ b/modules/mapbox/src/deck-utils.ts
@@ -157,8 +157,14 @@ export function drawLayerGroup(
   });
 }
 
-export function getProjection(map: Map): 'mercator' | 'globe' {
-  const projection = map.getProjection?.();
+export function getProjection(map: Map): 'mercator' | 'globe' | undefined {
+  let projection;
+  try {
+    projection = map.getProjection?.();
+  } catch (err) {
+    // getProjection() throws if style is not assigned
+    return undefined;
+  }
   const type =
     // maplibre projection spec
     projection?.type ||


### PR DESCRIPTION
Resolves #10549

This PR updates the `getProjection` utility in `@deck.gl/mapbox` to handle cases where `map.getProjection()` throws an error because the map's style hasn't fully loaded yet. By wrapping the call in a `try...catch` block, we now gracefully return `undefined` instead of crashing the component lifecycle, which is correctly handled by callers down the line.