### PR TITLE
Add per-axis orthographic maxBoundsAlignment

### DIFF
--- a/docs/api-reference/core/orthographic-controller.md
+++ b/docs/api-reference/core/orthographic-controller.md
@@ -47,8 +47,22 @@ Also accepts additional options:
 
 - `zoomAxis` (string) - which axes to apply zoom to. Affects scroll, keyboard +/- and double tap. One of `X` (zoom along the X axis only), `Y` (zoom along the Y axis only), `all`. Default `all`. If this option is set to `X` or `Y`, `viewState.zoom` must be an array to enable independent zoom for each axis.
 - `maxBounds` - constrains the target position within the specified bounding box `[[minX, minY], [maxX, maxY]]`
+- `maxBoundsAlignment` (`{x, y}`) - aligns bounded content when an axis remains smaller than the viewport after applying the existing zoom constraints. Each axis accepts `start`, `center`, or `end`. `start` aligns the minimum world coordinate and `end` aligns the maximum world coordinate, so their visual direction on the Y axis depends on `flipY`. This option does not change zoom. An omitted axis retains the default `maxBounds` behavior.
 - `maxBoundsPadding` - padding inside the viewport when fitting `maxBounds`, using the same `{left, right, top, bottom}` format as view padding. Numeric values are pixels; strings may be percentages or layout expressions such as `calc(10% - 4px)`. Each side is measured from the projected `target`, including any view padding. Default `0`.
 - `rubberBand` (boolean) - allows continuous pan and zoom interactions to temporarily overshoot `maxBounds`, `minZoom`, and `maxZoom` with increasing resistance. On release, the view returns within constraints using a 300 ms exponential ease-out independently of `inertia`. Default `false`.
+
+For example, a timeline that zooms only along X can keep short vertical content aligned to its minimum Y bound:
+
+```js
+new OrthographicView({
+  controller: {
+    maxBounds: contentBounds,
+    maxBoundsAlignment: {y: 'start'}
+  }
+});
+```
+
+Alignment applies to the area remaining after `maxBoundsPadding`. If the bounded content fills or exceeds the viewport on an axis, the controller uses ordinary target clamping on that axis.
 
 ## Custom OrthographicController
 

--- a/docs/api-reference/core/orthographic-view.md
+++ b/docs/api-reference/core/orthographic-view.md
@@ -61,6 +61,19 @@ const view = new OrthographicView({id: '2d-scene', controller: true});
 
 Visit the [OrthographicController](./orthographic-controller.md) documentation for a full list of supported options.
 
