### PR TITLE
fix: export MapLibre integration and update peer ranges

### DIFF
--- a/docs/api-reference/maplibre/overview.md
+++ b/docs/api-reference/maplibre/overview.md
@@ -12,6 +12,13 @@ The module supports both [overlaid and interleaved](../../get-started/using-with
 npm install @deck.gl/maplibre maplibre-gl
 ```
 
+Applications that already depend on the `deck.gl` umbrella package do not need to install the
+MapLibre module separately:
+
+```ts
+import {MapLibreOverlay, type MapLibreOverlayProps} from 'deck.gl';
+```
+
 `MapLibreOverlay` is also available as `deck.MapLibreOverlay` in the standalone `deck.gl` bundle.
 
 Bundled applications must configure the MapLibre worker. The example below uses Vite. See the [MapLibre installation guide](https://maplibre.org/maplibre-gl-js/docs/#installation) for other bundlers. Direct browser ES module imports configure the worker automatically.

--- a/docs/api-reference/maplibre/overview.md
+++ b/docs/api-reference/maplibre/overview.md
@@ -12,15 +12,6 @@ The module supports both [overlaid and interleaved](../../get-started/using-with
 npm install @deck.gl/maplibre maplibre-gl
 ```
 
-Applications that already depend on the `deck.gl` umbrella package do not need to install the
-MapLibre module separately:
-
-```ts
-import {MapLibreOverlay, type MapLibreOverlayProps} from 'deck.gl';
-```
-
-`MapLibreOverlay` is also available as `deck.MapLibreOverlay` in the standalone `deck.gl` bundle.
-
 Bundled applications must configure the MapLibre worker. The example below uses Vite. See the [MapLibre installation guide](https://maplibre.org/maplibre-gl-js/docs/#installation) for other bundlers. Direct browser ES module imports configure the worker automatically.
 
 ## Example

--- a/modules/aggregation-layers/package.json
+++ b/modules/aggregation-layers/package.json
@@ -53,8 +53,8 @@
     "d3-hexbin": "^0.2.1"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
-    "@deck.gl/layers": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
+    "@deck.gl/layers": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4"
   },

--- a/modules/arcgis/package.json
+++ b/modules/arcgis/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@arcgis/core": "^4.0.0",
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4",
     "@luma.gl/webgl": "~9.4.0-beta.4"

--- a/modules/carto/package.json
+++ b/modules/carto/package.json
@@ -71,11 +71,11 @@
     "quadbin": "^0.4.0"
   },
   "peerDependencies": {
-    "@deck.gl/aggregation-layers": "~9.3.0-beta.2",
-    "@deck.gl/core": "~9.3.0-beta.2",
-    "@deck.gl/extensions": "~9.3.0-beta.2",
-    "@deck.gl/geo-layers": "~9.3.0-beta.2",
-    "@deck.gl/layers": "~9.3.0-beta.2",
+    "@deck.gl/aggregation-layers": "~9.4.0-beta.3",
+    "@deck.gl/core": "~9.4.0-beta.3",
+    "@deck.gl/extensions": "~9.4.0-beta.3",
+    "@deck.gl/geo-layers": "~9.4.0-beta.3",
+    "@deck.gl/layers": "~9.4.0-beta.3",
     "@loaders.gl/core": "^4.4.3",
     "@luma.gl/core": "~9.4.0-beta.4"
   },

--- a/modules/extensions/package.json
+++ b/modules/extensions/package.json
@@ -47,7 +47,7 @@
     "@math.gl/core": "^4.1.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4"
   },

--- a/modules/geo-layers/package.json
+++ b/modules/geo-layers/package.json
@@ -66,10 +66,10 @@
     "long": "^3.2.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
-    "@deck.gl/extensions": "~9.3.0-beta.2",
-    "@deck.gl/layers": "~9.3.0-beta.2",
-    "@deck.gl/mesh-layers": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
+    "@deck.gl/extensions": "~9.4.0-beta.3",
+    "@deck.gl/layers": "~9.4.0-beta.3",
+    "@deck.gl/mesh-layers": "~9.4.0-beta.3",
     "@loaders.gl/core": "^4.4.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4"

