### PR TITLE
test: update projection app MapLibre wrapper

### DIFF
--- a/test/apps/projection/app.tsx
+++ b/test/apps/projection/app.tsx
@@ -14,7 +14,7 @@ import {
 } from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {makePointGrid, makeLineGrid, Point} from './data';
-import {Map, Source, Layer} from '@vis.gl/react-maplibre';
+import {Map, Source, Layer} from 'react-map-gl/maplibre';
 // Use dev build for source map and debugging
 import maplibregl from 'maplibre-gl/dist/maplibre-gl-dev';
 import {CPULineLayer} from './cpu-line-layer';

--- a/test/apps/projection/package.json
+++ b/test/apps/projection/package.json
@@ -5,10 +5,10 @@
   },
   "dependencies": {
     "deck.gl": "^9.0.0",
-    "maplibre-gl": "5.0.0-pre.1",
+    "maplibre-gl": "^5.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "@vis.gl/react-maplibre": "^1.0.0-alpha.4"
+    "react-map-gl": "^8.0.0"
   },
   "devDependencies": {
     "vite": "^7.3.1"


### PR DESCRIPTION
## Problem

The projection comparison app was added in #9201 while MapLibre GL JS v5 support was still prerelease. It therefore pinned both `maplibre-gl@5.0.0-pre.1` and the standalone `@vis.gl/react-maplibre@1.0.0-alpha.4` wrapper.

That alpha pairing is now stale. The maintained repository convention is the stable MapLibre entry point from `react-map-gl`, and current `react-map-gl` v8 expects the released MapLibre v5 API rather than the old prerelease API.

## Changes

- Import `Map`, `Source`, and `Layer` from `react-map-gl/maplibre`.
- Replace the standalone alpha wrapper dependency with `react-map-gl@^8.0.0`.
- Move the app from `maplibre-gl@5.0.0-pre.1` to the stable v5 line.

This is the only source import of `@vis.gl/react-maplibre` in the deck.gl repository.

## Validation

- Installed the app dependencies without generating a lockfile.
- Started the local projection app through the repository Vite aliases.
- Headless Chromium rendered the Map, Globe, and Orthographic modes with the expected canvas counts and no page or console errors.
- `yarn lint` passed.
- Commit-hook affected tests passed 15/15.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-app-only dependency and import swap with no production or core library changes.
> 
> **Overview**
> Updates the **projection comparison test app** to use the maintained MapLibre integration instead of the prerelease stack.
> 
> **Import path:** `Map`, `Source`, and `Layer` now come from `react-map-gl/maplibre` rather than `@vis.gl/react-maplibre`.
> 
> **Dependencies:** Drops `@vis.gl/react-maplibre@^1.0.0-alpha.4` in favor of `react-map-gl@^8.0.0`, and bumps `maplibre-gl` from `5.0.0-pre.1` to stable `^5.0.0`. No other application logic in `app.tsx` changes beyond the import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133cf876b4b94ee23d2e0c8f5a9b022be233db69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->