### PR TITLE
feat(examples): add native Coit Gaussian splat viewer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # deck.gl Examples
 
-All deck.gl examples are set up to be "stand-alone", which means that
+Most deck.gl examples are set up to be "stand-alone", which means that
 you can copy the example folder to your own environment, run `yarn` or `npm install`
 and `npm start` and within minutes have a running, minimal app that you can
 start modifying and experimenting with.

--- a/examples/experimental/gaussian-splats/README.md
+++ b/examples/experimental/gaussian-splats/README.md
@@ -1,0 +1,56 @@
+# Gaussian splats: Coit Tower
+
+This experimental example renders the public 50.9-million-splat Coit RAD scene with the same
+quality-critical architecture as the luma.gl showcase. `RADSource` range-loads independently
+decoded pages, `SplatRADHierarchyManager` continuously selects a camera-dependent row frontier,
+and `GPUPagedSplatRenderer` retains float colors and spherical harmonics while applying one exact
+global GPU depth order across all active pages.
+
+During camera interaction, the renderer immediately reprojects the retained coherent frontier but
+does not synchronously retarget and republish it for every raw pointer event. When interaction
+settles, `SplatRADHierarchyManager` retargets the retained tree instead of restarting traversal from
+the roots. Existing visible leaves stay selected until their branch is re-evaluated for the changed
+camera, so a bounded update cannot replace fine detail with a handful of coarse ancestors. Newly
+visible siblings refine into the same tree without mixing a parent with its descendants.
+
+Already active page loads continue during the gesture. The residency window has a 15-million-splat
+steady minimum and temporarily adds 5 million splats of transition headroom so incoming pages can
+load without evicting the still-visible frontier. Current-view requests are reprioritized as soon as
+interaction settles. The window then shrinks to the larger of that minimum or the exact intact-page
+footprint of the current frontier. A stable screen-center fovea and larger stationary traversal
+slice resolve the center without putting hierarchy publication on the interaction path.
+
+The earlier proof flattened every selected page into one Arrow table before handing it to a
+tile-local renderer. That bridge discarded non-DC spherical harmonics, clamped HDR color to eight
+bits, and replaced global ordering with per-tile sorting. Increasing the page count could not
+restore the missing renderer invariants, so this reference deliberately keeps pages intact.
+
+## Run
+
+Install dependencies in both the deck.gl root and this example directory. Until the retained-camera
+retargeting prerequisite is released by luma.gl, `LUMA_GL_ROOT` must point to a local luma.gl
+checkout containing that change. `LOADERS_GL_ROOT` remains an optional override for the published
+loaders.gl dependency:
+
+```bash
+yarn
+cd examples/experimental/gaussian-splats
+yarn
+LUMA_GL_ROOT=/path/to/luma.gl yarn start-local
+```
+
+The example requires a browser and adapter with WebGPU support. Once a luma.gl release includes the
+retained-camera retargeting behavior, the package pin and run instructions can return to the
+published dependency.
+
+## Ownership boundary
+
+- `@loaders.gl/splats` range-loads and decodes native Spark RAD pages.
+- `SplatRADHierarchyManager` owns camera-driven row selection, fallback continuity, and residency.
+- `GPUPagedSplatRenderer` owns sparse projection, global GPU ordering, and float/SH presentation.
+- The browser shell owns camera interaction, transition residency, and active/resident page
+  diagnostics.
+
+This is the visual-parity reference for a future deck.gl/Tile3D integration. Such an integration
+must feed intact pages and sparse active-row masks into the paged renderer; flattening them into a
+`SplatLayer` table is not a quality-preserving adapter.