--- a/modules/google-maps/package.json
+++ b/modules/google-maps/package.json
@@ -47,7 +47,7 @@
     "@types/google.maps": "^3.48.6"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/webgl": "~9.4.0-beta.4"
   },

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -45,7 +45,7 @@
     "jsep": "^0.3.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2"
+    "@deck.gl/core": "~9.4.0-beta.3"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"
 }

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -57,7 +57,7 @@
     "earcut": "^2.2.4"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@loaders.gl/core": "^4.4.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4"

--- a/modules/main/src/index.ts
+++ b/modules/main/src/index.ts
@@ -130,6 +130,13 @@ export {
 export {ScenegraphLayer, SimpleMeshLayer} from '@deck.gl/mesh-layers';
 
 //
+// MAPLIBRE INTEGRATION PACKAGE
+//
+
+export {MapLibreOverlay} from '@deck.gl/maplibre';
+export type {MapLibreOverlayProps} from '@deck.gl/maplibre';
+
+//
 // REACT BINDINGS PACKAGE
 //
 

--- a/modules/mapbox/package.json
+++ b/modules/mapbox/package.json
@@ -45,7 +45,7 @@
     "@math.gl/web-mercator": "^4.1.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@math.gl/web-mercator": "^4.1.0"
   },

--- a/modules/maplibre/package.json
+++ b/modules/maplibre/package.json
@@ -35,7 +35,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@deck.gl/core": "~9.4.0-alpha.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "maplibre-gl": "^4.5.1 || ^5.0.0 || ^6.0.0"
   },

--- a/modules/mesh-layers/package.json
+++ b/modules/mesh-layers/package.json
@@ -53,7 +53,7 @@
     "@luma.gl/shadertools": "^9.4.0-beta.4"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4",
     "@luma.gl/gltf": "~9.4.0-beta.4",

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -37,8 +37,8 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
-    "@deck.gl/widgets": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
+    "@deck.gl/widgets": "~9.4.0-beta.3",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -45,7 +45,7 @@
     "@luma.gl/webgl": "^9.4.0-beta.4"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4",
     "@luma.gl/engine": "~9.4.0-beta.4",
     "@probe.gl/test-utils": "^4.1.1",

--- a/modules/widgets/package.json
+++ b/modules/widgets/package.json
@@ -50,7 +50,7 @@
     "preact": "^10.17.0"
   },
   "peerDependencies": {
-    "@deck.gl/core": "~9.3.0-beta.2",
+    "@deck.gl/core": "~9.4.0-beta.3",
     "@luma.gl/core": "~9.4.0-beta.4"
   },
   "gitHead": "13ace64fc2cee08c133afc882fc307253489a4e4"

--- a/test/modules/imports.node.spec.ts
+++ b/test/modules/imports.node.spec.ts
@@ -7,7 +7,6 @@ import '@luma.gl/core';
 
 import DeckGL from 'deck.gl';
 import * as deck from 'deck.gl';
-import type {MapLibreOverlayProps} from 'deck.gl';
 
 import * as layers from '@deck.gl/layers';
 import * as aggregationLayers from '@deck.gl/aggregation-layers';
