### PR TITLE
feat(fill-style): fillPatternSizeUnits

### DIFF
--- a/docs/api-reference/extensions/fill-style-extension.md
+++ b/docs/api-reference/extensions/fill-style-extension.md
@@ -118,6 +118,26 @@ In both cases the pattern is composited over
 the pattern and the background color styles the area behind it.
 
 
+#### `fillPatternSizeUnits` (string, optional) {#fillpatternsizeunits}
+
+- Default: `'meters'`
+
+The units of the pattern size, one of `'meters'`, `'common'` and `'pixels'`. See [unit system](../../developer-guide/coordinate-systems.md#supported-units). A 24 x 24 pixel pattern at [`getFillPatternScale: 1`](#getfillpatternscale) covers 24 units of the chosen unit.
+
++ `'meters'` anchors the pattern to the ground, so it zooms along with the rest of the map.
++ `'common'` sizes the pattern in [common space](../../developer-guide/coordinate-systems.md) units, which is what a non-geospatial view (`COORDINATE_SYSTEM.CARTESIAN`) wants - meters are converted with a fixed Web Mercator ratio and are not meaningful there.
++ `'pixels'` keeps the pattern at a constant size on screen instead. The size is re-anchored at each integer zoom level rather than followed continuously, so that the tiling stays put while zooming within a level; the pattern therefore stays within a factor of `sqrt(2)` of its nominal pixel size.
+
+```js
+new GeoJsonLayer({
+  // ...
+  // A 24 x 24 pattern drawn at 24 x 24 screen pixels, at any zoom
+  fillPatternSizeUnits: 'pixels',
+  getFillPatternScale: 1,
+  extensions: [new FillStyleExtension({pattern: true})]
+});
+```
+
 #### `getFillPattern` ([Accessor&lt;string&gt;](../../developer-guide/using-layers.md#accessors)) {#getfillpattern}
 
 Called to retrieve the name of the pattern. Returns a string key from the `fillPatternMapping` object.
@@ -127,7 +147,7 @@ Called to retrieve the name of the pattern. Returns a string key from the `fillP
 
 - Default: `1`
 
-The scale of the pattern, relative to the original size. If the pattern is 24 x 24 pixels, scale `1` roughly yields 24 meters.
+The scale of the pattern, relative to the original size. If the pattern is 24 x 24 pixels, scale `1` roughly yields 24 meters, or 24 of whichever unit [`fillPatternSizeUnits`](#fillpatternsizeunits) selects.
 
 - If a number is provided, it is used as the pattern scale for all objects.
 - If a function is provided, it is called on each object to retrieve its pattern scale.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -71,6 +71,7 @@ new GlobeView({
 ### @deck.gl/extensions
 
 - [`FillStyleExtension`](./api-reference/extensions/fill-style-extension.md) adds a `getFillPatternBackgroundColor` accessor.
+- [`FillStyleExtension`](./api-reference/extensions/fill-style-extension.md) adds a `fillPatternSizeUnits` prop, which can hold the pattern at a constant size on screen instead of scaling it with the map.
 
 ### @deck.gl/arcgis
 

--- a/examples/layer-browser/src/examples/core-layers.js
+++ b/examples/layer-browser/src/examples/core-layers.js
@@ -200,6 +200,11 @@ const PolygonLayerBinaryExample = {
       // Convert each polygon from an array of points to an array of numbers
       return flattenVertices(polygon, {dimensions: 2});
     }),
+  propTypes: {
+    ...PolygonLayerExample.propTypes,
+    fillPatternSizeUnits: {type: 'category', value: ['meters', 'pixels']},
+    getFillPatternScale: {type: 'number', max: 3}
+  },
   props: {
     ...PolygonLayerExample.props,
     getPolygon: d => d,
@@ -210,7 +215,8 @@ const PolygonLayerBinaryExample = {
     getFillPattern: f =>
       ['hatch-1x', 'hatch-2x', 'hatch-cross', 'dots'][Math.floor(Math.random() * 4)],
     getFillPatternOffset: [0, 0],
-    getFillPatternScale: 5,
+    getFillPatternScale: 3,
+    fillPatternSizeUnits: 'meters',
     getFillPatternBackgroundColor: [220, 220, 220, 200],
     extensions: [new FillStyleExtension({pattern: true})]
   }

--- a/modules/extensions/src/fill-style/fill-style-extension.ts
+++ b/modules/extensions/src/fill-style/fill-style-extension.ts
@@ -14,6 +14,7 @@ import type {
   Accessor,
   AccessorFunction,
   TextureSource,
+  Unit,
   UpdateParameters
 } from '@deck.gl/core';
 import type {Texture} from '@luma.gl/core';
@@ -35,6 +36,7 @@ const defaultProps: DefaultProps<FillStyleExtensionProps> = {
   },
   fillPatternMapping: {type: 'object', value: {}, async: true},
   fillPatternMask: true,
+  fillPatternSizeUnits: 'meters',
   getFillPattern: {type: 'accessor', value: d => d.pattern},
   getFillPatternScale: {type: 'accessor', value: 1},
   getFillPatternOffset: {type: 'accessor', value: [0, 0]},
@@ -69,6 +71,16 @@ export type FillStyleExtensionProps<DataT = any> = {
    * @default true
    */
   fillPatternMask?: boolean;
+  /**
+   * The units of the pattern size, one of `'meters'`, `'common'` and `'pixels'`. A 24 x 24 pixel
+   * pattern at scale `1` covers 24 units of the chosen unit.
+   *
+   * With `'meters'` (the default) the pattern is anchored to the ground and zooms with the map.
+   * With `'pixels'` it keeps a constant size on screen instead, re-anchored at each integer zoom
+   * level so that the tiling is stable while zooming within a level.
+   * @default 'meters'
+   */
+  fillPatternSizeUnits?: Unit;
   /** Accessor for the name of the pattern. */
   getFillPattern?: AccessorFunction<DataT, string>;
   /** Accessor for the scale of the pattern, relative to the original size. If the pattern is 24 x 24 pixels, scale `1` roughly yields 24 meters.
@@ -189,11 +201,13 @@ export default class FillStyleExtension extends LayerExtension<FillStyleExtensio
       return;
     }
 
-    const {fillPatternAtlas, fillPatternEnabled, fillPatternMask} = this.props;
+    const {fillPatternAtlas, fillPatternEnabled, fillPatternMask, fillPatternSizeUnits} =
+      this.props;
     const fillProps: FillStyleModuleProps = {
       project: params.shaderModuleProps.project,
       fillPatternEnabled,
       fillPatternMask,
+      fillPatternSizeUnits,
       fillPatternTexture: (fillPatternAtlas || this.state.emptyTexture) as Texture,
       fillPatternCommonFrame: this.state.commonFrame as [number, number] | null
     };

--- a/modules/extensions/src/fill-style/shader-module.ts
+++ b/modules/extensions/src/fill-style/shader-module.ts
@@ -4,16 +4,33 @@
 
 import type {ShaderModule} from '@luma.gl/shadertools';
 import {project, fp64LowPart} from '@deck.gl/core';
-import type {ProjectProps, ProjectUniforms} from '@deck.gl/core';
+import type {ProjectProps, ProjectUniforms, Unit, Viewport} from '@deck.gl/core';
 
 import type {Texture} from '@luma.gl/core';
 
 // Common-space size of one atlas texel: the equator measures 40,000km and spans 512 common units
 const FILL_UV_SCALE = 512 / 40000000;
 
+/** Common-space size of one atlas texel, i.e. what turns the pixel size of a frame into the size
+ * of one tile in common space. */
+function getPatternUnitScale(sizeUnits: Unit, viewport: Viewport): number {
+  switch (sizeUnits) {
+    case 'pixels':
+      // Following the zoom exactly would rescale the pattern on every fractional zoom change,
+      // which never lets the tiling settle. The pattern is re-anchored once per zoom level
+      // instead, and within a level stays within a factor of sqrt(2) of its nominal size.
+      return 2 ** -Math.round(viewport.zoom);
+    case 'common':
+      return 1;
+    default:
+      return FILL_UV_SCALE;
+  }
+}
+
 const uniformBlock = /* glsl */ `\
 layout(std140) uniform fillUniforms {
   vec2 patternTextureSize;
+  float patternUnitScale;
   bool patternEnabled;
   bool patternMask;
   vec2 uvCoordinateOrigin;
@@ -33,8 +50,6 @@ in vec4 fillPatternBackgroundColors;
 out vec2 fill_uv;
 out vec4 fill_patternBounds;
 out vec4 fill_backgroundColor;
-
-const float FILL_UV_SCALE = ${FILL_UV_SCALE};
 `;
 
 const vs = `
@@ -69,7 +84,7 @@ const inject = {
     if (fill.patternEnabled) {
       fill_patternBounds = fillPatternFrames / vec4(fill.patternTextureSize, fill.patternTextureSize);
 
-      vec2 patternFrameCommon = FILL_UV_SCALE * fillPatternScales * fillPatternFrames.zw;
+      vec2 patternFrameCommon = fill.patternUnitScale * fillPatternScales * fillPatternFrames.zw;
       // Reduce the coordinate origin to within one tile before adding the vertex position. The
       // origin is large in common space, and fp32 cannot carry the sum at full precision.
       vec2 origin = mod(fill.uvCoordinateOrigin, patternFrameCommon) + fill.uvCoordinateOrigin64Low;
@@ -105,11 +120,13 @@ export type FillStyleModuleProps = {
   fillPatternEnabled?: boolean;
   fillPatternMask?: boolean;
   fillPatternTexture: Texture;
+  fillPatternSizeUnits?: Unit;
   fillPatternCommonFrame?: [number, number] | null;
 };
 
 type FillStyleModuleUniforms = {
   patternTextureSize?: [number, number];
+  patternUnitScale?: number;
   patternEnabled?: boolean;
   patternMask?: boolean;
   uvCoordinateOrigin?: [number, number];
@@ -134,20 +151,27 @@ function getPatternUniforms(
     uniforms.patternTextureSize = [fillPatternTexture.width, fillPatternTexture.height];
   }
   if ('project' in opts) {
-    const {fillPatternMask = true, fillPatternEnabled = true, fillPatternCommonFrame = null} = opts;
+    const {
+      fillPatternMask = true,
+      fillPatternEnabled = true,
+      fillPatternSizeUnits = 'meters',
+      fillPatternCommonFrame = null
+    } = opts;
     const projectUniforms = project.getUniforms(opts.project) as ProjectUniforms;
     const {commonOrigin: coordinateOriginCommon} = projectUniforms;
+    const unitScale = getPatternUnitScale(fillPatternSizeUnits, opts.project.viewport);
 
     // Improve the precision of the uv mapping by removing an integer multiple of the
     // pattern frames. This results in the same result, without wobbling at high zooms
     const origin: [number, number] = [coordinateOriginCommon[0], coordinateOriginCommon[1]];
     if (fillPatternCommonFrame) {
-      origin[0] %= FILL_UV_SCALE * fillPatternCommonFrame[0];
-      origin[1] %= FILL_UV_SCALE * fillPatternCommonFrame[1];
+      origin[0] %= unitScale * fillPatternCommonFrame[0];
+      origin[1] %= unitScale * fillPatternCommonFrame[1];
     }
 
     uniforms.uvCoordinateOrigin = origin;
     uniforms.uvCoordinateOrigin64Low = [fp64LowPart(origin[0]), fp64LowPart(origin[1])];
+    uniforms.patternUnitScale = unitScale;
     uniforms.patternMask = fillPatternMask;
     uniforms.patternEnabled = fillPatternEnabled;
   }
@@ -163,6 +187,7 @@ export const patternShaders = {
   getUniforms: getPatternUniforms,
   uniformTypes: {
     patternTextureSize: 'vec2<f32>',
+    patternUnitScale: 'f32',
     patternEnabled: 'i32',
     patternMask: 'i32',
     uvCoordinateOrigin: 'vec2<f32>',

--- a/test/modules/extensions/fill-style.spec.ts
+++ b/test/modules/extensions/fill-style.spec.ts
@@ -183,3 +183,70 @@ webglTest('FillStyleExtension#originPrecision', () => {
 
   testLayer({Layer: PolygonLayer, testCases, onError: err => expect(err).toBeFalsy()});
 });
+
+webglTest('FillStyleExtension#fillPatternSizeUnits', () => {
+  const viewport = new MapView({}).makeViewport({
+    width: 100,
+    height: 100,
+    viewState: {longitude: 12.3, latitude: 45.6, zoom: 14.4}
+  }) as Viewport;
+
+  const METERS_PER_COMMON_UNIT = 512 / 40000000;
+
+  const testCases = [
+    {
+      props: {
+        id: 'fill-style-size-units-test',
+        data: FIXTURES.polygons,
+        getPolygon: d => d,
+
+        fillPatternAtlas: FILL_PATTERN_ATLAS,
+        fillPatternMapping: FILL_PATTERN_MAPPING,
+        getFillPattern: () => 'pattern',
+        getFillPatternScale: 2,
+
+        extensions: [new FillStyleExtension({pattern: true})]
+      },
+      viewport,
+      onAfterUpdate: ({subLayers}) => {
+        const fillLayer = subLayers.find(l => l.id.includes('fill'));
+        expect(
+          getLayerUniforms(fillLayer).patternUnitScale,
+          'defaults to sizing the pattern in meters'
+        ).toBeCloseTo(METERS_PER_COMMON_UNIT, 12);
+      }
+    },
+    {
+      title: 'fillPatternSizeUnits: pixels',
+      updateProps: {
+        fillPatternSizeUnits: 'pixels'
+      },
+      viewport,
+      onAfterUpdate: ({subLayers}) => {
+        const fillLayer = subLayers.find(l => l.id.includes('fill'));
+        const uniforms = getLayerUniforms(fillLayer);
+        expect(
+          uniforms.patternUnitScale,
+          'one texel spans one screen pixel at the rounded zoom level'
+        ).toBeCloseTo(2 ** -14, 12);
+        expect(
+          Math.abs(uniforms.uvCoordinateOrigin[0]),
+          'the origin is reduced by a period that follows the zoom'
+        ).toBeLessThan(2 * 1 * 2 ** -14);
+      }
+    },
+    {
+      title: 'fillPatternSizeUnits: common',
+      updateProps: {
+        fillPatternSizeUnits: 'common'
+      },
+      viewport,
+      onAfterUpdate: ({subLayers}) => {
+        const fillLayer = subLayers.find(l => l.id.includes('fill'));
+        expect(getLayerUniforms(fillLayer).patternUnitScale, 'one texel spans one unit').toBe(1);
+      }
+    }
+  ];
+
+  testLayer({Layer: PolygonLayer, testCases, onError: err => expect(err).toBeFalsy()});
+});


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- Reference the issue that this closes -->
<!-- If it only partially resolves it, change this to "For #" -->
Closes #7600

<!-- For other PRs without open issue -->
#### Background

Adds capability to set `fillPatternSizeUnits` to `pixels` to keep rendered pattern at constant size relative to screen pixels. Size is snapped to the nearest zoom level to avoid drift


https://github.com/user-attachments/assets/17c746f2-3763-41a4-a4b6-b2bb3aeb1c48

Builds on top of https://github.com/visgl/deck.gl/pull/10633

<!-- For all the PRs -->
#### Change List
- Add `fillPatternSizeUnits` and hook up to shader to implement `'pixels'` option
- Update layer browser for demo
- Test & doc
