### PR TITLE
fix(fill-style): Improve accuracy at high zooms

### DIFF
--- a/modules/extensions/src/fill-style/fill-style-extension.ts
+++ b/modules/extensions/src/fill-style/fill-style-extension.ts
@@ -19,6 +19,14 @@ import type {
 } from '@deck.gl/core';
 import type {Texture} from '@luma.gl/core';
 
+function leastCommonMultiple(a: number, b: number): number {
+  if (!Number.isInteger(b) || b <= 0) return 0;
+  if (a === 0) return b;
+  let [x, y] = [a, b];
+  while (y > 0) [x, y] = [y, x % y];
+  return (a / x) * b;
+}
+
 const defaultProps: DefaultProps<FillStyleExtensionProps> = {
   fillPatternEnabled: true,
   fillPatternAtlas: {
@@ -179,6 +187,13 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
     if (props.fillPatternMapping && props.fillPatternMapping !== oldProps.fillPatternMapping) {
       this.getAttributeManager()!.invalidate('getFillPattern');
     }
+
+    if (
+      props.fillPatternMapping !== oldProps.fillPatternMapping ||
+      props.getFillPatternScale !== oldProps.getFillPatternScale
+    ) {
+      this.setState({commonFrame: extension.getCommonFrame(props)});
+    }
   }
 
   draw(this: Layer<FillStyleExtensionProps>, params: any, extension: this) {
@@ -193,7 +208,8 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
       fillPatternEnabled,
       fillPatternMask,
       fillPatternSizeUnits,
-      fillPatternTexture: (fillPatternAtlas || this.state.emptyTexture) as Texture
+      fillPatternTexture: (fillPatternAtlas || this.state.emptyTexture) as Texture,
+      fillPatternCommonFrame: this.state.commonFrame as [number, number] | null
     };
     this.setShaderModuleProps({fill: fillProps});
   }
@@ -207,5 +223,24 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
     const {fillPatternMapping} = this.getCurrentLayer()!.props;
     const def = fillPatternMapping && fillPatternMapping[name];
     return def ? [def.x, def.y, def.width, def.height] : [0, 0, 0, 0];
+  }
+
+  /**
+   * Returns common frame into which all patterns fit as integer multiples
+   */
+  getCommonFrame(props: FillStyleExtensionProps): [number, number] | null {
+    const {fillPatternMapping, getFillPatternScale: scale} = props;
+    if (typeof scale !== 'number' || !(scale > 0) || typeof fillPatternMapping !== 'object') {
+      return null;
+    }
+    let width = 0;
+    let height = 0;
+    for (const name in fillPatternMapping) {
+      const frame = fillPatternMapping[name];
+      width = leastCommonMultiple(width, frame.width);
+      height = leastCommonMultiple(height, frame.height);
+      if (!width || !height) return null;
+    }
+    return width ? [scale * width, scale * height] : null;
   }
 }

