### PR TITLE
fix(core): compare viewport projection state in equals

### DIFF
--- a/modules/core/src/viewports/viewport.ts
+++ b/modules/core/src/viewports/viewport.ts
@@ -211,11 +211,6 @@ export default class Viewport {
     return PROJECTION_MODE.IDENTITY;
   }
 
-  /** Whether meter projection uses the legacy viewport-centered approximation. */
-  protected get usesPseudoMeters(): boolean {
-    return false;
-  }
-
   // Two viewports are equal if their dimensions, common-space scale, and
   // view and projection matrices are (approximately) equal.
   equals(viewport: Viewport): boolean {
@@ -232,7 +227,6 @@ export default class Viewport {
       viewport.scale === this.scale &&
       viewport.projectionMode === this.projectionMode &&
       viewport.resolution === this.resolution &&
-      viewport.usesPseudoMeters === this.usesPseudoMeters &&
       equals(viewport.distanceScales.unitsPerMeter, this.distanceScales.unitsPerMeter) &&
       equals(viewport.projectionMatrix, this.projectionMatrix) &&
       equals(viewport.viewMatrix, this.viewMatrix)

--- a/modules/core/src/viewports/viewport.ts
+++ b/modules/core/src/viewports/viewport.ts
@@ -125,6 +125,9 @@ function createProjectionMatrix({
  * A new viewport instance should be created if any parameters have changed.
  */
 export default class Viewport {
+  /** Internal projection flag used by WebMercatorViewport. */
+  protected declare readonly _pseudoMeters?: boolean;
+
   static displayName = 'Viewport';
 
   /** Init parameters */
@@ -227,6 +230,7 @@ export default class Viewport {
       viewport.scale === this.scale &&
       viewport.projectionMode === this.projectionMode &&
       viewport.resolution === this.resolution &&
+      viewport._pseudoMeters === this._pseudoMeters &&
       equals(viewport.distanceScales.unitsPerMeter, this.distanceScales.unitsPerMeter) &&
       equals(viewport.projectionMatrix, this.projectionMatrix) &&
       equals(viewport.viewMatrix, this.viewMatrix)

--- a/modules/core/src/viewports/viewport.ts
+++ b/modules/core/src/viewports/viewport.ts
@@ -211,8 +211,8 @@ export default class Viewport {
     return PROJECTION_MODE.IDENTITY;
   }
 
-  // Two viewports are equal if width and height are identical, and if
-  // their view and projection matrices are (approximately) equal.
+  // Two viewports are equal if their dimensions, common-space scale, and
+  // view and projection matrices are (approximately) equal.
   equals(viewport: Viewport): boolean {
     if (!(viewport instanceof Viewport)) {
       return false;
@@ -225,6 +225,9 @@ export default class Viewport {
       viewport.width === this.width &&
       viewport.height === this.height &&
       viewport.scale === this.scale &&
+      viewport.projectionMode === this.projectionMode &&
+      viewport.resolution === this.resolution &&
+      equals(viewport.distanceScales.unitsPerMeter, this.distanceScales.unitsPerMeter) &&
       equals(viewport.projectionMatrix, this.projectionMatrix) &&
       equals(viewport.viewMatrix, this.viewMatrix)
     );

--- a/modules/core/src/viewports/viewport.ts
+++ b/modules/core/src/viewports/viewport.ts
@@ -125,9 +125,6 @@ function createProjectionMatrix({
  * A new viewport instance should be created if any parameters have changed.
  */
 export default class Viewport {
-  /** Internal projection flag used by WebMercatorViewport. */
-  protected declare readonly _pseudoMeters?: boolean;
-
   static displayName = 'Viewport';
 
   /** Init parameters */
@@ -214,6 +211,11 @@ export default class Viewport {
     return PROJECTION_MODE.IDENTITY;
   }
 
+  /** Whether meter projection uses the legacy viewport-centered approximation. */
+  protected get usesPseudoMeters(): boolean {
+    return false;
+  }
+
   // Two viewports are equal if their dimensions, common-space scale, and
   // view and projection matrices are (approximately) equal.
   equals(viewport: Viewport): boolean {
@@ -230,12 +232,11 @@ export default class Viewport {
       viewport.scale === this.scale &&
       viewport.projectionMode === this.projectionMode &&
       viewport.resolution === this.resolution &&
-      viewport._pseudoMeters === this._pseudoMeters &&
+      viewport.usesPseudoMeters === this.usesPseudoMeters &&
       equals(viewport.distanceScales.unitsPerMeter, this.distanceScales.unitsPerMeter) &&
       equals(viewport.projectionMatrix, this.projectionMatrix) &&
       equals(viewport.viewMatrix, this.viewMatrix)
     );
-    // TODO - check distance scales?
   }
 
   /**

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -89,7 +89,7 @@ export default class WebMercatorViewport extends Viewport {
   /** Each sub viewport renders one copy of the world if repeat:true. The list is generated and cached on first request. */
   private _subViewports: WebMercatorViewport[] | null;
   /** @deprecated Revert to approximated meter size calculation prior to v8.5 */
-  private _pseudoMeters: boolean;
+  protected readonly _pseudoMeters: boolean;
 
   /* eslint-disable complexity, max-statements */
   constructor(opts: WebMercatorViewportOptions = {}) {

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -89,7 +89,7 @@ export default class WebMercatorViewport extends Viewport {
   /** Each sub viewport renders one copy of the world if repeat:true. The list is generated and cached on first request. */
   private _subViewports: WebMercatorViewport[] | null;
   /** @deprecated Revert to approximated meter size calculation prior to v8.5 */
-  protected readonly _pseudoMeters: boolean;
+  private _pseudoMeters: boolean;
 
   /* eslint-disable complexity, max-statements */
   constructor(opts: WebMercatorViewportOptions = {}) {
@@ -234,6 +234,10 @@ export default class WebMercatorViewport extends Viewport {
       }
     }
     return this._subViewports;
+  }
+
+  protected get usesPseudoMeters(): boolean {
+    return this._pseudoMeters;
   }
 
   projectPosition(xyz: number[]): [number, number, number] {

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -236,8 +236,13 @@ export default class WebMercatorViewport extends Viewport {
     return this._subViewports;
   }
 
-  protected get usesPseudoMeters(): boolean {
-    return this._pseudoMeters;
+  /** Returns whether two Web Mercator viewports use the same projection settings. */
+  equals(viewport: Viewport): boolean {
+    return (
+      viewport instanceof WebMercatorViewport &&
+      viewport._pseudoMeters === this._pseudoMeters &&
+      super.equals(viewport)
+    );
   }
 
   projectPosition(xyz: number[]): [number, number, number] {

--- a/test/modules/core/viewports/viewport.spec.ts
+++ b/test/modules/core/viewports/viewport.spec.ts
@@ -4,7 +4,12 @@
 
 import {test, expect} from 'vitest';
 import {vecNormalized} from '../../../utils/utils';
-import {OrthographicViewport, Viewport, _GlobeViewport as GlobeViewport} from 'deck.gl';
+import {
+  OrthographicViewport,
+  Viewport,
+  WebMercatorViewport,
+  _GlobeViewport as GlobeViewport
+} from 'deck.gl';
 import {Matrix4, Vector3} from '@math.gl/core';
 
 /* eslint-disable */
@@ -112,6 +117,17 @@ test('Viewport#equals', () => {
   expect(
     orthographicZoom1a.equals(orthographicZoom2),
     'different anisotropic common-space scales are not equal'
+  ).toBeFalsy();
+
+  const webMercatorOptions = {width: 800, height: 600, longitude: 0, latitude: 20, zoom: 10};
+  const currentMeterSizes = new WebMercatorViewport(webMercatorOptions);
+  const legacyMeterSizes = new WebMercatorViewport({
+    ...webMercatorOptions,
+    legacyMeterSizes: true
+  });
+  expect(
+    currentMeterSizes.equals(legacyMeterSizes),
+    'different meter projection modes are not equal'
   ).toBeFalsy();
 });
 

--- a/test/modules/core/viewports/viewport.spec.ts
+++ b/test/modules/core/viewports/viewport.spec.ts
@@ -125,10 +125,22 @@ test('Viewport#equals', () => {
     ...webMercatorOptions,
     legacyMeterSizes: true
   });
+  const matchingLegacyMeterSizes = new WebMercatorViewport({
+    ...webMercatorOptions,
+    legacyMeterSizes: true
+  });
   expect(
     currentMeterSizes.equals(legacyMeterSizes),
     'different meter projection modes are not equal'
   ).toBeFalsy();
+  expect(
+    legacyMeterSizes.equals(currentMeterSizes),
+    'meter projection equality is symmetric'
+  ).toBeFalsy();
+  expect(
+    legacyMeterSizes.equals(matchingLegacyMeterSizes),
+    'matching legacy meter projection modes are equal'
+  ).toBeTruthy();
 });
 
 test('Viewport.getScales', () => {

--- a/test/modules/core/viewports/viewport.spec.ts
+++ b/test/modules/core/viewports/viewport.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect} from 'vitest';
 import {vecNormalized} from '../../../utils/utils';
-import {Viewport} from 'deck.gl';
+import {OrthographicViewport, Viewport, _GlobeViewport as GlobeViewport} from 'deck.gl';
 import {Matrix4, Vector3} from '@math.gl/core';
 
 /* eslint-disable */
@@ -87,6 +87,32 @@ test('Viewport#equals', () => {
   expect(viewport1a.equals(viewport1b), 'Viewport equality correct').toBeTruthy();
   expect(viewport2a.equals(viewport2b), 'Viewport equality correct').toBeTruthy();
   expect(viewport1a.equals(viewport2a), 'Viewport equality correct').toBeFalsy();
+
+  const globeOptions = {width: 800, height: 600, longitude: 0, latitude: 0, zoom: 1};
+  const globeResolution10a = new GlobeViewport({...globeOptions, resolution: 10});
+  const globeResolution10b = new GlobeViewport({...globeOptions, resolution: 10});
+  const globeResolution5 = new GlobeViewport({...globeOptions, resolution: 5});
+  expect(
+    globeResolution10a.equals(globeResolution10b),
+    'matching globe tessellation resolutions are equal'
+  ).toBeTruthy();
+  expect(
+    globeResolution10a.equals(globeResolution5),
+    'different globe tessellation resolutions are not equal'
+  ).toBeFalsy();
+
+  const orthographicOptions = {width: 800, height: 600, zoomY: 0};
+  const orthographicZoom1a = new OrthographicViewport({...orthographicOptions, zoomX: 1});
+  const orthographicZoom1b = new OrthographicViewport({...orthographicOptions, zoomX: 1});
+  const orthographicZoom2 = new OrthographicViewport({...orthographicOptions, zoomX: 2});
+  expect(
+    orthographicZoom1a.equals(orthographicZoom1b),
+    'matching anisotropic common-space scales are equal'
+  ).toBeTruthy();
+  expect(
+    orthographicZoom1a.equals(orthographicZoom2),
+    'different anisotropic common-space scales are not equal'
+  ).toBeFalsy();
 });
 
 test('Viewport.getScales', () => {


### PR DESCRIPTION
## Problem

`Viewport#equals` is a cache-invalidation gate. `Layer.activateViewport` uses it to set `viewportChanged`, and tilesets, terrain, masks, collision filtering, tooltips, and widgets also use it to decide whether projection-dependent state must be refreshed.

The old comparison covered dimensions, scalar scale, and view/projection matrices, but not all state that controls common-space geometry. It could therefore return `true` for viewports that project or tessellate the same input differently:

- Changing Globe `resolution` changes path and polygon subdivision without changing the camera matrices. A `resolution: 30 → 10` update could retain geometry generated for the old resolution.
- Changing one axis of an `OrthographicViewport` changes `distanceScales.unitsPerMeter`. In the regression fixture, `zoomX: 0 → 1` changes the common-space length of a `[3, 4]` segment from `5` to `sqrt(52)`, but the old equality check suppressed the update.
- Toggling Web Mercator `legacyMeterSizes` changes altitude projection and the `pseudoMeters` shader uniform while leaving camera and dimensions unchanged.

In each case, consumers that trusted `Viewport#equals` could retain stale tessellation, projected attributes, or shader inputs.

## Changes

- Compare `projectionMode` and Globe `resolution`.
- Compare `distanceScales.unitsPerMeter` so anisotropic Orthographic scale changes are detected.
- Compare Web Mercator's internal legacy-meter projection mode in a `WebMercatorViewport#equals` override while keeping `_pseudoMeters` private and out of the base viewport contract.
- Add equality regressions for Globe resolution, Orthographic `zoomX`, and `legacyMeterSizes` while preserving equality for matching viewports.

## Performance

No draw-time benchmark applies. The additional scalar/three-component comparisons run only when viewport state is compared. They cause extra invalidation only when projection semantics actually differ.

## Validation

- `yarn vitest run --project headless test/modules/core/viewports/viewport.spec.ts` — 6/6 passed.
- `yarn lint` — passed.
- Commit-hook affected tests — 15/15 passed.
- `git diff --check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when layers and widgets invalidate projection-dependent caches; fixes stale-state bugs but may increase refresh work when projection semantics differ while matrices look the same.
> 
> **Overview**
> **`Viewport#equals`** now treats viewports as different when projection-related state changes, not only when size, scalar scale, and camera matrices match. The base check adds **`projectionMode`**, **`resolution`** (Globe tessellation), and **`distanceScales.unitsPerMeter`** (e.g. anisotropic Orthographic **`zoomX`**), and drops the old distance-scales TODO.
> 
> **`WebMercatorViewport#equals`** extends that with **`_pseudoMeters`** / **`legacyMeterSizes`**, so altitude projection and shader inputs stay in sync without exposing that flag on the base viewport API.
> 
> **Tests** cover Globe resolution, Orthographic **`zoomX`**, and legacy vs current meter sizing so **`equals`** correctly drives **`viewportChanged`** / refresh paths (layers, tooltips, view manager) instead of keeping stale geometry or uniforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33de218c397ec76aa211042b7bebcb8fb6223837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

