### PR TITLE
docs(extensions): document Fp64Extension view limitations

### DIFF
--- a/docs/api-reference/extensions/fp64-extension.md
+++ b/docs/api-reference/extensions/fp64-extension.md
@@ -56,6 +56,10 @@ new Fp64Extension();
 
 When added to a layer via the `extensions` prop, the `Fp64Extension` requires the `coordinateSystem` prop of the layer to be `'lnglat'`.
 
+## Limitations
+
+- The extension implements the Web Mercator projection only. It is not supported in [GlobeView](../core/globe-view.md): layers using it will be projected onto the flat map rather than the sphere. Use the default 32-bit projection mode in `GlobeView`.
+- Only `MapView` (and other Web Mercator based viewports) are supported. Non-geospatial views such as `OrthographicView` and `OrbitView` are not supported.
 
 ## Source
 

--- a/docs/api-reference/extensions/fp64-extension.md
+++ b/docs/api-reference/extensions/fp64-extension.md
@@ -58,8 +58,7 @@ When added to a layer via the `extensions` prop, the `Fp64Extension` requires th
 
 ## Limitations
 
-- The extension implements the Web Mercator projection only. It is not supported in [GlobeView](../core/globe-view.md): layers using it will be projected onto the flat map rather than the sphere. Use the default 32-bit projection mode in `GlobeView`.
-- Only `MapView` (and other Web Mercator based viewports) are supported. Non-geospatial views such as `OrthographicView` and `OrbitView` are not supported.
+- Only `MapView` (and other Web Mercator based viewports) are supported. `GlobeView` and Non-geospatial views such as `OrthographicView` and `OrbitView` are not supported.
 
 ## Source
 


### PR DESCRIPTION
#### Background

`Fp64Extension`'s `project64` shader module implements the Web Mercator projection only (`mercatorProject_fp64`) and has no `PROJECTION_MODE_GLOBE` branch. Under `GlobeView`, layers using the extension are projected onto the flat map rather than the sphere, and the extension likewise does not apply to non-geospatial views. This was not documented anywhere.

Part of a series auditing extension support across views (see also the MaskExtension GlobeView fix and follow-up PRs). Since the extension is deprecated in favor of the default 32-bit projection, this PR documents the limitation rather than adding a globe code path.

#### Change List
- Add a **Limitations** section to `docs/api-reference/extensions/fp64-extension.md` stating that the extension is Web Mercator only, is not supported in `GlobeView`, and does not apply to `OrthographicView` / `OrbitView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyzWaF5TmQPmGjh3Zr3XL9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyzWaF5TmQPmGjh3Zr3XL9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Adds a **Limitations** section to the `Fp64Extension` API reference so users know where the extension actually works.
> 
> The new text states that only Web Mercator–based views (e.g. `MapView`) are supported, and that `GlobeView`, `OrthographicView`, and `OrbitView` are not. This matches the extension’s Mercator-only `project64` shader path and avoids surprise mis-projection when the extension is used outside `MapView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb12932e40bec41ecf40569a5e819e6a4b657a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->