### PR TITLE
website: publish llms.txt and per-page Markdown for AI coding agents

### DIFF
--- a/docs/api-reference/aggregation-layers/contour-layer.md
+++ b/docs/api-reference/aggregation-layers/contour-layer.md
@@ -1,3 +1,7 @@
+---
+description: "ContourLayer aggregates points into a grid and renders iso-lines or iso-bands at given thresholds."
+---
+
 # ContourLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/aggregation-layers/heatmap-layer.md
+++ b/docs/api-reference/aggregation-layers/heatmap-layer.md
@@ -1,3 +1,7 @@
+---
+description: "HeatmapLayer renders a smooth density heatmap from weighted points."
+---
+
 # HeatmapLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/aggregation-layers/hexagon-layer.md
+++ b/docs/api-reference/aggregation-layers/hexagon-layer.md
@@ -1,3 +1,7 @@
+---
+description: "HexagonLayer aggregates points into hexagonal bins and encodes counts or weights as color and elevation."
+---
+
 # HexagonLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/aggregation-layers/screen-grid-layer.md
+++ b/docs/api-reference/aggregation-layers/screen-grid-layer.md
@@ -1,3 +1,7 @@
+---
+description: "ScreenGridLayer aggregates points into screen-space grid cells colored by count or weight."
+---
+
 # ScreenGridLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/geo-layers/tile-layer.md
+++ b/docs/api-reference/geo-layers/tile-layer.md
@@ -1,3 +1,7 @@
+---
+description: "TileLayer loads tiled data for the current viewport and renders it through sub-layers."
+---
+
 # TileLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/json/conversion-reference.md
+++ b/docs/api-reference/json/conversion-reference.md
@@ -1,3 +1,7 @@
+---
+description: "Reference for the @deck.gl/json prefixes: @@type, @@function, @@# constants and enumerations, and @@= accessor expressions."
+---
+
 # Conversion Reference
 
 | Prefix | Description | Example usage |

--- a/docs/api-reference/layers/arc-layer.md
+++ b/docs/api-reference/layers/arc-layer.md
@@ -1,3 +1,7 @@
+---
+description: "ArcLayer renders arcs between pairs of source and target coordinates."
+---
+
 # ArcLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/column-layer.md
+++ b/docs/api-reference/layers/column-layer.md
@@ -1,3 +1,7 @@
+---
+description: "ColumnLayer renders extruded cylinders or regular polygons at given coordinates."
+---
+
 # ColumnLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/grid-cell-layer.md
+++ b/docs/api-reference/layers/grid-cell-layer.md
@@ -1,3 +1,7 @@
+---
+description: "GridCellLayer renders extruded square grid cells at given coordinates."
+---
+
 # GridCellLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/icon-layer.md
+++ b/docs/api-reference/layers/icon-layer.md
@@ -1,3 +1,7 @@
+---
+description: "IconLayer renders raster icons from an atlas or auto-packed images at given coordinates."
+---
+
 # IconLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/line-layer.md
+++ b/docs/api-reference/layers/line-layer.md
@@ -1,3 +1,7 @@
+---
+description: "LineLayer renders straight lines between pairs of source and target coordinates."
+---
+
 # LineLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/path-layer.md
+++ b/docs/api-reference/layers/path-layer.md
@@ -1,3 +1,7 @@
+---
+description: "PathLayer renders polylines with configurable width, joints and caps."
+---
+
 # PathLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/point-cloud-layer.md
+++ b/docs/api-reference/layers/point-cloud-layer.md
@@ -1,3 +1,7 @@
+---
+description: "PointCloudLayer renders 3D point clouds with optional normals and per-point colors."
+---
+
 # PointCloudLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/polygon-layer.md
+++ b/docs/api-reference/layers/polygon-layer.md
@@ -1,3 +1,7 @@
+---
+description: "PolygonLayer renders filled, stroked and optionally extruded polygons."
+---
+
 # PolygonLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/scatterplot-layer.md
+++ b/docs/api-reference/layers/scatterplot-layer.md
@@ -1,3 +1,7 @@
+---
+description: "ScatterplotLayer renders circles at given coordinates with data-driven radius, fill and stroke."
+---
+
 # ScatterplotLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/layers/solid-polygon-layer.md
+++ b/docs/api-reference/layers/solid-polygon-layer.md
@@ -1,3 +1,7 @@
+---
+description: "SolidPolygonLayer renders filled and optionally extruded polygons without strokes."
+---
+
 # SolidPolygonLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/mesh-layers/scenegraph-layer.md
