### PR TITLE
feat: flat common-space helpers for non-flat projections + view-matrix render tests

### DIFF
--- a/docs/api-reference/core/project.md
+++ b/docs/api-reference/core/project.md
@@ -140,6 +140,16 @@ vec4 project_common_position_to_clipspace(vec4 position)
 Converts the coordinates of a point from the common space to the clip space, which can be assigned to `gl_Position` as the "return value" from the vertex shader.
 
 
+### project_common_position_to_flat
+
+```glsl
+vec2 project_common_position_to_flat(vec3 commonPosition)
+vec2 project_common_position_to_flat(vec4 commonPosition)
+```
+
+Converts a position in the common space of the current projection mode into flat common space: Web Mercator for geospatial views, cartesian otherwise. Returns `commonPosition.xy` unchanged for flat projections; in `GlobeView` the sphere position is inverted back to absolute Mercator. Use it when looking up textures or bounds that were computed in a flat viewport, such as an effect's framebuffer.
+
+
 ### project_get_orientation_matrix
 
 ```glsl

--- a/modules/core/src/shaderlib/project/project.glsl.ts
+++ b/modules/core/src/shaderlib/project/project.glsl.ts
@@ -182,6 +182,37 @@ vec3 project_globe_(vec3 lnglatz) {
   ) * D;
 }
 
+// Inverse of project_globe_ followed by a Mercator projection: converts a position in
+// globe common space (sphere XYZ) into absolute Mercator common space.
+vec2 project_globe_to_mercator_(vec3 spherePos) {
+  float D = length(spherePos);
+  float lat = degrees(asin(clamp(spherePos.z / D, -1.0, 1.0)));
+  float lng = degrees(atan(spherePos.x, -spherePos.y));
+  return project_mercator_(vec2(lng, lat));
+}
+
+//
+// Projects a common space position (geometry.position, or the output of project_position)
+// into FLAT common space: Web Mercator for geospatial projections, cartesian for identity.
+// Identity for flat projection modes, so the result stays in the same frame as
+// geometry.position (offset-relative under WEB_MERCATOR_AUTO_OFFSET). Under GLOBE the result
+// is absolute Mercator: do NOT add project.commonOrigin to it (for meter-offsets on the globe
+// commonOrigin is a sphere position, not a Mercator one).
+// Use when sampling a texture or testing bounds produced by a flat viewport (mask FBO, clip
+// bounds, fill pattern UVs, terrain height map).
+// Adding a non-flat projection mode: invert it HERE. This is the single GPU switch point.
+//
+vec2 project_common_position_to_flat(vec3 commonPosition) {
+  if (project.projectionMode == PROJECTION_MODE_GLOBE) {
+    return project_globe_to_mercator_(commonPosition);
+  }
+  return commonPosition.xy;
+}
+
+vec2 project_common_position_to_flat(vec4 commonPosition) {
+  return project_common_position_to_flat(commonPosition.xyz);
+}
+
 //
 // Projects positions (defined by project.coordinateSystem) to common space (defined by project.projectionMode)
 //

--- a/modules/core/src/shaderlib/project/project.wgsl.ts
+++ b/modules/core/src/shaderlib/project/project.wgsl.ts
@@ -204,6 +204,26 @@ fn project_globe_(lnglatz: vec3<f32>) -> vec3<f32> {
   ) * D;
 }
 
+// Inverse of project_globe_ followed by a Mercator projection: converts a position in
+// globe common space (sphere XYZ) into absolute Mercator common space.
+fn project_globe_to_mercator_(spherePos: vec3<f32>) -> vec2<f32> {
+  let D = length(spherePos);
+  let lat = degrees(asin(clamp(spherePos.z / D, -1.0, 1.0)));
+  let lng = degrees(atan2(spherePos.x, -spherePos.y));
+  return project_mercator_(vec2<f32>(lng, lat));
+}
+
+// Projects a common space position into FLAT common space: Web Mercator for geospatial
+// projections, cartesian for identity. Identity for flat projection modes; absolute Mercator
+// under GLOBE (do not add project.commonOrigin to it). See project.glsl.ts for details.
+// WGSL has no function overloading: pass position.xyz for a vec4.
+fn project_common_position_to_flat(commonPosition: vec3<f32>) -> vec2<f32> {
+  if (project.projectionMode == PROJECTION_MODE_GLOBE) {
+    return project_globe_to_mercator_(commonPosition);
+  }
+  return commonPosition.xy;
+}
+
 // Projects positions (with an optional 64-bit low part) from the input
 // coordinate system to the common space.
 fn project_position_vec4_f64(position: vec4<f32>, position64Low: vec3<f32>) -> vec4<f32> {

--- a/modules/extensions/src/utils/projection-utils.ts
+++ b/modules/extensions/src/utils/projection-utils.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {WebMercatorViewport, OrthographicViewport} from '@deck.gl/core';
-import type {Layer, Viewport} from '@deck.gl/core';
+import {WebMercatorViewport, OrthographicViewport, _GlobeViewport} from '@deck.gl/core';
+import type {CoordinateSystem, Layer, ProjectUniforms, Viewport} from '@deck.gl/core';
+import type {NumericArray} from '@math.gl/core';
 
 /** Bounds in CARTESIAN coordinates */
 export type Bounds = [minX: number, minY: number, maxX: number, maxY: number];
@@ -26,6 +27,86 @@ export function lngLatToMercatorCommon(lngLat: number[]): [number, number] {
 /** Returns a Mercator viewport for bounds computation, bypassing GlobeView. */
 export function getMercatorReferenceViewport(viewport: Viewport): Viewport {
   return viewport.isGeospatial ? MERCATOR_REFERENCE_VIEWPORT : viewport;
+}
+
+/*
+ * Flat common space
+ * -----------------
+ * Texture/bounds based extensions (mask, clip, fill pattern, terrain) index a FLAT plane:
+ * Web Mercator for geospatial viewports, cartesian for OrthographicView. GlobeViewport's common
+ * space is sphere XYZ, so positions must be converted. The GPU side is
+ * `project_common_position_to_flat()` in the core `project` shader module; the helpers below are
+ * its CPU twins.
+ * Adding a non-flat projection: (1) core project.glsl.ts / project.wgsl.ts flatten branch,
+ * (2) isFlatViewport() here, (3) a preset in test/render/view-presets.ts.
+ */
+
+/**
+ * True when the viewport's common space is a flat plane. GlobeViewport is the only non-flat
+ * viewport today. This is the only place in @deck.gl/extensions that tests for globe; swap the
+ * body for a projectionMode comparison if core ever exports PROJECTION_MODE constants.
+ */
+export function isFlatViewport(viewport: Viewport): boolean {
+  return !(viewport instanceof _GlobeViewport);
+}
+
+export type FlatProjectOptions = {
+  fromCoordinateSystem?: CoordinateSystem;
+  fromCoordinateOrigin?: [number, number, number];
+  modelMatrix?: NumericArray | null;
+};
+
+/**
+ * CPU twin of `project_common_position_to_flat(project_position(position))` for the viewport the
+ * layer is drawn into:
+ * - flat viewport: `Layer.projectPosition` with autoOffset, i.e. exactly `geometry.position`
+ *   (offset-relative under WEB_MERCATOR_AUTO_OFFSET at zoom >= 12)
+ * - non-flat viewport: absolute Mercator through the reference viewport (autoOffset off)
+ * Always pair with the GPU function; a raw `layer.projectPosition()` on either side silently
+ * disagrees in one of the two modes.
+ */
+export function projectToFlatCommon(
+  layer: Layer,
+  position: number[],
+  opts: FlatProjectOptions = {}
+): [number, number, number] {
+  // Same resolution as Layer.projectPosition so multi-view setups stay consistent
+  const viewport = layer.internalState?.viewport || layer.context.viewport;
+  return isFlatViewport(viewport)
+    ? layer.projectPosition(position, opts)
+    : layer.projectPosition(position, {
+        ...opts,
+        viewport: getMercatorReferenceViewport(viewport),
+        autoOffset: false
+      });
+}
+
+/**
+ * Projects `[minX, minY, maxX, maxY]` in the layer's (or `opts.fromCoordinateSystem`) coordinates
+ * into normalized flat common bounds.
+ */
+export function projectBoundsToFlatCommon(
+  layer: Layer,
+  bounds: Readonly<[number, number, number, number]>,
+  opts?: FlatProjectOptions
+): Bounds {
+  const a = projectToFlatCommon(layer, [bounds[0], bounds[1], 0], opts);
+  const b = projectToFlatCommon(layer, [bounds[2], bounds[3], 0], opts);
+  return [Math.min(a[0], b[0]), Math.min(a[1], b[1]), Math.max(a[0], b[0]), Math.max(a[1], b[1])];
+}
+
+/**
+ * The origin that `project_common_position_to_flat()` results are relative to:
+ * `project.commonOrigin` on flat viewports, `[0, 0]` on non-flat ones (absolute Mercator).
+ * For GLOBE + meter-offsets, commonOrigin holds a sphere-space position that must never be re-added.
+ */
+export function getFlatCommonOrigin(
+  projectUniforms: ProjectUniforms,
+  viewport: Viewport
+): [number, number] {
+  return isFlatViewport(viewport)
+    ? [projectUniforms.commonOrigin[0], projectUniforms.commonOrigin[1]]
+    : [0, 0];
 }
 
 /*
@@ -179,6 +260,12 @@ export function getRenderBounds(
 ): Bounds {
   if (!layerBounds) {
     return [0, 0, 1, 1];
+  }
+
+  // layerBounds are flat (Mercator) but getViewportBounds() would return sphere coordinates for a
+  // non-flat viewport; the two cannot be intersected. Render the full layer extent instead.
+  if (!isFlatViewport(viewport)) {
+    return layerBounds;
   }
 
   const viewportBounds = getViewportBounds(viewport, zRange);

--- a/test/modules/extensions/index.ts
+++ b/test/modules/extensions/index.ts
@@ -11,3 +11,4 @@ import './path.spec';
 import './fill-style.spec';
 import './mask';
 import './terrain';
+import './projection-utils.spec';

--- a/test/modules/extensions/projection-utils.spec.ts
+++ b/test/modules/extensions/projection-utils.spec.ts
@@ -1,0 +1,106 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {
+  COORDINATE_SYSTEM,
+  OrthographicViewport,
+  WebMercatorViewport,
+  _GlobeViewport as GlobeViewport,
+  project
+} from '@deck.gl/core';
+import type {ProjectUniforms} from '@deck.gl/core';
+import {ScatterplotLayer} from '@deck.gl/layers';
+import {testLayer} from '@deck.gl/test-utils/vitest';
+import {
+  getFlatCommonOrigin,
+  isFlatViewport,
+  lngLatToMercatorCommon,
+  projectBoundsToFlatCommon,
+  projectToFlatCommon
+} from '@deck.gl/extensions/utils/projection-utils';
+
+const SF = {longitude: -122.42694203247012, latitude: 37.751537058389985};
+const SIZE = {width: 800, height: 450};
+const POSITION = [-122.43, 37.75, 0];
+
+const mercatorViewport = new WebMercatorViewport({...SF, ...SIZE, zoom: 11.5});
+// zoom >= 12 switches the shader to WEB_MERCATOR_AUTO_OFFSET (offset-relative common space)
+const mercatorHighZoomViewport = new WebMercatorViewport({...SF, ...SIZE, zoom: 14});
+const globeViewport = new GlobeViewport({...SF, ...SIZE, zoom: 11.5});
+const orthographicViewport = new OrthographicViewport({...SIZE, target: [0, 0, 0], zoom: 0});
+
+test('projection-utils#isFlatViewport', () => {
+  expect(isFlatViewport(mercatorViewport)).toBe(true);
+  expect(isFlatViewport(mercatorHighZoomViewport)).toBe(true);
+  expect(isFlatViewport(orthographicViewport)).toBe(true);
+  expect(isFlatViewport(globeViewport)).toBe(false);
+});
+
+test('projection-utils#getFlatCommonOrigin', () => {
+  // Under GLOBE the flat space is absolute Mercator: never re-add commonOrigin, which for
+  // meter-offsets on the globe holds a sphere-space position
+  const globeUniforms = project.getUniforms({
+    viewport: globeViewport,
+    coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
+    coordinateOrigin: [-122.43, 37.75, 0]
+  }) as ProjectUniforms;
+  expect(getFlatCommonOrigin(globeUniforms, globeViewport)).toEqual([0, 0]);
+
+  // Under WEB_MERCATOR_AUTO_OFFSET the flat space is offset-relative, like geometry.position
+  const mercatorUniforms = project.getUniforms({
+    viewport: mercatorHighZoomViewport,
+    coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
+    coordinateOrigin: [0, 0, 0]
+  }) as ProjectUniforms;
+  expect(mercatorUniforms.commonOrigin[0]).not.toBe(0);
+  expect(getFlatCommonOrigin(mercatorUniforms, mercatorHighZoomViewport)).toEqual([
+    mercatorUniforms.commonOrigin[0],
+    mercatorUniforms.commonOrigin[1]
+  ]);
+});
+
+test('projection-utils#projectToFlatCommon pairs with project_common_position_to_flat', () => {
+  testLayer({
+    Layer: ScatterplotLayer,
+    onError: err => expect(err).toBeFalsy(),
+    testCases: [
+      {
+        title: 'GlobeViewport: absolute Mercator',
+        viewport: globeViewport,
+        props: {data: [POSITION], getPosition: d => d},
+        onAfterUpdate: ({layer}) => {
+          // The layer's own projection is sphere XYZ (radius GLOBE_RADIUS = 256)...
+          const sphere = layer.projectPosition(POSITION);
+          expect(Math.hypot(sphere[0], sphere[1], sphere[2])).toBeCloseTo(256, 3);
+          // ...while the flat helper yields absolute Mercator common space
+          const flat = projectToFlatCommon(layer, POSITION);
+          const [x, y] = lngLatToMercatorCommon(POSITION);
+          expect(flat[0]).toBeCloseTo(x, 6);
+          expect(flat[1]).toBeCloseTo(y, 6);
+        }
+      },
+      {
+        title: 'WebMercatorViewport zoom 14: offset-relative like geometry.position',
+        viewport: mercatorHighZoomViewport,
+        updateProps: {radiusScale: 2},
+        onAfterUpdate: ({layer}) => {
+          const flat = projectToFlatCommon(layer, POSITION);
+          expect(flat).toEqual(layer.projectPosition(POSITION));
+          expect(flat).not.toEqual(layer.projectPosition(POSITION, {autoOffset: false}));
+        }
+      },
+      {
+        title: 'OrthographicViewport: cartesian identity',
+        viewport: orthographicViewport,
+        updateProps: {coordinateSystem: COORDINATE_SYSTEM.CARTESIAN, data: [[10, -20, 0]]},
+        onAfterUpdate: ({layer}) => {
+          expect(projectToFlatCommon(layer, [10, -20, 0])).toEqual([10, -20, 0]);
+          // corners are re-ordered into min/max bounds
+          expect(projectBoundsToFlatCommon(layer, [10, 20, -10, -20])).toEqual([-10, -20, 10, 20]);
+        }
+      }
+    ]
+  });
+});

--- a/test/render/view-presets.spec.ts
+++ b/test/render/view-presets.spec.ts
@@ -1,0 +1,130 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, test, expect} from 'vitest';
+import {_GlobeViewport as GlobeViewport, MapView, OrthographicView} from '@deck.gl/core';
+import {WIDTH, HEIGHT} from './constants';
+import {expandViewMatrix, SF_VIEW_STATE, VIEW_PRESETS} from './view-presets';
+
+// expandViewMatrix never touches layer instances; a placeholder is enough
+const layer = {id: 'test-layer'} as any;
+
+describe('view-presets', () => {
+  test('presets', () => {
+    expect(VIEW_PRESETS.map.views).toBeInstanceOf(MapView);
+    expect(VIEW_PRESETS.orthographic.views).toBeInstanceOf(OrthographicView);
+    expect(VIEW_PRESETS.globe.views.getViewportType(SF_VIEW_STATE)).toBe(GlobeViewport);
+    expect(VIEW_PRESETS.map.toPosition([1, 2])).toEqual([1, 2]);
+
+    // The orthographic preset is the pixel space of the map preset
+    const center = VIEW_PRESETS.orthographic.toPosition([
+      SF_VIEW_STATE.longitude,
+      SF_VIEW_STATE.latitude
+    ]);
+    expect(center[0]).toBeCloseTo(WIDTH / 2, 6);
+    expect(center[1]).toBeCloseTo(HEIGHT / 2, 6);
+    // North is up in lng/lat but down in pixels, so toBounds must re-order min/max
+    const bounds = VIEW_PRESETS.orthographic.toBounds([-122.47, 37.73, -122.39, 37.78]);
+    expect(bounds[0]).toBeLessThan(bounds[2]);
+    expect(bounds[1]).toBeLessThan(bounds[3]);
+  });
+
+  test('expandViewMatrix#names, views and goldens', () => {
+    const cases = expandViewMatrix({name: 'my-case', layers: [layer]}, [
+      'map',
+      'globe',
+      'orthographic'
+    ]);
+    expect(cases.map(c => c.name)).toEqual(['my-case', 'my-case-globe', 'my-case-orthographic']);
+    expect(cases.map(c => c.goldenImage)).toEqual([
+      './test/render/golden-images/my-case.png',
+      './test/render/golden-images/my-case-globe.png',
+      './test/render/golden-images/my-case-orthographic.png'
+    ]);
+    expect(cases[0].views).toBe(VIEW_PRESETS.map.views);
+    expect(cases[1].views).toBe(VIEW_PRESETS.globe.views);
+    expect(cases[0].viewState).toBe(SF_VIEW_STATE);
+    expect(cases[2].viewState).toEqual({target: [WIDTH / 2, HEIGHT / 2, 0], zoom: 0});
+    expect(cases[0].layers).toEqual([layer]);
+
+    // Default presets
+    expect(expandViewMatrix({name: 'x', layers: []}).map(c => c.name)).toEqual(['x', 'x-globe']);
+
+    // Explicit base golden
+    const custom = expandViewMatrix({
+      name: 'x',
+      layers: [],
+      goldenImage: './test/render/golden-images/other.png'
+    });
+    expect(custom.map(c => c.goldenImage)).toEqual([
+      './test/render/golden-images/other.png',
+      './test/render/golden-images/other-globe.png'
+    ]);
+  });
+
+  test('expandViewMatrix#viewState resolution', () => {
+    const viewState = {longitude: 0, latitude: 0, zoom: 8};
+    const cases = expandViewMatrix(
+      {
+        name: 'x',
+        layers: [],
+        viewState,
+        overrides: {globe: {viewState: {longitude: 1, latitude: 1, zoom: 3}}}
+      },
+      ['map', 'globe', 'orthographic']
+    );
+    // geospatial override applies to the map preset
+    expect(cases[0].viewState).toBe(viewState);
+    // per-preset override wins
+    expect(cases[1].viewState).toEqual({longitude: 1, latitude: 1, zoom: 3});
+    // not applied to the cartesian preset
+    expect(cases[2].viewState).toEqual(VIEW_PRESETS.orthographic.viewState);
+  });
+
+  test('expandViewMatrix#layers factory receives the preset', () => {
+    const seen: string[] = [];
+    const cases = expandViewMatrix(
+      {
+        name: 'x',
+        layers: preset => {
+          seen.push(preset.coordinateSystem);
+          return [layer];
+        }
+      },
+      ['map', 'globe', 'orthographic']
+    );
+    expect(seen).toEqual(['lnglat', 'lnglat', 'cartesian']);
+    expect(cases[2].layers).toEqual([layer]);
+  });
+
+  test('expandViewMatrix#skip merging and overrides', () => {
+    const cases = expandViewMatrix({
+      name: 'x',
+      layers: [],
+      skip: ['webgpu'],
+      imageDiffOptions: {threshold: 0.99},
+      overrides: {globe: {skip: ['webgl'], imageDiffOptions: {threshold: 0.985}}}
+    });
+    expect(cases[0].skip).toEqual(['webgpu']);
+    expect(cases[1].skip).toEqual(['webgpu', 'webgl']);
+    expect(cases[0].imageDiffOptions).toEqual({threshold: 0.99});
+    expect(cases[1].imageDiffOptions).toEqual({threshold: 0.985});
+    expect(
+      expandViewMatrix({name: 'x', layers: [], overrides: {globe: {skip: true}}})[1].skip
+    ).toBe(true);
+    expect(expandViewMatrix({name: 'x', layers: []})[0].skip).toBeUndefined();
+  });
+
+  test('expandViewMatrix#globe guard', () => {
+    const highZoom = {longitude: 0, latitude: 0, zoom: 13};
+    expect(() => expandViewMatrix({name: 'x', layers: [], viewState: highZoom})).toThrow(/globe/);
+    expect(() =>
+      expandViewMatrix({name: 'x', layers: [], viewState: {...highZoom, zoom: 12}})
+    ).not.toThrow();
+    // The guard does not apply to map-only expansions
+    expect(() =>
+      expandViewMatrix({name: 'x', layers: [], viewState: highZoom}, ['map'])
+    ).not.toThrow();
+  });
+});

--- a/test/render/view-presets.ts
+++ b/test/render/view-presets.ts
@@ -34,8 +34,11 @@ export type ViewPreset = {
   /** map/globe share lng/lat data; orthographic needs cartesian data (use toPosition/toBounds) */
   isGeospatial: boolean;
   coordinateSystem: 'lnglat' | 'cartesian';
-  /** Map a lng/lat from the shared San Francisco test data into this preset's world space */
-  toPosition: (lngLat: number[]) => number[];
+  /**
+   * Map a lng/lat from the shared San Francisco test data into this preset's world space.
+   * Returns a 2-tuple so it can be used directly in `getPosition` accessors.
+   */
+  toPosition: (lngLat: number[]) => [number, number];
   /** Same for `[minX, minY, maxX, maxY]` bounds (e.g. `clipBounds`) */
   toBounds: (bounds: [number, number, number, number]) => [number, number, number, number];
 };
@@ -50,6 +53,7 @@ export const SF_VIEW_STATE = {
 };
 
 const identity = <T>(value: T): T => value;
+const toLngLat = (lngLat: number[]): [number, number] => [lngLat[0], lngLat[1]];
 
 /** Pixel projection of the map preset; expresses the same picture in cartesian coordinates */
 const sfPixelViewport = new WebMercatorViewport({...SF_VIEW_STATE, width: WIDTH, height: HEIGHT});
@@ -61,7 +65,7 @@ export const VIEW_PRESETS: Record<ViewPresetName, ViewPreset> = {
     viewState: SF_VIEW_STATE,
     isGeospatial: true,
     coordinateSystem: 'lnglat',
-    toPosition: identity,
+    toPosition: toLngLat,
     toBounds: identity
   },
   // Same lng/lat/zoom as the map preset. GlobeViewport scales by 2^(zoom - log2(PI * cos(lat))),
@@ -73,7 +77,7 @@ export const VIEW_PRESETS: Record<ViewPresetName, ViewPreset> = {
     viewState: SF_VIEW_STATE,
     isGeospatial: true,
     coordinateSystem: 'lnglat',
-    toPosition: identity,
+    toPosition: toLngLat,
     toBounds: identity
   },
   // Pixel space of the map preset. OrthographicView defaults to flipY: true (+y = screen down),
@@ -84,7 +88,10 @@ export const VIEW_PRESETS: Record<ViewPresetName, ViewPreset> = {
     viewState: {target: [WIDTH / 2, HEIGHT / 2, 0], zoom: 0},
     isGeospatial: false,
     coordinateSystem: 'cartesian',
-    toPosition: lngLat => sfPixelViewport.project(lngLat).slice(0, 2),
+    toPosition: lngLat => {
+      const [x, y] = sfPixelViewport.project(lngLat);
+      return [x, y];
+    },
     toBounds: ([x0, y0, x1, y1]) => {
       const a = sfPixelViewport.project([x0, y0]);
       const b = sfPixelViewport.project([x1, y1]);

--- a/test/render/view-presets.ts
+++ b/test/render/view-presets.ts
@@ -1,0 +1,157 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  MapView,
+  OrthographicView,
+  WebMercatorViewport,
+  _GlobeView as GlobeView,
+  _GlobeViewport as GlobeViewport
+} from '@deck.gl/core';
+import {WIDTH, HEIGHT} from './constants';
+import type {TestCase} from './deck-test-utils';
+
+/**
+ * View matrix helper for render tests.
+ *
+ * Expands one test case into one `TestCase` per view preset so that the same layers (and
+ * extensions) are rendered under MapView, GlobeView and OrthographicView. The 'map' preset keeps
+ * the bare name and golden image so that existing goldens are reused; the other presets append
+ * `-<preset>` to both (matching the existing `polygon-globe`, `path-globe`, `orthographic-64`
+ * naming).
+ *
+ * Adding a non-flat projection: add a preset here, plus the flatten branch in the core `project`
+ * shader module and `isFlatViewport()` in @deck.gl/extensions.
+ */
+
+export type ViewPresetName = 'map' | 'globe' | 'orthographic';
+
+export type ViewPreset = {
+  name: ViewPresetName;
+  views: any;
+  viewState: any;
+  /** map/globe share lng/lat data; orthographic needs cartesian data (use toPosition/toBounds) */
+  isGeospatial: boolean;
+  coordinateSystem: 'lnglat' | 'cartesian';
+  /** Map a lng/lat from the shared San Francisco test data into this preset's world space */
+  toPosition: (lngLat: number[]) => number[];
+  /** Same for `[minX, minY, maxX, maxY]` bounds (e.g. `clipBounds`) */
+  toBounds: (bounds: [number, number, number, number]) => [number, number, number, number];
+};
+
+/** The San Francisco view used by collision-filter, mask-effect, polygon-lnglat and path-miter goldens */
+export const SF_VIEW_STATE = {
+  latitude: 37.751537058389985,
+  longitude: -122.42694203247012,
+  zoom: 11.5,
+  pitch: 0,
+  bearing: 0
+};
+
+const identity = <T>(value: T): T => value;
+
+/** Pixel projection of the map preset; expresses the same picture in cartesian coordinates */
+const sfPixelViewport = new WebMercatorViewport({...SF_VIEW_STATE, width: WIDTH, height: HEIGHT});
+
+export const VIEW_PRESETS: Record<ViewPresetName, ViewPreset> = {
+  map: {
+    name: 'map',
+    views: new MapView(),
+    viewState: SF_VIEW_STATE,
+    isGeospatial: true,
+    coordinateSystem: 'lnglat',
+    toPosition: identity,
+    toBounds: identity
+  },
+  // Same lng/lat/zoom as the map preset. GlobeViewport scales by 2^(zoom - log2(PI * cos(lat))),
+  // calibrated so that globe and Mercator framing converge at city zooms (see globe-viewport.ts),
+  // so the picture matches the map golden up to the curvature of the sphere.
+  globe: {
+    name: 'globe',
+    views: new GlobeView(),
+    viewState: SF_VIEW_STATE,
+    isGeospatial: true,
+    coordinateSystem: 'lnglat',
+    toPosition: identity,
+    toBounds: identity
+  },
+  // Pixel space of the map preset. OrthographicView defaults to flipY: true (+y = screen down),
+  // like viewport.project(), so target = canvas centre at zoom 0 reproduces the map framing.
+  orthographic: {
+    name: 'orthographic',
+    views: new OrthographicView(),
+    viewState: {target: [WIDTH / 2, HEIGHT / 2, 0], zoom: 0},
+    isGeospatial: false,
+    coordinateSystem: 'cartesian',
+    toPosition: lngLat => sfPixelViewport.project(lngLat).slice(0, 2),
+    toBounds: ([x0, y0, x1, y1]) => {
+      const a = sfPixelViewport.project([x0, y0]);
+      const b = sfPixelViewport.project([x1, y1]);
+      return [
+        Math.min(a[0], b[0]),
+        Math.min(a[1], b[1]),
+        Math.max(a[0], b[0]),
+        Math.max(a[1], b[1])
+      ];
+    }
+  }
+};
+
+export type ViewMatrixCase = Omit<TestCase, 'views' | 'viewState' | 'layers' | 'goldenImage'> & {
+  /** Static layers (geospatial presets) or a factory receiving the preset (required for 'orthographic') */
+  layers: any[] | ((preset: ViewPreset) => any[]);
+  /** Geospatial viewState override for 'map' and 'globe', e.g. to keep a golden that uses a non-SF view */
+  viewState?: any;
+  /** Golden for 'map'; default `./test/render/golden-images/<name>.png`. Other presets append `-<preset>`. */
+  goldenImage?: string;
+  /** Per-preset overrides of any TestCase field; `skip` is merged with the base rather than replaced */
+  overrides?: Partial<Record<ViewPresetName, Partial<TestCase>>>;
+};
+
+/** Expands one case into one `TestCase` per preset (default: map + globe). */
+export function expandViewMatrix(
+  base: ViewMatrixCase,
+  presets: ViewPresetName[] = ['map', 'globe']
+): TestCase[] {
+  const {layers, viewState, goldenImage, overrides, ...rest} = base;
+  const baseGolden = goldenImage ?? `./test/render/golden-images/${base.name}.png`;
+  return presets.map(presetName => {
+    const preset = VIEW_PRESETS[presetName];
+    const suffix = presetName === 'map' ? '' : `-${presetName}`;
+    const override: Partial<TestCase> = overrides?.[presetName] ?? {};
+    const resolvedViewState =
+      override.viewState ?? (preset.isGeospatial && viewState ? viewState : preset.viewState);
+    assertUsesGlobeViewport(preset, resolvedViewState);
+    return {
+      ...rest,
+      ...override,
+      name: `${base.name}${suffix}`,
+      views: preset.views,
+      viewState: resolvedViewState,
+      layers: typeof layers === 'function' ? layers(preset) : layers,
+      skip: mergeSkip(rest.skip, override.skip),
+      goldenImage: override.goldenImage ?? baseGolden.replace(/\.png$/, `${suffix}.png`)
+    };
+  });
+}
+
+/**
+ * GlobeView instantiates a WebMercatorViewport above zoom 12 (GlobeView.getViewportType).
+ * Refuse a 'globe' case that would silently test Mercator.
+ */
+function assertUsesGlobeViewport(preset: ViewPreset, viewState: any): void {
+  if (preset.name === 'globe' && preset.views.getViewportType(viewState) !== GlobeViewport) {
+    throw new Error(
+      `view preset 'globe' resolves to a WebMercatorViewport at zoom ${viewState.zoom}; use zoom <= 12 or a plain map case`
+    );
+  }
+}
+
+function mergeSkip(a?: boolean | string[], b?: boolean | string[]): boolean | string[] | undefined {
+  if (a === true || b === true) {
+    return true;
+  }
+  const list = [...(Array.isArray(a) ? a : []), ...(Array.isArray(b) ? b : [])];
+  return list.length ? list : undefined;
+}


### PR DESCRIPTION
Base of the GlobeView extension series: #10658, #10659, #10660, #10661, #10662, #10663, #10664, #10666

#### Background

`MaskExtension`, `ClipExtension`, `FillStyleExtension` and `TerrainExtension` sample a flat common space (Web Mercator, or cartesian in `OrthographicView`), but under `GlobeView` `geometry.position` is sphere XYZ and `GlobeViewport.projectFlat()` is an identity. Each extension either carries its own `PROJECTION_MODE_GLOBE` branch or renders incorrectly on the globe. This PR adds one shared GPU/CPU conversion so the fixes in the stacked PRs are one-line calls, and a render test helper to run the same case in several views. Additive only: no behavior change for shipped extensions, no new core exports.

#### Change List
- `project` shader module (GLSL and WGSL): add `project_globe_to_mercator_(vec3)` and `project_common_position_to_flat(vec3|vec4)`, identity for flat projection modes and sphere to absolute Mercator under `GLOBE`
- `project_common_position_to_flat_wrapped(position, referenceX)`: x moved to the world copy nearest a reference in every geospatial mode, for bounds and texture lookups (pass the bounds centre)
- `project_common_position_to_flat_continuous(position, referenceX)`: same, but only under `GLOBE`, so a polygon spanning the antimeridian stays continuous while flat maps are untouched; for periodic patterns (pass the camera)
- `@deck.gl/extensions` `projection-utils`: add CPU twins `isFlatViewport`, `projectToFlatCommon`, `projectBoundsToFlatCommon`, `getFlatCommonOrigin`; `getRenderBounds` returns the full layer extent for non-flat viewports
- `projectToFlatCommon` mirrors the `GLOBE` + `METER_OFFSETS` shader branch exactly (ENU displacement on the sphere, then the sphere's inverse) instead of going through lng/lat, which diverges by about 200 m at a 300 km offset
- `projectBoundsToFlatCommon` unwraps lng/lat bounds whose left edge is east of their right edge, so bounds can describe a region across the antimeridian
- `test/render/view-presets.ts`: `expandViewMatrix(case, ['map', 'globe', 'orthographic'])` expands one case into per-view cases with shared San Francisco presets and guards against globe cases above the zoom-12 Mercator hand-off
- Unit tests: GPU/CPU pairing on `WebMercatorViewport` (zoom 11.5 and 14), `GlobeViewport` and `OrthographicViewport`, including a 300 km meter offset and antimeridian bounds; `expandViewMatrix` naming and overrides
- Documentation: `project.md`

Ran the unit specs, `tsc` for core and extensions, and lint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core projection shaders and shared bounds logic used by mask/terrain on GlobeView; additive for most users but incorrect pairing of CPU/GPU helpers could cause subtle globe misalignment in follow-up extension PRs.
> 
> **Overview**
> Introduces shared **GPU and CPU conversion** from common space (sphere XYZ under `GlobeView`) into **flat common space** (Web Mercator or cartesian), so texture- and bounds-based extensions can align with flat viewports without duplicating globe branches.
> 
> The core **`project` shader module** (GLSL and WGSL) gains `project_globe_to_mercator_`, `project_common_position_to_flat`, plus **`_wrapped`** and **`_continuous`** variants that re-home Mercator **x** near a reference for antimeridian bounds, regional textures, and periodic patterns. **`project.md`** documents the new entry points.
> 
> **`@deck.gl/extensions` `projection-utils`** adds CPU twins (`isFlatViewport`, `projectToFlatCommon`, `projectBoundsToFlatCommon`, `getFlatCommonOrigin`), including a **globe + meter-offsets** path that matches the shader’s ENU-on-sphere math. **`getRenderBounds`** skips viewport intersection on non-flat viewports so flat layer bounds are not mixed with sphere viewport bounds.
> 
> **Render test infrastructure**: `test/render/view-presets.ts` and **`expandViewMatrix`** duplicate cases across map, globe, and orthographic presets (with a zoom guard so globe cases stay on `GlobeViewport`). Unit coverage exercises GPU/CPU pairing, large meter offsets, and antimeridian bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c5906c6d8e563ebf6bc7a5ef767eb1c2354901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->