--- a/examples/experimental/gaussian-splats/app.tsx
+++ b/examples/experimental/gaussian-splats/app.tsx
@@ -1,0 +1,132 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {useEffect, useRef, useState} from 'react';
+import {createRoot} from 'react-dom/client';
+import {
+  createCoitNativeRenderer,
+  type CoitNativeRendererHandle,
+  type CoitNativeRenderStatus
+} from './coit-native-renderer';
+import './styles.css';
+
+const INITIAL_STATUS: CoitNativeRenderStatus = {
+  phase: 'initializing',
+  backend: 'Requesting WebGPU',
+  message: 'Opening the native Coit RAD hierarchy…',
+  residentPageCount: 0,
+  activePageCount: 0,
+  activeRowCount: 0,
+  requestedPageCount: 1,
+  sourceSplatCount: 50_937_127,
+  activeSplatCapacity: 5_000_000,
+  residentSplatCapacity: 15_000_000,
+  sortMode: 'global'
+};
+
+export default function App() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<CoitNativeRendererHandle>();
+  const [status, setStatus] = useState<CoitNativeRenderStatus>(INITIAL_STATUS);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+    let cancelled = false;
+    let renderer: CoitNativeRendererHandle | undefined;
+    const abortController = new AbortController();
+    void createCoitNativeRenderer(
+      container,
+      nextStatus => {
+        if (!cancelled) {
+          setStatus(nextStatus);
+        }
+      },
+      abortController.signal
+    )
+      .then(handle => {
+        if (cancelled) {
+          handle.destroy();
+        } else {
+          renderer = handle;
+          rendererRef.current = handle;
+        }
+      })
+      .catch(error => {
+        if (!cancelled) {
+          setStatus(current => ({
+            ...current,
+            phase:
+              error instanceof Error && error.message.includes('WebGPU') ? 'unsupported' : 'error',
+            message: error instanceof Error ? error.message : 'Unable to start the Coit renderer.'
+          }));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+      renderer?.destroy();
+      rendererRef.current = undefined;
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="canvas-host" ref={containerRef} />
+      <aside className="panel" aria-live="polite">
+        <p className="eyebrow">luma.gl paged RAD</p>
+        <h1>Coit Tower, native resolution</h1>
+        <p className="description">
+          Camera motion immediately reprojects the coherent hierarchy already in memory. Once input
+          settles, newly exposed branches retarget and refine center-first. Drag to orbit, scroll to
+          zoom, or double-click to restore the authored camera.
+        </p>
+        <dl className="metrics">
+          <div className="metric">
+            <dt>Retargeted frontier</dt>
+            <dd>{formatCount(status.activeRowCount)} splats</dd>
+          </div>
+          <div className="metric">
+            <dt>Page cache</dt>
+            <dd>
+              {status.activePageCount} shown / {status.residentPageCount} resident
+            </dd>
+          </div>
+          <div className="metric">
+            <dt>Pending pages</dt>
+            <dd>{status.requestedPageCount}</dd>
+          </div>
+          <div className="metric">
+            <dt>Draw / cache budgets</dt>
+            <dd>
+              {formatCount(status.activeSplatCapacity)} /{' '}
+              {formatCount(status.residentSplatCapacity)}
+            </dd>
+          </div>
+          <div className="metric">
+            <dt>Renderer</dt>
+            <dd>
+              {status.backend} · {status.sortMode}
+            </dd>
+          </div>
+        </dl>
+        <div className="status" data-phase={status.phase}>
+          {status.message}
+        </div>
+        <button type="button" onClick={() => rendererRef.current?.resetCamera()}>
+          Reset authored view
+        </button>
+      </aside>
+    </>
+  );
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+createRoot(document.getElementById('app')!).render(<App />);

--- a/examples/experimental/gaussian-splats/coit-frontier-retention.ts
+++ b/examples/experimental/gaussian-splats/coit-frontier-retention.ts
@@ -1,0 +1,78 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type ContinuitySettlementState = {
+  activePageLoadCount: number;
+  isCameraInteracting: boolean;
+  pageRequestCount: number;
+  traversalPending: boolean;
+};
+
+export type RefinementTraversalState = {
+  activePageLoadCount: number;
+  isCameraInteracting: boolean;
+  traversalPending: boolean;
+};
+
+export type TraversalPhase = 'camera-update' | 'settled-refinement';
+
+export type RefinementFoveation = {
+  center: [number, number];
+  radius: number;
+  strength: number;
+};
+
+const CAMERA_UPDATE_TRAVERSAL_ROWS = 4_095;
+const SETTLED_REFINEMENT_TRAVERSAL_ROWS = 65_535;
+const CONCURRENT_PAGE_LOAD_LIMIT = 8;
+
+/** Returns a small synchronous camera slice or a larger center-first refinement slice. */
+export function getTraversalRowBudget(phase: TraversalPhase): number {
+  return phase === 'camera-update'
+    ? CAMERA_UPDATE_TRAVERSAL_ROWS
+    : SETTLED_REFINEMENT_TRAVERSAL_ROWS;
+}
+
+/** Returns the bounded transport width used to fill newly exposed current-view detail. */
+export function getConcurrentPageLoadLimit(): number {
+  return CONCURRENT_PAGE_LOAD_LIMIT;
+}
+
+/** Returns the current-view page capacity while preserving optional transition headroom. */
+export function getResidencySplatCapacity(
+  steadySplatCapacity: number,
+  transitionSplatCapacity: number,
+  isTransitionActive: boolean
+): number {
+  return steadySplatCapacity + (isTransitionActive ? transitionSplatCapacity : 0);
+}
+
+/** Returns a stable screen-center fovea for center-first hierarchy refinement and page loading. */
+export function getRefinementFoveation(): RefinementFoveation {
+  return {
+    center: [0.5, 0.5],
+    radius: 0.12,
+    strength: 12
+  };
+}
+
+/** Returns whether an unchanged camera can refine without racing an active page-admission batch. */
+export function shouldAdvanceRefinementTraversal(state: RefinementTraversalState): boolean {
+  return !state.isCameraInteracting && state.activePageLoadCount === 0 && state.traversalPending;
+}
+
+/** Returns whether a camera update should synchronously retarget and republish the hierarchy. */
+export function shouldRetargetHierarchyForCameraUpdate(isCameraInteracting: boolean): boolean {
+  return !isCameraInteracting;
+}
+
+/** Returns whether traversal and every current-view page request have completed. */
+export function isContinuityViewSettled(state: ContinuitySettlementState): boolean {
+  return (
+    !state.isCameraInteracting &&
+    !state.traversalPending &&
+    state.pageRequestCount === 0 &&
+    state.activePageLoadCount === 0
+  );
+}

--- a/examples/experimental/gaussian-splats/coit-native-renderer.ts
+++ b/examples/experimental/gaussian-splats/coit-native-renderer.ts
@@ -1,0 +1,680 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {luma} from '@luma.gl/core';
+import {
+  GPUPagedSplatRenderer,
+  makeGPUSplatData,
+  SplatRADHierarchyManager,
+  type SplatHierarchyView,
+  type SplatRADHierarchyFrontierEntry
+} from '@luma.gl/splats';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import {Matrix4} from '@math.gl/core';
+import {RADSource} from '@loaders.gl/splats';
+import {
+  getConcurrentPageLoadLimit,
+  getRefinementFoveation,
+  getResidencySplatCapacity,
+  getTraversalRowBudget,
+  isContinuityViewSettled,
+  shouldAdvanceRefinementTraversal,
+  shouldRetargetHierarchyForCameraUpdate
+} from './coit-frontier-retention';
+
+const COIT_RAD_URL =
+  'https://storage.googleapis.com/download/storage/v1/b/forge-dev-public/o/asundqui%2Frad%2F260217%2Fcoit-40m-sh1-lod.rad?alt=media';
+const COIT_SOURCE_SPLAT_COUNT = 50_937_127;
+const COIT_PAGE_SPLAT_COUNT = 65_536;
+const MAXIMUM_RESIDENT_SPLATS = 15_000_000;
+const MAXIMUM_ACTIVE_SPLATS = 5_000_000;
+const MAXIMUM_CONCURRENT_PAGE_LOADS = getConcurrentPageLoadLimit();
+const CAMERA_UPDATE_TRAVERSAL_ROWS = getTraversalRowBudget('camera-update');
+const SETTLED_REFINEMENT_TRAVERSAL_ROWS = getTraversalRowBudget('settled-refinement');
+const CAMERA_SETTLE_DELAY_MILLISECONDS = 160;
+const FIELD_OF_VIEW_RADIANS = (75 * Math.PI) / 180;
+const SH_C0 = 0.28209479177387814;
+const CLEAR_COLOR: [number, number, number, number] = [202 / 255, 254 / 255, 254 / 255, 1];
+const CAMERA_UP: [number, number, number] = [0, -1, 0];
+const CAMERA_FORWARD: [number, number, number] = [0, 0, 1];
+const CAMERA_RIGHT: [number, number, number] = [-1, 0, 0];
+const AUTHORED_CAMERA_POSITION: [number, number, number] = [-0.0858, -0.2203, 0.1128];
+const AUTHORED_CAMERA_TARGET: [number, number, number] = [
+  0.0226670563, -0.1886351632, 0.0141479052
+];
+
+type GaussianSplats = {
+  splatCount: number;
+  positions: Float32Array;
+  scales: Float32Array;
+  rotations: Float32Array;
+  colors: Uint8Array;
+  sphericalHarmonicDcs?: Float32Array;
+  sphericalHarmonics?: Float32Array;
+  sphericalHarmonicsComponentCount?: number;
+  opacities: Float32Array;
+  loaderData?: Record<string, unknown>;
+};
+
+export type CoitNativeRenderStatus = {
+  phase:
+    | 'initializing'
+    | 'streaming'
+    | 'interactive'
+    | 'refining'
+    | 'ready'
+    | 'unsupported'
+    | 'error';
+  backend: string;
+  message: string;
+  residentPageCount: number;
+  activePageCount: number;
+  activeRowCount: number;
+  requestedPageCount: number;
+  sourceSplatCount: number;
+  activeSplatCapacity: number;
+  residentSplatCapacity: number;
+  sortMode: string;
+};
+
+export type CoitNativeRendererHandle = {
+  destroy: () => void;
+  resetCamera: () => void;
+};
+
+type CameraState = {
+  target: [number, number, number];
+  yaw: number;
+  pitch: number;
+  distance: number;
+};
+
+/** Runs the same intact-page, global-GPU-order path used by luma.gl's Coit showcase. */
+export async function createCoitNativeRenderer(
+  container: HTMLDivElement,
+  onStatus: (status: CoitNativeRenderStatus) => void,
+  signal?: AbortSignal
+): Promise<CoitNativeRendererHandle> {
+  const device = await luma.createDevice({
+    type: 'webgpu',
+    adapters: [webgpuAdapter],
+    createCanvasContext: {
+      container,
+      width: Math.max(container.clientWidth, 1),
+      height: Math.max(container.clientHeight, 1),
+      useDevicePixels: true,
+      autoResize: true
+    }
+  });
+  if (signal?.aborted) {
+    device.destroy();
+    signal.throwIfAborted();
+  }
+  if (device.type !== 'webgpu') {
+    device.destroy();
+    throw new Error('The Coit reference renderer requires WebGPU.');
+  }
+
+  const canvasElement = container.querySelector<HTMLCanvasElement>('canvas');
+  if (!canvasElement) {
+    device.destroy();
+    throw new Error('Unable to create the Coit rendering canvas.');
+  }
+  const canvas: HTMLCanvasElement = canvasElement;
+
+  const source = new RADSource(COIT_RAD_URL, {});
+  const renderer = new GPUPagedSplatRenderer(device, {
+    clearColor: CLEAR_COLOR,
+    sortMode: 'global',
+    radiusScale: 1,
+    alphaScale: 1,
+    alphaCutoff: 0.5 / 255,
+    gaussianSupportRadius: Math.sqrt(8),
+    kernel2DSize: Math.sqrt(0.3),
+    maxScreenSpaceSplatSize: 512,
+    toneMapping: 'none',
+    lodOpacity: true
+  });
+  const authoredOffset = subtractVectors(AUTHORED_CAMERA_POSITION, AUTHORED_CAMERA_TARGET);
+  const camera: CameraState = {
+    target: [...AUTHORED_CAMERA_TARGET],
+    yaw: Math.atan2(
+      dotVectors(authoredOffset, CAMERA_RIGHT),
+      dotVectors(authoredOffset, CAMERA_FORWARD)
+    ),
+    pitch: Math.asin(dotVectors(authoredOffset, CAMERA_UP) / Math.hypot(...authoredOffset)),
+    distance: Math.hypot(...authoredOffset)
+  };
+  const initialCamera = {...camera, target: [...camera.target] as [number, number, number]};
+  let sceneRadius = 0.5;
+  let currentView: SplatHierarchyView | undefined;
+  let animationFrame = 0;
+  let needsRender = true;
+  let destroyed = false;
+  let pointerId: number | undefined;
+  let pointerX = 0;
+  let pointerY = 0;
+  let lastStatusKey = '';
+  let isCameraInteracting = false;
+  let isTransitionResidencyActive = false;
+  let steadyResidencySplatCapacity = MAXIMUM_RESIDENT_SPLATS;
+  const refinementFoveation = getRefinementFoveation();
+  let cameraSettleTimeout: ReturnType<typeof setTimeout> | undefined;
+  let presentedFrontier: readonly SplatRADHierarchyFrontierEntry[] = [];
+  let presentedRowCount = 0;
+  const pageLoads = new Map<number, AbortController>();
+  const rejectedPageIndices = new Set<number>();
+
+  const hierarchy = new SplatRADHierarchyManager({
+    pageSize: COIT_PAGE_SPLAT_COUNT,
+    residencyBudget: {maxResidentSplats: MAXIMUM_RESIDENT_SPLATS},
+    maximumActiveRows: MAXIMUM_ACTIVE_SPLATS,
+    lodOpacity: true,
+    lodSplatScale: 1.5,
+    lodRenderScale: 1.5,
+    coneFov0: 70,
+    coneFov: 120,
+    coneFoveate: 0.4,
+    behindFoveate: 0.2,
+    refinementHysteresis: 0.15,
+    maxTraversalRows: CAMERA_UPDATE_TRAVERSAL_ROWS,
+    onFrontierChange: frontier => {
+      publishFrontier(frontier);
+      reportStatus(
+        isCameraInteracting ? 'interactive' : 'refining',
+        isCameraInteracting
+          ? 'Retargeting the coherent hierarchy frontier around the moving camera…'
+          : 'Refining the retargeted current-view frontier…'
+      );
+    },
+    onPageRequest: () => queueMicrotask(pumpPageLoads),
+    onPageCancel: request => pageLoads.get(request.pageIndex)?.abort()
+  });
+
+  function reportStatus(phase: CoitNativeRenderStatus['phase'], message: string): void {
+    const stats = hierarchy.stats;
+    const status: CoitNativeRenderStatus = {
+      phase,
+      backend: device.type,
+      message,
+      residentPageCount: stats.pageCount,
+      activePageCount: presentedFrontier.length,
+      activeRowCount: presentedRowCount,
+      requestedPageCount: getPendingPageCount(),
+      sourceSplatCount: COIT_SOURCE_SPLAT_COUNT,
+      activeSplatCapacity: MAXIMUM_ACTIVE_SPLATS,
+      residentSplatCapacity: hierarchy.residencyManager.stats.maxResidentSplats,
+      sortMode: renderer.stats.sortMode
+    };
+    const statusKey = JSON.stringify(status);
+    if (statusKey !== lastStatusKey) {
+      lastStatusKey = statusKey;
+      onStatus(status);
+    }
+  }
+
+  function publishFrontier(nextFrontier: readonly SplatRADHierarchyFrontierEntry[]): void {
+    if (nextFrontier === presentedFrontier) {
+      return;
+    }
+    renderer.setFrontier(nextFrontier);
+    presentedFrontier = nextFrontier;
+    presentedRowCount = getFrontierRowCount(nextFrontier);
+    steadyResidencySplatCapacity = Math.max(
+      MAXIMUM_RESIDENT_SPLATS,
+      nextFrontier.reduce((splatCount, entry) => splatCount + entry.data.length, 0)
+    );
+    needsRender = true;
+    const targetResidencySplatCapacity = getResidencySplatCapacity(
+      steadyResidencySplatCapacity,
+      MAXIMUM_ACTIVE_SPLATS,
+      isTransitionResidencyActive
+    );
+    if (hierarchy.residencyManager.stats.maxResidentSplats < targetResidencySplatCapacity) {
+      hierarchy.residencyManager.setBudget({
+        maxResidentSplats: targetResidencySplatCapacity
+      });
+    }
+    rejectedPageIndices.clear();
+  }
+
+  function updateCamera(): void {
+    const viewportSize = getViewportSize(canvas);
+    const cosinePitch = Math.cos(camera.pitch);
+    const horizontalDistance = cosinePitch * camera.distance;
+    const forwardDistance = Math.cos(camera.yaw) * horizontalDistance;
+    const rightDistance = Math.sin(camera.yaw) * horizontalDistance;
+    const upwardDistance = Math.sin(camera.pitch) * camera.distance;
+    const cameraPosition: [number, number, number] = [
+      camera.target[0] +
+        CAMERA_FORWARD[0] * forwardDistance +
+        CAMERA_RIGHT[0] * rightDistance +
+        CAMERA_UP[0] * upwardDistance,
+      camera.target[1] +
+        CAMERA_FORWARD[1] * forwardDistance +
+        CAMERA_RIGHT[1] * rightDistance +
+        CAMERA_UP[1] * upwardDistance,
+      camera.target[2] +
+        CAMERA_FORWARD[2] * forwardDistance +
+        CAMERA_RIGHT[2] * rightDistance +
+        CAMERA_UP[2] * upwardDistance
+    ];
+    const near = Math.max(Math.min(camera.distance * 0.02, sceneRadius * 0.05), 0.001);
+    const far = Math.max(camera.distance + sceneRadius * 12, near * 100);
+    const projectionMatrix = new Matrix4().perspective({
+      fovy: FIELD_OF_VIEW_RADIANS,
+      aspect: viewportSize[0] / viewportSize[1],
+      near,
+      far
+    });
+    const viewMatrix = new Matrix4().lookAt({
+      eye: cameraPosition,
+      center: camera.target,
+      up: CAMERA_UP
+    });
+    const modelViewProjectionMatrix = new Matrix4(projectionMatrix).multiplyRight(viewMatrix);
+    renderer.setProps({modelViewProjectionMatrix, viewportSize, cameraPosition});
+    currentView = {
+      cameraPosition,
+      foveation: refinementFoveation,
+      modelViewProjectionMatrix,
+      viewportSize,
+      verticalFieldOfView: FIELD_OF_VIEW_RADIANS
+    };
+    if (shouldRetargetHierarchyForCameraUpdate(isCameraInteracting)) {
+      hierarchy.update(currentView);
+    }
+    needsRender = true;
+  }
+
+  async function loadPage(
+    pageIndex: number,
+    priority: number,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    const pageId = `rad:${pageIndex}`;
+    let splats: GaussianSplats | undefined;
+    const residentChunk = await hierarchy.residencyManager.load(
+      pageId,
+      async () => {
+        splats = (await source.getChunkSplats(pageIndex, {
+          signal,
+          radChunk: {includeLoDTree: true, includeSphericalHarmonics: true}
+        })) as GaussianSplats;
+        signal?.throwIfAborted();
+        return makeGPUSplatData(device, {
+          positions: splats.positions,
+          scales: splats.scales,
+          rotations: splats.rotations,
+          colors: makeFloatingPointColors(splats),
+          opacities: splats.opacities,
+          ...(splats.sphericalHarmonics ? {sphericalHarmonics: splats.sphericalHarmonics} : {}),
+          sourceBatchIndex: pageIndex,
+          rowIndexBase: Number(splats.loaderData?.base)
+        });
+      },
+      {
+        priority,
+        estimatedSplatCount: Math.min(
+          COIT_PAGE_SPLAT_COUNT,
+          COIT_SOURCE_SPLAT_COUNT - pageIndex * COIT_PAGE_SPLAT_COUNT
+        ),
+        ownsData: true
+      }
+    );
+    if (!residentChunk || !splats || destroyed || signal?.aborted) {
+      return false;
+    }
+    const rowIndexBase = Number(splats.loaderData?.base);
+    const childCounts = splats.loaderData?.childCounts;
+    const childStarts = splats.loaderData?.childStarts;
+    if (
+      !Number.isSafeInteger(rowIndexBase) ||
+      !(childCounts instanceof Uint16Array) ||
+      !(childStarts instanceof Uint32Array)
+    ) {
+      throw new Error(`Coit RAD page ${pageIndex} is missing hierarchy metadata.`);
+    }
+    if (pageIndex === 0) {
+      sceneRadius = estimateSceneRadius(splats.positions);
+    }
+    const accepted = hierarchy.registerPage({
+      id: pageId,
+      data: residentChunk.data,
+      childCounts,
+      childStarts,
+      ownsData: true
+    });
+    if (!accepted) {
+      hierarchy.residencyManager.remove(pageId);
+      return false;
+    }
+    return true;
+  }
+
+  function pumpPageLoads(): void {
+    const demandedPageIndices = new Set(hierarchy.requests.map(request => request.pageIndex));
+    for (const [pageIndex, controller] of pageLoads) {
+      if (!demandedPageIndices.has(pageIndex)) {
+        controller.abort();
+      }
+    }
+    const availableSlots = MAXIMUM_CONCURRENT_PAGE_LOADS - pageLoads.size;
+    if (availableSlots <= 0) {
+      return;
+    }
+    const requests = hierarchy.requests
+      .sort((left, right) => right.priority - left.priority)
+      .filter(
+        request =>
+          !hierarchy.getPage(`rad:${request.pageIndex}`) &&
+          !pageLoads.has(request.pageIndex) &&
+          !rejectedPageIndices.has(request.pageIndex)
+      )
+      .slice(0, availableSlots);
+    for (const request of requests) {
+      const controller = new AbortController();
+      pageLoads.set(request.pageIndex, controller);
+      void loadPage(request.pageIndex, request.priority, controller.signal)
+        .then(accepted => {
+          if (!accepted && !controller.signal.aborted) {
+            rejectedPageIndices.add(request.pageIndex);
+          }
+        })
+        .catch(error => {
+          if (!destroyed && !controller.signal.aborted) {
+            rejectedPageIndices.add(request.pageIndex);
+            onStatus({
+              phase: 'error',
+              backend: device.type,
+              message: error instanceof Error ? error.message : 'RAD page loading failed.',
+              residentPageCount: hierarchy.stats.pageCount,
+              activePageCount: presentedFrontier.length,
+              activeRowCount: presentedRowCount,
+              requestedPageCount: getPendingPageCount(),
+              sourceSplatCount: COIT_SOURCE_SPLAT_COUNT,
+              activeSplatCapacity: MAXIMUM_ACTIVE_SPLATS,
+              residentSplatCapacity: hierarchy.residencyManager.stats.maxResidentSplats,
+              sortMode: renderer.stats.sortMode
+            });
+          }
+        })
+        .finally(() => {
+          pageLoads.delete(request.pageIndex);
+          if (!destroyed) {
+            if (currentView && pageLoads.size === 0 && !isCameraInteracting) {
+              hierarchy.update(currentView);
+            }
+            pumpPageLoads();
+          }
+        });
+    }
+  }
+
+  function getPendingPageCount(): number {
+    const pendingPageIndices = new Set(hierarchy.requests.map(request => request.pageIndex));
+    for (const pageIndex of pageLoads.keys()) {
+      pendingPageIndices.add(pageIndex);
+    }
+    return pendingPageIndices.size;
+  }
+
+  function renderFrame(): void {
+    if (destroyed) {
+      return;
+    }
+    const viewportSize = getViewportSize(canvas);
+    if (
+      currentView &&
+      (viewportSize[0] !== currentView.viewportSize[0] ||
+        viewportSize[1] !== currentView.viewportSize[1])
+    ) {
+      updateCamera();
+    }
+    if (
+      shouldAdvanceRefinementTraversal({
+        activePageLoadCount: pageLoads.size,
+        isCameraInteracting,
+        traversalPending: hierarchy.hasPendingTraversal
+      })
+    ) {
+      hierarchy.continueTraversal(SETTLED_REFINEMENT_TRAVERSAL_ROWS);
+      pumpPageLoads();
+    }
+    if (needsRender) {
+      renderer.encode(device.commandEncoder);
+      device.submit();
+      needsRender = false;
+    }
+    const isSettled = isContinuityViewSettled({
+      activePageLoadCount: pageLoads.size,
+      isCameraInteracting,
+      pageRequestCount: hierarchy.requests.length,
+      traversalPending: hierarchy.hasPendingTraversal
+    });
+    if (isSettled) {
+      restoreSteadyResidencyBudget();
+      reportStatus('ready', 'Settled luma.gl frontier with exact global GPU depth ordering.');
+    }
+    animationFrame = requestAnimationFrame(renderFrame);
+  }
+
+  function handlePointerDown(event: PointerEvent): void {
+    beginCameraInteraction();
+    pointerId = event.pointerId;
+    pointerX = event.clientX;
+    pointerY = event.clientY;
+    canvas.setPointerCapture(event.pointerId);
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (event.pointerId !== pointerId) {
+      return;
+    }
+    const deltaX = event.clientX - pointerX;
+    const deltaY = event.clientY - pointerY;
+    pointerX = event.clientX;
+    pointerY = event.clientY;
+    camera.yaw -= deltaX * 0.006;
+    camera.pitch = Math.max(-1.32, Math.min(1.32, camera.pitch - deltaY * 0.005));
+    updateCamera();
+  }
+
+  function handlePointerUp(event: PointerEvent): void {
+    if (event.pointerId === pointerId) {
+      pointerId = undefined;
+      if (canvas.hasPointerCapture(event.pointerId)) {
+        canvas.releasePointerCapture(event.pointerId);
+      }
+      finishCameraInteraction();
+    }
+  }
+
+  function handleWheel(event: WheelEvent): void {
+    event.preventDefault();
+    beginCameraInteraction();
+    camera.distance = Math.max(
+      0.025,
+      Math.min(15, camera.distance * Math.exp(event.deltaY * 0.001))
+    );
+    updateCamera();
+    cameraSettleTimeout = setTimeout(finishCameraInteraction, CAMERA_SETTLE_DELAY_MILLISECONDS);
+  }
+
+  function beginCameraInteraction(): void {
+    isCameraInteracting = true;
+    if (!isTransitionResidencyActive) {
+      hierarchy.residencyManager.setBudget({
+        maxResidentSplats: steadyResidencySplatCapacity + MAXIMUM_ACTIVE_SPLATS
+      });
+      isTransitionResidencyActive = true;
+    }
+    if (cameraSettleTimeout !== undefined) {
+      clearTimeout(cameraSettleTimeout);
+      cameraSettleTimeout = undefined;
+    }
+  }
+
+  function finishCameraInteraction(): void {
+    if (!isCameraInteracting) {
+      return;
+    }
+    isCameraInteracting = false;
+    cameraSettleTimeout = undefined;
+    rejectedPageIndices.clear();
+    if (currentView) {
+      hierarchy.update(currentView);
+      pumpPageLoads();
+    }
+    if (!hierarchy.hasPendingTraversal && getPendingPageCount() === 0) {
+      restoreSteadyResidencyBudget();
+    }
+  }
+
+  function restoreSteadyResidencyBudget(): void {
+    if (!isTransitionResidencyActive) {
+      return;
+    }
+    hierarchy.residencyManager.setBudget({
+      maxResidentSplats: steadyResidencySplatCapacity
+    });
+    isTransitionResidencyActive = false;
+  }
+
+  function resetCamera(): void {
+    beginCameraInteraction();
+    camera.target = [...initialCamera.target];
+    camera.yaw = initialCamera.yaw;
+    camera.pitch = initialCamera.pitch;
+    camera.distance = initialCamera.distance;
+    updateCamera();
+    finishCameraInteraction();
+  }
+
+  function destroyRenderer(): void {
+    if (destroyed) {
+      return;
+    }
+    destroyed = true;
+    cancelAnimationFrame(animationFrame);
+    if (cameraSettleTimeout !== undefined) {
+      clearTimeout(cameraSettleTimeout);
+    }
+    for (const controller of pageLoads.values()) {
+      controller.abort();
+    }
+    pageLoads.clear();
+    canvas.removeEventListener('pointerdown', handlePointerDown);
+    canvas.removeEventListener('pointermove', handlePointerMove);
+    canvas.removeEventListener('pointerup', handlePointerUp);
+    canvas.removeEventListener('pointercancel', handlePointerUp);
+    canvas.removeEventListener('wheel', handleWheel);
+    canvas.removeEventListener('dblclick', resetCamera);
+    renderer.destroy();
+    hierarchy.destroy();
+    device.destroy();
+  }
+
+  onStatus({
+    phase: 'streaming',
+    backend: device.type,
+    message: 'Loading the root RAD page without flattening its source buffers…',
+    residentPageCount: 0,
+    activePageCount: 0,
+    activeRowCount: 0,
+    requestedPageCount: 1,
+    sourceSplatCount: COIT_SOURCE_SPLAT_COUNT,
+    activeSplatCapacity: MAXIMUM_ACTIVE_SPLATS,
+    residentSplatCapacity: MAXIMUM_RESIDENT_SPLATS,
+    sortMode: 'global'
+  });
+  try {
+    await source.getMetadata();
+    signal?.throwIfAborted();
+    const rootPageLoaded = await loadPage(0, Number.MAX_SAFE_INTEGER, signal);
+    signal?.throwIfAborted();
+    if (!rootPageLoaded) {
+      throw new RangeError('The Coit RAD root page exceeds the resident source budget.');
+    }
+  } catch (error) {
+    destroyRenderer();
+    throw error;
+  }
+  updateCamera();
+  pumpPageLoads();
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointercancel', handlePointerUp);
+  canvas.addEventListener('wheel', handleWheel, {passive: false});
+  canvas.addEventListener('dblclick', resetCamera);
+  animationFrame = requestAnimationFrame(renderFrame);
+
+  return {
+    resetCamera,
+    destroy: destroyRenderer
+  };
+}
+
+function makeFloatingPointColors(splats: GaussianSplats): Float32Array {
+  const colors = new Float32Array(splats.splatCount * 4);
+  for (let rowIndex = 0; rowIndex < splats.splatCount; rowIndex++) {
+    const sourceOffset = rowIndex * 3;
+    const targetOffset = rowIndex * 4;
+    if (splats.sphericalHarmonicDcs) {
+      colors[targetOffset + 0] = 0.5 + SH_C0 * splats.sphericalHarmonicDcs[sourceOffset + 0];
+      colors[targetOffset + 1] = 0.5 + SH_C0 * splats.sphericalHarmonicDcs[sourceOffset + 1];
+      colors[targetOffset + 2] = 0.5 + SH_C0 * splats.sphericalHarmonicDcs[sourceOffset + 2];
+    } else {
+      colors[targetOffset + 0] = splats.colors[sourceOffset + 0] / 255;
+      colors[targetOffset + 1] = splats.colors[sourceOffset + 1] / 255;
+      colors[targetOffset + 2] = splats.colors[sourceOffset + 2] / 255;
+    }
+    colors[targetOffset + 3] = 1;
+  }
+  return colors;
+}
+
+function getFrontierRowCount(frontier: readonly SplatRADHierarchyFrontierEntry[]): number {
+  return frontier.reduce((rowCount, entry) => rowCount + entry.activeRows.length, 0);
+}
+
+function estimateSceneRadius(positions: Float32Array): number {
+  const rowCount = positions.length / 3;
+  const sampleStride = Math.max(1, Math.ceil(rowCount / 8192));
+  const coordinates: [number[], number[], number[]] = [[], [], []];
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += sampleStride) {
+    for (let axisIndex = 0; axisIndex < 3; axisIndex++) {
+      const coordinate = positions[rowIndex * 3 + axisIndex];
+      if (Number.isFinite(coordinate)) {
+        coordinates[axisIndex].push(coordinate);
+      }
+    }
+  }
+  const extents = coordinates.map(axisCoordinates => {
+    axisCoordinates.sort((left, right) => left - right);
+    const lowerIndex = Math.floor((axisCoordinates.length - 1) * 0.02);
+    const upperIndex = Math.ceil((axisCoordinates.length - 1) * 0.98);
+    return Math.max(axisCoordinates[upperIndex] - axisCoordinates[lowerIndex], 0);
+  });
+  return Math.max(Math.hypot(...extents) / 2, 0.05);
+}
+
+function getViewportSize(canvas: HTMLCanvasElement): [number, number] {
+  return [Math.max(canvas.width, 1), Math.max(canvas.height, 1)];
+}
+
+function subtractVectors(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number]
+): [number, number, number] {
+  return [left[0] - right[0], left[1] - right[1], left[2] - right[2]];
+}
+
+function dotVectors(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number]
+): number {
+  return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+}