+++ b/docs/api-reference/mesh-layers/scenegraph-layer.md
@@ -1,3 +1,7 @@
+---
+description: "ScenegraphLayer renders glTF scenegraph models at given coordinates."
+---
+
 # ScenegraphLayer
 ![webgpu](https://img.shields.io/badge/webgpu-supported-blue.svg?style=flat-square)
 

--- a/docs/api-reference/widgets/styling.md
+++ b/docs/api-reference/widgets/styling.md
@@ -1,3 +1,7 @@
+---
+description: "Styling deck.gl widgets with CSS variables, themes and custom class names."
+---
+
 import {WidgetThemes} from '@site/src/doc-demos/widgets';
 
 # Styling Widgets

--- a/docs/developer-guide/base-maps/using-with-arcgis.md
+++ b/docs/developer-guide/base-maps/using-with-arcgis.md
@@ -1,3 +1,7 @@
+---
+description: "Render deck.gl layers in ArcGIS Maps SDK for JavaScript maps and scenes with @deck.gl/arcgis."
+---
+
 # Using with ArcGIS
 
 | Pure JS | React | Overlaid | Interleaved |

--- a/docs/developer-guide/base-maps/using-with-google-maps.md
+++ b/docs/developer-guide/base-maps/using-with-google-maps.md
@@ -1,3 +1,7 @@
+---
+description: "Render deck.gl layers over Google Maps with GoogleMapsOverlay from @deck.gl/google-maps, overlaid or interleaved."
+---
+
 # Using with Google Maps Platform
 
 | Pure JS | React | Overlaid | Interleaved |

--- a/docs/developer-guide/base-maps/using-with-mapbox.md
+++ b/docs/developer-guide/base-maps/using-with-mapbox.md
@@ -1,3 +1,7 @@
+---
+description: "Render deck.gl layers over Mapbox GL JS with MapboxOverlay from @deck.gl/mapbox, overlaid or interleaved."
+---
+
 # Using with Mapbox
 
 | Pure JS | React | Overlaid | Interleaved |

--- a/docs/developer-guide/base-maps/using-with-maplibre.md
+++ b/docs/developer-guide/base-maps/using-with-maplibre.md
@@ -1,3 +1,7 @@
+---
+description: "Render deck.gl layers over MapLibre GL JS with MapLibreOverlay from @deck.gl/maplibre, overlaid or interleaved."
+---
+
 # Using with MapLibre
 
 | Pure JS | React | Overlaid | Interleaved |

--- a/docs/developer-guide/custom-layers/README.md
+++ b/docs/developer-guide/custom-layers/README.md
@@ -1,3 +1,7 @@
+---
+description: "How to write your own deck.gl layer: subclassing, composite layers and the layer lifecycle."
+---
+
 # Writing Your Own Layer
 
 ## Preparations

--- a/docs/developer-guide/custom-layers/attribute-management.md
+++ b/docs/developer-guide/custom-layers/attribute-management.md
@@ -1,3 +1,7 @@
+---
+description: "How layers manage GPU attributes: the AttributeManager, accessors, update triggers and instanced attributes."
+---
+
 # Attribute Management
 
 ## Overview

--- a/docs/developer-guide/interactivity.md
+++ b/docs/developer-guide/interactivity.md
@@ -1,3 +1,7 @@
+---
+description: "Controlling the camera and view state, picking, and handling hover and click events in deck.gl."
+---
+
 # Interactivity
 
 ## Controlling the Camera

--- a/docs/developer-guide/tips-and-tricks.md
+++ b/docs/developer-guide/tips-and-tricks.md
@@ -1,3 +1,7 @@
+---
+description: "Rendering, data handling and performance tips for building deck.gl applications."
+---
+
 # Tips and Tricks
 
 

--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -1,3 +1,7 @@
+---
+description: "Install deck.gl with npm or from a CDN, run the examples, and pick a base map integration."
+---
+
 # Installing and Running Examples
 
 ## Installation

--- a/docs/get-started/learning-resources.md
+++ b/docs/get-started/learning-resources.md
@@ -1,3 +1,7 @@
+---
+description: "Where to learn deck.gl: API reference, developer guide, examples, tutorials and community channels."
+---
+
 # Learning Resources
 
 ## API Documentation

--- a/docs/get-started/using-with-typescript.md
+++ b/docs/get-started/using-with-typescript.md
@@ -1,3 +1,7 @@
+---
+description: "Using deck.gl with TypeScript: typed layer props, generic data types and type-checked accessors."
+---
+
 # Using deck.gl with TypeScript
 
 ## deck.gl v9+

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,3 +1,7 @@
+---
+description: "Breaking changes, removals and deprecations for each deck.gl release, with migration notes."
+---
+
 # Upgrade Guide
 
 ## Upgrading to v9.4

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,6 +12,14 @@ const darkCodeTheme = prismThemes.nightOwl;
 const {getSwcLoaderOptions, rspack} = require('@docusaurus/faster');
 const {resolve} = require('path');
 const websiteBaseUrl = process.env.WEBSITE_BASE_URL || '/';
+const websiteBasePathSegments = websiteBaseUrl.split('/').filter(Boolean);
+const websiteBasePath =
+  websiteBasePathSegments.length === 0 ? '' : `/${websiteBasePathSegments.join('/')}`;
+
+/** Prefix a site-relative route with the configured website base path (staging builds). */
+function prefixWebsiteRoute(route) {
+  return `${websiteBasePath}${route}`;
+}
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -89,6 +97,45 @@ const config = {
   ],
 
   plugins: [
+    // Publishes /llms.txt (a curated Markdown index of the documentation) and a raw
+    // Markdown sibling for every docs page (e.g. /docs/api-reference/json/overview.md),
+    // so coding agents can read current deck.gl documentation at inference time.
+    // Mirrors the setup used by luma.gl (https://luma.gl/llms.txt).
+    [
+      '@signalwire/docusaurus-plugin-llms-txt',
+      {
+        siteTitle: 'deck.gl',
+        siteDescription:
+          'GPU-powered, highly performant large-scale data visualization. Layers, views, ' +
+          'base map integrations (MapLibre, Mapbox, Google Maps, ArcGIS), the @deck.gl/json ' +
+          'declarative format, and the developer guide.',
+        // Plugin 1.x builds its route tree from base-prefixed Docusaurus paths.
+        // Preserve the configured three levels after the post-build base-path normalization
+        // (scripts/normalize-llm-output.mjs).
+        depth: Math.min(5, 3 + websiteBasePathSegments.length),
+        enableDescriptions: true,
+        includeOrder: [
+          '/docs/get-started/**',
+          '/docs/whats-new',
+          '/docs/upgrade-guide',
+          '/docs/developer-guide/**',
+          '/docs/api-reference/**'
+        ].map(prefixWebsiteRoute),
+        onRouteError: 'warn',
+        content: {
+          enableMarkdownFiles: true,
+          enableLlmsFullTxt: false,
+          relativePaths: false,
+          includeBlog: false,
+          includePages: false,
+          includeDocs: true,
+          includeVersionedDocs: false,
+          includeGeneratedIndex: true,
+          // /examples is the only other docs instance; TEST-STATUS is an internal tracker.
+          excludeRoutes: ['/examples/**', '/docs/TEST-STATUS'].map(prefixWebsiteRoute)
+        }
+      }
+    ],
     [
       './ocular-docusaurus-plugin',
       {

--- a/website/package.json
+++ b/website/package.json
@@ -53,6 +53,7 @@
     "@docusaurus/plugin-content-docs": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@mdx-js/react": "^3.1.0",
+    "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
     "@swc/plugin-styled-components": "12.4.0",
     "algoliasearch": "^4.18.0",
     "algoliasearch-helper": "^3.13.3",

--- a/website/scripts/build.sh
+++ b/website/scripts/build.sh
@@ -36,6 +36,10 @@ case $MODE in
     ;;
 esac
 
+# repair llms.txt / raw Markdown links for base-path deploys (WEBSITE_BASE_URL) and validate them
+node ./scripts/normalize-llm-output.mjs
+node ./scripts/check-llm-output.mjs
+
 # transpile workers
 BABEL_ENV=es5 npx babel ./static/workers --out-dir ./$OUTPUT_DIR/workers
 BABEL_ENV=esm npx babel ../examples/pydeck/src/pyodide-worker.ts --out-file ./$OUTPUT_DIR/workers/pyodide-worker.mjs

--- a/website/scripts/check-llm-output.mjs
+++ b/website/scripts/check-llm-output.mjs
@@ -1,0 +1,187 @@
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const websiteDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const buildDirectory = path.join(websiteDirectory, 'build');
+const llmsTxtPath = path.join(buildDirectory, 'llms.txt');
+const llmsFullTxtPath = path.join(buildDirectory, 'llms-full.txt');
+const websiteOrigin = 'https://deck.gl';
+const websiteBasePath = normalizeWebsiteBasePath(process.env.WEBSITE_BASE_URL || '/');
+const websiteUrl = new URL(websiteBasePath, websiteOrigin);
+const duplicatedWebsiteBaseUrl =
+  websiteBasePath === '/' ? null : new URL(websiteBasePath.slice(1), websiteUrl).href;
+
+function normalizeWebsiteBasePath(basePath) {
+  const pathSegments = basePath.split('/').filter(Boolean);
+  return pathSegments.length === 0 ? '/' : `/${pathSegments.join('/')}/`;
+}
+
+function stripWebsiteBasePath(pathname) {
+  if (websiteBasePath === '/' || !pathname.startsWith(websiteBasePath)) {
+    return pathname;
+  }
+  return `/${pathname.slice(websiteBasePath.length)}`;
+}
+
+function fail(message) {
+  throw new Error(`llms.txt output check failed: ${message}`);
+}
+
+function requireFile(relativePath) {
+  const filePath = path.join(buildDirectory, relativePath);
+  if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+    fail(`missing ${relativePath}`);
+  }
+  return filePath;
+}
+
+function findFiles(directory, extension) {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  const filePaths = [];
+  for (const entry of readdirSync(directory, {withFileTypes: true})) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      filePaths.push(...findFiles(entryPath, extension));
+    } else if (entry.isFile() && entryPath.endsWith(extension)) {
+      filePaths.push(entryPath);
+    }
+  }
+  return filePaths;
+}
+
+function extractMarkdownLinks(markdown) {
+  const links = [];
+  const markdownLinkPattern = /!?\[[^\]]*\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+  for (const match of markdown.matchAll(markdownLinkPattern)) {
+    links.push(match[1].replace(/^<|>$/g, ''));
+  }
+  return links;
+}
+
+function resolveGeneratedMarkdownLink(sourcePath, link) {
+  if (link.startsWith('#') || link.startsWith('mailto:')) {
+    return null;
+  }
+
+  let pathname;
+  try {
+    const url = new URL(link);
+    if (url.origin !== websiteUrl.origin) {
+      return null;
+    }
+    pathname = decodeURIComponent(url.pathname);
+  } catch {
+    const linkWithoutFragment = link.split('#', 1)[0].split('?', 1)[0];
+    if (!linkWithoutFragment.endsWith('.md')) {
+      return null;
+    }
+    if (linkWithoutFragment.startsWith('/')) {
+      pathname = decodeURIComponent(linkWithoutFragment);
+    } else {
+      return path.resolve(path.dirname(sourcePath), decodeURIComponent(linkWithoutFragment));
+    }
+  }
+
+  if (!pathname.endsWith('.md')) {
+    return null;
+  }
+  pathname = stripWebsiteBasePath(pathname);
+  if (path.isAbsolute(pathname) && pathname.startsWith(buildDirectory)) {
+    return pathname;
+  }
+  return path.join(buildDirectory, pathname.replace(/^\/+/, ''));
+}
+
+if (!existsSync(llmsTxtPath)) {
+  fail('missing llms.txt');
+}
+if (existsSync(llmsFullTxtPath)) {
+  fail('llms-full.txt must not be generated');
+}
+
+const llmsTxt = readFileSync(llmsTxtPath, 'utf8');
+if (!llmsTxt.startsWith('# deck.gl\n')) {
+  fail('llms.txt has an unexpected title');
+}
+const firstSectionHeading = llmsTxt.match(/^## .+$/m)?.[0];
+if (firstSectionHeading !== '## docs') {
+  fail(`llms.txt has an unexpected first section: ${firstSectionHeading || 'none'}`);
+}
+if (llmsTxt.includes('/docs/legacy/')) {
+  fail('llms.txt contains a legacy guide');
+}
+if (llmsTxt.includes('/examples/')) {
+  fail('llms.txt contains a standalone example page');
+}
+
+const requiredIndexLinks = [
+  'docs.md',
+  'docs/get-started/getting-started.md',
+  'docs/whats-new.md',
+  'docs/upgrade-guide.md',
+  'docs/developer-guide/base-maps/using-with-maplibre.md',
+  'docs/api-reference/layers/scatterplot-layer.md',
+  'docs/api-reference/json/overview.md'
+].map((relativePath) => new URL(relativePath, websiteUrl).href);
+for (const link of requiredIndexLinks) {
+  if (!llmsTxt.includes(link)) {
+    fail(`llms.txt is missing ${link}`);
+  }
+}
+
+const gettingStartedPath = requireFile('docs/get-started/getting-started.md');
+requireFile('docs.md');
+requireFile('docs/whats-new.md');
+requireFile('docs/upgrade-guide.md');
+requireFile('docs/developer-guide/base-maps/using-with-maplibre.md');
+requireFile('docs/api-reference/layers/scatterplot-layer.md');
+requireFile('docs/api-reference/json/overview.md');
+
+
+const markdownFiles = findFiles(buildDirectory, '.md');
+if (markdownFiles.length < 100) {
+  fail(`only ${markdownFiles.length} documentation Markdown files were generated`);
+}
+
+const gettingStarted = readFileSync(gettingStartedPath, 'utf8');
+if (gettingStarted.trim().length < 80) {
+  fail('rendered Getting Started Markdown has empty editorial content');
+}
+if (/<(?:Tabs|TabItem|Link)\b/.test(gettingStarted)) {
+  fail('rendered Getting Started Markdown contains unprocessed MDX components');
+}
+
+
+const brokenLinks = [];
+for (const markdownPath of [llmsTxtPath, ...markdownFiles]) {
+  const markdown = readFileSync(markdownPath, 'utf8');
+  const relativeMarkdownPath = path.relative(buildDirectory, markdownPath);
+  if (markdown.trim().length < 40) {
+    fail(`${relativeMarkdownPath} has empty extracted content`);
+  }
+  if (duplicatedWebsiteBaseUrl && markdown.includes(duplicatedWebsiteBaseUrl)) {
+    fail(`${relativeMarkdownPath} contains a duplicated website base path`);
+  }
+
+  for (const link of extractMarkdownLinks(markdown)) {
+    const targetPath = resolveGeneratedMarkdownLink(markdownPath, link);
+    if (targetPath && !existsSync(targetPath)) {
+      brokenLinks.push(
+        `${path.relative(buildDirectory, markdownPath)} -> ${path.relative(
+          buildDirectory,
+          targetPath
+        )}`
+      );
+    }
+  }
+}
+
+if (brokenLinks.length > 0) {
+  fail(`broken Markdown links:\n${brokenLinks.slice(0, 20).join('\n')}`);
+}
+
+console.log(`Validated llms.txt and ${markdownFiles.length} raw documentation pages.`);

--- a/website/scripts/normalize-llm-output.mjs
+++ b/website/scripts/normalize-llm-output.mjs
@@ -1,0 +1,94 @@
+import {existsSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const websiteDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const buildDirectory = path.join(websiteDirectory, 'build');
+const llmsTxtPath = path.join(buildDirectory, 'llms.txt');
+const websiteOrigin = 'https://deck.gl';
+const websiteBasePathSegments = (process.env.WEBSITE_BASE_URL || '/').split('/').filter(Boolean);
+
+function fail(message) {
+  throw new Error(`llms.txt output normalization failed: ${message}`);
+}
+
+function findFiles(directory, extension) {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  const filePaths = [];
+  for (const entry of readdirSync(directory, {withFileTypes: true})) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      filePaths.push(...findFiles(entryPath, extension));
+    } else if (entry.isFile() && entryPath.endsWith(extension)) {
+      filePaths.push(entryPath);
+    }
+  }
+  return filePaths;
+}
+
+function normalizeIndexHierarchy(markdown) {
+  const lines = markdown.split('\n');
+  const firstSectionIndex = lines.findIndex((line) => line.startsWith('## '));
+  if (firstSectionIndex === -1) {
+    fail('llms.txt does not contain a section heading');
+  }
+  if (lines[firstSectionIndex] === '## docs') {
+    return markdown;
+  }
+
+  let wrapperIndex = firstSectionIndex;
+  for (const [segmentIndex, segment] of websiteBasePathSegments.entries()) {
+    const expectedHeading = `${'#'.repeat(segmentIndex + 2)} ${segment}`;
+    if (lines[wrapperIndex] !== expectedHeading) {
+      fail(`expected base-path heading "${expectedHeading}"`);
+    }
+    lines.splice(wrapperIndex, 1);
+    while (lines[wrapperIndex] === '') {
+      lines.splice(wrapperIndex, 1);
+    }
+  }
+
+  const basePathDepth = websiteBasePathSegments.length;
+  const firstContentHeadingDepth = basePathDepth + 2;
+  const normalizedLines = lines.map((line) => {
+    const headingMatch = line.match(/^(#+) (.+)$/);
+    if (!headingMatch || headingMatch[1].length < firstContentHeadingDepth) {
+      return line;
+    }
+    return `${headingMatch[1].slice(basePathDepth)} ${headingMatch[2]}`;
+  });
+  return normalizedLines.join('\n');
+}
+
+if (websiteBasePathSegments.length === 0) {
+  console.log('No llms.txt base-path normalization needed.');
+  process.exit(0);
+}
+if (!existsSync(llmsTxtPath) || !statSync(llmsTxtPath).isFile()) {
+  fail('missing llms.txt');
+}
+
+const websiteBasePath = `/${websiteBasePathSegments.join('/')}/`;
+const websiteUrl = new URL(websiteBasePath, websiteOrigin);
+const duplicatedWebsiteBaseUrl = new URL(websiteBasePath.slice(1), websiteUrl).href;
+const markdownPaths = [llmsTxtPath, ...findFiles(buildDirectory, '.md')];
+let normalizedFileCount = 0;
+
+for (const markdownPath of markdownPaths) {
+  const markdown = readFileSync(markdownPath, 'utf8');
+  // Stable plugin 1.2.2 prepends the already-based site URL to base-prefixed links.
+  let normalizedMarkdown = markdown.split(duplicatedWebsiteBaseUrl).join(websiteUrl.href);
+  if (markdownPath === llmsTxtPath) {
+    // The same plugin version exposes each base-path segment as an index category.
+    normalizedMarkdown = normalizeIndexHierarchy(normalizedMarkdown);
+  }
+  if (normalizedMarkdown !== markdown) {
+    writeFileSync(markdownPath, normalizedMarkdown);
+    normalizedFileCount++;
+  }
+}
+
+console.log(`Normalized ${normalizedFileCount} LLM documentation files for ${websiteBasePath}.`);

--- a/website/scripts/test-build.sh
+++ b/website/scripts/test-build.sh
@@ -15,6 +15,8 @@ export MapboxAccessToken="dummy-mapbox-access-token"
 # clean up cache
 docusaurus clear
 docusaurus build
+node ./scripts/normalize-llm-output.mjs
+node ./scripts/check-llm-output.mjs
 
 # build gallery (scripting) examples
 (

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3223,6 +3223,24 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@signalwire/docusaurus-plugin-llms-txt@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@signalwire/docusaurus-plugin-llms-txt/-/docusaurus-plugin-llms-txt-1.2.2.tgz#a18990f5df8733687492eb1d141b3160aa52df4f"
+  integrity sha512-Qo5ZBDZpyXFlcrWwise77vs6B0R3m3/qjIIm1IHf4VzW6sVYgaR/y46BJwoAxMrV3WJkn0CVGpyYC+pMASFBZw==
+  dependencies:
+    fs-extra "^11.0.0"
+    hast-util-select "^6.0.4"
+    hast-util-to-html "^9.0.5"
+    hast-util-to-string "^3.0.1"
+    p-map "^7.0.2"
+    rehype-parse "^9"
+    rehype-remark "^10"
+    remark-gfm "^4"
+    remark-stringify "^11"
+    string-width "^5.0.0"
+    unified "^11"
+    unist-util-visit "^5"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
@@ -5981,6 +5999,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
+bcp-47-match@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/bcp-47-match/-/bcp-47-match-2.0.3.tgz#603226f6e5d3914a581408be33b28a53144b09d0"
+  integrity sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -6720,6 +6743,11 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
+css-selector-parser@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-3.3.0.tgz#1a34220d76762c929ae99993df5a60721f505082"
+  integrity sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==
+
 css-to-react-native@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
@@ -7096,6 +7124,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+direction@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/direction/-/direction-2.0.1.tgz#71800dd3c4fa102406502905d3866e65bdebb985"
+  integrity sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==
 
 dns-packet@^5.2.2:
   version "5.6.1"
@@ -7723,6 +7756,15 @@ fresh@~0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-extra@^11.0.0:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.4.0.tgz#f88ed6d180ac9e14b61b08e679468f0b1b6b4730"
+  integrity sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^11.1.1, fs-extra@^11.2.0:
   version "11.3.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.3.tgz#a27da23b72524e81ac6c3815cc0179b8c74c59ee"
@@ -7981,6 +8023,26 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-embedded@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz#be4477780fbbe079cdba22982e357a0de4ba853e"
+  integrity sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-is-element "^3.0.0"
+
+hast-util-from-html@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz#485c74785358beb80c4ba6346299311ac4c49c82"
+  integrity sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.1.0"
+    hast-util-from-parse5 "^8.0.0"
+    parse5 "^7.0.0"
+    vfile "^6.0.0"
+    vfile-message "^4.0.0"
+
 hast-util-from-parse5@^8.0.0:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
@@ -7995,12 +8057,55 @@ hast-util-from-parse5@^8.0.0:
     vfile-location "^5.0.0"
     web-namespaces "^2.0.0"
 
+hast-util-has-property@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz#4e595e3cddb8ce530ea92f6fc4111a818d8e7f93"
+  integrity sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-is-body-ok-link@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz#ef63cb2f14f04ecf775139cd92bda5026380d8b4"
+  integrity sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-is-element@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz#6e31a6532c217e5b533848c7e52c9d9369ca0932"
+  integrity sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-minify-whitespace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz#7588fd1a53f48f1d30406b81959dffc3650daf55"
+  integrity sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-embedded "^3.0.0"
+    hast-util-is-element "^3.0.0"
+    hast-util-whitespace "^3.0.0"
+    unist-util-is "^6.0.0"
+
 hast-util-parse-selector@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
   integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hast-util-phrasing@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz#fa284c0cd4a82a0dd6020de8300a7b1ebffa1690"
+  integrity sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-embedded "^3.0.0"
+    hast-util-has-property "^3.0.0"
+    hast-util-is-body-ok-link "^3.0.0"
+    hast-util-is-element "^3.0.0"
 
 hast-util-raw@^9.0.0:
   version "9.1.0"
@@ -8019,6 +8124,27 @@ hast-util-raw@^9.0.0:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
     web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
+hast-util-select@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-select/-/hast-util-select-6.0.4.tgz#1d8f69657a57441d0ce0ade35887874d3e65a303"
+  integrity sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    bcp-47-match "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    css-selector-parser "^3.0.0"
+    devlop "^1.0.0"
+    direction "^2.0.0"
+    hast-util-has-property "^3.0.0"
+    hast-util-to-string "^3.0.0"
+    hast-util-whitespace "^3.0.0"
+    nth-check "^2.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    unist-util-visit "^5.0.0"
     zwitch "^2.0.0"
 
 hast-util-to-estree@^3.0.0:
@@ -8043,6 +8169,23 @@ hast-util-to-estree@^3.0.0:
     unist-util-position "^5.0.0"
     zwitch "^2.0.0"
 
+hast-util-to-html@^9.0.0, hast-util-to-html@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
@@ -8064,6 +8207,26 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-mdast@^10.0.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz#bc76f7f5f72f2cde4d6a66ad4cd0aba82bb79909"
+  integrity sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-phrasing "^3.0.0"
+    hast-util-to-html "^9.0.0"
+    hast-util-to-text "^4.0.0"
+    hast-util-whitespace "^3.0.0"
+    mdast-util-phrasing "^4.0.0"
+    mdast-util-to-hast "^13.0.0"
+    mdast-util-to-string "^4.0.0"
+    rehype-minify-whitespace "^6.0.0"
+    trim-trailing-lines "^2.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+
 hast-util-to-parse5@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
@@ -8076,6 +8239,23 @@ hast-util-to-parse5@^8.0.0:
     space-separated-tokens "^2.0.0"
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
+
+hast-util-to-string@^3.0.0, hast-util-to-string@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz#a4f15e682849326dd211c97129c94b0c3e76527c"
+  integrity sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-to-text@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz#57b676931e71bf9cb852453678495b3080bfae3e"
+  integrity sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    hast-util-is-element "^3.0.0"
+    unist-util-find-after "^5.0.0"
 
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
@@ -10026,7 +10206,7 @@ nprogress@^0.2.0:
   resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
   integrity sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==
 
-nth-check@^2.0.1:
+nth-check@^2.0.0, nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
@@ -10153,6 +10333,11 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-map@^7.0.2:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-7.0.7.tgz#a82175dd690468a930b9ae45c2b9829c5bf60fa3"
+  integrity sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==
 
 p-queue@^6.6.2:
   version "6.6.2"
@@ -11385,6 +11570,23 @@ regjsparser@^0.13.0:
   dependencies:
     jsesc "~3.1.0"
 
+rehype-minify-whitespace@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz#7dd234ce0775656ce6b6b0aad0a6093de29b2278"
+  integrity sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-minify-whitespace "^1.0.0"
+
+rehype-parse@^9:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-9.0.1.tgz#9993bda129acc64c417a9d3654a7be38b2a94c20"
+  integrity sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-from-html "^2.0.0"
+    unified "^11.0.0"
+
 rehype-raw@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
@@ -11402,6 +11604,17 @@ rehype-recma@^1.0.0:
     "@types/estree" "^1.0.0"
     "@types/hast" "^3.0.0"
     hast-util-to-estree "^3.0.0"
+
+rehype-remark@^10:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-remark/-/rehype-remark-10.0.1.tgz#f669fa68cfb8b5baaf4fa95476a923516111a43b"
+  integrity sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    hast-util-to-mdast "^10.0.0"
+    unified "^11.0.0"
+    vfile "^6.0.0"
 
 relateurl@^0.2.7:
   version "0.2.7"
@@ -11439,7 +11652,7 @@ remark-frontmatter@^5.0.0:
     micromark-extension-frontmatter "^2.0.0"
     unified "^11.0.0"
 
-remark-gfm@^4.0.0:
+remark-gfm@^4, remark-gfm@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
   integrity sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==
@@ -11480,7 +11693,7 @@ remark-rehype@^11.0.0:
     unified "^11.0.0"
     vfile "^6.0.0"
 
-remark-stringify@^11.0.0:
+remark-stringify@^11, remark-stringify@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-11.0.0.tgz#4c5b01dd711c269df1aaae11743eb7e2e7636fd3"
   integrity sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==
@@ -12082,7 +12295,7 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.1, string-width@^5.1.2:
+string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -12385,6 +12598,11 @@ trim-lines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
+trim-trailing-lines@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz#9aac7e89b09cb35badf663de7133c6de164f86df"
+  integrity sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==
+
 trough@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
@@ -12511,7 +12729,7 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz#301d4f8a43d2b75c97adfad87c9dd5350c9475d1"
   integrity sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==
 
-unified@^11.0.0, unified@^11.0.3, unified@^11.0.4:
+unified@^11, unified@^11.0.0, unified@^11.0.3, unified@^11.0.4:
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
   integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
@@ -12540,6 +12758,14 @@ unique-string@^3.0.0:
   integrity sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==
   dependencies:
     crypto-random-string "^4.0.0"
+
+unist-util-find-after@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz#3fccc1b086b56f34c8b798e1ff90b5c54468e896"
+  integrity sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
 
 unist-util-is@^6.0.0:
   version "6.0.1"
@@ -12577,7 +12803,7 @@ unist-util-visit-parents@^6.0.0:
     "@types/unist" "^3.0.0"
     unist-util-is "^6.0.0"
 
-unist-util-visit@^5.0.0:
+unist-util-visit@^5, unist-util-visit@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
   integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
@@ -12981,7 +13207,7 @@ zustand@^5.0.5:
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.11.tgz#99f912e590de1ca9ce6c6d1cab6cdb1f034ab494"
   integrity sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==
 
-zwitch@^2.0.0:
+zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
## Summary

Publishes `https://deck.gl/llms.txt`, a curated Markdown index of the documentation, plus a raw Markdown sibling for every docs page (for example `/docs/api-reference/json/overview.md`), so coding agents can fetch current deck.gl documentation at inference time instead of relying on training data, which for deck.gl is consistently a major version stale. Sibling projects already publish one (luma.gl, MapLibre, Mapbox); `deck.gl/llms.txt` currently returns 404.

This mirrors luma.gl's setup: the same `@signalwire/docusaurus-plugin-llms-txt` plugin and configuration pattern, and the same two post-build scripts.

## Changes

- `website/package.json`, `website/yarn.lock`: add `@signalwire/docusaurus-plugin-llms-txt` (same major as luma.gl).
- `website/docusaurus.config.js`: register the plugin; include get-started, what's new, upgrade guide, developer guide and API reference; exclude the examples docs instance and the internal `TEST-STATUS` page; base-path aware for `/next/` and staging builds.
- `website/scripts/normalize-llm-output.mjs`, `check-llm-output.mjs` (ported from luma.gl): plugin 1.x prefixes the base path twice on base-path deploys, so the normalizer repairs links and headings; the checker validates the index title, required pages, page count and internal links. Wired into `build.sh` and `test-build.sh` so CI gates the output.
- Frontmatter `description:` on 30 docs pages whose first line is a badge or a heading; without it the index entry for every layer page read `webgpu`.

## Validation

Full local builds on this branch (Node 24, `yarn bootstrap`, `yarn build`, `docusaurus build` with dummy provider tokens) followed by both scripts:

- Production build: `llms.txt` 46 KB, 185 links, 185 raw Markdown pages validated. Sample entries:
  `Installing and Running Examples: Install deck.gl with npm or from a CDN, run the examples, and pick a base map integration.`
  `Using with MapLibre: Render deck.gl layers over MapLibre GL JS with MapLibreOverlay from @deck.gl/maplibre, overlaid or interleaved.`
- `WEBSITE_BASE_URL=/next/` build (the master deploy): normalizer repaired 164 files, checker passed, zero duplicated base paths, links resolve to `https://deck.gl/next/docs/….md`.
- No `llms-full.txt` (disabled, as in luma.gl).

## Notes for reviewers

Descriptions were written for the 30 pages that needed them; the remaining pages use their first paragraph, which reads well. A separate PR, #10678, adds a "Working with AI coding agents" guide and an in-repo skill that link this index.

## Disclosure

Drafted with an AI coding agent (Claude Code), revised after an independent review pass, and reviewed by me; the commit carries an `Assisted-by:` trailer. Opened as a draft for discussion at the Open Visualization Summit this week.

https://claude.ai/code/session_01RszQw7B8p94Hyxy4LFsxYj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and website build tooling only; no changes to deck.gl runtime libraries or application APIs.
> 
> **Overview**
> Adds machine-readable documentation exports so coding agents can fetch current deck.gl docs at inference time: **`/llms.txt`** as a curated index plus a **`.md` sibling for each included docs page**.
> 
> The Docusaurus site registers **`@signalwire/docusaurus-plugin-llms-txt`** (aligned with luma.gl), scoped to get-started, what's new, upgrade guide, developer guide, and API reference, while excluding the examples docs instance and internal **`TEST-STATUS`**. **`prefixWebsiteRoute`** and dynamic index depth keep routes correct when **`WEBSITE_BASE_URL`** is set (staging **`/deck.gl/`**, **`/next/`**, etc.).
> 
> Post-build **`normalize-llm-output.mjs`** repairs duplicated base-path URLs and index headings from plugin 1.x; **`check-llm-output.mjs`** asserts index shape, required links, minimum page count, non-empty extracted content, and internal `.md` link integrity. Both run from **`build.sh`** and **`test-build.sh`**.
> 
> **30** docs pages gain YAML **`description:`** frontmatter so **`llms.txt`** entries are meaningful instead of picking up the leading WebGPU badge line on layer pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712a7661078ff4b65f6142ed1c50beda1ff27b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->