### PR TITLE
fix(extensions): follow up FillStyleExtension flipY fix

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -50,6 +50,10 @@ In rare cases, custom WebGL layer shaders may need an update if they explicitly 
 - In such cases, use the new picking shader helper functions to derive the color from the instance id, for example `picking_setPickingColorFromInstanceID()` in GLSL or `picking_getPickingColorFromIndex(instanceIndex)` in WGSL.
 - However, if the logical picking id is different from the rendered instance id, layers can register and populate an explicit `rowIndexes` attribute.
 
+### FillStyleExtension
+
+Pattern atlas orientation previously aligned with the orientation of common space (bottom-left origin for most viewports), result in vertically flipped patterns from the supplied image. They now align with the screen space.
+
 ## Upgrading to v9.3
 
 Upgraded dependencies to [luma.gl v9.3](https://luma.gl/docs/upgrade-guide) and [loaders.gl v4.4](https://loaders.gl/docs/upgrade-guide). Your app may be affected if it contains custom layers.

--- a/modules/extensions/src/fill-style/shader-module.ts
+++ b/modules/extensions/src/fill-style/shader-module.ts
@@ -4,7 +4,7 @@
 
 import type {ShaderModule} from '@luma.gl/shadertools';
 import {project, fp64LowPart} from '@deck.gl/core';
-import type {ProjectProps, ProjectUniforms} from '@deck.gl/core';
+import type {OrthographicViewport, ProjectProps, ProjectUniforms} from '@deck.gl/core';
 
 import type {Texture} from '@luma.gl/core';
 
@@ -13,6 +13,7 @@ layout(std140) uniform fillUniforms {
   vec2 patternTextureSize;
   bool patternEnabled;
   bool patternMask;
+  bool flipY;
   vec2 uvCoordinateOrigin;
   vec2 uvCoordinateOrigin64Low;
 } fill;
@@ -70,7 +71,10 @@ const inject = {
       // Reduce the coordinate origin to within one tile before adding the vertex position. The
       // origin is large in common space, and fp32 cannot carry the sum at full precision.
       vec2 origin = mod(fill.uvCoordinateOrigin, patternFrameCommon) + fill.uvCoordinateOrigin64Low;
-      fill_uv = (origin + geometry.position.xy) / patternFrameCommon + fillPatternOffsets;
+      fill_uv = (origin + geometry.position.xy) / patternFrameCommon;
+      // Pattern atlases use top-left coordinates, so reverse common-space Y in bottom-left views.
+      fill_uv.y *= fill.flipY ? 1.0 : -1.0;
+      fill_uv += fillPatternOffsets;
 
       fill_backgroundColor = fillPatternBackgroundColors;
     }
@@ -79,7 +83,7 @@ const inject = {
   'fs:DECKGL_FILTER_COLOR': /* glsl */ `
     if (fill.patternEnabled) {
       vec2 patternUV = fract(fill_uv);
-      vec2 texCoords = fill_patternBounds.xy + fill_patternBounds.zw * vec2(patternUV.x, 1.0 - patternUV.y);
+      vec2 texCoords = fill_patternBounds.xy + fill_patternBounds.zw * patternUV;
 
       // Tiling is emulated by wrapping the coordinate, so texCoords jumps from the end of the
       // frame back to its start once per tile, leading to the wrong mip level being selected,
@@ -108,6 +112,7 @@ type FillStyleModuleUniforms = {
   patternTextureSize?: [number, number];
   patternEnabled?: boolean;
   patternMask?: boolean;
+  flipY?: boolean;
   uvCoordinateOrigin?: [number, number];
   uvCoordinateOrigin64Low?: [number, number];
 };
@@ -143,6 +148,7 @@ function getPatternUniforms(
     uniforms.uvCoordinateOrigin64Low = coordinateOriginCommon64Low;
     uniforms.patternMask = fillPatternMask;
     uniforms.patternEnabled = fillPatternEnabled;
+    uniforms.flipY = (opts.project.viewport as OrthographicViewport)?.flipY ?? false;
   }
   return uniforms;
 }
@@ -158,6 +164,7 @@ export const patternShaders = {
     patternTextureSize: 'vec2<f32>',
     patternEnabled: 'i32',
     patternMask: 'i32',
+    flipY: 'i32',
     uvCoordinateOrigin: 'vec2<f32>',
     uvCoordinateOrigin64Low: 'vec2<f32>'
   }

--- a/test/modules/extensions/fill-style.spec.ts
+++ b/test/modules/extensions/fill-style.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
+import {OrthographicViewport} from '@deck.gl/core';
 import {FillStyleExtension} from '@deck.gl/extensions';
 import {PolygonLayer} from '@deck.gl/layers';
 import {getLayerUniforms, testLayer, device} from '@deck.gl/test-utils/vitest';
@@ -40,6 +41,7 @@ webglTest('FillStyleExtension#PolygonLayer', () => {
         expect(fillLayer.state.emptyTexture, 'should be enabled in composite layer').toBeTruthy();
         let uniforms = getLayerUniforms(fillLayer);
         expect(uniforms.patternMask, 'has patternMask uniform').toBeTruthy();
+        expect(uniforms.flipY, 'defaults to bottom-left common coordinates').toBeFalsy();
         expect(
           fillLayer.getAttributeManager().getAttributes().fillPatternScales.value,
           'fillPatternScales attribute is populated'
@@ -65,6 +67,15 @@ webglTest('FillStyleExtension#PolygonLayer', () => {
         uniforms = getLayerUniforms(strokeLayer);
         expect(strokeLayer.state.emptyTexture, 'should not be enabled in PathLayer').toBeFalsy();
         expect('patternMask' in uniforms, 'should not be enabled in PathLayer').toBeFalsy();
+      }
+    },
+    {
+      title: 'top-left common coordinates',
+      viewport: new OrthographicViewport({width: 100, height: 100, flipY: true}),
+      onAfterUpdate: ({subLayers}) => {
+        const fillLayer = subLayers.find(l => l.id.includes('fill'));
+        const uniforms = getLayerUniforms(fillLayer);
+        expect(uniforms.flipY, 'uses the viewport Y orientation').toBeTruthy();
       }
     },
     {


### PR DESCRIPTION
Follow up of #10550

#### Change List
- Un-flip top-left viewports (OrthographicView default)
- Add breaking change to upgrade guide