+Bounded charts and timelines can use the controller's `maxBoundsAlignment` option to place content that remains smaller than the viewport on either world axis:
+
+```js
+const view = new OrthographicView({
+  controller: {
+    maxBounds: contentBounds,
+    maxBoundsAlignment: {x: 'center', y: 'start'}
+  }
+});
+```
+
+This alignment changes only the constrained target. It does not alter the orthographic projection or the existing `maxBounds` zoom behavior.
+
 
 ## Remarks
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -51,6 +51,7 @@ new GlobeView({
 #### Controllers
 
 - All [controllers](./api-reference/core/controller.md) now support a `doubleClickDragZoom` gesture that enables continuous zooming by double-clicking and dragging vertically.
+- [OrthographicController](./api-reference/core/orthographic-controller.md) adds `maxBoundsAlignment` to align bounded content that remains smaller than the viewport to the start, center, or end of either world axis without changing zoom behavior.
 
 #### View Layout
 

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -96,6 +96,17 @@ export type ControllerOptions = {
     | [min: [number, number, number], max: [number, number, number]]
     | null;
   /**
+   * Alignment of orthographic `maxBounds` on axes where the viewport is larger than the bounds.
+   * `start` aligns the minimum world coordinate, and `end` aligns the maximum world coordinate.
+   * Unspecified axes retain their default constraint behavior. Default `null`.
+   */
+  maxBoundsAlignment?: {
+    /** Alignment along the world X axis. */
+    x?: 'start' | 'center' | 'end';
+    /** Alignment along the world Y axis. */
+    y?: 'start' | 'center' | 'end';
+  } | null;
+  /**
    * Padding inside the viewport when fitting `maxBounds`, in the shape of
    * `{left, right, top, bottom}` where each value is either a relative (e.g. `'50%'`)
    * or absolute pixels. These values support the same CSS-style expressions
@@ -358,6 +369,9 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     if (props.maxBoundsPadding === undefined) {
       props.maxBoundsPadding = null;
     }
+    if (props.maxBoundsAlignment === undefined) {
+      props.maxBoundsAlignment = null;
+    }
     if (props.dragMode) {
       this.dragMode = props.dragMode;
     }
@@ -424,7 +438,9 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
       oldProps.height !== props.height ||
       oldProps.width !== props.width ||
       oldProps.maxBounds !== props.maxBounds ||
-      oldProps.maxBoundsPadding !== props.maxBoundsPadding;
+      oldProps.maxBoundsPadding !== props.maxBoundsPadding ||
+      oldProps.maxBoundsAlignment?.x !== props.maxBoundsAlignment?.x ||
+      oldProps.maxBoundsAlignment?.y !== props.maxBoundsAlignment?.y;
     if (constraintChanged && props.maxBounds) {
       // Constraint inputs changed, try re-normalize the props
       const controllerState = new this.ControllerState({...props, makeViewport: this.makeViewport});

--- a/modules/core/src/controllers/orthographic-controller.ts
+++ b/modules/core/src/controllers/orthographic-controller.ts
@@ -37,6 +37,8 @@ export type OrthographicStateProps = {
   minZoomY?: number;
 
   maxBounds?: ControllerProps['maxBounds'];
+  /** Alignment used when an axis of `maxBounds` is smaller than the viewport. */
+  maxBoundsAlignment?: ControllerProps['maxBoundsAlignment'];
   /** Padding inside the viewport used when fitting `maxBounds`. Defaults to `0`. */
   maxBoundsPadding?: ControllerProps['maxBoundsPadding'];
   /** Enables elastic bounds and zoom constraints during interaction. Defaults to `false`. */
@@ -73,21 +75,24 @@ function getAxisBounds(
   index: number,
   negativeExtent: number,
   positiveExtent: number,
-  target: number
+  target: number,
+  alignment: NonNullable<ControllerProps['maxBoundsAlignment']>['x'] | undefined
 ) {
   const minimum = maxBounds[0][index] + negativeExtent;
   const maximum = maxBounds[1][index] - positiveExtent;
   // An inverted interval has one stable resting target, including when asymmetric
   // viewport padding means that target is not the geometric center of maxBounds.
   const midpoint = (minimum + maximum) / 2;
+  const hasFiniteExtents = Number.isFinite(negativeExtent) && Number.isFinite(positiveExtent);
+  const isUndersized = hasFiniteExtents && minimum > maximum;
+  const alignedTarget = alignment === 'start' ? minimum : alignment === 'end' ? maximum : midpoint;
   return {
     minimum,
     maximum,
     midpoint,
+    isUndersized,
     settledTarget:
-      Number.isFinite(negativeExtent) && Number.isFinite(positiveExtent) && minimum <= maximum
-        ? clamp(target, minimum, maximum)
-        : midpoint
+      hasFiniteExtents && minimum <= maximum ? clamp(target, minimum, maximum) : alignedTarget
   };
 }
 
@@ -129,6 +134,7 @@ export class OrthographicState extends ViewState<
       maxZoomY = maxZoom,
 
       maxBounds = null,
+      maxBoundsAlignment = null,
       maxBoundsPadding = null,
       rubberBand = false,
 
@@ -156,6 +162,7 @@ export class OrthographicState extends ViewState<
         minZoomY,
         maxZoomY,
         maxBounds,
+        maxBoundsAlignment,
         maxBoundsPadding,
         rubberBand,
         ...{[CONSTRAINT_AROUND]: constraintAround}
@@ -470,7 +477,7 @@ export class OrthographicState extends ViewState<
         ? [props.zoomX, props.zoomY]
         : props.zoomX;
 
-    const {maxBounds, rubberBand, target} = props;
+    const {maxBounds, maxBoundsAlignment, rubberBand, target} = props;
     if (maxBounds) {
       const maxBoundsRect = getMaxBoundsRect(props.width, props.height, props.maxBoundsPadding);
       const viewport = this.makeViewport(props);
@@ -499,12 +506,14 @@ export class OrthographicState extends ViewState<
         if (targetDimensions[index] < 0) {
           continue;
         }
-        const {minimum, maximum, midpoint, settledTarget} = getAxisBounds(
+        const alignment = index === 0 ? maxBoundsAlignment?.x : maxBoundsAlignment?.y;
+        const {minimum, maximum, midpoint, isUndersized, settledTarget} = getAxisBounds(
           maxBounds,
           index,
           negativeExtent,
           positiveExtent,
-          target[index]
+          target[index],
+          alignment
         );
 
         if (
@@ -516,7 +525,12 @@ export class OrthographicState extends ViewState<
           continue;
         }
 
-        const constrained = rubberBand ? settledTarget : clamp(target[index], minimum, maximum);
+        const constrained =
+          isUndersized && alignment
+            ? settledTarget
+            : rubberBand
+              ? settledTarget
+              : clamp(target[index], minimum, maximum);
         constrainedTarget[index] =
           constraintContext?.mode === 'preserve'
             ? target[index]

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -429,6 +429,87 @@ test('OrthographicController keeps maxBounds hard by default', () => {
   }
 });
 
+test('OrthographicController keeps hard panning at an aligned undersized bound', () => {
+  const controller = createTestController({
+    view: new OrthographicView({
+      controller: {
+        maxBounds: [
+          [0, 0],
+          [200, 25]
+        ],
+        maxBoundsAlignment: {y: 'start'}
+      }
+    }),
+    initialViewState: {target: [100, 0, 0], zoom: 0, zoomAxis: 'X'}
+  });
+
+  expect(controller.props.target, 'initial state aligns the minimum Y bound').toEqual([100, 50, 0]);
+  controller.handleEvent(makeGestureEvent('panstart') as any);
+  controller.handleEvent(makeGestureEvent('panmove', {y: 200}) as any);
+  expect(controller.props.target, 'hard panning keeps the aligned axis fixed').toEqual([100, 50]);
+  controller.handleEvent(makeGestureEvent('panend', {y: 200}) as any);
+  controller.finalize();
+});
+
+test('OrthographicController re-normalizes changed maxBoundsAlignment', () => {
+  const viewStateChanges: Record<string, any>[] = [];
+  const controller = createTestController({
+    view: new OrthographicView({
+      controller: {
+        maxBounds: [
+          [0, 0],
+          [200, 25]
+        ],
+        maxBoundsAlignment: {y: 'start'}
+      }
+    }),
+    initialViewState: {target: [100, 0, 0], zoom: 0, zoomAxis: 'X'},
+    onViewStateChange: ({viewState}) => {
+      viewStateChanges.push(viewState);
+    }
+  });
+  viewStateChanges.length = 0;
+
+  controller.setProps({...controller.props, maxBoundsAlignment: {y: 'end'}});
+  expect(controller.props.target, 'changing alignment publishes the new anchor').toEqual([
+    100, -25, 0
+  ]);
+  expect(viewStateChanges, 'one semantic alignment update is emitted').toHaveLength(1);
+
+  controller.setProps({...controller.props, maxBoundsAlignment: {y: 'end'}});
+  expect(viewStateChanges, 'equivalent alignment objects do not emit updates').toHaveLength(1);
+  controller.finalize();
+});
+
+test('OrthographicController rubber-bands around an aligned undersized bound', () => {
+  const controller = createTestController({
+    view: new OrthographicView({
+      controller: {
+        maxBounds: [
+          [0, 0],
+          [200, 25]
+        ],
+        maxBoundsAlignment: {y: 'start'},
+        rubberBand: true
+      }
+    }),
+    initialViewState: {target: [100, 0, 0], zoom: 0, zoomAxis: 'X'}
+  });
+
+  expect(controller.props.target[1], 'initial state uses the aligned anchor').toBe(50);
+  controller.handleEvent(makeGestureEvent('panstart') as any);
+  controller.handleEvent(makeGestureEvent('panmove', {y: 200}) as any);
+  expect(controller.props.target[1], 'dragging can overshoot the aligned anchor').toBeLessThan(50);
+  expect(controller.props.target[1], 'overshoot is resisted').toBeGreaterThan(-100);
+
+  controller.handleEvent(makeGestureEvent('panend', {y: 200}) as any);
+  const transition = controller.transitionManager.transition;
+  expect(transition.inProgress, 'release starts a rebound').toBe(true);
+  advanceRubberBandTransition(controller, transition.settings.duration);
+  expect(controller.props.target, 'rebound settles at the same aligned anchor').toEqual([100, 50]);
+  controller.finalize();
+});
+
 test.each([
   {description: 'maxZoom', scale: 4, expectedElasticZoom: 1.5, expectedSettledZoom: 1},
   {description: 'minZoom', scale: 0.25, expectedElasticZoom: -1.5, expectedSettledZoom: -1}

--- a/test/modules/core/controllers/view-states.spec.ts
+++ b/test/modules/core/controllers/view-states.spec.ts
@@ -10,11 +10,13 @@ import {
   _GlobeController as GlobeController,
   OrbitViewport,
   OrthographicController,
+  OrthographicViewport,
   Viewport
 } from '@deck.gl/core';
 import {normalizeViewportProps} from '@math.gl/web-mercator';
 
 const dummyMakeViewport = (props: any) => new Viewport(props);
+const makeOrthographicViewport = (props: any) => new OrthographicViewport(props);
 
 test('MapViewState', () => {
   const MapViewState = new MapController({} as any).ControllerState;
@@ -289,6 +291,173 @@ test('OrthographicViewState', () => {
   expect(viewportProps.target, 'adjusted target to maxBounds').toEqual([150, 300, 0]);
   expect(viewportProps.zoomX, 'adjusted zoom to maxBounds').toBe(3);
   expect(viewportProps.zoomY, 'adjusted zoom to maxBounds').toBe(0);
+});
+
+test.each([
+  {axis: 'x', alignment: 'start', expected: 50},
+  {axis: 'x', alignment: 'center', expected: 12.5},
+  {axis: 'x', alignment: 'end', expected: -25},
+  {axis: 'y', alignment: 'start', expected: 50},
+  {axis: 'y', alignment: 'center', expected: 12.5},
+  {axis: 'y', alignment: 'end', expected: -25}
+] as const)(
+  'OrthographicViewState aligns undersized $axis bounds to $alignment',
+  ({axis, alignment, expected}) => {
+    const OrthographicViewState = new OrthographicController({} as any).ControllerState;
+    const isXAxis = axis === 'x';
+    const viewState = new OrthographicViewState({
+      width: 100,
+      height: 100,
+      target: isXAxis ? [0, 100, 0] : [100, 0, 0],
+      zoomX: 0,
+      zoomY: 0,
+      zoomAxis: isXAxis ? 'Y' : 'X',
+      maxBounds: isXAxis
+        ? [
+            [0, 0],
+            [25, 200]
+          ]
+        : [
+            [0, 0],
+            [200, 25]
+          ],
+      maxBoundsAlignment: {[axis]: alignment},
+      makeViewport: makeOrthographicViewport
+    });
+    const viewportProps = viewState.getViewportProps();
+
+    expect(viewportProps.target[isXAxis ? 0 : 1], 'aligned the undersized axis').toBe(expected);
+    expect(viewportProps.target[isXAxis ? 1 : 0], 'left the fitting axis centered').toBe(100);
+    expect(viewportProps.zoomX, 'did not change X zoom behavior').toBe(0);
+    expect(viewportProps.zoomY, 'did not change Y zoom behavior').toBe(0);
+  }
+);
+
+test.each([
+  {description: 'exact-fit', boundsSize: 100, target: 1_000, expected: 50},
+  {description: 'larger', boundsSize: 200, target: 1_000, expected: 150}
+])(
+  'OrthographicViewState uses ordinary clamping for $description aligned bounds',
+  ({boundsSize, target, expected}) => {
+    const OrthographicViewState = new OrthographicController({} as any).ControllerState;
+    const viewState = new OrthographicViewState({
+      width: 100,
+      height: 100,
+      target: [target, target, 0],
+      zoom: 0,
+      zoomAxis: 'X',
+      maxBounds: [
+        [0, 0],
+        [boundsSize, boundsSize]
+      ],
+      maxBoundsAlignment: {x: 'start', y: 'end'},
+      makeViewport: makeOrthographicViewport
+    });
+
+    expect(viewState.getViewportProps().target, 'alignment is inactive when bounds fill').toEqual([
+      expected,
+      expected,
+      0
+    ]);
+  }
+);
+
+test.each([true, false])(
+  'OrthographicViewState treats alignment as world-relative with flipY=$flipY',
+  flipY => {
+    const OrthographicViewState = new OrthographicController({} as any).ControllerState;
+    const makeViewport = (props: any) => new OrthographicViewport({...props, flipY});
+    const viewState = new OrthographicViewState({
+      width: 100,
+      height: 100,
+      target: [100, 0, 0],
+      zoom: 0,
+      zoomAxis: 'X',
+      maxBounds: [
+        [0, 0],
+        [200, 25]
+      ],
+      maxBoundsAlignment: {y: 'start'},
+      makeViewport
+    });
+
+    expect(viewState.getViewportProps().target[1], 'start follows the minimum Y bound').toBe(50);
+  }
+);
+
+test('OrthographicViewState aligns within asymmetric maxBoundsPadding', () => {
+  const OrthographicViewState = new OrthographicController({} as any).ControllerState;
+  const baseProps = {
+    width: 100,
+    height: 100,
+    target: [100, 0, 0],
+    zoom: 0,
+    zoomAxis: 'X' as const,
+    maxBounds: [
+      [0, 0],
+      [200, 25]
+    ],
+    maxBoundsPadding: {top: 10, bottom: 30},
+    makeViewport: makeOrthographicViewport
+  };
+
+  for (const [alignment, expected] of [
+    ['start', 40],
+    ['center', 22.5],
+    ['end', 5]
+  ] as const) {
+    const viewState = new OrthographicViewState({
+      ...baseProps,
+      maxBoundsAlignment: {y: alignment}
+    });
+    expect(viewState.getViewportProps().target[1], `${alignment} uses padded extents`).toBe(
+      expected
+    );
+  }
+});
+
+test.each([
+  {height: 100, expected: -25},
+  {height: 200, expected: -75}
+])('OrthographicViewState reapplies alignment at height $height', ({height, expected}) => {
+  const OrthographicViewState = new OrthographicController({} as any).ControllerState;
+  const viewState = new OrthographicViewState({
+    width: 100,
+    height,
+    target: [100, 0, 0],
+    zoom: 0,
+    zoomAxis: 'X',
+    maxBounds: [
+      [0, 0],
+      [200, 25]
+    ],
+    maxBoundsAlignment: {y: 'end'},
+    makeViewport: makeOrthographicViewport
+  });
+
+  expect(viewState.getViewportProps().target[1], 'alignment uses the current dimensions').toBe(
+    expected
+  );
+});
+
+test('OrthographicViewState preserves default undersized maxBounds behavior', () => {
+  const OrthographicViewState = new OrthographicController({} as any).ControllerState;
+  const viewState = new OrthographicViewState({
+    width: 100,
+    height: 100,
+    target: [100, 0, 0],
+    zoom: 0,
+    zoomAxis: 'X',
+    maxBounds: [
+      [0, 0],
+      [200, 25]
+    ],
+    makeViewport: makeOrthographicViewport
+  });
+  const viewportProps = viewState.getViewportProps();
+
+  expect(viewportProps.target, 'legacy hard constraints remain unchanged').toEqual([100, 50, 0]);
+  expect(viewportProps.zoomY, 'legacy zoom fitting remains unchanged').toBe(0);
 });
 
 test('FirstPersonViewState', () => {


### PR DESCRIPTION
## Goals

Add an opt-in way to align orthographic `maxBounds` content when an axis remains smaller than the viewport after the existing zoom constraints are applied.

This is useful for bounded charts and timelines. For example, a timeline may zoom only along X while short Y-axis content should stay attached to its minimum world bound instead of using the controller default. Applications currently need custom controller logic for this positioning, which can diverge across hard panning, elastic dragging, inertia, resizing, and rebound settlement.

```ts
new OrthographicView({
  controller: {
    maxBounds,
    maxBoundsAlignment: {
      x: 'center',
      y: 'start'
    }
  }
});
```

`start` and `end` are defined in world coordinates: `start` aligns the minimum bound and `end` aligns the maximum bound.

## Changes

- Add per-axis `maxBoundsAlignment` controller options for `start`, `center`, and `end`.
- Apply alignment only when the viewport extent is larger than the bounded extent on that axis.
- Use the same aligned target for hard constraints, rubber-band interaction, inertia, rebound settlement, resizing, and runtime option changes.
- Account for asymmetric `maxBoundsPadding` and preserve world-relative behavior for both `flipY` orientations.
- Preserve existing projection, zoom fitting, exact-fit/larger-content clamping, and all behavior when the option or an axis is omitted.
- Document the option in the orthographic controller/view references and the v9.4 release notes.
- Add coverage for both axes, all alignment values, independent zoom, padding, `flipY`, hard panning, rubber-band rebound, resizing, runtime changes, and default behavior.

## Validation

- `yarn vitest run --project=headless test/modules/core/controllers/view-states.spec.ts test/modules/core/controllers/controllers.spec.ts` — 89 passed
- `yarn lint` — passed
- `yarn build` — passed
- `yarn test-website` — passed; existing source-map, SSG markup, and broken-anchor warnings remain
- `yarn test-headless` — 984 passed, 7 skipped, 1 unrelated failure in `test/modules/widgets/loading-widget.spec.ts` because the spinner remains present after loading completes

The branch is rebased onto `visgl/deck.gl` master at `6066374db9eb4ba1e7de98c7007e43c3f29d183c`.
