### PR TITLE
docs: explain antialiasing without MSAA

### DIFF
--- a/dev-docs/RFCs/v9.4/analytic-antialiasing-rfc.md
+++ b/dev-docs/RFCs/v9.4/analytic-antialiasing-rfc.md
@@ -2,7 +2,7 @@
 
 - **Authors**: Chris Gervang
 - **Date**: Aug 2, 2026
-- **Status**: Proposed
+- **Status**: Implemented
 
 Summary: `PathLayer`, `LineLayer`, `ArcLayer`, and `PointCloudLayer` have no antialiasing of their
 own; their edges are smoothed entirely by the framebuffer's MSAA. This RFC proposes an opt-in

--- a/docs/api-reference/arcgis/overview.md
+++ b/docs/api-reference/arcgis/overview.md
@@ -64,3 +64,9 @@ Not supported features:
 - Multiple views
 - Controller
 - React integration
+
+### Antialiasing
+
+deck.gl renders into an auxiliary framebuffer here and composites the result into the ArcGIS scene. That framebuffer is not multisampled, so layers whose edges depend on MSAA — including [PathLayer](../layers/path-layer.md), [LineLayer](../layers/line-layer.md), [ArcLayer](../layers/arc-layer.md), and [PointCloudLayer](../layers/point-cloud-layer.md) — render with hard, aliased edges regardless of how the ArcGIS API created its context.
+
+Set `antialiasing: true` on those layers to have them compute edge coverage in the shader instead. On composite layers the prop is named `lineAntialiasing` ([GeoJsonLayer](../layers/geojson-layer.md#lineantialiasing), [PolygonLayer](../layers/polygon-layer.md#lineantialiasing)).

--- a/docs/api-reference/core/post-process-effect.md
+++ b/docs/api-reference/core/post-process-effect.md
@@ -43,6 +43,14 @@ const deckgl = new Deck({
 });
 ```
 
+## Remarks
+
+### Antialiasing
+
+Adding a post-processing effect redirects layer rendering into an offscreen framebuffer, which is not multisampled. Layers whose edges depend on the canvas' MSAA — including [PathLayer](../layers/path-layer.md), [LineLayer](../layers/line-layer.md), [ArcLayer](../layers/arc-layer.md), and [PointCloudLayer](../layers/point-cloud-layer.md) — therefore render with hard, aliased edges once any effect is added, even though the canvas itself was created with `antialias: true`. See [#10404](https://github.com/visgl/deck.gl/issues/10404).
+
+Set `antialiasing: true` on those layers to have them compute edge coverage in the shader instead. On composite layers the prop is named `lineAntialiasing` ([GeoJsonLayer](../layers/geojson-layer.md#lineantialiasing), [PolygonLayer](../layers/polygon-layer.md#lineantialiasing)).
+
 ## Source
 
 [/modules/core/src/effects/post-process-effect.ts](https://github.com/visgl/deck.gl/tree/master/modules/core/src/effects/post-process-effect.ts)

--- a/docs/api-reference/google-maps/google-maps-overlay.md
+++ b/docs/api-reference/google-maps/google-maps-overlay.md
@@ -119,6 +119,14 @@ The constructor additionally accepts the following option:
 
 - `interleaved` (boolean) - When set to `false`, a dedicated deck.gl canvas is layered on top of the base map. If set to `true` and the Google Map is configured for Vector rendering, deck.gl layers are inserted into the Google Maps layer stack, sharing the same WebGL2RenderingContext. Default is `true`.
 
+## Remarks
+
+### Antialiasing
+
+With `interleaved: true` on a Vector map, deck.gl shares the WebGL context created by Google Maps, which does not provide multisampling and exposes no option to request it. Layers whose edges depend on it — including [PathLayer](../layers/path-layer.md), [LineLayer](../layers/line-layer.md), [ArcLayer](../layers/arc-layer.md), and [PointCloudLayer](../layers/point-cloud-layer.md) — render with hard, aliased edges. See [#7647](https://github.com/visgl/deck.gl/issues/7647).
+
+Set `antialiasing: true` on those layers to have them compute edge coverage in the shader instead. On composite layers the prop is named `lineAntialiasing` ([GeoJsonLayer](../layers/geojson-layer.md#lineantialiasing), [PolygonLayer](../layers/polygon-layer.md#lineantialiasing)).
+
 ## Methods
 
 #### `setMap` {#setmap}

--- a/docs/api-reference/mapbox/mapbox-overlay.md
+++ b/docs/api-reference/mapbox/mapbox-overlay.md
@@ -165,6 +165,10 @@ See [Deck.getCanvas](../core/deck.md#getcanvas). When using `interleaved: true`,
 
 ## Remarks
 
+### Antialiasing
+
+Base maps create their WebGL context with `antialias: false`, so in interleaved mode deck.gl layers receive no multisampling. Layers that rely on it — including [PathLayer](../layers/path-layer.md), [LineLayer](../layers/line-layer.md), [ArcLayer](../layers/arc-layer.md), and [PointCloudLayer](../layers/point-cloud-layer.md) — will look aliased against the base map. Set `antialiasing: true` on those layers, or enable MSAA on the base map itself.
+
 ### Multi-view usage
 
 When using `MapboxOverlay` with multiple views passed to the `views` prop, only one of the views can match the base map and receive interaction.

--- a/docs/api-reference/maplibre/overview.md
+++ b/docs/api-reference/maplibre/overview.md
@@ -92,3 +92,9 @@ new ScatterplotLayer({
 - Mercator is supported. Globe integration uses deck.gl's experimental [`GlobeView`](../core/globe-view.md). With default back-face culling, `TextLayer` and non-billboard `IconLayer` do not render. Disabling culling makes them visible, but non-billboard icons render rotated 180°.
 - Non-default vertical field of view and camera roll are not synchronized.
 - One interleaved overlay may be attached to a map.
+
+### Antialiasing
+
+MapLibre creates its WebGL context with `antialias: false` by default. In interleaved mode, deck.gl shares that context, so layers whose edges depend on MSAA — including [PathLayer](../layers/path-layer.md), [LineLayer](../layers/line-layer.md), [ArcLayer](../layers/arc-layer.md), and [PointCloudLayer](../layers/point-cloud-layer.md) — render with hard, aliased edges.
+
+Set `antialiasing: true` on those layers to have them compute edge coverage in the shader instead. On composite layers the prop is named `lineAntialiasing` ([GeoJsonLayer](../layers/geojson-layer.md#lineantialiasing), [PolygonLayer](../layers/polygon-layer.md#lineantialiasing)). Alternatively, set `antialias: true` when creating the MapLibre map to enable MSAA for the shared context.


### PR DESCRIPTION
#### Goal

Explain when host integrations and offscreen rendering lose framebuffer multisampling, and point users to the layer-level analytic antialiasing options added by this stack.

#### Change List

- Document interleaved Mapbox/MapLibre behavior and the host-MSAA alternative.
- Document Google Maps interleaved rendering, where no MSAA option is exposed.
- Document ArcGIS auxiliary-framebuffer behavior.
- Document the effect of PostProcessEffect's offscreen render target.
- Link PathLayer, LineLayer, ArcLayer, PointCloudLayer, and composite `lineAntialiasing` options.

Feature-specific API documentation remains embedded in each corresponding feature PR; this PR contains only broader integration guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, API, or security changes.
> 
> **Overview**
> Explains that interleaved Mapbox/MapLibre/Google Maps, ArcGIS’s auxiliary framebuffer, and `PostProcessEffect` all render without MSAA, so path/line/arc/point edges look aliased.
> 
> Points users to `antialiasing: true` on those layers (or `lineAntialiasing` on GeoJson/Polygon), and notes host `antialias: true` as an alternative where the map SDK allows it. Marks the analytic-antialiasing RFC as Implemented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc83422b431c57a9a2baf8bd52c906f4999afc8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->