### PR TITLE
feat(core): add map and ball globe navigation

### DIFF
--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -81,9 +81,11 @@ See [Event object documentation](https://visgl.github.io/mjolnir.js/docs/api-ref
 
 Called by the view when the view state updates. This method handles adding/removing event listeners based on user options.
 
-#### `updateViewport(newMapState, extraProps, interactionState)` {#updateviewport}
+#### `updateViewport(newMapState, extraProps, interactionState, [oldViewState])` {#updateviewport}
 
 Called by the event handlers, this method updates internal state, and invokes `onViewStateChange` callback with a new map state.
+
+Pass `oldViewState` to preserve the previous view state when a controller configuration change resets its internal state. If omitted, the callback uses the current controller state's viewport props.
 
 #### `getCenter(event)` {#getcenter}
 

--- a/docs/api-reference/core/controller.md
+++ b/docs/api-reference/core/controller.md
@@ -34,6 +34,16 @@ The base Controller class supports the following options:
 
 > **Mobile users:** See [Optimization for Mobile](../../developer-guide/tips-and-tricks.md#optimization-for-mobile) for CSS and browser event guards that help prevent native selection, tap highlight, and touch callout UI during repeated touch gestures.
 
+### `navigation` (string) {#navigation}
+
+Navigation behavior for [GlobeController](./globe-controller.md#navigation). Default `'map'`.
+
+- `'map'`: preserve bearing during panning, zooming, and inertia. With `bearing: 0`, north stays up.
+- `'ball'`: rotate the camera frame freely, allowing bearing to evolve through the poles.
+
+This option is only used by `GlobeController`. It does not change input bindings such as `dragMode`,
+disable explicit rotation gestures, or choose the zoom anchor (`zoomAround`).
+
 ## Methods
 
 > A controller is not meant to be instantiated by the application. The following methods are documented for creating custom controllers that extend the base Controller class.

--- a/docs/api-reference/core/globe-controller.md
+++ b/docs/api-reference/core/globe-controller.md
@@ -41,10 +41,32 @@ Supports all [Controller options](./controller.md#options) with the following de
 - `dragRotate`: shift+drag or right-click drag to change bearing and pitch
 - `multiTouchDrag`: two-pointer translation can pan or change bearing and pitch
 - `keyboard`: arrow keys to pan, +/- to zoom
-- `zoomAround`: default `'pointer'`. Pointer zoom rotates the full camera frame around the sphere, so bearing may change as zoom steers around a pole. Use `'center'` to change scale without steering.
+- `navigation`: default `'map'`. Preserve bearing while navigating, or use `'ball'` for free rotation through the poles.
+- `zoomAround`: default `'pointer'`. Keep the zoom anchored near the pointer, subject to the navigation mode and bounds. Use `'center'` to change scale without steering.
 - `inertia`: when set to a number (milliseconds), the globe continues spinning after a fling gesture with exponential decay
 - `maxBounds` - constrains the viewport to the specified bounding box `[[minLng, minLat], [maxLng, maxLat]]`
 - `maxBoundsPadding` - padding inside the viewport when fitting `maxBounds`, using the same `{left, right, top, bottom}` format as view padding. Numeric values are pixels; strings may be percentages or layout expressions such as `calc(10% - 4px)`. Each side is measured from the projected globe center. Default `0`.
+
+### `navigation` (string) {#navigation}
+
+Select how the globe moves independently of the input gesture bindings:
+
+- `'map'` (default): dragging, keyboard panning, pointer-anchored zoom, and pan inertia preserve the current bearing. North stays up when `bearing` is `0`. Latitude is constrained to approximately `±85.051°` to prevent crossing the poles. Explicit rotation gestures, such as shift+drag or right-click drag, can still change bearing and pitch.
+- `'ball'`: dragging and pointer-anchored zoom rotate the full camera frame. Bearing evolves naturally through the poles, even when it starts at `0`. Pan inertia continues rotating around a fixed sphere axis.
+
+```js
+new GlobeView({
+  controller: {
+    navigation: 'ball', // 'map' | 'ball'
+    zoomAround: 'pointer',
+    inertia: true
+  }
+});
+```
+
+`navigation` does not switch automatically based on bearing or zoom. Changing it cancels the previous
+gesture's anchors and inertia. `dragMode` still selects the primary drag gesture; `zoomAround: 'center'`
+zooms without steering in either navigation mode. `maxBounds` can impose additional geographic limits.
 
 ## Custom GlobeController
 

--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -77,7 +77,11 @@ To render, `GlobeView` needs to be used together with a `viewState` with the fol
 - `maxPitch` (number, optional) - max pitch angle. Default `60`.
 - `minPitch` (number, optional) - min pitch angle. Default `0`.
 
-The globe behaves like a physical ball. Dragging and pointer-anchored zoom rotate the full camera frame, so an initial `bearing` of `0` does not lock north up: `bearing` evolves naturally as the camera crosses a pole. This avoids orientation discontinuities and keeps interaction consistent across latitudes. Use `zoomAround: 'center'` to zoom without steering the camera frame.
+By default, navigation preserves the current bearing, so north stays up when `bearing` is `0`.
+Set `controller: {navigation: 'ball'}` to rotate the globe like a physical ball: dragging and
+pointer-anchored zoom rotate the full camera frame, allowing bearing to evolve naturally through
+the poles. Use `zoomAround: 'center'` to zoom without steering in either mode. See
+[GlobeController navigation](./globe-controller.md#navigation) for the interaction and latitude limits.
 
 To limit how far the camera can travel, set the shared controller [`maxBounds`](./controller.md#options) option. For example, `maxBounds: [[-180, -85], [180, 85]]` keeps the viewport center between `±85°` latitude.
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,6 +2,13 @@
 
 ## Upgrading to v9.4
 
+### Globe navigation
+
+`GlobeController` defaults to `navigation: 'map'`, preserving the current bearing during panning and
+zooming and limiting latitude to approximately `±85.051°`. If you relied on the free-rotation behavior
+introduced during the v9.4 prereleases, set `controller: {navigation: 'ball'}` to retain pole crossing
+and evolving bearing. Explicit rotation gestures remain available in both modes.
+
 ### pydeck lighting
 
 The obsolete `pydeck.LightSettings` binding has been removed. It serialized the

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -35,7 +35,7 @@ deck.gl v9.4 brings additional view and controller improvements on top of the su
 - [TerrainLayer](./api-reference/geo-layers/terrain-layer.md) now renders correctly on `GlobeView`, producing properly projected terrain meshes on the globe.
 - [TerrainExtension](./api-reference/extensions/terrain-extension.md) now supports `GlobeView`, enabling terrain-draped layers on the globe.
 - [Tile3DLayer](./api-reference/geo-layers/tile-3d-layer.md) renders correctly on `GlobeView`.
-- Pointer-anchored zoom now rotates the camera frame like a physical ball, keeping steering smooth and consistent around the poles while allowing bearing to evolve naturally.
+- [`GlobeController.navigation`](./api-reference/core/globe-controller.md#navigation) selects `'map'` (the default, preserving bearing) or `'ball'` (free rotation through the poles). Drag, pointer-anchored zoom, keyboard movement, and inertia follow the selected navigation mode.
 
 #### Views
 

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -89,6 +89,12 @@ export type ControllerOptions = {
       };
   /** Drag behavior without pressing function keys, one of `pan` and `rotate`. */
   dragMode?: 'pan' | 'rotate';
+  /**
+   * Globe navigation behavior. `'map'` preserves bearing while panning and zooming;
+   * `'ball'` rotates the camera frame freely through the poles. Default `'map'`.
+   * Only used by GlobeController. Explicit rotation gestures are unchanged.
+   */
+  navigation?: 'map' | 'ball';
   /** Screen position that remains fixed while zooming. Default `'pointer'`. */
   zoomAround?: 'center' | 'pointer';
   /** Enable inertia after panning/pinching. If a number is provided, indicates the duration of time over which the velocity reduces to zero, in milliseconds. Default `false`. */
@@ -458,6 +464,26 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
 
   updateTransition() {
     this.transitionManager.updateTransition();
+  }
+
+  /** Cancel active gestures and inertia before changing navigation behavior. */
+  protected _cancelInteraction(): void {
+    this.state = {};
+    this._controllerState = undefined;
+    this._panMove = false;
+    this._multiPanMode = null;
+    this._doubleClickDragAnchor = null;
+    if (this._eventStartBlocked) {
+      clearTimeout(this._eventStartBlocked);
+      this._eventStartBlocked = null;
+    }
+    this.transitionManager.finalize();
+    this._setInteractionState({
+      isDragging: false,
+      isPanning: false,
+      isRotating: false,
+      isZooming: false
+    });
   }
 
   toggleEvents(eventNames, enabled) {

--- a/modules/core/src/controllers/controller.ts
+++ b/modules/core/src/controllers/controller.ts
@@ -505,12 +505,15 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
 
   // Private Methods
 
-  /* Callback util */
-  // formats map state and invokes callback function
+  /**
+   * Format viewport state and invoke the change callback.
+   * @param oldViewState - Optional snapshot from before a controller configuration change.
+   */
   protected updateViewport(
     newControllerState: ControllerState,
     extraProps: Record<string, any> | null = null,
-    interactionState: InteractionState = {}
+    interactionState: InteractionState = {},
+    oldViewState?: Record<string, any>
   ) {
     const viewState = {...newControllerState.getViewportProps(), ...extraProps};
 
@@ -523,12 +526,11 @@ export default abstract class Controller<ControllerState extends IViewState<Cont
     this._setInteractionState(interactionState);
 
     if (changed) {
-      const oldViewState = this.controllerState && this.controllerState.getViewportProps();
       if (this.onViewStateChange) {
         this.onViewStateChange({
           viewState,
           interactionState: this._interactionState,
-          oldViewState,
+          oldViewState: oldViewState ?? this.controllerState.getViewportProps(),
           viewId: this.props.id
         });
       }

--- a/modules/core/src/controllers/globe-controller.ts
+++ b/modules/core/src/controllers/globe-controller.ts
@@ -3,7 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {clamp} from '@math.gl/core';
-import Controller from './controller';
+import {MAX_LATITUDE} from '@math.gl/web-mercator';
+import Controller, {type ControllerProps} from './controller';
 import {getMaxBoundsExtents, getMaxBoundsRect} from './utils';
 
 import {MapState, MapStateProps} from './map-controller';
@@ -87,11 +88,31 @@ class GlobeState extends MapState {
       return this;
     }
 
-    const dx = startPanPos[0] - pos[0];
-    const dy = startPanPos[1] - pos[1];
+    const deltaX = startPanPos[0] - pos[0];
+    const deltaY = startPanPos[1] - pos[1];
 
-    const hAngle = dx * rate;
-    const vAngle = -dy * rate;
+    if (this.getViewportProps().navigation === 'map') {
+      const bearing = frame.bearing * DEGREES_TO_RADIANS;
+      // Resolve screen movement into east/north without rotating the camera up vector.
+      const longitudeDelta =
+        ((deltaX * Math.cos(bearing) - deltaY * Math.sin(bearing)) * rate) /
+        Math.max(Math.cos(frame.latitude * DEGREES_TO_RADIANS), 0.25);
+      const latitudeDelta = -(deltaX * Math.sin(bearing) + deltaY * Math.cos(bearing)) * rate;
+      const latitude = clamp(
+        frame.latitude + latitudeDelta * RADIANS_TO_DEGREES,
+        -MAX_LATITUDE,
+        MAX_LATITUDE
+      );
+      return this._getUpdatedState({
+        longitude: frame.longitude + longitudeDelta * RADIANS_TO_DEGREES,
+        latitude,
+        bearing: frame.bearing,
+        zoom: startZoom + zoomAdjust(latitude, true) - zoomAdjust(frame.latitude, true)
+      }) as GlobeState;
+    }
+
+    const hAngle = deltaX * rate;
+    const vAngle = -deltaY * rate;
     const rotated = Globe.rotateFrame(frame, hAngle, vAngle);
     const zoom = startZoom + zoomAdjust(rotated.latitude, true) - zoomAdjust(frame.latitude, true);
 
@@ -129,20 +150,51 @@ class GlobeState extends MapState {
     props.zoom = this._constrainZoom(props.zoom, props);
 
     if (constraintAround) {
-      const viewport = this.makeViewport(props) as GlobeViewport;
-      const anchorStrength = viewport.getZoomAnchorStrength(constraintAround.screenPosition);
-      if (anchorStrength > 0) {
-        const currentCoordinates = viewport.unproject(constraintAround.screenPosition);
-        const cameraFrame = Globe.cameraFrame(props.longitude, props.latitude, props.bearing || 0);
-        const rotatedFrame = Globe.rotateFrameToMatch(
-          cameraFrame,
-          [currentCoordinates[0], currentCoordinates[1]],
-          [constraintAround.position[0], constraintAround.position[1]],
-          anchorStrength
+      const viewport = this.makeViewport(props);
+      const currentCoordinates = viewport.unproject(constraintAround.screenPosition);
+      const longitudeDelta =
+        mod(constraintAround.position[0] - currentCoordinates[0] + 180, 360) - 180;
+      // Map anchors can pass behind a pole as the globe shrinks, at any bearing.
+      const crossesMapPole =
+        props.navigation === 'map' &&
+        viewport instanceof GlobeViewport &&
+        (Math.abs(currentCoordinates[1]) > MAX_LATITUDE || Math.abs(longitudeDelta) > 90);
+      if (!crossesMapPole && (props.navigation === 'map' || !(viewport instanceof GlobeViewport))) {
+        const nextProps = viewport.panByPosition(
+          constraintAround.position,
+          constraintAround.screenPosition
         );
-        props.longitude = rotatedFrame.longitude;
-        props.latitude = rotatedFrame.latitude;
-        props.bearing = rotatedFrame.bearing;
+        if (props.navigation === 'map' && nextProps.latitude !== undefined) {
+          const latitudeDelta = nextProps.latitude - props.latitude;
+          const latitude = clamp(nextProps.latitude, -MAX_LATITUDE, MAX_LATITUDE);
+          // Release both axes together when a fixed-bearing anchor reaches a pole.
+          if (latitudeDelta && nextProps.longitude !== undefined) {
+            nextProps.longitude =
+              props.longitude +
+              ((nextProps.longitude - props.longitude) * (latitude - props.latitude)) /
+                latitudeDelta;
+          }
+          nextProps.latitude = latitude;
+        }
+        Object.assign(props, nextProps);
+      } else if (props.navigation === 'ball' && viewport instanceof GlobeViewport) {
+        const anchorStrength = viewport.getZoomAnchorStrength(constraintAround.screenPosition);
+        if (anchorStrength > 0) {
+          const cameraFrame = Globe.cameraFrame(
+            props.longitude,
+            props.latitude,
+            props.bearing || 0
+          );
+          const rotatedFrame = Globe.rotateFrameToMatch(
+            cameraFrame,
+            [currentCoordinates[0], currentCoordinates[1]],
+            [constraintAround.position[0], constraintAround.position[1]],
+            anchorStrength
+          );
+          props.longitude = rotatedFrame.longitude;
+          props.latitude = rotatedFrame.latitude;
+          props.bearing = rotatedFrame.bearing;
+        }
       }
     }
 
@@ -152,7 +204,8 @@ class GlobeState extends MapState {
     if (props.bearing < -180 || props.bearing > 180) {
       props.bearing = mod(props.bearing + 180, 360) - 180;
     }
-    props.latitude = clamp(props.latitude, -90, 90);
+    const latitudeLimit = props.navigation === 'map' ? MAX_LATITUDE : 90;
+    props.latitude = clamp(props.latitude, -latitudeLimit, latitudeLimit);
     props.pitch = clamp(props.pitch, props.minPitch, props.maxPitch);
 
     const maxBoundsRect = maxBounds
@@ -223,7 +276,7 @@ class GlobeState extends MapState {
       }
     }
     // maxBounds may extend past the globe's coordinate range.
-    props.latitude = clamp(props.latitude, -90, 90);
+    props.latitude = clamp(props.latitude, -latitudeLimit, latitudeLimit);
     if (props.latitude !== latitude) {
       props.zoom += zoomAdjust(props.latitude, true) - zoomAdjust(latitude, true);
     }
@@ -282,6 +335,24 @@ export default class GlobeController extends Controller<MapState> {
   // Ring buffer tracking globe position during pan for inertia velocity
   private _panHistory: Array<{longitude: number; latitude: number; timestamp: number}> = [];
 
+  /** Update navigation policy without retaining gestures or inertia from the previous mode. */
+  setProps(props: ControllerProps & MapStateProps): void {
+    const navigation = props.navigation || 'map';
+    const navigationChanged = this.props && navigation !== (this.props.navigation || 'map');
+    if (navigationChanged) {
+      this._panHistory = [];
+      this._cancelInteraction();
+      props = {...props, transitionDuration: 0};
+    }
+    super.setProps(props);
+    if (navigationChanged) {
+      this.updateViewport(
+        new this.ControllerState({...props, makeViewport: this.makeViewport}),
+        null
+      );
+    }
+  }
+
   protected _onPanStart(event: MjolnirGestureEvent): boolean {
     this._panHistory = [];
     return super._onPanStart(event);
@@ -331,22 +402,36 @@ export default class GlobeController extends Controller<MapState> {
 
         if (angularVelocity > 1e-6) {
           const totalAngle = (angularVelocity * inertia) / 2;
-          // Spin around one fixed axis so position and up stay in the same
-          // rigid camera frame through poles and across the antimeridian.
-          const axis = Globe.greatCircleAxis(first, last);
-          const currentFrame = Globe.cameraFrame(
-            viewportProps.longitude,
-            viewportProps.latitude,
-            viewportProps.bearing || 0
-          );
-          const endFrame = Globe.rotateFrame(
-            {...currentFrame, axisHorizontal: axis},
-            totalAngle,
-            0
-          );
-          const endLng = endFrame.longitude;
-          const endLat = clamp(endFrame.latitude, -90, 90);
-          const interpolator = new GlobeInertiaInterpolator({axis, totalAngle});
+          let endLongitude: number;
+          let endLatitude: number;
+          let interpolator: GlobeInertiaInterpolator;
+          if (viewportProps.navigation === 'map') {
+            const longitudeDelta = mod(last.longitude - first.longitude + 180, 360) - 180;
+            endLongitude = viewportProps.longitude + (longitudeDelta * inertia) / (2 * dt);
+            endLatitude = clamp(
+              viewportProps.latitude + ((last.latitude - first.latitude) * inertia) / (2 * dt),
+              -MAX_LATITUDE,
+              MAX_LATITUDE
+            );
+            interpolator = new GlobeInertiaInterpolator({targetLongitude: endLongitude});
+          } else {
+            // Spin around one fixed axis so position and up stay in the same
+            // rigid camera frame through poles and across the antimeridian.
+            const axis = Globe.greatCircleAxis(first, last);
+            const currentFrame = Globe.cameraFrame(
+              viewportProps.longitude,
+              viewportProps.latitude,
+              viewportProps.bearing || 0
+            );
+            const endFrame = Globe.rotateFrame(
+              {...currentFrame, axisHorizontal: axis},
+              totalAngle,
+              0
+            );
+            endLongitude = endFrame.longitude;
+            endLatitude = clamp(endFrame.latitude, -90, 90);
+            interpolator = new GlobeInertiaInterpolator({axis, totalAngle});
+          }
 
           const newControllerState = this.controllerState.panEnd();
           this.updateViewport(
@@ -355,8 +440,8 @@ export default class GlobeController extends Controller<MapState> {
               transitionInterpolator: interpolator,
               transitionDuration: inertia,
               transitionEasing: GLOBE_INERTIA_EASING,
-              longitude: endLng,
-              latitude: endLat
+              longitude: endLongitude,
+              latitude: endLatitude
             },
             {
               isDragging: false,

--- a/modules/core/src/controllers/globe-controller.ts
+++ b/modules/core/src/controllers/globe-controller.ts
@@ -63,6 +63,11 @@ class GlobeState extends MapState {
   panStart({pos}: {pos: [number, number]}): GlobeState {
     const {latitude, longitude, zoom, bearing = 0} = this.getViewportProps();
     const cameraFrame = Globe.cameraFrame(longitude, latitude, bearing);
+    if (this.getViewportProps().navigation === 'map') {
+      // Use geographic axes for locked navigation, including deliberately rotated maps.
+      cameraFrame.axisHorizontal = [0, 0, 1];
+      cameraFrame.axisVertical = Globe.cameraFrame(longitude, latitude, 0).axisVertical;
+    }
 
     // Radians of arc per pixel, derived from zoom scale
     const scale = Math.pow(2, zoom - zoomAdjust(latitude, true));
@@ -90,30 +95,22 @@ class GlobeState extends MapState {
 
     const deltaX = startPanPos[0] - pos[0];
     const deltaY = startPanPos[1] - pos[1];
-
-    if (this.getViewportProps().navigation === 'map') {
+    const lockBearing = this.getViewportProps().navigation === 'map';
+    let horizontalAngle = deltaX * rate;
+    let verticalAngle = -deltaY * rate;
+    if (lockBearing) {
       const bearing = frame.bearing * DEGREES_TO_RADIANS;
-      // Resolve screen movement into east/north without rotating the camera up vector.
-      const longitudeDelta =
+      // Resolve screen movement into geographic angles; compensate for smaller latitude circles.
+      horizontalAngle =
         ((deltaX * Math.cos(bearing) - deltaY * Math.sin(bearing)) * rate) /
         Math.max(Math.cos(frame.latitude * DEGREES_TO_RADIANS), 0.25);
-      const latitudeDelta = -(deltaX * Math.sin(bearing) + deltaY * Math.cos(bearing)) * rate;
-      const latitude = clamp(
-        frame.latitude + latitudeDelta * RADIANS_TO_DEGREES,
-        -MAX_LATITUDE,
-        MAX_LATITUDE
+      verticalAngle = clamp(
+        -(deltaX * Math.sin(bearing) + deltaY * Math.cos(bearing)) * rate,
+        -(MAX_LATITUDE + frame.latitude) * DEGREES_TO_RADIANS,
+        (MAX_LATITUDE - frame.latitude) * DEGREES_TO_RADIANS
       );
-      return this._getUpdatedState({
-        longitude: frame.longitude + longitudeDelta * RADIANS_TO_DEGREES,
-        latitude,
-        bearing: frame.bearing,
-        zoom: startZoom + zoomAdjust(latitude, true) - zoomAdjust(frame.latitude, true)
-      }) as GlobeState;
     }
-
-    const hAngle = deltaX * rate;
-    const vAngle = -deltaY * rate;
-    const rotated = Globe.rotateFrame(frame, hAngle, vAngle);
+    const rotated = Globe.rotateFrame(frame, horizontalAngle, verticalAngle, lockBearing);
     const zoom = startZoom + zoomAdjust(rotated.latitude, true) - zoomAdjust(frame.latitude, true);
 
     return this._getUpdatedState({
@@ -151,35 +148,18 @@ class GlobeState extends MapState {
 
     if (constraintAround) {
       const viewport = this.makeViewport(props);
-      const currentCoordinates = viewport.unproject(constraintAround.screenPosition);
-      const longitudeDelta =
-        mod(constraintAround.position[0] - currentCoordinates[0] + 180, 360) - 180;
-      // Map anchors can pass behind a pole as the globe shrinks, at any bearing.
-      const crossesMapPole =
-        props.navigation === 'map' &&
-        viewport instanceof GlobeViewport &&
-        (Math.abs(currentCoordinates[1]) > MAX_LATITUDE || Math.abs(longitudeDelta) > 90);
-      if (!crossesMapPole && (props.navigation === 'map' || !(viewport instanceof GlobeViewport))) {
-        const nextProps = viewport.panByPosition(
-          constraintAround.position,
-          constraintAround.screenPosition
+      const {position, screenPosition} = constraintAround;
+      if (!(viewport instanceof GlobeViewport) || props.navigation === 'map') {
+        Object.assign(
+          props,
+          viewport instanceof GlobeViewport
+            ? viewport.panByPosition(position, screenPosition, undefined, true)
+            : viewport.panByPosition(position, screenPosition)
         );
-        if (props.navigation === 'map' && nextProps.latitude !== undefined) {
-          const latitudeDelta = nextProps.latitude - props.latitude;
-          const latitude = clamp(nextProps.latitude, -MAX_LATITUDE, MAX_LATITUDE);
-          // Release both axes together when a fixed-bearing anchor reaches a pole.
-          if (latitudeDelta && nextProps.longitude !== undefined) {
-            nextProps.longitude =
-              props.longitude +
-              ((nextProps.longitude - props.longitude) * (latitude - props.latitude)) /
-                latitudeDelta;
-          }
-          nextProps.latitude = latitude;
-        }
-        Object.assign(props, nextProps);
-      } else if (props.navigation === 'ball' && viewport instanceof GlobeViewport) {
-        const anchorStrength = viewport.getZoomAnchorStrength(constraintAround.screenPosition);
+      } else {
+        const anchorStrength = viewport.getZoomAnchorStrength(screenPosition);
         if (anchorStrength > 0) {
+          const currentCoordinates = viewport.unproject(screenPosition);
           const cameraFrame = Globe.cameraFrame(
             props.longitude,
             props.latitude,
@@ -188,7 +168,7 @@ class GlobeState extends MapState {
           const rotatedFrame = Globe.rotateFrameToMatch(
             cameraFrame,
             [currentCoordinates[0], currentCoordinates[1]],
-            [constraintAround.position[0], constraintAround.position[1]],
+            [position[0], position[1]],
             anchorStrength
           );
           props.longitude = rotatedFrame.longitude;
@@ -339,6 +319,13 @@ export default class GlobeController extends Controller<MapState> {
   setProps(props: ControllerProps & MapStateProps): void {
     const navigation = props.navigation || 'map';
     const navigationChanged = this.props && navigation !== (this.props.navigation || 'map');
+    // The event's cached controller state may precede the latest controlled view state.
+    const oldViewState = navigationChanged
+      ? new this.ControllerState({
+          ...(this.props as ControllerProps & MapStateProps),
+          makeViewport: this.makeViewport
+        }).getViewportProps()
+      : undefined;
     if (navigationChanged) {
       this._panHistory = [];
       this._cancelInteraction();
@@ -348,7 +335,9 @@ export default class GlobeController extends Controller<MapState> {
     if (navigationChanged) {
       this.updateViewport(
         new this.ControllerState({...props, makeViewport: this.makeViewport}),
-        null
+        null,
+        {},
+        oldViewState
       );
     }
   }

--- a/modules/core/src/controllers/map-controller.ts
+++ b/modules/core/src/controllers/map-controller.ts
@@ -78,6 +78,8 @@ export type MapStateProps = {
   maxBoundsPadding?: ControllerProps['maxBoundsPadding'];
   /** Enables elastic bounds and zoom constraints during interaction. Defaults to `false`. */
   rubberBand?: boolean;
+  /** Globe navigation policy, forwarded by GlobeController. Default `'map'`. */
+  navigation?: ControllerProps['navigation'];
 };
 
 export type MapStateInternal = {
@@ -165,7 +167,8 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
 
       /** Normalize viewport props to fit map height into viewport */
       normalize = true,
-      rubberBand = false
+      rubberBand = false,
+      navigation = 'map'
     } = options;
     const {[CONSTRAINT_AROUND]: constraintAround} = options as typeof options & ConstraintAround;
 
@@ -195,6 +198,7 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
         maxBounds,
         maxBoundsPadding,
         rubberBand,
+        navigation,
         ...{[CONSTRAINT_AROUND]: constraintAround}
       },
       {

--- a/modules/core/src/viewports/globe-utils.ts
+++ b/modules/core/src/viewports/globe-utils.ts
@@ -127,7 +127,8 @@ export class Globe {
   /**
    * Rotate a camera frame by horizontal/vertical angles (radians).
    * Returns a new frame with updated position, up, longitude, latitude,
-   * and bearing. If lockBearing is true, bearing is forced to 0.
+   * and bearing. If lockBearing is true, preserve the input bearing and rebuild
+   * the up vector at the new position to match it.
    */
   static rotateFrame(
     frame: CameraFrame,
@@ -137,11 +138,17 @@ export class Globe {
   ): CameraFrame {
     let position = Globe.rotate(frame.position, frame.axisHorizontal, horizontalAngle);
     position = Globe.rotate(position, frame.axisVertical, verticalAngle);
-    let up = Globe.rotate(frame.up, frame.axisHorizontal, horizontalAngle);
-    up = Globe.rotate(up, frame.axisVertical, verticalAngle);
-
     const [longitude, latitude] = Globe.toLngLat(position);
-    const b = lockBearing ? 0 : Globe.bearing(up, longitude, latitude);
+    let up: Vec3;
+    let bearing: number;
+    if (lockBearing) {
+      bearing = frame.bearing;
+      up = Globe.upVector(longitude, latitude, bearing);
+    } else {
+      up = Globe.rotate(frame.up, frame.axisHorizontal, horizontalAngle);
+      up = Globe.rotate(up, frame.axisVertical, verticalAngle);
+      bearing = Globe.bearing(up, longitude, latitude);
+    }
 
     return {
       ...frame, // preserve axes
@@ -149,7 +156,7 @@ export class Globe {
       up,
       longitude,
       latitude,
-      bearing: b
+      bearing
     };
   }
 

--- a/modules/core/src/viewports/globe-viewport.ts
+++ b/modules/core/src/viewports/globe-viewport.ts
@@ -365,12 +365,14 @@ export default class GlobeViewport extends Viewport {
    * @param coordinates - Geographic anchor, or the starting longitude, latitude and zoom.
    * @param screenPosition - Current screen position.
    * @param dragStartPosition - Screen position where a drag started.
+   * @param lockBearing - Apply fixed-bearing zoom anchor limits. Defaults to whether the viewport is north-up.
    * @returns Updated viewport options.
    */
   panByPosition(
     coordinates: number[],
     screenPosition: number[],
-    dragStartPosition?: number[]
+    dragStartPosition?: number[],
+    lockBearing: boolean = isGlobeNorthUp(this.bearing)
   ): GlobeViewportOptions {
     if (!dragStartPosition) {
       let anchorStrength = this.getZoomAnchorStrength(screenPosition);
@@ -383,14 +385,14 @@ export default class GlobeViewport extends Viewport {
       const latitudeDelta = coordinates[1] - currentCoordinates[1];
       const crossesPole =
         Math.abs(currentCoordinates[1]) > MAX_LATITUDE || Math.abs(longitudeDelta) > 90;
-      if (isGlobeNorthUp(this.bearing) && crossesPole) {
+      if (lockBearing && crossesPole) {
         // A zoom gesture keeps its original geographic anchor. Once the
         // pointer crosses a pole it can reappear in the opposite hemisphere,
         // reversing longitude. Continue zooming around center in either case.
         return {longitude: this.longitude, latitude: this.latitude};
       }
-      if (isGlobeNorthUp(this.bearing) && latitudeDelta !== 0) {
-        // Longitude and latitude are one coupled correction. If north-up runs
+      if (lockBearing && latitudeDelta !== 0) {
+        // Longitude and latitude are one coupled correction. If a locked bearing runs
         // out of latitude headroom, scale both axes together instead of
         // clipping latitude while applying the full sideways rotation.
         const latitudeLimit = latitudeDelta > 0 ? MAX_LATITUDE : -MAX_LATITUDE;

--- a/modules/core/src/views/globe-view.ts
+++ b/modules/core/src/views/globe-view.ts
@@ -60,4 +60,10 @@ export default class GlobeView extends View<GlobeViewState, GlobeViewProps> {
   get ControllerType() {
     return GlobeController;
   }
+
+  /** Resolve navigation explicitly so saved view state cannot override the default. */
+  get controller() {
+    const controller = super.controller;
+    return controller && {...controller, navigation: controller.navigation ?? 'map'};
+  }
 }

--- a/test/apps/globe/app.js
+++ b/test/apps/globe/app.js
@@ -29,13 +29,21 @@ const INITIAL_VIEW_STATE = {
 let currentViewState = {...INITIAL_VIEW_STATE};
 let zoomAround = 'pointer';
 let viewType = 'globe';
+let navigation = 'map';
+
+const PRESETS = {
+  north: {latitude: 80, longitude: 0, zoom: 2},
+  south: {latitude: -80, longitude: 0, zoom: 2},
+  rotated: {latitude: 75, longitude: 0, zoom: 2, bearing: 45},
+  street: {latitude: 51.47, longitude: 0.45, zoom: 14}
+};
 
 const GRATICULES = getGraticules(30);
 
 export const deck = new Deck({
   views: getView(viewType),
   initialViewState: INITIAL_VIEW_STATE,
-  controller: {inertia: 500, zoomAround},
+  controller: {inertia: 500, zoomAround, navigation},
   parameters: {
     cull: true
   },
@@ -133,7 +141,12 @@ function getView(nextViewType) {
 const settingsControl = createSettingsControl({
   onZoomAroundChange: nextZoomAround => {
     zoomAround = nextZoomAround;
-    deck.setProps({controller: {inertia: 500, zoomAround}});
+    deck.setProps({controller: {inertia: 500, zoomAround, navigation}});
+    updateSettingsControl();
+  },
+  onNavigationChange: nextNavigation => {
+    navigation = nextNavigation;
+    deck.setProps({controller: {inertia: 500, zoomAround, navigation}});
     updateSettingsControl();
   },
   onViewChange: nextViewType => {
@@ -141,7 +154,8 @@ const settingsControl = createSettingsControl({
     deck.setProps({views: getView(viewType)});
     updateSettingsControl();
   },
-  onReset: () => setViewState(INITIAL_VIEW_STATE)
+  onReset: () => setViewState(INITIAL_VIEW_STATE),
+  onPresetChange: preset => setViewState({...INITIAL_VIEW_STATE, ...PRESETS[preset]})
 });
 
 function setViewState(nextViewState) {
@@ -151,7 +165,7 @@ function setViewState(nextViewState) {
 }
 
 function updateSettingsControl() {
-  settingsControl.update({viewState: currentViewState, zoomAround, viewType});
+  settingsControl.update({viewState: currentViewState, zoomAround, viewType, navigation});
 }
 
 updateSettingsControl();

--- a/test/apps/globe/settings-control.js
+++ b/test/apps/globe/settings-control.js
@@ -4,13 +4,19 @@
 
 /* global document */
 
-export function createSettingsControl({onZoomAroundChange, onViewChange, onReset}) {
+export function createSettingsControl({
+  onZoomAroundChange,
+  onViewChange,
+  onNavigationChange,
+  onPresetChange,
+  onReset
+}) {
   document.body.style.margin = '0px';
 
   const overlay = document.createElement('div');
   Object.assign(overlay.style, {
     position: 'fixed',
-    top: '10px',
+    bottom: '10px',
     left: '10px',
     background: 'rgba(0,0,0,0.7)',
     color: '#fff',
@@ -27,10 +33,16 @@ export function createSettingsControl({onZoomAroundChange, onViewChange, onReset
 
   const controls = document.createElement('div');
   controls.innerHTML = `
-    <div>View</div>
+    <div>Globe navigation review</div>
+    <div class="label">Projection</div>
     <div class="button-row" role="group" aria-label="View">
       <button type="button" data-view-type="globe">Globe</button>
       <button type="button" data-view-type="map">Map</button>
+    </div>
+    <div class="label">Navigation</div>
+    <div class="button-row" role="group" aria-label="Navigation">
+      <button type="button" data-navigation="map">Map</button>
+      <button type="button" data-navigation="ball">Ball</button>
     </div>
     <div class="label">Zoom anchor</div>
     <div class="button-row" role="group" aria-label="Zoom anchor">
@@ -40,6 +52,16 @@ export function createSettingsControl({onZoomAroundChange, onViewChange, onReset
     <div class="button-row">
       <button type="button" data-action="reset">Reset</button>
     </div>
+    <div class="label">Test presets</div>
+    <div class="button-row">
+      <button type="button" data-preset="north">North pole</button>
+      <button type="button" data-preset="south">South pole</button>
+    </div>
+    <div class="button-row">
+      <button type="button" data-preset="rotated">45° bearing</button>
+      <button type="button" data-preset="street">High zoom</button>
+    </div>
+    <div>Drag: pan · Shift+drag: rotate<br>Scroll/pinch: zoom · Release: inertia</div>
   `;
   Object.assign(controls.style, {
     position: 'fixed',
@@ -73,6 +95,10 @@ export function createSettingsControl({onZoomAroundChange, onViewChange, onReset
     const button = event.target.closest('button');
     if (button?.dataset.zoomAround) {
       onZoomAroundChange(button.dataset.zoomAround);
+    } else if (button?.dataset.navigation) {
+      onNavigationChange(button.dataset.navigation);
+    } else if (button?.dataset.preset) {
+      onPresetChange(button.dataset.preset);
     } else if (button?.dataset.viewType) {
       onViewChange(button.dataset.viewType);
     } else if (button?.dataset.action === 'reset') {
@@ -81,19 +107,25 @@ export function createSettingsControl({onZoomAroundChange, onViewChange, onReset
   });
 
   return {
-    update({viewState, zoomAround, viewType}) {
+    update({viewState, zoomAround, viewType, navigation}) {
       const {longitude = 0, latitude = 0, zoom = 0, bearing = 0, pitch = 0} = viewState;
       overlay.textContent =
-        `view: ${viewType}  zoomAround: ${zoomAround}\n` +
+        `view: ${viewType}  navigation: ${navigation}\nzoomAround: ${zoomAround}\n` +
         `lat: ${latitude.toFixed(2)}  lng: ${longitude.toFixed(2)}\n` +
         `zoom: ${zoom.toFixed(2)}  bearing: ${bearing.toFixed(2)}  pitch: ${pitch.toFixed(2)}`;
 
       for (const button of controls.querySelectorAll('button')) {
-        if (!button.dataset.zoomAround && !button.dataset.viewType) {
+        if (!button.dataset.zoomAround && !button.dataset.viewType && !button.dataset.navigation) {
           continue;
         }
         const isSelected =
-          button.dataset.zoomAround === zoomAround || button.dataset.viewType === viewType;
+          button.dataset.zoomAround === zoomAround ||
+          button.dataset.viewType === viewType ||
+          button.dataset.navigation === navigation;
+        if (button.dataset.navigation) {
+          button.disabled = viewType !== 'globe';
+          button.style.opacity = viewType === 'globe' ? '1' : '0.4';
+        }
         button.setAttribute('aria-pressed', String(isSelected));
         button.style.background = isSelected ? 'rgba(70,120,255,0.85)' : 'rgba(255,255,255,0.12)';
       }

--- a/test/modules/core/controllers/controllers.spec.ts
+++ b/test/modules/core/controllers/controllers.spec.ts
@@ -548,9 +548,9 @@ test('GlobeController falls back to center zoom when the pointer is off the glob
   expect(controller.props.zoom, 'off-globe zoom still changes scale').not.toBeCloseTo(1);
 });
 
-test('GlobeController drags through a pole from bearing zero', () => {
+test('GlobeController ball navigation drags through a pole from bearing zero', () => {
   const controller = createTestController({
-    view: new GlobeView({controller: true}),
+    view: new GlobeView({controller: {navigation: 'ball'}}),
     initialViewState: {
       width: 800,
       height: 600,
@@ -588,7 +588,7 @@ test('GlobeController drags through a pole from bearing zero', () => {
 test('GlobeController keeps pointer zoom stable when the anchor crosses a pole', () => {
   for (const latitude of [-75, 75]) {
     const controller = createTestController({
-      view: new GlobeView({controller: {zoomAround: 'pointer'}}),
+      view: new GlobeView({controller: {navigation: 'ball', zoomAround: 'pointer'}}),
       initialViewState: {
         width: 1280,
         height: 720,
@@ -626,7 +626,7 @@ test('GlobeController keeps pointer zoom stable when the anchor crosses a pole',
 test('GlobeController rotates pointer zoom smoothly from the north-up latitude limit', () => {
   for (const latitude of [-85, 85]) {
     const controller = createTestController({
-      view: new GlobeView({controller: {zoomAround: 'pointer'}}),
+      view: new GlobeView({controller: {navigation: 'ball', zoomAround: 'pointer'}}),
       initialViewState: {
         width: 1280,
         height: 720,
@@ -664,7 +664,7 @@ test('GlobeController rotates pointer zoom smoothly from the north-up latitude l
 test('GlobeController pointer zoom rotates the globe uniformly across latitudes', () => {
   for (const latitude of [0, 45, 75, 85]) {
     const controller = createTestController({
-      view: new GlobeView({controller: {zoomAround: 'pointer'}}),
+      view: new GlobeView({controller: {navigation: 'ball', zoomAround: 'pointer'}}),
       initialViewState: {
         width: 1280,
         height: 720,
@@ -709,7 +709,7 @@ test('GlobeController pointer zoom rotates the globe uniformly across latitudes'
 
 test('GlobeController center zoom does not steer the camera frame', () => {
   const controller = createTestController({
-    view: new GlobeView({controller: {zoomAround: 'center'}}),
+    view: new GlobeView({controller: {navigation: 'ball', zoomAround: 'center'}}),
     initialViewState: {
       width: 1280,
       height: 720,
@@ -733,7 +733,7 @@ test('GlobeController center zoom does not steer the camera frame', () => {
 test('GlobeController smooth wheel zoom rotates the camera frame continuously', () => {
   const controller = createTestController({
     view: new GlobeView({
-      controller: {zoomAround: 'pointer', scrollZoom: {smooth: true}}
+      controller: {navigation: 'ball', zoomAround: 'pointer', scrollZoom: {smooth: true}}
     }),
     initialViewState: {
       width: 1280,
@@ -779,7 +779,7 @@ test('GlobeController smooth wheel zoom rotates the camera frame continuously', 
 test('GlobeController keeps continuous pinch zoom stable across a pole', () => {
   for (const latitude of [-75, 75]) {
     const controller = createTestController({
-      view: new GlobeView({controller: {zoomAround: 'pointer'}}),
+      view: new GlobeView({controller: {navigation: 'ball', zoomAround: 'pointer'}}),
       initialViewState: {
         width: 1280,
         height: 720,
@@ -832,7 +832,7 @@ test('GlobeController keeps continuous pinch zoom stable across a pole', () => {
 test('GlobeController preserves pointer zoom in free rotation mode', () => {
   const makeController = (zoomAround: 'pointer' | 'center') =>
     createTestController({
-      view: new GlobeView({controller: {zoomAround}}),
+      view: new GlobeView({controller: {navigation: 'ball', zoomAround}}),
       initialViewState: {
         width: 1280,
         height: 720,

--- a/test/modules/core/controllers/globe-navigation.spec.ts
+++ b/test/modules/core/controllers/globe-navigation.spec.ts
@@ -1,0 +1,534 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {
+  _GlobeController as GlobeController,
+  _GlobeView as GlobeView,
+  _GlobeViewport as GlobeViewport
+} from '@deck.gl/core';
+import ViewManager from '@deck.gl/core/lib/view-manager';
+import {Timeline} from '@luma.gl/engine';
+import {createTestController} from './test-controller';
+
+const INITIAL_VIEW_STATE = {
+  width: 800,
+  height: 600,
+  longitude: 0,
+  latitude: 75,
+  zoom: 0,
+  bearing: 0
+};
+
+const makePanEvent = (type: string, x = 400, y = 300) => ({
+  type,
+  pointerType: 'mouse',
+  offsetCenter: {x, y},
+  velocity: 0,
+  velocityX: 0,
+  velocityY: 0,
+  srcEvent: {},
+  stopPropagation() {}
+});
+
+const makeWheelEvent = () => ({
+  type: 'wheel',
+  pointerType: 'mouse',
+  offsetCenter: {x: 550, y: 150},
+  delta: -60,
+  srcEvent: {preventDefault() {}},
+  stopPropagation() {}
+});
+
+const makeViewport = props => new GlobeViewport(props);
+const GlobeState = new GlobeController({} as any).ControllerState;
+
+test.each([0, 45, 360, 405])(
+  'GlobeController defaults to map navigation at bearing %s',
+  bearing => {
+    const makeController = controller =>
+      createTestController({
+        view: new GlobeView({controller}),
+        initialViewState: {...INITIAL_VIEW_STATE, bearing}
+      });
+    const defaultController = makeController(true);
+    const mapController = makeController({navigation: 'map'});
+    const ballController = makeController({navigation: 'ball'});
+
+    for (const controller of [defaultController, mapController, ballController]) {
+      controller.handleEvent(makePanEvent('panstart'));
+      controller.handleEvent(makePanEvent('panmove', 500, 350));
+      controller.handleEvent(makePanEvent('panend', 500, 350));
+    }
+
+    const normalizedBearing = ((bearing + 180) % 360) - 180;
+    expect(defaultController.props.bearing, 'default navigation preserves bearing').toBeCloseTo(
+      normalizedBearing
+    );
+    for (const property of ['longitude', 'latitude', 'bearing', 'zoom']) {
+      expect(defaultController.props[property], `default ${property} matches map mode`).toBeCloseTo(
+        mapController.props[property]
+      );
+    }
+    expect(ballController.props.bearing, 'ball mode is not inferred from bearing').not.toBeCloseTo(
+      normalizedBearing
+    );
+  }
+);
+
+test.each([-1, 1])('GlobeController map drag stops before pole %s', direction => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'map'}}),
+    initialViewState: {...INITIAL_VIEW_STATE, latitude: direction * 80}
+  });
+  controller.handleEvent(makePanEvent('panstart'));
+  let previousLatitude = Math.abs(controller.props.latitude);
+  for (let index = 1; index <= 20; index++) {
+    controller.handleEvent(makePanEvent('panmove', 400, 300 + direction * index * 10));
+    expect(
+      Math.abs(controller.props.latitude),
+      'drag approaches the pole without reversing'
+    ).toBeGreaterThanOrEqual(previousLatitude);
+    expect(
+      Math.abs(controller.props.latitude),
+      'map navigation does not reach the singularity'
+    ).toBeLessThan(90);
+    expect(controller.props.longitude, 'map navigation does not cross hemispheres').toBeCloseTo(0);
+    expect(controller.props.bearing, 'map navigation stays north-up').toBeCloseTo(0);
+    previousLatitude = Math.abs(controller.props.latitude);
+  }
+  expect(previousLatitude, 'drag moved toward the pole').toBeGreaterThan(80);
+});
+
+test.each([-1, 1])(
+  'GlobeController ball drag crosses pole %s with equivalent north-up bearing',
+  direction => {
+    const controller = createTestController({
+      view: new GlobeView({controller: {navigation: 'ball'}}),
+      initialViewState: {...INITIAL_VIEW_STATE, latitude: direction * 80, bearing: 360}
+    });
+    controller.handleEvent(makePanEvent('panstart'));
+    for (let index = 1; index <= 15; index++) {
+      controller.handleEvent(makePanEvent('panmove', 400, 300 + direction * index * 10));
+      expect(Number.isFinite(controller.props.zoom), 'pole crossing keeps a finite zoom').toBe(
+        true
+      );
+    }
+    expect(Math.abs(controller.props.longitude), 'ball crosses hemispheres').toBeCloseTo(180);
+    expect(Math.abs(controller.props.bearing), 'ball keeps rotating its camera frame').toBeCloseTo(
+      180
+    );
+  }
+);
+
+test.each(['map', 'ball'] as const)(
+  'GlobeState preserves %s navigation through reconstruction',
+  navigation => {
+    const initialState = new GlobeState({
+      ...INITIAL_VIEW_STATE,
+      navigation,
+      bearing: 45,
+      makeViewport
+    });
+    const startedState = initialState.panStart({pos: [400, 300]});
+    const reconstructedState = new GlobeState({
+      ...startedState.getViewportProps(),
+      ...startedState.getState(),
+      makeViewport
+    });
+    const movedState = reconstructedState.pan({pos: [480, 340]}).panEnd();
+    const movedProps = movedState.getViewportProps();
+    if (navigation === 'map') {
+      expect(movedProps.bearing, 'reconstructed map drag preserves configured bearing').toBeCloseTo(
+        45
+      );
+    } else {
+      expect(movedProps.bearing, 'reconstructed ball drag keeps the rigid frame').not.toBeCloseTo(
+        45
+      );
+    }
+    const nextState = new GlobeState({
+      ...movedProps,
+      ...movedState.getState(),
+      makeViewport
+    }).moveLeft();
+    if (navigation === 'map') {
+      expect(nextState.getViewportProps().bearing, 'keyboard state remains map mode').toBeCloseTo(
+        45
+      );
+    } else {
+      expect(
+        nextState.getViewportProps().bearing,
+        'keyboard state remains ball mode'
+      ).not.toBeCloseTo(movedProps.bearing);
+    }
+  }
+);
+
+test.each([-80, 80])(
+  'GlobeController map pointer zoom preserves bearing at latitude %s',
+  latitude => {
+    const makeController = (zoomAround: 'center' | 'pointer') =>
+      createTestController({
+        view: new GlobeView({controller: {navigation: 'map', zoomAround}}),
+        initialViewState: {...INITIAL_VIEW_STATE, latitude, zoom: 5, bearing: 397}
+      });
+    const centerController = makeController('center');
+    const pointerController = makeController('pointer');
+    const wheelEvent = makeWheelEvent();
+    wheelEvent.offsetCenter.y = latitude > 0 ? 100 : 500;
+    for (let index = 0; index < 16; index++) {
+      centerController.handleEvent(wheelEvent);
+      pointerController.handleEvent(wheelEvent);
+      expect(
+        pointerController.props.bearing,
+        'pointer steering preserves configured bearing'
+      ).toBeCloseTo(37);
+      expect(
+        Math.abs(pointerController.props.latitude),
+        'pointer zoom cannot cross a pole'
+      ).toBeLessThan(90);
+      expect(
+        centerController.props.bearing,
+        'center zoom preserves configured bearing'
+      ).toBeCloseTo(37);
+      expect(centerController.props.latitude, 'center zoom preserves latitude').toBeCloseTo(
+        latitude
+      );
+      expect(centerController.props.longitude, 'center zoom preserves longitude').toBeCloseTo(0);
+    }
+    expect(
+      pointerController.props.longitude,
+      'map pointer zoom still steers toward its anchor'
+    ).not.toBeCloseTo(0);
+  }
+);
+
+test('GlobeController map smooth zoom preserves bearing in every transition frame', () => {
+  const controller = createTestController({
+    view: new GlobeView({
+      controller: {navigation: 'map', zoomAround: 'pointer', scrollZoom: {smooth: true}}
+    }),
+    initialViewState: {...INITIAL_VIEW_STATE, zoom: 5, bearing: 35}
+  });
+  controller.handleEvent(makeWheelEvent());
+  const transition = controller.transitionManager.transition;
+  expect(transition.inProgress, 'smooth wheel starts a transition').toBe(true);
+  const startTime = transition._timeline.getTime();
+  for (let elapsed = 16; elapsed <= 304; elapsed += 16) {
+    transition._timeline.setTime(startTime + elapsed);
+    controller.updateTransition();
+    expect(controller.props.bearing, 'smooth map zoom preserves bearing throughout').toBeCloseTo(
+      35
+    );
+    expect(
+      Math.abs(controller.props.latitude),
+      'smooth map zoom remains inside poles'
+    ).toBeLessThan(90);
+  }
+});
+
+test.each([-80, 80])('GlobeController map pinch preserves bearing near latitude %s', latitude => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'map', zoomAround: 'pointer'}}),
+    initialViewState: {...INITIAL_VIEW_STATE, latitude, zoom: 5, bearing: 35}
+  });
+  const makePinchEvent = (type: string, scale: number) => ({
+    ...makePanEvent(type, 550, latitude > 0 ? 100 : 500),
+    pointerType: 'touch',
+    scale,
+    rotation: 0,
+    deltaTime: type === 'pinchstart' ? 0 : 16
+  });
+  controller.handleEvent(makePinchEvent('pinchstart', 1));
+  for (let index = 1; index <= 16; index++) {
+    controller.handleEvent(makePinchEvent('pinchmove', Math.pow(0.85, index)));
+    expect(controller.props.bearing, 'continuous pinch preserves map bearing').toBeCloseTo(35);
+    expect(
+      Math.abs(controller.props.latitude),
+      'continuous map pinch remains inside poles'
+    ).toBeLessThan(90);
+    expect(Number.isFinite(controller.props.zoom), 'continuous map pinch keeps finite zoom').toBe(
+      true
+    );
+  }
+  controller.handleEvent(makePinchEvent('pinchend', Math.pow(0.85, 16)));
+});
+
+test.each([
+  {latitude: 75, bearing: 90, pos: [480, 360] as [number, number]},
+  {latitude: 80, bearing: 1, pos: [640, 120] as [number, number]}
+])(
+  'GlobeState map pinch keeps its anchor continuous at bearing $bearing',
+  ({latitude, bearing, pos}) => {
+    let state = new GlobeState({
+      ...INITIAL_VIEW_STATE,
+      width: 1280,
+      height: 720,
+      navigation: 'map',
+      latitude,
+      bearing,
+      zoom: 2,
+      makeViewport
+    }).zoomStart({pos});
+    let previousProps = state.getViewportProps();
+    for (let index = 1; index <= 10; index++) {
+      state = state.zoom({pos, scale: Math.pow(0.85, index)});
+      const props = state.getViewportProps();
+      const longitudeDelta = ((props.longitude - previousProps.longitude + 540) % 360) - 180;
+      expect(
+        Math.abs(longitudeDelta),
+        'a small pinch step does not jump across hemispheres'
+      ).toBeLessThan(60);
+      expect(
+        Math.abs(props.latitude - previousProps.latitude),
+        'latitude changes continuously'
+      ).toBeLessThan(15);
+      expect(props.bearing, 'anchor steering preserves the chosen bearing').toBeCloseTo(bearing);
+      previousProps = props;
+    }
+  }
+);
+
+test.each(['map', 'ball'] as const)(
+  'GlobeController %s pointer zoom supports the high-zoom viewport',
+  navigation => {
+    const view = new GlobeView({controller: {navigation, zoomAround: 'pointer'}});
+    const controller = createTestController({
+      view,
+      initialViewState: {...INITIAL_VIEW_STATE, latitude: 45, zoom: 14, bearing: 35}
+    });
+    expect(
+      view.makeViewport({width: 800, height: 600, viewState: controller.props}),
+      'high zoom uses the flat viewport'
+    ).not.toBeInstanceOf(GlobeViewport);
+    expect(
+      () => controller.handleEvent(makeWheelEvent()),
+      'high-zoom pointer zoom is supported'
+    ).not.toThrow();
+    expect(controller.props.zoom, 'wheel changes zoom').not.toBeCloseTo(14);
+    expect(controller.props.longitude, 'pointer zoom still anchors away from center').not.toBe(0);
+    expect(controller.props.bearing, 'flat pointer zoom preserves bearing').toBeCloseTo(35);
+  }
+);
+
+test.each([true, {inertia: true}] as const)(
+  'GlobeView restores map navigation when ball is removed from controller %j',
+  nextController => {
+    const viewManager = new ViewManager({
+      views: [new GlobeView({id: 'globe', controller: {navigation: 'ball'}})],
+      viewState: {...INITIAL_VIEW_STATE, bearing: 45},
+      width: 800,
+      height: 600,
+      timeline: new Timeline(),
+      eventManager: null,
+      onViewStateChange: ({viewState}) => viewManager.setProps({viewState})
+    });
+    const controller = viewManager.controllers.globe!;
+    const drag = () => {
+      controller.handleEvent(makePanEvent('panstart') as any);
+      controller.handleEvent(makePanEvent('panmove', 480, 340) as any);
+      controller.handleEvent(makePanEvent('panend', 480, 340) as any);
+    };
+    drag();
+    const bearing = controller.props.bearing;
+    expect(bearing, 'the original ball gesture changes bearing').not.toBeCloseTo(45);
+    viewManager.setProps({
+      views: [new GlobeView({id: 'globe', controller: nextController})]
+    });
+    expect(viewManager.controllers.globe, 'the view manager keeps the existing controller').toBe(
+      controller
+    );
+    drag();
+    expect(
+      controller.props.bearing,
+      'omitting navigation restores map policy despite saved ball state'
+    ).toBeCloseTo(bearing);
+    viewManager.finalize();
+  }
+);
+
+test('GlobeController map navigation permits explicit drag rotation', () => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'map', dragMode: 'rotate', dragRotate: true}}),
+    initialViewState: {...INITIAL_VIEW_STATE, bearing: 35}
+  });
+  controller.handleEvent(makePanEvent('panstart'));
+  controller.handleEvent(makePanEvent('panmove', 480, 300));
+  controller.handleEvent(makePanEvent('panend', 480, 300));
+  expect(controller.props.bearing, 'explicit rotate gesture changes map bearing').not.toBeCloseTo(
+    35
+  );
+});
+
+test.each([-75, 75])('GlobeController map inertia preserves bearing at latitude %s', latitude => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'map', inertia: 600}}),
+    initialViewState: {...INITIAL_VIEW_STATE, latitude, bearing: 35}
+  });
+  const direction = Math.sign(latitude);
+  controller.handleEvent(makePanEvent('panstart'));
+  for (let index = 1; index <= 5; index++) {
+    controller.handleEvent(makePanEvent('panmove', 400 + index * 10, 300 + direction * index * 10));
+  }
+  controller._panHistory.forEach((sample, index) => {
+    sample.timestamp = index * 16;
+  });
+  controller.handleEvent({
+    ...makePanEvent('panend', 450, 300 + direction * 50),
+    velocity: Math.SQRT2,
+    velocityX: 1,
+    velocityY: direction
+  });
+  const transition = controller.transitionManager.transition;
+  expect(transition.inProgress, 'release starts inertial movement').toBe(true);
+  const startTime = transition._timeline.getTime();
+  for (let elapsed = 16; elapsed <= 608; elapsed += 16) {
+    transition._timeline.setTime(startTime + elapsed);
+    controller.updateTransition();
+    expect(controller.props.bearing, 'each map inertia frame preserves bearing').toBeCloseTo(35);
+    expect(Math.abs(controller.props.latitude), 'map inertia stays inside poles').toBeLessThan(90);
+    expect(Number.isFinite(controller.props.longitude), 'inertia longitude remains finite').toBe(
+      true
+    );
+  }
+});
+
+test.each([-75, 75])('GlobeController ball inertia crosses a pole from latitude %s', latitude => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'ball', inertia: 600}}),
+    initialViewState: {...INITIAL_VIEW_STATE, latitude}
+  });
+  const direction = Math.sign(latitude);
+  controller.handleEvent(makePanEvent('panstart'));
+  for (let index = 1; index <= 5; index++) {
+    controller.handleEvent(makePanEvent('panmove', 400, 300 + direction * index * 10));
+  }
+  expect(controller.props.bearing, 'drag has not crossed the pole at release').toBeCloseTo(0);
+  controller._panHistory.forEach((sample, index) => {
+    sample.timestamp = index * 16;
+  });
+  controller.handleEvent(makePanEvent('panend', 400, 300 + direction * 50));
+  const transition = controller.transitionManager.transition;
+  expect(transition.inProgress, 'release starts ball inertia').toBe(true);
+  const startTime = transition._timeline.getTime();
+  for (let elapsed = 16; elapsed <= 608; elapsed += 16) {
+    transition._timeline.setTime(startTime + elapsed);
+    controller.updateTransition();
+    for (const property of ['longitude', 'latitude', 'bearing', 'zoom']) {
+      expect(Number.isFinite(controller.props[property]), `inertia ${property} stays finite`).toBe(
+        true
+      );
+    }
+  }
+  expect(Math.abs(controller.props.longitude), 'ball inertia crosses hemispheres').toBeCloseTo(180);
+  expect(Math.abs(controller.props.bearing), 'ball inertia rotates its up vector').toBeCloseTo(180);
+});
+
+test('GlobeController map keyboard movement preserves bearing and explicit rotation changes it', () => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'map'}}),
+    initialViewState: {...INITIAL_VIEW_STATE, bearing: 45}
+  });
+  const pressKey = (code: string, shiftKey = false) => {
+    controller.handleEvent({type: 'keydown', srcEvent: {code, shiftKey}});
+    const timeline = controller.transitionManager.transition._timeline;
+    timeline.setTime(timeline.getTime() + 300);
+    controller.updateTransition();
+  };
+  for (const code of ['ArrowUp', 'ArrowLeft', 'ArrowDown', 'ArrowRight', 'Minus', 'Equal']) {
+    pressKey(code);
+    expect(controller.props.bearing, `${code} preserves bearing in map mode`).toBeCloseTo(45);
+  }
+  pressKey('ArrowRight', true);
+  expect(controller.props.bearing, 'explicit keyboard rotation changes map bearing').toBeCloseTo(
+    60
+  );
+  pressKey('ArrowUp');
+  expect(
+    controller.props.bearing,
+    'navigation preserves the deliberately rotated bearing'
+  ).toBeCloseTo(60);
+});
+
+test('GlobeController applies navigation changes without recreating the view', () => {
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'map'}}),
+    initialViewState: {...INITIAL_VIEW_STATE, bearing: 45}
+  });
+  const drag = () => {
+    controller.handleEvent(makePanEvent('panstart'));
+    controller.handleEvent(makePanEvent('panmove', 480, 340));
+    controller.handleEvent(makePanEvent('panend', 480, 340));
+  };
+  drag();
+  expect(controller.props.bearing, 'initial map drag preserves bearing').toBeCloseTo(45);
+  controller.setProps({...controller.props, navigation: 'ball'});
+  drag();
+  expect(controller.props.bearing, 'updated ball mode rotates the frame').not.toBeCloseTo(45);
+  const ballBearing = controller.props.bearing;
+  controller.setProps({...controller.props, navigation: 'map'});
+  drag();
+  expect(controller.props.bearing, 'updated map mode preserves the current bearing').toBeCloseTo(
+    ballBearing
+  );
+});
+
+test('GlobeController switching navigation stops the previous transition', () => {
+  const controller = createTestController({
+    view: new GlobeView({
+      controller: {navigation: 'ball', zoomAround: 'pointer', scrollZoom: {smooth: true}}
+    }),
+    initialViewState: {...INITIAL_VIEW_STATE, zoom: 5, bearing: 35}
+  });
+  controller.handleEvent(makeWheelEvent());
+  const transition = controller.transitionManager.transition;
+  expect(transition.inProgress, 'ball zoom starts a transition').toBe(true);
+  controller.setProps({...controller.props, navigation: 'map'});
+  expect(transition.inProgress, 'navigation change cancels the old transition').toBe(false);
+  const bearing = controller.props.bearing;
+  controller.handleEvent(makePanEvent('panstart'));
+  controller.handleEvent(makePanEvent('panmove', 480, 340));
+  expect(controller.props.bearing, 'the next gesture uses map navigation').toBeCloseTo(bearing);
+});
+
+test.each([
+  {navigation: 'map', gesture: 'pinch'},
+  {navigation: 'ball', gesture: 'pinch'},
+  {navigation: 'map', gesture: 'dblclickdrag'},
+  {navigation: 'ball', gesture: 'dblclickdrag'}
+] as const)(
+  'GlobeController changing from $navigation navigation cancels an active $gesture',
+  ({navigation, gesture}) => {
+    const controller = createTestController({
+      view: new GlobeView({
+        controller: {navigation, zoomAround: 'center', doubleClickDragZoom: true}
+      }),
+      initialViewState: {...INITIAL_VIEW_STATE, latitude: 45, zoom: 5, bearing: 35}
+    });
+    const makeZoomEvent = (phase: 'start' | 'move' | 'end', scale: number) => ({
+      ...makePanEvent(`${gesture}${phase}`),
+      pointerType: 'touch',
+      scale,
+      rotation: 0,
+      deltaTime: phase === 'start' ? 0 : 16
+    });
+    controller.handleEvent(makeZoomEvent('start', 1));
+    controller.handleEvent(makeZoomEvent('move', 1.2));
+    controller.setProps({
+      ...controller.props,
+      navigation: navigation === 'map' ? 'ball' : 'map'
+    });
+    const zoom = controller.props.zoom;
+    controller.handleEvent(makeZoomEvent('move', 1.2));
+    expect(controller.props.zoom, 'stale cumulative zoom scale is not reapplied').toBeCloseTo(zoom);
+    controller.handleEvent(makeZoomEvent('end', 1.2));
+    controller.handleEvent(makeZoomEvent('start', 1));
+    controller.handleEvent(makeZoomEvent('move', 1.2));
+    expect(
+      controller.props.zoom,
+      'a new gesture works in the selected navigation mode'
+    ).toBeGreaterThan(zoom);
+  }
+);

--- a/test/modules/core/controllers/globe-navigation.spec.ts
+++ b/test/modules/core/controllers/globe-navigation.spec.ts
@@ -9,6 +9,7 @@ import {
   _GlobeViewport as GlobeViewport
 } from '@deck.gl/core';
 import ViewManager from '@deck.gl/core/lib/view-manager';
+import {Globe} from '@deck.gl/core/viewports/globe-utils';
 import {Timeline} from '@luma.gl/engine';
 import {createTestController} from './test-controller';
 
@@ -43,6 +44,110 @@ const makeWheelEvent = () => ({
 
 const makeViewport = props => new GlobeViewport(props);
 const GlobeState = new GlobeController({} as any).ControllerState;
+
+// Characterization values from #10298's locked pan, before #10598 removed that path.
+test.each([
+  {
+    latitude: -75,
+    longitude: 0,
+    offset: [80, 40],
+    expected: [-7.368659198256055, -73.99256541637756, 3.0914803297151443]
+  },
+  {
+    latitude: 0,
+    longitude: 0,
+    offset: [80, 40],
+    expected: [-7.872233702373929, 3.890096841116076, 2.9966722242700756]
+  },
+  {
+    latitude: 75,
+    longitude: 0,
+    offset: [80, 40],
+    expected: [-8.41004469276098, 76.00617245907846, 2.901974064385081]
+  },
+  {latitude: 45, longitude: 179, offset: [-120, 0], expected: [-169.21902754903826, 45, 3]}
+])(
+  'GlobeState map pan reuses the original locked trajectory at $latitude',
+  ({latitude, longitude, offset, expected}) => {
+    const state = new GlobeState({
+      ...INITIAL_VIEW_STATE,
+      latitude,
+      longitude,
+      zoom: 3,
+      navigation: 'map',
+      makeViewport
+    })
+      .panStart({pos: [400, 300]})
+      .pan({pos: [400 + offset[0], 300 + offset[1]]});
+    const props = state.getViewportProps();
+    expect(props.longitude).toBeCloseTo(expected[0], 10);
+    expect(props.latitude).toBeCloseTo(expected[1], 10);
+    expect(props.zoom).toBeCloseTo(expected[2], 10);
+    expect(props.bearing).toBe(0);
+  }
+);
+
+test.each([0, 45, -120])(
+  'Globe.rotateFrame keeps locked bearing %s and its up vector consistent',
+  bearing => {
+    const frame = Globe.cameraFrame(10, 75, bearing);
+    const locked = Globe.rotateFrame(frame, 0.1, 0.2, true);
+    expect(locked.bearing).toBe(bearing);
+    expect(Globe.bearing(locked.up, locked.longitude, locked.latitude)).toBeCloseTo(bearing, 10);
+    const free = Globe.rotateFrame(frame, 0.1, 0.2, false);
+    expect(free.position).toEqual(locked.position);
+    expect(Globe.bearing(free.up, free.longitude, free.latitude)).toBeCloseTo(free.bearing, 10);
+    expect(free.bearing).not.toBeCloseTo(bearing);
+  }
+);
+
+test('GlobeController navigation change emits the actual previous view state', () => {
+  const updates: any[] = [];
+  const controller = createTestController({
+    view: new GlobeView({controller: {navigation: 'ball'}}),
+    initialViewState: {...INITIAL_VIEW_STATE, latitude: 89, zoom: 3, bearing: 45},
+    onViewStateChange: update => {
+      updates.push(update);
+    }
+  });
+  controller.setProps({...controller.props, navigation: 'map'});
+  expect(updates).toHaveLength(1);
+  expect(updates[0].oldViewState.latitude).toBe(89);
+  expect(updates[0].oldViewState.navigation).toBe('ball');
+  expect(updates[0].viewState.latitude).toBeCloseTo(85.051129);
+  expect(updates[0].viewState.navigation).toBe('map');
+});
+
+test.each(['map', 'ball'] as const)(
+  'GlobeController navigation change after a %s drag emits the latest view state',
+  navigation => {
+    const updates: any[] = [];
+    const controller = createTestController({
+      view: new GlobeView({controller: {navigation}}),
+      initialViewState: {...INITIAL_VIEW_STATE, zoom: 3, bearing: 45},
+      onViewStateChange: update => {
+        updates.push(update);
+      }
+    });
+    controller.handleEvent(makePanEvent('panstart'));
+    controller.handleEvent(makePanEvent('panmove', 480, 340));
+    const previousViewState = {...controller.props};
+    expect(previousViewState.latitude).not.toBeCloseTo(INITIAL_VIEW_STATE.latitude);
+    updates.length = 0;
+    const nextNavigation = navigation === 'map' ? 'ball' : 'map';
+    controller.setProps({...controller.props, navigation: nextNavigation});
+    expect(updates).toHaveLength(1);
+    for (const property of ['longitude', 'latitude', 'zoom', 'bearing']) {
+      expect(updates[0].oldViewState[property], `previous ${property}`).toBeCloseTo(
+        previousViewState[property],
+        10
+      );
+    }
+    expect(updates[0].oldViewState.navigation).toBe(navigation);
+    expect(updates[0].viewState.navigation).toBe(nextNavigation);
+    controller.finalize();
+  }
+);
 
 test.each([0, 45, 360, 405])(
   'GlobeController defaults to map navigation at bearing %s',

--- a/test/modules/core/controllers/index.ts
+++ b/test/modules/core/controllers/index.ts
@@ -4,4 +4,5 @@
 
 import './controllers.spec';
 import './custom-controller.spec';
+import './globe-navigation.spec';
 import './view-states.spec';

--- a/test/modules/core/controllers/view-states.spec.ts
+++ b/test/modules/core/controllers/view-states.spec.ts
@@ -118,10 +118,11 @@ test('GlobeViewState', () => {
     longitude: 0,
     latitude: 90,
     zoom: 5,
+    navigation: 'ball',
     makeViewport: dummyMakeViewport
   });
   viewportProps = viewState.getViewportProps();
-  expect(viewportProps.latitude, 'the default camera can reach the pole').toBe(90);
+  expect(viewportProps.latitude, 'ball navigation can reach the pole').toBe(90);
 
   viewState = new GlobeViewState({
     width: 800,
@@ -130,6 +131,7 @@ test('GlobeViewState', () => {
     latitude: 90,
     zoom: 5,
     bearing: 360,
+    navigation: 'ball',
     makeViewport: dummyMakeViewport
   });
   viewportProps = viewState.getViewportProps();
@@ -157,6 +159,7 @@ test('GlobeViewState', () => {
     longitude: 0,
     latitude: 90,
     zoom: 5,
+    navigation: 'ball',
     maxBounds: [
       [-10, 86],
       [10, 89]


### PR DESCRIPTION
## Goals

Expose one controller option for map-style or free-ball globe navigation, following the [navigation discussion on #10598](https://github.com/visgl/deck.gl/pull/10598#discussion_r3921969238), while reusing the existing globe rotation and anchor helpers.

```js
new GlobeView({
  controller: {
    navigation: 'map' // 'map' | 'ball'
  }
});
```

## Revert-first review order

This PR is stacked on #10713, which reverts the prematurely merged #10598 and restores the original north-up behavior. Its temporary base is `codex/revert-ball-globe`, so this diff includes the full ball implementation behind an explicit option instead of depending on #10598 remaining merged.

**Merge #10713 first. Then retarget this PR to `master`, refresh its base and checks, and seek maintainer consensus before merging. Do not merge this PR into the temporary revert branch.**

The integration preserves both existing proposal commits and brings in the current upstream baseline without rewriting history. The controller implementation, demo, and regression tests are unchanged from `bc65df77c3`. Release notes retain the upstream bearing/pitch feature, and the upgrade guide now explains the actual compatibility change: a nonzero bearing no longer implicitly selects free rotation.

## Changes

- Default to `navigation: 'map'`: pan, pointer zoom, keyboard navigation, and pan inertia preserve the configured bearing. North stays up at `bearing: 0`; latitude stops at approximately ±85.051°.
- Keep rigid-camera-frame navigation under `navigation: 'ball'`, including pole crossing and fixed-axis inertia. Explicit rotation and `zoomAround` remain independent of navigation mode.
- Cancel stale gestures and inertia on runtime mode changes. Removing the option restores the map default, including with saved ball-mode view state.
- Handle pointer zoom through the high-zoom flat viewport and prevent map-mode hemisphere jumps near poles at nonzero bearings.
- Update controller API documentation, v9.4 release notes, and prerelease migration guidance. No dependency or package version changes relative to the reverted baseline.

## Revision: reuse the existing implementation

Addresses the [helper-reuse feedback on #10598](https://github.com/visgl/deck.gl/pull/10598#discussion_r3923492665):

- Route map panning through the original geographic-axis `Globe.rotateFrame(..., lockBearing)` path instead of separate direct longitude/latitude arithmetic.
- Make `lockBearing` preserve the input bearing and rebuild a matching up vector, including deliberately rotated maps.
- Reuse `GlobeViewport.panByPosition` for fixed-bearing zoom-anchor limits; remove duplicated pole and coupled-axis constraint logic from the controller.
- Retain the existing linear and fixed-axis `GlobeInertiaInterpolator` modes.
- Fix the [mode-switch callback issue](https://github.com/visgl/deck.gl/pull/10650#discussion_r3922428559): capture the previous view state from current props before cancellation, including immediately after a drag when the event cache can be stale.
- Keep the 43-case navigation suite, including historical locked trajectories, bearing/up-vector consistency, and old-view-state callbacks, plus the ball regression tests carried over from #10598 with explicit ball selection.
- Extend the existing globe test app with Map/Ball navigation controls, pole/45° bearing/high-zoom presets, and a live camera readout.

## Validation

Rerun on the integrated branch:

- PASS: `yarn lint`.
- PASS: `yarn test-fast`: 3 files, 19 Node tests.
- PASS: `yarn test-headless --maxWorkers=1 test/modules/core/controllers test/modules/core/viewports test/modules/core/lib/view-manager.spec.ts`: 11 files, 176 tests, using the exact installed Playwright Chromium.
- PASS: `yarn test-website`, including the full WebGL/WebGPU package and declaration build, static-site generation, and gallery builds. Non-blocking warnings remain for dependency source maps, unrelated static HTML, and the existing `/docs/TEST-STATUS` anchor.
- PASS: diff check against the reverted baseline; no unrelated changes in the 17-file proposal diff.

The previously reviewed interactive globe demo is unchanged; manual browser interaction was not repeated for this integration. The full render suite and physical touch-device gestures were not run. New-head CI is separate from these local results.
