### PR TITLE
test(render): support isolated device suites

### DIFF
--- a/test/render/deck-test-utils.ts
+++ b/test/render/deck-test-utils.ts
@@ -27,6 +27,12 @@ export interface TestCase {
   imageDiffOptions?: {
     threshold?: number;
     tolerance?: number;
+    /**
+     * pixelmatch detects antialiased pixels and excludes them from the mismatch count by
+     * default, which makes a diff blind to changes that only affect edge coverage. Set to
+     * `true` when antialiasing itself is what the test is checking.
+     */
+    includeAA?: boolean;
   };
 }
 
@@ -45,10 +51,19 @@ export interface DeviceLossState {
 /**
  * Creates a device and canvas for a render test.
  */
-export function createTestDevice(type: TestDeviceType, container: HTMLDivElement): Promise<Device> {
+export function createTestDevice(
+  type: TestDeviceType,
+  container: HTMLDivElement,
+  /**
+   * WebGL context attributes. Defaults to the browser's, which enables MSAA - pass
+   * `{antialias: false}` to test what applications get when a base map owns the context.
+   */
+  webgl?: {antialias?: boolean}
+): Promise<Device> {
   return luma.createDevice({
     type,
     adapters: type === 'webgl' ? [webgl2Adapter] : [webgpuAdapter],
+    webgl,
     createCanvasContext: {
       container,
       width: WIDTH,
@@ -281,6 +296,7 @@ async function captureAndDiffScreenshot(testCase: TestCase, ctx: DeckTestContext
     region,
     threshold: imageDiffOptions?.threshold ?? 0.99,
     tolerance: 0.1,
+    includeAA: imageDiffOptions?.includeAA ?? false,
     includeEmpty: false,
     platform: OS,
     saveOnFail: true,

--- a/test/render/render-test-suite.ts
+++ b/test/render/render-test-suite.ts
@@ -7,6 +7,7 @@ import {
   createTestDevice,
   createContainer,
   createDeck,
+  removeContainer,
   finalizeDeck,
   runRenderTest,
   updateDeckForTest,
@@ -17,9 +18,22 @@ import {
 } from './deck-test-utils';
 import {OS} from './constants';
 
-type RenderTestSuiteOptions = {
+type BaseRenderTestSuiteOptions = {
   beforeAll?: () => void | Promise<void>;
 };
+
+type RenderTestSuiteOptions = BaseRenderTestSuiteOptions &
+  (
+    | {
+        deviceMode?: 'shared';
+        webgl?: never;
+      }
+    | {
+        deviceMode: 'isolated';
+        /** WebGL context attributes for the suite's isolated device. */
+        webgl?: {antialias?: boolean};
+      }
+  );
 
 type SharedDeviceContext = {
   container: HTMLDivElement;
@@ -29,16 +43,37 @@ type SharedDeviceContext = {
 
 type RenderTestGlobal = typeof globalThis & {
   __deckRenderTestDeviceContexts?: Partial<Record<TestDeviceType, SharedDeviceContext>>;
+  __deckRenderTestDeviceContainers?: Set<HTMLDivElement>;
 };
 
 const renderTestGlobal = globalThis as RenderTestGlobal;
 const sharedDeviceContexts =
   renderTestGlobal.__deckRenderTestDeviceContexts ||
   (renderTestGlobal.__deckRenderTestDeviceContexts = {});
+const deviceContextContainers =
+  renderTestGlobal.__deckRenderTestDeviceContainers ||
+  (renderTestGlobal.__deckRenderTestDeviceContainers = new Set());
+
+let isolatedDeviceContextCount = 0;
 
 export function isRenderTestDeviceEnabled(deviceType: TestDeviceType): boolean {
   const enabledDeviceType = import.meta.env.RENDER_TEST_DEVICE as TestDeviceType | null;
   return !enabledDeviceType || enabledDeviceType === deviceType;
+}
+
+function createDeviceLossState(
+  device: NonNullable<DeckTestContext['device']>,
+  label: string
+): DeviceLossState {
+  const deviceLoss: DeviceLossState = {
+    error: null,
+    promise: device.lost.then(({reason, message}) => {
+      const error = new Error(`${label} device lost (${reason})${message ? `: ${message}` : ''}`);
+      deviceLoss.error = error;
+      return error;
+    })
+  };
+  return deviceLoss;
 }
 
 async function getSharedDeviceContext(deviceType: TestDeviceType): Promise<{
@@ -50,7 +85,8 @@ async function getSharedDeviceContext(deviceType: TestDeviceType): Promise<{
   if (sharedContext) {
     const device = await sharedContext.device;
     if (device.isLost || sharedContext.deviceLoss?.error) {
-      sharedContext.container.remove();
+      deviceContextContainers.delete(sharedContext.container);
+      removeContainer(sharedContext.container);
       delete sharedDeviceContexts[deviceType];
       sharedContext = undefined;
     }
@@ -64,20 +100,11 @@ async function getSharedDeviceContext(deviceType: TestDeviceType): Promise<{
     };
     sharedDeviceContexts[deviceType] = sharedContext;
   }
+  deviceContextContainers.add(sharedContext.container);
 
   const device = await sharedContext.device;
   if (!sharedContext.deviceLoss) {
-    const deviceLoss: DeviceLossState = {
-      error: null,
-      promise: device.lost.then(({reason, message}) => {
-        const error = new Error(
-          `Shared ${deviceType} device lost (${reason})${message ? `: ${message}` : ''}`
-        );
-        deviceLoss.error = error;
-        return error;
-      })
-    };
-    sharedContext.deviceLoss = deviceLoss;
+    sharedContext.deviceLoss = createDeviceLossState(device, `Shared ${deviceType}`);
   }
 
   return {
@@ -87,10 +114,36 @@ async function getSharedDeviceContext(deviceType: TestDeviceType): Promise<{
   };
 }
 
-function activateSharedDeviceContext(deviceType: TestDeviceType): void {
-  for (const [type, context] of Object.entries(sharedDeviceContexts)) {
-    context!.container.style.display = type === deviceType ? 'block' : 'none';
+async function createIsolatedDeviceContext(
+  deviceType: TestDeviceType,
+  /**
+   * WebGL context attributes. Defaults to the browser's, which enables MSAA - pass
+   * `{antialias: false}` to test what applications get when a base map owns the context.
+   */
+  webgl?: {antialias?: boolean}
+): Promise<{
+  container: HTMLDivElement;
+  device: NonNullable<DeckTestContext['device']>;
+  deviceLoss: DeviceLossState;
+}> {
+  const contextId = isolatedDeviceContextCount++;
+  const container = createContainer(`deck-container-${deviceType}-isolated-${contextId}`);
+  deviceContextContainers.add(container);
+  try {
+    const device = await createTestDevice(deviceType, container, webgl);
+    return {container, device, deviceLoss: createDeviceLossState(device, `Isolated ${deviceType}`)};
+  } catch (error) {
+    deviceContextContainers.delete(container);
+    removeContainer(container);
+    throw error;
   }
+}
+
+function activateDeviceContext(container: HTMLDivElement): void {
+  for (const deviceContainer of deviceContextContainers) {
+    deviceContainer.style.display = deviceContainer === container ? 'block' : 'none';
+  }
+  container.style.display = 'block';
 }
 
 async function finalizeDeckAfterGPUWork(ctx: DeckTestContext): Promise<void> {
@@ -144,18 +197,21 @@ export function runRenderTestSuite(
     deck: null,
     container: null
   };
+  const isIsolated = options.deviceMode === 'isolated';
 
   beforeAll(async () => {
-    const sharedContext = await getSharedDeviceContext(deviceType);
-    ctx.container = sharedContext.container;
-    ctx.device = sharedContext.device;
-    ctx.deviceLoss = sharedContext.deviceLoss;
-    activateSharedDeviceContext(deviceType);
+    const deviceContext = isIsolated
+      ? await createIsolatedDeviceContext(deviceType, options.webgl)
+      : await getSharedDeviceContext(deviceType);
+    ctx.container = deviceContext.container;
+    ctx.device = deviceContext.device;
+    ctx.deviceLoss = deviceContext.deviceLoss;
+    activateDeviceContext(deviceContext.container);
     await options.beforeAll?.();
   });
 
   beforeEach(() => {
-    activateSharedDeviceContext(deviceType);
+    activateDeviceContext(ctx.container!);
   });
 
   afterEach(async () => {
@@ -163,10 +219,20 @@ export function runRenderTestSuite(
   });
 
   afterAll(async () => {
-    await finalizeDeckAfterGPUWork(ctx);
-    ctx.device = undefined;
-    ctx.deviceLoss = undefined;
-    ctx.container = null;
+    const device = ctx.device;
+    const container = ctx.container;
+    try {
+      await finalizeDeckAfterGPUWork(ctx);
+    } finally {
+      if (isIsolated) {
+        device?.destroy();
+        deviceContextContainers.delete(container!);
+        removeContainer(container);
+      }
+      ctx.device = undefined;
+      ctx.deviceLoss = undefined;
+      ctx.container = null;
+    }
   });
 
   registerTests(deviceTestCases, {os: OS.toLowerCase(), deviceType}, testCase =>
@@ -194,12 +260,12 @@ export function runPersistentRenderTestSuite(
     ctx.container = sharedContext.container;
     ctx.device = sharedContext.device;
     ctx.deviceLoss = sharedContext.deviceLoss;
-    activateSharedDeviceContext(deviceType);
+    activateDeviceContext(sharedContext.container);
     ctx.deck = createDeck(ctx.container, ctx.device);
   });
 
   beforeEach(() => {
-    activateSharedDeviceContext(deviceType);
+    activateDeviceContext(ctx.container!);
   });
 
   afterAll(async () => {

--- a/test/render/render-test-suite.ts
+++ b/test/render/render-test-suite.ts
@@ -182,6 +182,18 @@ function registerTests(
   test.each(activeTests)(`$name:${environment['deviceType']}`, runTest);
 }
 
+function getRenderTestEnvironment(
+  deviceType: TestDeviceType,
+  options: RenderTestSuiteOptions = {}
+): Record<string, string> {
+  const webglAntialiasing = options.deviceMode !== 'isolated' || options.webgl?.antialias !== false;
+  return {
+    os: OS.toLowerCase(),
+    deviceType,
+    multisampling: deviceType === 'webgl' && webglAntialiasing ? 'msaa' : 'no-msaa'
+  };
+}
+
 export function runRenderTestSuite(
   testCases: TestCase[],
   deviceType: TestDeviceType,
@@ -235,7 +247,7 @@ export function runRenderTestSuite(
     }
   });
 
-  registerTests(deviceTestCases, {os: OS.toLowerCase(), deviceType}, testCase =>
+  registerTests(deviceTestCases, getRenderTestEnvironment(deviceType, options), testCase =>
     runRenderTest(testCase, ctx)
   );
 }
@@ -275,7 +287,7 @@ export function runPersistentRenderTestSuite(
     ctx.container = null;
   });
 
-  registerTests(deviceTestCases, {os: OS.toLowerCase(), deviceType}, testCase =>
+  registerTests(deviceTestCases, getRenderTestEnvironment(deviceType), testCase =>
     updateDeckForTest(testCase, ctx)
   );
 }


### PR DESCRIPTION
#### Goal

Allow render suites to own an isolated GPU device when a test needs context settings that must not leak into the shared render-test device.

#### Change List

- Add a discriminated `deviceMode` suite option; shared mode remains the default.
- Let isolated WebGL suites provide context attributes such as `{antialias: false}`.
- Create, activate, finalize, destroy, and remove the isolated device/container with the suite lifecycle.
- Preserve device-loss handling and GPU-work finalization.
- Add `imageDiffOptions.includeAA` support so golden tests can include antialiased pixels.
- Keep shared devices keyed by backend with no WebGL overrides.

#### Validation

- `yarn lint`
- `yarn build`
- Render-test harness commit hooks (15 node tests)
- Exercised by the isolated no-MSAA golden and numerical coverage tests later in this stack

This is internal test tooling only; no deck.gl public API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to internal render-test utilities; no deck.gl public API or production runtime paths are modified.
> 
> **Overview**
> Extends the render-test harness so suites can opt into an **isolated** GPU device instead of the shared per-backend device, and tightens golden-image diffing for antialiasing.
> 
> **Isolated device mode:** `runRenderTestSuite` accepts a discriminated `deviceMode` (`shared` default vs `isolated`). Isolated suites get their own container/device lifecycle (create, activate, finalize, destroy, remove) and may pass WebGL context attributes via `webgl` (e.g. `{antialias: false}`) through `createTestDevice`. Shared suites stay keyed by backend with no WebGL overrides.
> 
> **Container / activation:** A global `Set` tracks all device containers; `activateDeviceContext` shows one container and hides the rest (replacing per-device-type-only activation). Shared device recovery on loss uses `removeContainer` instead of raw `container.remove()`.
> 
> **Test environment labels:** `getRenderTestEnvironment` adds a `multisampling` dimension (`msaa` / `no-msaa` for WebGL based on isolated mode and `webgl.antialias`), used for skip matching and persistent suite registration.
> 
> **Golden diffs:** `imageDiffOptions.includeAA` is forwarded to capture/diff (default `false`); documented for tests that must count antialiased edge pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb11a7661e7b822a20c0a2754d29ad50ba49dec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->