### PR TITLE
feat(core): Handle webgpu constant attributes efficiently

### DIFF
--- a/modules/core/src/lib/attribute/attribute-buffer-groups.ts
+++ b/modules/core/src/lib/attribute/attribute-buffer-groups.ts
@@ -192,11 +192,14 @@ export default class AttributeBufferGroups {
     const layouts = attributes.map(attribute => attribute.getBufferLayout(modelInfo));
     const stepMode = layouts[0].stepMode;
     const rowCount = Math.max(1, attributes[0].numInstances);
+    const allConstant = requireValues && attributes.every(attribute => attribute.isConstant);
 
     for (let index = 0; index < attributes.length; index++) {
       const attribute = attributes[index];
       const accessor = attribute.getAccessor();
-      const naturalStride = attribute.size * accessor.bytesPerElement;
+      // Binary attributes may override the declared size and type. Eligibility must follow the
+      // resolved accessor because that is the row shape published in the buffer layout.
+      const naturalStride = accessor.size * accessor.bytesPerElement;
 
       if (
         excludeAttributes[attribute.id] ||
@@ -210,8 +213,11 @@ export default class AttributeBufferGroups {
         (accessor.vertexOffset || 0) !== 0 ||
         getStride(accessor) !== naturalStride ||
         (requireValues &&
-          (!ArrayBuffer.isView(attribute.value) ||
-            attribute.value.byteLength < rowCount * naturalStride))
+          (attribute.isConstant
+            ? !attribute.getConstantValue() ||
+              attribute.getConstantValue()!.byteLength < naturalStride
+            : !ArrayBuffer.isView(attribute.value) ||
+              attribute.value.byteLength < rowCount * naturalStride))
       ) {
         return null;
       }
@@ -243,7 +249,9 @@ export default class AttributeBufferGroups {
       rowCount,
       layout: {
         name: id,
-        byteStride,
+        // Interleave emits one row when every input is constant. A zero stride broadcasts that
+        // row without allocating one copy per vertex or instance.
+        byteStride: allConstant ? 0 : byteStride,
         stepMode,
         attributes: layoutAttributes
       }
@@ -321,16 +329,40 @@ export default class AttributeBufferGroups {
   }
 
   private _getInterleaveInput(group: PackedGroup, attribute: Attribute): GPUDataEvaluator {
-    const buffer = attribute.getBuffer();
     const rowByteLength = getStride(attribute.getAccessor());
+    const groupByteOffset = group.byteOffsets[attribute.id];
+
+    assertU32Aligned(`${group.id}.${attribute.id} rowByteLength`, rowByteLength);
+    assertU32Aligned(`${group.id}.${attribute.id} groupByteOffset`, groupByteOffset);
+
+    if (attribute.isConstant) {
+      const constantValue = attribute.getConstantValue();
+      if (!constantValue) {
+        throw new Error(`Attribute group ${group.id} is missing constant value ${attribute.id}`);
+      }
+      assertU32Aligned(`${group.id}.${attribute.id} constant byteOffset`, constantValue.byteOffset);
+
+      // The packed output is a byte-for-byte vertex buffer. Reinterpret the source row as u32
+      // so normalized integers retain their original bits when embedded as WGSL literals.
+      return new GPUDataEvaluator({
+        id: attribute.id,
+        type: 'uint32',
+        size: rowByteLength / 4,
+        isConstant: true,
+        value: new Uint32Array(
+          constantValue.buffer,
+          constantValue.byteOffset,
+          rowByteLength / Uint32Array.BYTES_PER_ELEMENT
+        )
+      });
+    }
+
+    const buffer = attribute.getBuffer();
     const byteOffset = attribute.byteOffset;
     const stride = attribute.getAccessor().stride || rowByteLength;
-    const groupByteOffset = group.byteOffsets[attribute.id];
 
     assertU32Aligned(`${group.id}.${attribute.id} byteOffset`, byteOffset);
     assertU32Aligned(`${group.id}.${attribute.id} stride`, stride);
-    assertU32Aligned(`${group.id}.${attribute.id} rowByteLength`, rowByteLength);
-    assertU32Aligned(`${group.id}.${attribute.id} groupByteOffset`, groupByteOffset);
 
     if (!buffer) {
       throw new Error(

--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -12,6 +12,7 @@ import DataColumn, {
 import assert from '../../utils/assert';
 import {createIterable, getAccessorFromBuffer} from '../../utils/iterable-utils';
 import {fillArray} from '../../utils/flatten';
+import {toDoublePrecisionArray} from '../../utils/math-utils';
 import * as range from '../../utils/range';
 import {bufferLayoutEqual} from './gl-utils';
 import {normalizeTransitionSettings, TransitionSettings} from './transition-settings';
@@ -65,6 +66,8 @@ export type BinaryAttribute = Partial<BufferAccessor> & {value?: TypedArray; buf
 
 type AttributeInternalState = {
   startIndices: NumericArray | null;
+  /** One unnormalized row retained for WebGPU buffer-group interleaving. */
+  constantValue: TypedArray | null;
   /** Legacy: external binary supplied via attribute name */
   lastExternalBuffer: TypedArray | Buffer | BinaryAttribute | null;
   /** External binary supplied via accessor name */
@@ -83,6 +86,7 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
   constructor(device: Device, opts: AttributeOptions) {
     super(device, opts, {
       startIndices: null,
+      constantValue: null,
       lastExternalBuffer: null,
       binaryValue: null,
       binaryAccessor: null,
@@ -188,7 +192,9 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
     }
 
     if (settings.update) {
+      const wasConstant = this.isConstant;
       super.allocate(numInstances, state.updateRanges !== range.FULL);
+      state.layoutChanged ||= wasConstant && this.device.type === 'webgpu';
       return true;
     }
 
@@ -229,11 +235,8 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
         this.buffer.byteLength < (this.value as TypedArray).byteLength + this.byteOffset
       ) {
         if (this.constant) {
-          // Route constant updater output through the same path used by constant accessors
-          // so WebGPU can materialize a real buffer while WebGL keeps a constant attribute.
+          // Route legacy constant updater output through the same path used by constant accessors.
           const constantValue = this.value;
-          // The updater replaced the allocated CPU array without uploading it. Clear the
-          // cached value so WebGPU cannot mistake it for an already materialized buffer.
           this.value = null;
           this.setConstantValue(context, constantValue);
         } else {
@@ -275,73 +278,53 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
       return false;
     }
 
+    const wasConstant = this.isConstant;
     const transformedValue =
       this.settings.transform && context ? this.settings.transform.call(context, value) : value;
-
-    if (this.device.type === 'webgpu') {
-      // WebGPU has no equivalent of WebGL constant vertex attributes, so we expand the
-      // constant into a full per-instance buffer before passing it to luma.gl.
-      return this.setConstantBufferValue(transformedValue, this.numInstances);
-    }
-
-    // WebGL can bind the normalized/transformed value directly as a constant attribute.
-    const hasChanged = this.setData({constant: true, value: transformedValue});
-
-    if (hasChanged) {
-      this.setNeedsRedraw();
-    }
-    this.clearNeedsUpdate();
-    return true;
-  }
-
-  setConstantBufferValue(value: any, numInstances: number): boolean {
     const ArrayType = this.settings.defaultType;
-    const constantValue = this._normalizeValue(value, new ArrayType(this.size), 0) as TypedArray;
-    if (this._hasConstantBufferValue(constantValue, numInstances)) {
-      // The emulated buffer already matches this constant, so avoid a redundant upload.
-      this.constant = false;
-      this.clearNeedsUpdate();
-      return false;
+    // DataColumn normalizes constants for shader consumption. Buffer grouping needs the original
+    // vertex-format bytes so that interleaving preserves integer and normalized attribute formats.
+    this.state.constantValue = this._normalizeValue(
+      transformedValue,
+      new ArrayType(this.size),
+      0
+    ) as TypedArray;
+    const hasChanged = this.setData({constant: true, value: transformedValue});
+    if (this.device.type === 'webgpu') {
+      let bufferValue = this.state.constantValue;
+      if (this.doublePrecision && this.settings.defaultType === Float64Array) {
+        if (bufferValue instanceof Float64Array) {
+          bufferValue = toDoublePrecisionArray(bufferValue, {size: this.size});
+        } else {
+          const expandedValue = new Float32Array(this.size * 2);
+          expandedValue.set(bufferValue, 0);
+          bufferValue = expandedValue;
+        }
+        this.setAccessor({
+          ...this.getAccessor(),
+          stride: this.size * 2 * Float32Array.BYTES_PER_ELEMENT
+        });
+      }
+      let buffer = this._buffer;
+      if (!buffer || buffer.byteLength < bufferValue.byteLength) {
+        buffer = this._createBuffer(bufferValue.byteLength);
+      }
+      buffer.write(bufferValue);
+      this.state.layoutChanged ||= !wasConstant;
     }
-
-    const repeatedValue = new ArrayType(Math.max(numInstances, 1) * this.size);
-
-    for (let i = 0; i < repeatedValue.length; i += this.size) {
-      repeatedValue.set(constantValue, i);
-    }
-
-    const hasChanged = this.setData({value: repeatedValue});
+    // `constant` is the legacy updater signal; persistent state lives in DataColumn.isConstant.
     this.constant = false;
-    this.clearNeedsUpdate();
 
     if (hasChanged) {
       this.setNeedsRedraw();
     }
-
-    return hasChanged;
+    this.clearNeedsUpdate();
+    return true;
   }
 
-  private _hasConstantBufferValue(value: NumericArray, numInstances: number): boolean {
-    const currentValue = this.value;
-    const expectedLength = Math.max(numInstances, 1) * this.size;
-
-    if (
-      !ArrayBuffer.isView(currentValue) ||
-      currentValue.length !== expectedLength ||
-      currentValue.length % this.size !== 0
-    ) {
-      return false;
-    }
-
-    for (let i = 0; i < currentValue.length; i += this.size) {
-      for (let j = 0; j < this.size; j++) {
-        if (currentValue[i + j] !== value[j]) {
-          return false;
-        }
-      }
-    }
-
-    return true;
+  /** Returns one row in its vertex-buffer representation for WebGPU buffer grouping. */
+  getConstantValue(): TypedArray | null {
+    return this.isConstant ? this.state.constantValue : null;
   }
 
   // Use external buffer

--- a/modules/core/src/lib/attribute/attribute.ts
+++ b/modules/core/src/lib/attribute/attribute.ts
@@ -311,9 +311,9 @@ export default class Attribute extends DataColumn<AttributeOptions, AttributeInt
       }
       buffer.write(bufferValue);
       this.state.layoutChanged ||= !wasConstant;
+      // `constant` is the legacy updater signal; persistent state lives in DataColumn.isConstant.
+      this.constant = false;
     }
-    // `constant` is the legacy updater signal; persistent state lives in DataColumn.isConstant.
-    this.constant = false;
 
     if (hasChanged) {
       this.setNeedsRedraw();

--- a/modules/core/src/lib/attribute/data-column.ts
+++ b/modules/core/src/lib/attribute/data-column.ts
@@ -228,7 +228,7 @@ export default class DataColumn<Options, State> {
   }
 
   getBuffer(): Buffer | null {
-    if (this.state.constant) {
+    if (this.state.constant && this.device.type !== 'webgpu') {
       return null;
     }
     return this.state.externalBuffer || this._buffer;
@@ -241,7 +241,9 @@ export default class DataColumn<Options, State> {
     const result: Record<string, Buffer | TypedArray | null> = {};
     if (this.state.constant) {
       const value = this.value as TypedArray;
-      if (options) {
+      if (this.device.type === 'webgpu' && this._buffer) {
+        result[attributeName] = this._buffer;
+      } else if (options) {
         const shaderAttributeDef = resolveShaderAttribute(this.getAccessor(), options);
         const offset = shaderAttributeDef.offset / value.BYTES_PER_ELEMENT;
         const size = shaderAttributeDef.size || this.size;
@@ -254,6 +256,10 @@ export default class DataColumn<Options, State> {
     }
     if (this.doublePrecision) {
       if (this.value instanceof Float64Array) {
+        result[`${attributeName}64Low`] = result[attributeName];
+      } else if (this.device.type === 'webgpu' && this.settings.defaultType === Float64Array) {
+        // WebGPU reads the zero low parts from the interleaved source buffer because it cannot
+        // override this shader attribute with a constant as WebGL does.
         result[`${attributeName}64Low`] = result[attributeName];
       } else {
         // Disable fp64 low part
@@ -271,7 +277,9 @@ export default class DataColumn<Options, State> {
     const attributes: (BufferAttributeLayout | null)[] = [];
     const result: BufferLayout = {
       name: this.id,
-      byteStride: getStride(accessor)
+      // WebGPU has no constant vertex attributes. A one-row buffer with zero stride provides
+      // equivalent broadcast semantics without scaling allocation with the instance count.
+      byteStride: this.device.type === 'webgpu' && this.state.constant ? 0 : getStride(accessor)
     };
 
     if (this.doublePrecision) {
@@ -432,6 +440,24 @@ export default class DataColumn<Options, State> {
 
       if (this.doublePrecision && value instanceof Float64Array) {
         value = toDoublePrecisionArray(value, accessor);
+      } else if (
+        this.doublePrecision &&
+        this.device.type === 'webgpu' &&
+        this.settings.defaultType === Float64Array
+      ) {
+        // A float32 binary position has no low parts. Interleave zeros into the same buffer so
+        // both fp64 shader attributes share one vertex-buffer slot on WebGPU.
+        const sourceValue = value;
+        const expandedValue = new Float32Array(sourceValue.length * 2);
+        const size = accessor.size;
+        for (let sourceIndex = 0, targetIndex = 0; sourceIndex < sourceValue.length; ) {
+          for (let componentIndex = 0; componentIndex < size; componentIndex++) {
+            expandedValue[targetIndex + componentIndex] = sourceValue[sourceIndex++];
+          }
+          targetIndex += size * 2;
+        }
+        value = expandedValue;
+        accessor.stride = size * 2 * Float32Array.BYTES_PER_ELEMENT;
       }
       if (this.settings.isIndexed) {
         const ArrayType = this.settings.defaultType;

--- a/test/modules/core/lib/attribute/attribute-buffer-groups.spec.ts
+++ b/test/modules/core/lib/attribute/attribute-buffer-groups.spec.ts
@@ -206,6 +206,81 @@ test('AttributeManager buffer groups pack IconLayer-style shader attributes', as
   expect(deleteSpy).not.toHaveBeenCalled();
 });
 
+test('AttributeManager buffer groups broadcast constant inputs', async () => {
+  if (!webgpuDevice) return;
+
+  const attributeManager = new AttributeManager(webgpuDevice);
+  attributeManager.addInstanced({
+    varying: {size: 1, accessor: 'getVarying', bufferGroup: 'group-a'},
+    constant: {size: 1, accessor: 'getConstant', bufferGroup: 'group-a'},
+    color: {
+      size: 4,
+      type: 'unorm8',
+      accessor: 'getColor',
+      bufferGroup: 'group-a'
+    }
+  });
+  attributeManager.update({
+    numInstances: 2,
+    data: [{varying: 1}, {varying: 2}],
+    props: {
+      getVarying: (object: {varying: number}) => object.varying,
+      getConstant: 9,
+      getColor: [255, 128, 0, 255]
+    },
+    transitions: {},
+    buffers: {},
+    context: {}
+  });
+
+  const attributes = attributeManager.getAttributes();
+  expect(attributes.constant.isConstant).toBeTruthy();
+  expect(attributes.color.isConstant).toBeTruthy();
+  expect(attributes.constant.getBuffer()?.byteLength).toBe(4);
+  expect(attributes.color.getBuffer()?.byteLength).toBe(4);
+
+  const bindings = attributeManager.getBufferGroupBindings(attributes, {isInstanced: true});
+  expect(bindings.bufferLayouts.map(layout => layout.name)).toEqual(['group-a']);
+  expect(bindings.bufferLayouts[0].byteStride).toBe(12);
+
+  const packedBytes = await bindings.buffers['group-a'].readAsync(0, 24);
+  const dataView = new DataView(packedBytes.buffer, packedBytes.byteOffset, packedBytes.byteLength);
+  expect(dataView.getFloat32(0, true)).toBe(1);
+  expect(dataView.getFloat32(4, true)).toBe(9);
+  expect(Array.from(packedBytes.slice(8, 12))).toEqual([255, 128, 0, 255]);
+  expect(dataView.getFloat32(12, true)).toBe(2);
+  expect(dataView.getFloat32(16, true)).toBe(9);
+  expect(Array.from(packedBytes.slice(20, 24))).toEqual([255, 128, 0, 255]);
+
+  attributeManager.finalize();
+});
+
+test('AttributeManager all-constant buffer groups use one row with zero stride', async () => {
+  if (!webgpuDevice) return;
+
+  const attributeManager = new AttributeManager(webgpuDevice);
+  addSimpleGroup(attributeManager);
+  attributeManager.update({
+    numInstances: 2,
+    data: [{}, {}],
+    props: {getA: 3, getB: 4},
+    transitions: {},
+    buffers: {},
+    context: {}
+  });
+
+  const bindings = attributeManager.getBufferGroupBindings(attributeManager.getAttributes(), {
+    isInstanced: true
+  });
+  expect(bindings.bufferLayouts[0].byteStride).toBe(0);
+  const packedBytes = await bindings.buffers['group-a'].readAsync(0, 8);
+  expect(Array.from(new Float32Array(packedBytes.buffer, packedBytes.byteOffset, 2))).toEqual([
+    3, 4
+  ]);
+
+  attributeManager.finalize();
+});
+
 test('AttributeManager buffer groups are shared across model step modes', () => {
   if (!webgpuDevice) return;
 

--- a/test/modules/core/lib/attribute/attribute-manager.spec.ts
+++ b/test/modules/core/lib/attribute/attribute-manager.spec.ts
@@ -217,10 +217,8 @@ test('AttributeManager.update - constant attribute webgpu', async ({skip}) => {
   });
 
   expect(updateCalled, 'legacy constant path skips updater').toBe(0);
-  expect(attribute.state.constant, 'webgpu constant is materialized as a buffer').toBeFalsy();
-  expect(attribute.value, 'constant value is expanded for each instance').toEqual([
-    0.5, 0.75, 0.125, 0.5, 0.75, 0.125
-  ]);
+  expect(attribute.state.constant, 'webgpu constant remains constant').toBeTruthy();
+  expect(attribute.value, 'constant value is retained once').toEqual([0.5, 0.75, 0.125]);
 
   attributeManager.invalidate('colors');
   attributeManager.update({
@@ -230,10 +228,8 @@ test('AttributeManager.update - constant attribute webgpu', async ({skip}) => {
   });
 
   expect(updateCalled, 'updater still runs for legacy constant updaters').toBe(1);
-  expect(attribute.state.constant, 'updater-backed constant also becomes a buffer').toBeFalsy();
-  expect(attribute.value, 'updater constant is expanded for each instance').toEqual([
-    0.25, 0.5, 0.75, 0.25, 0.5, 0.75
-  ]);
+  expect(attribute.state.constant, 'updater-backed constant remains constant').toBeTruthy();
+  expect(attribute.value, 'updater constant is retained once').toEqual([0.25, 0.5, 0.75]);
 });
 
 test('AttributeManager.update - external virtual buffers', () => {

--- a/test/modules/core/lib/attribute/attribute.spec.ts
+++ b/test/modules/core/lib/attribute/attribute.spec.ts
@@ -211,7 +211,7 @@ test('Attribute#setConstantValue', () => {
   expect(attribute.getValue().colors, 'constant value is normalized').toEqual([1, 1, 0]);
 });
 
-test('Attribute#setConstantBufferValue - webgpu', async ({skip}) => {
+test('Attribute#setConstantValue keeps one constant value - webgpu', async ({skip}) => {
   const webgpuDevice = await getWebGPUTestDevice();
   if (!webgpuDevice) {
     skip();
@@ -223,26 +223,25 @@ test('Attribute#setConstantBufferValue - webgpu', async ({skip}) => {
   });
 
   attribute.numInstances = 2;
-  expect(attribute.setConstantValue(this, [1, 2, 3]), 'webgpu constant materializes a buffer').toBe(
-    true
-  );
+  expect(attribute.setConstantValue(this, [1, 2, 3]), 'webgpu constant is accepted').toBe(true);
 
-  expect(attribute.state.constant, 'webgpu constant is materialized as a buffer').toBeFalsy();
-  expect(attribute.value, 'repeated attribute value is generated').toEqual([1, 2, 3, 1, 2, 3]);
-  expect(
-    attribute.getValue().positions instanceof Buffer,
-    'webgpu constant is exposed as a buffer'
-  ).toBeTruthy();
+  expect(attribute.state.constant, 'webgpu constant remains constant').toBeTruthy();
+  expect(attribute.value, 'only one attribute value is retained').toEqual([1, 2, 3]);
+  const buffer = attribute.getValue().positions as Buffer;
+  expect(buffer, 'webgpu constant is exposed as a one-row buffer').toBeInstanceOf(Buffer);
+  const bytes = await buffer.readAsync(0, 12);
+  expect(new Float32Array(bytes.buffer, bytes.byteOffset, 3)).toEqual(new Float32Array([1, 2, 3]));
+  expect(attribute.getBufferLayout().byteStride, 'constant buffer broadcasts its row').toBe(0);
+  expect(attribute.getConstantValue(), 'raw constant is retained for buffer grouping').toEqual([
+    1, 2, 3
+  ]);
 
-  expect(
-    attribute.setConstantValue(this, [1, 2, 3]),
-    'same emulated constant does not regenerate the buffer'
-  ).toBe(false);
+  expect(attribute.setConstantValue(this, [1, 2, 3]), 'same constant remains valid').toBe(true);
 
   attribute.delete();
 });
 
-test('Attribute#updateBuffer uploads a one-instance constant updater - webgpu', async ({skip}) => {
+test('Attribute#updateBuffer keeps a one-instance constant updater - webgpu', async ({skip}) => {
   const webgpuDevice = await getWebGPUTestDevice();
   if (!webgpuDevice) {
     skip();
@@ -266,13 +265,12 @@ test('Attribute#updateBuffer uploads a one-instance constant updater - webgpu', 
     context: null
   });
 
+  expect(attribute.isConstant, 'constant updater remains constant').toBeTruthy();
   const buffer = attribute.getValue().instanceModelMatrix as Buffer;
-  expect(buffer, 'constant updater is exposed as a buffer').toBeInstanceOf(Buffer);
-  const bytes = await buffer.readAsync();
-  expect(
-    new Float32Array(bytes.buffer).slice(0, matrix.length),
-    'constant matrix is uploaded'
-  ).toEqual(matrix);
+  expect(buffer, 'constant updater is exposed as a one-row buffer').toBeInstanceOf(Buffer);
+  const bytes = await buffer.readAsync(0, matrix.byteLength);
+  expect(new Float32Array(bytes.buffer, bytes.byteOffset, matrix.length)).toEqual(matrix);
+  expect(attribute.getBufferLayout().byteStride).toBe(0);
 
   attribute.delete();
 });


### PR DESCRIPTION
#### Change List
- WebGPU constants now allocate one row only and use vertex-buffer stride 0.
- `AttributeBufferGroups` now accepts constants as inputs