@@ -81,9 +80,6 @@ describe('Top-level imports', () => {
     expect(deck.ArcLayer, 'ArcLayer symbol imported').toBeTruthy();
     expect(deck.LineLayer, 'LineLayer symbol imported').toBeTruthy();
     expect(deck.MapLibreOverlay, 'MapLibreOverlay symbol imported').toBeTruthy();
-
-    const mapLibreOverlayProps: MapLibreOverlayProps = {layers: []};
-    expect(mapLibreOverlayProps.layers, 'MapLibreOverlayProps type imported').toEqual([]);
 
     expect(deck.COORDINATE_SYSTEM.LNGLAT, 'COORDINATE_SYSTEM.LNGLAT imported').toBe('lnglat');
     expect(deck.COORDINATE_SYSTEM.METER_OFFSETS, 'COORDINATE_SYSTEM.METERS imported').toBe(

--- a/test/modules/imports.node.spec.ts
+++ b/test/modules/imports.node.spec.ts
@@ -7,6 +7,7 @@ import '@luma.gl/core';
 
 import DeckGL from 'deck.gl';
 import * as deck from 'deck.gl';
+import type {MapLibreOverlayProps} from 'deck.gl';
 
 import * as layers from '@deck.gl/layers';
 import * as aggregationLayers from '@deck.gl/aggregation-layers';
@@ -79,6 +80,10 @@ describe('Top-level imports', () => {
     expect(deck.ScreenGridLayer, 'ScreenGridLayer symbol imported').toBeTruthy();
     expect(deck.ArcLayer, 'ArcLayer symbol imported').toBeTruthy();
     expect(deck.LineLayer, 'LineLayer symbol imported').toBeTruthy();
+    expect(deck.MapLibreOverlay, 'MapLibreOverlay symbol imported').toBeTruthy();
+
+    const mapLibreOverlayProps: MapLibreOverlayProps = {layers: []};
+    expect(mapLibreOverlayProps.layers, 'MapLibreOverlayProps type imported').toEqual([]);
 
     expect(deck.COORDINATE_SYSTEM.LNGLAT, 'COORDINATE_SYSTEM.LNGLAT imported').toBe('lnglat');
     expect(deck.COORDINATE_SYSTEM.METER_OFFSETS, 'COORDINATE_SYSTEM.METERS imported').toBe(
@@ -125,5 +130,9 @@ test('deck.gl re-exports', () => {
   expect(
     findMissingExports(meshLayers, deck),
     'deck.gl re-exports everything from @deck.gl/mesh-layers'
+  ).toBeFalsy();
+  expect(
+    findMissingExports(maplibre, deck),
+    'deck.gl re-exports everything from @deck.gl/maplibre'
   ).toBeFalsy();
 });


### PR DESCRIPTION
## Goal

Correct the npm package inconsistencies exposed by the 9.4.0-beta.3 release.

## Changes

- Re-export MapLibreOverlay and MapLibreOverlayProps from the deck.gl package entrypoint, matching the existing standalone bundle export.
- Update all internal @deck.gl peer dependency ranges from the stale 9.3 beta or 9.4 alpha ranges to ~9.4.0-beta.3.
- Add package-entrypoint regression coverage for the MapLibre runtime and type exports.
- Document that applications using the deck.gl umbrella package do not need to install @deck.gl/maplibre separately.

## Validation

- yarn vitest run test/modules/imports.node.spec.ts
- yarn lint
- yarn build
- yarn test-website
- pre-commit checks: 3 files and 19 tests passed
- verified every internal @deck.gl peer range accepts 9.4.0-beta.3

The website build passes with the existing source-map, HTML minifier, and broken-anchor warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging, documentation, and peer-version alignment with no runtime logic changes.
> 
> **Overview**
> Fixes **9.4.0-beta.3** packaging gaps by re-exporting **`MapLibreOverlay`** and **`MapLibreOverlayProps`** from the **`deck.gl`** entrypoint (same surface as the standalone bundle) and aligning internal **`@deck.gl/*`** peer dependency ranges to **`~9.4.0-beta.3`** across satellite packages (replacing stale **9.3** beta and **9.4** alpha pins).
> 
> **Regression tests** assert **`deck.MapLibreOverlay`** is importable and that **`deck.gl`** re-exports the full **`@deck.gl/maplibre`** public API. MapLibre docs drop the note that **`MapLibreOverlay`** is exposed only via the standalone **`deck.gl`** bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dda357a86e0b6b56773b758125a6a812bf776ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->