--- a/examples/experimental/gaussian-splats/index.html
+++ b/examples/experimental/gaussian-splats/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#cafeff" />
+    <title>deck.gl × luma.gl Gaussian splats</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/app.tsx"></script>
+  </body>
+</html>

--- a/examples/experimental/gaussian-splats/package.json
+++ b/examples/experimental/gaussian-splats/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "deckgl-examples-gaussian-splats",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "vite --config vite.config.mjs --open",
+    "start-local": "vite --config vite.config.mjs",
+    "build": "tsc --noEmit && vite build --config vite.config.mjs",
+    "test": "../../../node_modules/.bin/vitest run --root ../../.. --config vitest.config.ts --project headless test/modules/gaussian-splats/coit-frontier-retention.spec.ts"
+  },
+  "dependencies": {
+    "@loaders.gl/splats": "5.0.0-alpha.3",
+    "@luma.gl/core": "9.4.0-beta.3",
+    "@luma.gl/splats": "9.4.0-beta.3",
+    "@luma.gl/webgpu": "9.4.0-beta.3",
+    "@math.gl/core": "^4.1.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.9.0",
+    "vite": "^7.3.3"
+  }
+}

--- a/examples/experimental/gaussian-splats/styles.css
+++ b/examples/experimental/gaussian-splats/styles.css
@@ -1,0 +1,162 @@
+:root {
+  color: #152b31;
+  background: #07151a;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+}
+
+.canvas-host {
+  width: 100%;
+  height: 100%;
+}
+
+.panel {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 1;
+  width: min(360px, calc(100vw - 40px));
+  padding: 18px;
+  border: 1px solid rgb(255 255 255 / 68%);
+  border-radius: 18px;
+  color: #f7fbfb;
+  background: rgb(9 24 29 / 82%);
+  box-shadow: 0 18px 60px rgb(8 31 39 / 24%);
+  backdrop-filter: blur(18px);
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: #9fe7de;
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+.description {
+  margin: 8px 0 16px;
+  color: rgb(247 251 251 / 72%);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.metrics {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+}
+
+.metric {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  font-size: 12px;
+}
+
+.metric dt {
+  color: rgb(247 251 251 / 58%);
+}
+
+.metric dd {
+  margin: 0;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 15px;
+  padding-top: 13px;
+  border-top: 1px solid rgb(255 255 255 / 11%);
+  color: rgb(247 251 251 / 72%);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.status::before {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #82e5ad;
+  box-shadow: 0 0 0 4px rgb(130 229 173 / 14%);
+  content: "";
+}
+
+.status[data-phase="initializing"]::before,
+.status[data-phase="streaming"]::before {
+  background: #ffd08a;
+  box-shadow: 0 0 0 4px rgb(255 208 138 / 14%);
+}
+
+.status[data-phase="error"]::before,
+.status[data-phase="unsupported"]::before {
+  background: #ff9ba5;
+  box-shadow: 0 0 0 4px rgb(255 155 165 / 14%);
+}
+
+button {
+  min-height: 44px;
+  margin-top: 13px;
+  padding: 8px 11px;
+  border: 1px solid rgb(255 255 255 / 20%);
+  border-radius: 9px;
+  color: #f7fbfb;
+  background: rgb(255 255 255 / 8%);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: rgb(255 255 255 / 14%);
+}
+
+button:focus-visible {
+  outline: 2px solid #9fe7de;
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .panel {
+    top: 12px;
+    left: 12px;
+    width: calc(100vw - 24px);
+    padding: 15px;
+    border-radius: 15px;
+  }
+
+  h1 {
+    font-size: 19px;
+  }
+}

--- a/examples/experimental/gaussian-splats/tsconfig.json
+++ b/examples/experimental/gaussian-splats/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["."]
+}

--- a/examples/experimental/gaussian-splats/vite.config.mjs
+++ b/examples/experimental/gaussian-splats/vite.config.mjs
@@ -1,0 +1,73 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/* eslint-disable import/namespace */
+import {defineConfig} from 'vite';
+import {getOcularConfig} from '@vis.gl/dev-tools';
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
+
+const exampleDirectory = dirname(fileURLToPath(import.meta.url));
+const rootDirectory = join(exampleDirectory, '../../..');
+const loadersRootDirectory = process.env.LOADERS_GL_ROOT;
+const lumaRootDirectory = process.env.LUMA_GL_ROOT;
+
+if (!lumaRootDirectory) {
+  throw new Error(
+    'LUMA_GL_ROOT must point to a luma.gl checkout with retained camera retargeting support.'
+  );
+}
+
+function aliasScopedPackages(scope, directory = rootDirectory) {
+  return {
+    find: new RegExp(`^${scope.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/([^/]+)$`),
+    replacement: join(directory, `node_modules/${scope}/$1`)
+  };
+}
+
+function aliasLumaSourcePackages(directory) {
+  return {
+    find: /^@luma\.gl\/([^/]+)(\/.*)?$/,
+    replacement: join(directory, 'modules/$1/src$2')
+  };
+}
+
+export default defineConfig(async () => {
+  const {aliases} = await getOcularConfig({root: rootDirectory});
+  return {
+    resolve: {
+      alias: [
+        ...(loadersRootDirectory
+          ? [
+              {
+                find: /^@loaders\.gl\/([^/]+)$/,
+                replacement: join(loadersRootDirectory, 'modules/$1/src/index.ts')
+              }
+            ]
+          : []),
+        {
+          find: '@luma.gl/splats',
+          replacement: join(lumaRootDirectory, 'modules/splats/src/index.ts')
+        },
+        aliasLumaSourcePackages(lumaRootDirectory),
+        ...Object.entries(aliases).map(([find, replacement]) => ({find, replacement})),
+        {find: 'mjolnir.js', replacement: join(rootDirectory, 'node_modules/mjolnir.js')},
+        ...(loadersRootDirectory ? [aliasScopedPackages('@math.gl', loadersRootDirectory)] : [])
+      ]
+    },
+    server: {
+      port: 8098,
+      fs: {
+        allow: [
+          rootDirectory,
+          ...(loadersRootDirectory ? [loadersRootDirectory] : []),
+          lumaRootDirectory
+        ]
+      }
+    },
+    optimizeDeps: {
+      esbuildOptions: {target: 'es2022'}
+    }
+  };
+});

--- a/test/modules/gaussian-splats/coit-frontier-retention.spec.ts
+++ b/test/modules/gaussian-splats/coit-frontier-retention.spec.ts
@@ -1,0 +1,103 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {
+  getConcurrentPageLoadLimit,
+  getRefinementFoveation,
+  getResidencySplatCapacity,
+  getTraversalRowBudget,
+  isContinuityViewSettled,
+  shouldAdvanceRefinementTraversal,
+  shouldRetargetHierarchyForCameraUpdate
+} from '../../../examples/experimental/gaussian-splats/coit-frontier-retention';
+
+describe('frontier continuity', () => {
+  it('uses an eight-request transport limit for newly exposed detail', () => {
+    expect(getConcurrentPageLoadLimit()).toBe(8);
+  });
+
+  it('preserves transition headroom as the steady frontier footprint grows', () => {
+    expect(getResidencySplatCapacity(15_000_000, 5_000_000, true)).toBe(20_000_000);
+    expect(getResidencySplatCapacity(17_000_000, 5_000_000, true)).toBe(22_000_000);
+    expect(getResidencySplatCapacity(17_000_000, 5_000_000, false)).toBe(17_000_000);
+  });
+
+  it('keeps a tight refinement fovea fixed at screen center', () => {
+    expect(getRefinementFoveation()).toEqual({
+      center: [0.5, 0.5],
+      radius: 0.12,
+      strength: 12
+    });
+  });
+
+  it('spends substantially more traversal work after camera interaction settles', () => {
+    const cameraUpdateBudget = getTraversalRowBudget('camera-update');
+    const settledRefinementBudget = getTraversalRowBudget('settled-refinement');
+
+    expect(cameraUpdateBudget).toBe(4_095);
+    expect(settledRefinementBudget).toBe(65_535);
+    expect(settledRefinementBudget).toBeGreaterThanOrEqual(cameraUpdateBudget * 16);
+  });
+
+  it('defers hierarchy retargeting while camera interaction is active', () => {
+    expect(shouldRetargetHierarchyForCameraUpdate(true)).toBe(false);
+    expect(shouldRetargetHierarchyForCameraUpdate(false)).toBe(true);
+  });
+
+  it('waits for the active page-admission batch before restarting refinement', () => {
+    expect(
+      shouldAdvanceRefinementTraversal({
+        activePageLoadCount: 4,
+        isCameraInteracting: false,
+        traversalPending: true
+      })
+    ).toBe(false);
+    expect(
+      shouldAdvanceRefinementTraversal({
+        activePageLoadCount: 0,
+        isCameraInteracting: false,
+        traversalPending: true
+      })
+    ).toBe(true);
+  });
+
+  it('does not settle while a current-view page is queued or loading', () => {
+    expect(
+      isContinuityViewSettled({
+        activePageLoadCount: 0,
+        isCameraInteracting: false,
+        pageRequestCount: 1,
+        traversalPending: false
+      })
+    ).toBe(false);
+    expect(
+      isContinuityViewSettled({
+        activePageLoadCount: 1,
+        isCameraInteracting: false,
+        pageRequestCount: 0,
+        traversalPending: false
+      })
+    ).toBe(false);
+    expect(
+      isContinuityViewSettled({
+        activePageLoadCount: 0,
+        isCameraInteracting: false,
+        pageRequestCount: 0,
+        traversalPending: false
+      })
+    ).toBe(true);
+  });
+
+  it('never publishes a settled replacement during camera interaction', () => {
+    expect(
+      isContinuityViewSettled({
+        activePageLoadCount: 0,
+        isCameraInteracting: true,
+        pageRequestCount: 0,
+        traversalPending: false
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
#### Background

This adds a native WebGPU reference viewer for the public 50.9-million-splat Coit Tower RAD scene. The earlier prototype flattened selected pages into a replacement table before rendering, which discarded higher-order spherical harmonics, clamped HDR color, and lost one global depth order. Increasing page count could not recover those renderer invariants.

The new example keeps decoded pages intact: `RADSource` owns range loading, `SplatRADHierarchyManager` owns the coherent camera frontier and residency, and `GPUPagedSplatRenderer` owns sparse projection plus one global GPU sort.

#### Change List

- Add an experimental Coit Gaussian splat app with orbit/pan/zoom controls and renderer/residency diagnostics.
- Reproject the retained frontier immediately during interaction, then retarget and refine after pointer or wheel settling.
- Keep a 15-million-splat steady residency window with 5 million splats of transition headroom, 5 million maximum active splats, and eight concurrent page loads.
- Preserve float colors, spherical harmonics, sparse active-row masks, and global depth ordering across independently resident pages.
- Centralize traversal, refinement, and residency scheduling policies in tested pure helpers.
- Add lifecycle cancellation, deterministic cleanup, accessible controls, and documented ownership/run boundaries.

#### Dependency and draft status

This PR depends on [visgl/luma.gl#3167](https://github.com/visgl/luma.gl/pull/3167). The published luma.gl beta does not yet contain retained camera retargeting, so the example currently fails fast unless `LUMA_GL_ROOT` points to a checkout containing that prerequisite.

Keep this PR as a draft until the luma change lands and is released. Before marking ready, update the luma package pins to that release and remove the local-checkout requirement. The released `@loaders.gl/splats@5.0.0-alpha.3` already supplies `RADSource`; no loaders.gl PR is required.

#### Validation

- PASS — root `yarn`
- PASS — root `yarn lint`
- PASS — root `yarn build` against current `master`
- PASS — focused Coit policy tests: 8/8 from the example command; the commit hook passed 15/15 across its selected files
- PASS — production example build against the local luma prerequisite (885 modules)
- PASS — `yarn test-website`; existing source-map, static-generation, and broken-anchor warnings remain non-fatal
- PASS — manual WebGPU browser validation of stable retained detail, panning continuity, and the final interaction/performance balance

#### Coverage and remaining risk

The pure scheduling/residency helper is covered by focused tests. The browser renderer lifecycle and frontier-publication integration are not yet automated, so the PR intentionally remains an experimental linked draft in addition to the unreleased luma dependency.

#### Documentation

- The example README documents setup, architecture, continuity behavior, residency headroom, and the future Tile3D integration boundary.
- `examples/README.md` now accurately notes that experimental examples may have app-specific prerequisites.