--- a/modules/extensions/src/fill-style/shader-module.ts
+++ b/modules/extensions/src/fill-style/shader-module.ts
@@ -131,6 +131,7 @@ export type FillStyleModuleProps = {
   fillPatternMask?: boolean;
   fillPatternTexture: Texture;
   fillPatternSizeUnits?: Unit;
+  fillPatternCommonFrame?: [number, number] | null;
 };
 
 type FillStyleModuleUniforms = {
@@ -164,19 +165,23 @@ function getPatternUniforms(
     const {
       fillPatternMask = true,
       fillPatternEnabled = true,
-      fillPatternSizeUnits = 'meters'
+      fillPatternSizeUnits = 'meters',
+      fillPatternCommonFrame = null
     } = opts;
     const projectUniforms = project.getUniforms(opts.project) as ProjectUniforms;
     const {commonOrigin: coordinateOriginCommon} = projectUniforms;
     const unitScale = getPatternUnitScale(fillPatternSizeUnits, opts.project.viewport);
 
-    const coordinateOriginCommon64Low: [number, number] = [
-      fp64LowPart(coordinateOriginCommon[0]),
-      fp64LowPart(coordinateOriginCommon[1])
-    ];
+    // Improve the precision of the uv mapping by removing an integer multiple of the
+    // pattern frames. This results in the same result, without wobbling at high zooms
+    const origin: [number, number] = [coordinateOriginCommon[0], coordinateOriginCommon[1]];
+    if (fillPatternCommonFrame) {
+      origin[0] %= unitScale * fillPatternCommonFrame[0];
+      origin[1] %= unitScale * fillPatternCommonFrame[1];
+    }
 
-    uniforms.uvCoordinateOrigin = coordinateOriginCommon.slice(0, 2) as [number, number];
-    uniforms.uvCoordinateOrigin64Low = coordinateOriginCommon64Low;
+    uniforms.uvCoordinateOrigin = origin;
+    uniforms.uvCoordinateOrigin64Low = [fp64LowPart(origin[0]), fp64LowPart(origin[1])];
     uniforms.patternUnitScale = unitScale;
     uniforms.patternMask = fillPatternMask;
     uniforms.patternEnabled = fillPatternEnabled;

--- a/test/modules/extensions/fill-style.spec.ts
+++ b/test/modules/extensions/fill-style.spec.ts
@@ -9,6 +9,8 @@ import {FillStyleExtension} from '@deck.gl/extensions';
 import {PolygonLayer} from '@deck.gl/layers';
 import {getLayerUniforms, testLayer, device} from '@deck.gl/test-utils/vitest';
 
+import type {Viewport} from '@deck.gl/core';
+
 import * as FIXTURES from 'deck.gl-test/data';
 const webglTest = device.type === 'webgl' ? test : test.skip;
 
@@ -127,6 +129,72 @@ webglTest('FillStyleExtension#PolygonLayer', () => {
 
   testLayer({Layer: PolygonLayer, testCases, onError: err => expect(err).toBeFalsy()});
 });
+
+webglTest('FillStyleExtension#originPrecision', () => {
+  // Above zoom 12 the shader coordinate origin is a large common-space value, which is what the
+  // origin reduction exists for
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 12.3, latitude: 45.6, zoom: 14.4}
+  }) as Viewport;
+
+  // Frames of different sizes: the origin may only be reduced by a period that both tile in
+  // whole - lcm(4, 6) = 12 texels, scaled by getFillPatternScale
+  const METERS_PER_COMMON_UNIT = 512 / 40000000;
+  const ORIGIN_PERIOD = 2 * 12 * METERS_PER_COMMON_UNIT;
+
+  const testCases = [
+    {
+      props: {
+        id: 'fill-style-origin-precision-test',
+        data: FIXTURES.polygons,
+        getPolygon: d => d,
+
+        fillPatternAtlas: FILL_PATTERN_ATLAS,
+        fillPatternMapping: {
+          small: {x: 0, y: 0, width: 4, height: 4},
+          large: {x: 4, y: 0, width: 6, height: 6}
+        },
+        getFillPattern: () => 'small',
+        getFillPatternScale: 2,
+
+        extensions: [new FillStyleExtension({pattern: true})]
+      },
+      viewport,
+      onAfterUpdate: ({subLayers}) => {
+        const fillLayer = subLayers.find(l => l.id.includes('fill'));
+        const uniforms = getLayerUniforms(fillLayer);
+        expect(
+          Math.abs(uniforms.uvCoordinateOrigin[0]),
+          'coordinate origin is reduced to within one period'
+        ).toBeLessThan(ORIGIN_PERIOD);
+        expect(
+          Math.abs(uniforms.uvCoordinateOrigin[1]),
+          'coordinate origin is reduced to within one period'
+        ).toBeLessThan(ORIGIN_PERIOD);
+      }
+    },
+    {
+      title: 'data driven getFillPatternScale',
+      updateProps: {
+        getFillPatternScale: () => 2,
+        updateTriggers: {getFillPatternScale: 1}
+      },
+      viewport,
+      onAfterUpdate: ({subLayers}) => {
+        const fillLayer = subLayers.find(l => l.id.includes('fill'));
+        expect(
+          Math.abs(getLayerUniforms(fillLayer).uvCoordinateOrigin[0]),
+          'tile sizes are unknown, so the coordinate origin is left alone'
+        ).toBeGreaterThan(1);
+      }
+    }
+  ];
+
+  testLayer({Layer: PolygonLayer, testCases, onError: err => expect(err).toBeFalsy()});
+});
+
 webglTest('FillStyleExtension#fillPatternSizeUnits', () => {
   const viewport = new MapView({}).makeViewport({
     width: 100,
@@ -172,6 +240,10 @@ webglTest('FillStyleExtension#fillPatternSizeUnits', () => {
           uniforms.patternUnitScale,
           'one texel spans one screen pixel at the rounded zoom level'
         ).toBeCloseTo(2 ** -14, 12);
+        expect(
+          Math.abs(uniforms.uvCoordinateOrigin[0]),
+          'the origin is reduced by a period that follows the zoom'
+        ).toBeLessThan(2 * 1 * 2 ** -14);
       }
     },
     {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
For #7600

<!-- For other PRs without open issue -->
#### Background

Improves accuracy at high zooms by removing common multiple from pattern origin

##### Current behavior


https://github.com/user-attachments/assets/b2510318-e341-478e-8d97-36494f0116e6



<!-- For all the PRs -->
#### Change List
- Compute common frame of texture patterns and subtract from `uvCoordinateOrigin` to improve accuracy
- Tests
