### PR TITLE
fix(layers): support binary geometry on WebGPU

### DIFF
--- a/modules/layers/src/path-layer/path-layer.ts
+++ b/modules/layers/src/path-layer/path-layer.ts
@@ -5,6 +5,7 @@
 import {Layer, project32, color, picking, UNIT} from '@deck.gl/core';
 import {Geometry} from '@luma.gl/engine';
 import {Model} from '@luma.gl/engine';
+import type {TypedArray} from '@math.gl/core';
 import PathTesselator from './path-tesselator';
 
 import {pathUniforms, PathProps} from './path-layer-uniforms';
@@ -165,7 +166,7 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         ? {
             // WebGPU cannot express WebGL's vertexOffset window in one vertex buffer layout.
             // Pack each segment's [left, start, end, right] high and low position parts instead.
-            instancePositions: {
+            pathPositions: {
               size: 24,
               type: 'float32',
               transition: false,
@@ -433,9 +434,22 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
 
   protected calculateWebGPUPositions(attribute) {
     const {pathTesselator} = this.state;
-    const value = pathTesselator.get('positions');
+    const binaryPositions = (this.props.data as any)?.attributes?.getPath;
+    let value = binaryPositions ? binaryPositions.value || binaryPositions : null;
+    let sourceSize = 3;
+    let sourceStride = 3;
+    let sourceOffset = 0;
 
-    if (!value) {
+    if (binaryPositions && ArrayBuffer.isView(value)) {
+      sourceSize = binaryPositions.size || (this.props.positionFormat === 'XY' ? 2 : 3);
+      const bytesPerElement = (value as TypedArray).BYTES_PER_ELEMENT;
+      sourceStride = binaryPositions.stride ? binaryPositions.stride / bytesPerElement : sourceSize;
+      sourceOffset = binaryPositions.offset ? binaryPositions.offset / bytesPerElement : 0;
+    } else {
+      value = pathTesselator.get('positions');
+    }
+
+    if (!value || !ArrayBuffer.isView(value)) {
       attribute.value = null;
       return;
     }
@@ -453,7 +467,9 @@ export default class PathLayer<DataT = any, ExtraPropsT extends {} = {}> extends
         const targetOffset = targetIndex + vertexOffset * 3;
         for (let j = 0; j < 3; j++) {
           const position =
-            sourceVertex >= 0 && sourceVertex < numInstances ? value[sourceVertex * 3 + j] : 0;
+            sourceVertex >= 0 && sourceVertex < numInstances && j < sourceSize
+              ? value[sourceVertex * sourceStride + sourceOffset + j]
+              : 0;
           const highPart = Math.fround(position);
           result[targetOffset + j] = highPart;
           result[targetOffset + j + 12] = position - highPart;

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.ts
@@ -209,32 +209,37 @@ export default class ScatterplotLayer<DataT = any, ExtraPropsT extends {} = {}> 
         size: 1,
         transition: true,
         accessor: 'getRadius',
-        defaultValue: 1
+        defaultValue: 1,
+        bufferGroup: 'scatterplot-instance-data'
       },
       instanceFillColors: {
         size: this.props.colorFormat.length,
         transition: true,
         type: 'unorm8',
         accessor: 'getFillColor',
-        defaultValue: [0, 0, 0, 255]
+        defaultValue: [0, 0, 0, 255],
+        bufferGroup: 'scatterplot-instance-data'
       },
       instanceLineColors: {
         size: this.props.colorFormat.length,
         transition: true,
         type: 'unorm8',
         accessor: 'getLineColor',
-        defaultValue: [0, 0, 0, 255]
+        defaultValue: [0, 0, 0, 255],
+        bufferGroup: 'scatterplot-instance-data'
       },
       instanceLineWidths: {
         size: 1,
         transition: true,
         accessor: 'getLineWidth',
-        defaultValue: 1
+        defaultValue: 1,
+        bufferGroup: 'scatterplot-instance-data'
       },
       instancePixelOffset: {
         size: 2,
         transition: true,
-        accessor: 'getPixelOffset'
+        accessor: 'getPixelOffset',
+        bufferGroup: 'scatterplot-instance-data'
       },
       ...attributes
     });

--- a/test/modules/layers/geojson-layer-webgpu.spec.ts
+++ b/test/modules/layers/geojson-layer-webgpu.spec.ts
@@ -1,0 +1,69 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {LayerManager, MapView} from '@deck.gl/core';
+import {GeoJsonLayer, PathLayer, ScatterplotLayer} from '@deck.gl/layers';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {geojsonToBinary} from '@loaders.gl/gis';
+
+test('GeoJsonLayer#WebGPU binary points and paths', async ({skip}) => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    skip();
+    return;
+  }
+
+  const viewport = new MapView().makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 0, latitude: 0, zoom: 1}
+  });
+  const data = geojsonToBinary([
+    {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [0, 0]}},
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [-1, 0],
+          [1, 0]
+        ]
+      }
+    }
+  ] as any);
+  const errors: Error[] = [];
+  const layerManager = new LayerManager(webgpuDevice, {viewport});
+  layerManager.setProps({onError: error => errors.push(error)});
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  layerManager.setLayers([
+    new GeoJsonLayer({
+      id: 'webgpu-binary-geojson',
+      data
+    })
+  ]);
+
+  const scatterplotLayer = layerManager.layers.find(layer => layer instanceof ScatterplotLayer) as
+    | ScatterplotLayer
+    | undefined;
+  const pathLayer = layerManager.layers.find(layer => layer instanceof PathLayer) as
+    | PathLayer
+    | undefined;
+  const pathPositions = pathLayer?.getAttributeManager()?.getAttributes().pathPositions.value;
+
+  expect(errors, 'binary sublayers initialize').toEqual([]);
+  expect(scatterplotLayer?.state.model, 'creates the point pipeline').toBeDefined();
+  expect(pathLayer?.state.model, 'creates the path pipeline').toBeDefined();
+  expect(
+    pathPositions && Array.from(pathPositions).some(Boolean),
+    'expands binary XY positions into the WebGPU neighbor window'
+  ).toBe(true);
+
+  await webgpuDevice.handle.queue.onSubmittedWorkDone();
+  expect(await webgpuDevice.handle.popErrorScope(), 'pipelines pass WebGPU validation').toBeNull();
+
+  layerManager.finalize();
+});


### PR DESCRIPTION
## Goal

Prepare `ScatterplotLayer` and `PathLayer` to render binary geometry reliably on WebGPU. These fixes are prerequisites for enabling binary `MVTLayer` rendering, but do not add clipping support themselves.

## Changes

- Pack ScatterplotLayer's scalar/color instance attributes into one WebGPU buffer group so binary points remain within WebGPU's vertex-buffer limit.
- Rename PathLayer's packed WebGPU parent attribute so it is not mistaken for an anchor-position attribute.
- Build PathLayer's WebGPU neighbor window directly from external binary `getPath` data, respecting XY/XYZ size, byte stride, and byte offset.
- Add a focused WebGPU binary GeoJSON regression test covering point and path pipeline validation and non-empty packed path positions.

## Validation

- `npx vitest run --project headless test/modules/layers/geojson-layer-webgpu.spec.ts` — passed
- commit hook node tests — 15 passed
- `yarn lint` — passed
- `git diff --check` — passed
- `yarn build` — WebGL-only and WebGPU TypeScript/declaration/package compilation passed; the final unrelated `lerna run build` wrapper failed to construct its Nx project graph in the isolated worktree