### PR TITLE
docs: add a deck.gl agent skill and a Working with AI Coding Agents guide

### DIFF
--- a/docs/developer-guide/working-with-ai.md
+++ b/docs/developer-guide/working-with-ai.md
@@ -1,10 +1,9 @@
 # Working with AI Coding Agents
 
-AI coding agents write deck.gl fluently, and mostly a version behind. Asked in September 2026
-which deck.gl was current, every frontier model answered 9.0 or 9.1; asked to build maps, most
-loaded a deck.gl 8 bundle and used 8-era integration patterns. The maps rendered. The code was
-old. This page describes a workflow that keeps agents on the version you actually use, first for
-application developers, then for contributors to the deck.gl repository.
+AI coding agents often generate code for an older deck.gl release than the one installed: 8.x
+bundles, 8-era base map integration and deprecated props are common in generated code even when
+the map renders. This page describes a workflow that keeps agents on the version you actually
+use, first for application developers, then for contributors to the deck.gl repository.
 
 ## Start from local truth
 
@@ -43,8 +42,8 @@ version, the base map and the observable success condition:
 > Confirm the installed deck.gl version, keep the layer update immutable, open the page in a
 > browser, and report console errors and a screenshot with the data visible.
 
-The skill carries procedural judgment and the mistakes we have seen agents make. It does not copy
-the API reference into every conversation.
+The skill carries procedural judgment and the common mistakes in generated deck.gl code. It does
+not copy the API reference into every conversation.
 
 ## Give agents exact documentation
 

--- a/docs/developer-guide/working-with-ai.md
+++ b/docs/developer-guide/working-with-ai.md
@@ -1,0 +1,75 @@
+# Working with AI Coding Agents
+
+AI coding agents write deck.gl fluently, and mostly a version behind. Asked in September 2026
+which deck.gl was current, every frontier model answered 9.0 or 9.1; asked to build maps, most
+loaded a deck.gl 8 bundle and used 8-era integration patterns. The maps rendered. The code was
+old. This page describes a workflow that keeps agents on the version you actually use, first for
+application developers, then for contributors to the deck.gl repository.
+
+## Start from local truth
+
+Do not let an agent rely on its memory of deck.gl APIs. Give it the application and ask it to
+identify the installed versions first:
+
+```bash
+npm ls deck.gl @deck.gl/core @deck.gl/layers @deck.gl/geo-layers @deck.gl/maplibre
+```
+
+The installed TypeScript declarations are the authority for constructor props, classes and
+types; the website describes the newest release. When a project is pinned to an older release,
+point the agent at the documentation for that release and ask it to cite the declaration or page
+it used when an API choice is uncertain.
+
+Two facts trip agents up more than any other and are worth stating in the prompt:
+
+- Layers are immutable. Updates mean new layer instances with new props, never mutation.
+- MapLibre integration in deck.gl 9.4 is `MapLibreOverlay` from `@deck.gl/maplibre`, attached
+  with `map.addControl`. Earlier 9.x releases use `MapboxOverlay` from `@deck.gl/mapbox` for
+  MapLibre as well.
+
+## Install the deck.gl skill
+
+The repository contains an Agent Skill that routes version selection, base map integration,
+layer and data patterns, declarative JSON and single-page deliverables:
+
+```bash
+npx skills add visgl/deck.gl --skill deckgl
+```
+
+After installation, ask your agent to use the `deckgl` skill and name the goal, the installed
+version, the base map and the observable success condition:
+
+> Use the deckgl skill to add a hexagon aggregation of these points over our MapLibre map.
+> Confirm the installed deck.gl version, keep the layer update immutable, open the page in a
+> browser, and report console errors and a screenshot with the data visible.
+
+The skill carries procedural judgment and the mistakes we have seen agents make. It does not copy
+the API reference into every conversation.
+
+## Give agents exact documentation
+
+The website publishes [llms.txt](https://deck.gl/llms.txt), a curated index of the current
+documentation, and a raw Markdown sibling for every page, for example
+`https://deck.gl/docs/api-reference/layers/scatterplot-layer.md`. Ask the agent to fetch only
+the pages the task needs. `llms.txt` is an inference-time documentation index; it is not crawler
+policy or a training opt-out.
+
+## Require an observable verification loop
+
+Typechecking cannot prove that a map renders. Ask the agent to produce evidence in this order:
+
+1. Run the typecheck and relevant tests.
+2. Open the actual page in a current browser, not a DOM-only test environment.
+3. Capture console messages, page errors and failed network requests. A script URL that returns
+   an HTML 404 is the most common reason for an empty map.
+4. Capture a screenshot after the data has loaded, and a second one later for animations.
+5. Treat "basemap visible, data missing" as a failure and debug from the outside in: scripts
+   loaded, `deck` defined, basemap style loaded, layer class registered, data shape matches
+   accessors, sizes visible at the current zoom, layer inside the view.
+
+## Working inside the deck.gl repository
+
+Repository contributors should direct the agent to read the root `AGENTS.md` before editing. It
+records the setup commands, quality gates, the "ready for merge" checklist and the code style.
+Targeted tests do not replace the final `yarn build`, `yarn lint` and `yarn test` gates.
+This page describes a workflow; it does not change the contribution policy.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -42,7 +42,8 @@
           "developer-guide/building-apps",
           "developer-guide/debugging",
           "developer-guide/testing",
-          "developer-guide/webgpu"
+          "developer-guide/webgpu",
+          "developer-guide/working-with-ai"
         ]
       },
       {

--- a/skills/deckgl/SKILL.md
+++ b/skills/deckgl/SKILL.md
@@ -40,9 +40,9 @@ Read every reference that applies; integration and layer rules usually both matt
 ## Implement
 
 1. Pick the smallest correct surface: a base map library for the basemap, deck.gl for the data
-   layers, connected through the overlay class for that library. deck.gl is not a marker-and-popup
-   library; for a handful of markers on a slippy map, a plain base map library may be the better
-   answer, and saying so is part of the job.
+   layers, connected through the overlay class for that library. For a handful of static markers
+   with popups, the base map library's own markers may suffice; deck.gl earns its place as soon as
+   the data is large, data-driven, aggregated, 3D or animated.
 2. Treat layers as immutable. Never mutate `layer.props` or call internal state methods; create
    new layer instances with new props and pass them to `setProps` or `layers`. deck.gl diffs by
    layer `id`.

--- a/skills/deckgl/SKILL.md
+++ b/skills/deckgl/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: deckgl
+description: Design, implement, update and debug deck.gl applications and declarative deck.gl JSON with version-aware API selection, correct base map integration (MapLibre, Mapbox, Google Maps), immutable-layer update patterns, aggregation and animation layer rules, and browser-based verification. Use when working with deck.gl or @deck.gl/* packages, single-page deck.gl maps, @deck.gl/json specs, empty or blank maps, or the visgl/deck.gl repository.
+---
+
+# deck.gl
+
+Work from the installed packages and observable browser behavior. Do not substitute model
+memory for the project's declarations: deck.gl 9 changed the integration story, the base map
+modules and the rendering stack, and training data over-represents deck.gl 8 examples.
+
+## Establish local truth
+
+1. Identify whether the task is in a consumer application, a single self-contained HTML page,
+   or the `visgl/deck.gl` repository.
+2. Inspect the lockfile and installed versions: `npm ls deck.gl @deck.gl/core @deck.gl/layers`
+   (or the CDN URL pinned in a `<script>` tag). Treat the installed version as authoritative.
+3. Read the installed packages' TypeScript declarations for every API you use. Consult the
+   documentation for the same release. For the current release read
+   [deck.gl documentation](https://deck.gl/docs) and fetch only the pages relevant to the task;
+   `https://deck.gl/llms.txt` indexes them with raw Markdown siblings once published.
+4. State any version constraint that changes the implementation, and never silently modernize
+   code to an API absent from the installed declarations, or the reverse.
+
+## Route the task
+
+- Choosing a version, a CDN bundle, or integrating with MapLibre, Mapbox or Google Maps: read
+  [references/versions-and-integration.md](references/versions-and-integration.md).
+- Writing or updating layers, data-driven styling, aggregation, animation, large data: read
+  [references/layers-and-data.md](references/layers-and-data.md).
+- Producing or consuming `@deck.gl/json` declarative specs, or letting an agent drive a map:
+  read [references/declarative-json.md](references/declarative-json.md).
+- A self-contained HTML page (an artifact, a demo, a gist): read
+  [references/single-file-page.md](references/single-file-page.md).
+- Work inside `visgl/deck.gl`: read the repository's root `AGENTS.md` before editing and follow
+  its commands and merge-readiness checklist.
+
+Read every reference that applies; integration and layer rules usually both matter.
+
+## Implement
+
+1. Pick the smallest correct surface: a base map library for the basemap, deck.gl for the data
+   layers, connected through the overlay class for that library. deck.gl is not a marker-and-popup
+   library; for a handful of markers on a slippy map, a plain base map library may be the better
+   answer, and saying so is part of the job.
+2. Treat layers as immutable. Never mutate `layer.props` or call internal state methods; create
+   new layer instances with new props and pass them to `setProps` or `layers`. deck.gl diffs by
+   layer `id`.
+3. Use `updateTriggers` when an accessor closes over changing state.
+4. For large data, pass binary attributes or a compact format, not millions of objects.
+5. Prefer token-free base map styles unless the project already has a provider account.
+6. Keep the first change minimal and independently verifiable.
+
+## Verify
+
+Run the project's typecheck and focused tests, then open the actual page in a current browser.
+Collect console messages, page errors, failed network requests and a screenshot after the data
+has loaded. A map with a basemap but no data is a failure, not a partial success.
+
+When the map is empty, debug from the outside in: did the scripts load (a wrong CDN version
+returns an HTML 404 that the browser blocks) → is `deck` defined → did the basemap style load →
+is the layer class registered or imported → does the data URL return what the accessors expect →
+are accessor values in range (radius in meters at world zoom is invisible) → is the layer
+`visible` and inside the view. Do not change styling until the layer has been seen to render.
+
+Report which browser, version and backend were actually observed. Do not claim success from a
+clean process exit.

--- a/skills/deckgl/references/declarative-json.md
+++ b/skills/deckgl/references/declarative-json.md
@@ -1,0 +1,65 @@
+# Declarative deck.gl JSON (`@deck.gl/json`)
+
+`@deck.gl/json` converts a JSON document into deck.gl props: layers, views, effects, widgets.
+It is the natural interface when a program or an agent produces the map rather than hand-written
+code, and it is what pydeck, kepler.gl-style configs and several agent products build on.
+
+## Syntax
+
+- `"@@type": "ScatterplotLayer"` selects a class from the converter's registry. Plain `"type"`
+  is not recognized.
+- `"@@function": "name"` calls a registered function with the sibling keys as its argument
+  object. `"@@#Enum.VALUE"` resolves a registered constant or enumeration.
+- `"@@=expression"` turns a string into an accessor. The expression runs in a small safe
+  evaluator: property access, indexing, arithmetic, comparisons, logical and ternary operators.
+  **No function calls** (`Math.log`, `.toFixed`, `.includes`), no optional chaining, no template
+  literals, no object literals. Precompute transformations in the data instead.
+- Top-level keys mirror `Deck` props: `initialViewState`, `views`, `layers`, `effects`,
+  `getTooltip`, plus `mapStyle` in the scripting integration.
+
+```json
+{
+  "initialViewState": {"longitude": 10, "latitude": 50, "zoom": 4},
+  "views": [{"@@type": "MapView", "controller": true}],
+  "layers": [{
+    "@@type": "GeoJsonLayer",
+    "id": "countries",
+    "data": "https://example.com/countries.geojson",
+    "filled": true,
+    "getFillColor": "@@=properties.population > 5e7 ? [189, 0, 38] : [254, 217, 118]",
+    "pickable": true
+  }]
+}
+```
+
+## The registry decides what exists
+
+`new JSONConverter({configuration: {classes, functions, constants, enumerations, log}})`.
+Only registered classes and functions are valid. There is no `interpolateColor`,
+`quantileColorScale` or `colorBinScale` helper in the stock registry; color helpers such as
+`colorBins`, `colorContinuous` and `colorCategories` exist only when `@deck.gl/carto` registers
+them. Mapbox/MapLibre style expressions (`["interpolate", ["linear"], ["get", "x"], ...]`) are
+not deck.gl accessors.
+
+## Failure is silent today
+
+- An unknown `@@type` or `@@function` is logged as a warning (if a `log` is configured) and
+  replaced with `null`. The map renders without that layer and **no error is thrown**.
+- A wrong accessor expression can evaluate to `undefined` and become a transparent color or a
+  zero radius. The map renders empty.
+- Because of this, a converter used by an agent should: count layers in the spec versus layers
+  produced and report any drop; configure `log` and surface warnings; validate the document
+  before converting when a schema for the registry exists; and tell the agent exactly which
+  names are legal. Treat "rendered but empty" as an error.
+
+## Data
+
+`data` accepts a URL, an array or a promise. For SQL, tiles, Arrow or vendor sources, register
+a `@@function` source builder in the configuration; keep credentials out of the document and
+inject them in the registered function.
+
+## Direction of travel
+
+A v2 of the module is tracked in `visgl/deck.gl-community` (issue #596): Zod-based schemas with
+generated JSON Schema, LLM-friendly documentation and data-source declarations. Until then,
+treat the registry configuration as the schema and validate against it explicitly.

--- a/skills/deckgl/references/declarative-json.md
+++ b/skills/deckgl/references/declarative-json.md
@@ -11,9 +11,10 @@ code, and it is what pydeck, kepler.gl-style configs and several agent products 
 - `"@@function": "name"` calls a registered function with the sibling keys as its argument
   object. `"@@#Enum.VALUE"` resolves a registered constant or enumeration.
 - `"@@=expression"` turns a string into an accessor. The expression runs in a small safe
-  evaluator: property access, indexing, arithmetic, comparisons, logical and ternary operators.
-  **No function calls** (`Math.log`, `.toFixed`, `.includes`), no optional chaining, no template
-  literals, no object literals. Precompute transformations in the data instead.
+  evaluator: property access, indexing, arithmetic, comparisons, logical and ternary operators,
+  and array literals; `"getPosition": "@@=[lng, lat]"` is the standard form. Function calls
+  (`Math.log`, `.toFixed`, `.includes`) throw at parse time; there is no optional chaining, no
+  template literal and no object literal. Precompute transformations in the data instead.
 - Top-level keys mirror `Deck` props: `initialViewState`, `views`, `layers`, `effects`,
   `getTooltip`, plus `mapStyle` in the scripting integration.
 
@@ -43,8 +44,8 @@ not deck.gl accessors.
 
 ## Failure is silent today
 
-- An unknown `@@type` or `@@function` is logged as a warning (if a `log` is configured) and
-  replaced with `null`. The map renders without that layer and **no error is thrown**.
+- An unknown `@@type` or `@@function` is logged as a warning (the configuration's `log` defaults
+  to `console`) and replaced with `null`. The map renders without that layer and **no error is thrown**.
 - A wrong accessor expression can evaluate to `undefined` and become a transparent color or a
   zero radius. The map renders empty.
 - Because of this, a converter used by an agent should: count layers in the spec versus layers

--- a/skills/deckgl/references/layers-and-data.md
+++ b/skills/deckgl/references/layers-and-data.md
@@ -15,8 +15,9 @@
 
 ## Sizes and units
 
-- `radiusUnits`, `lineWidthUnits`, `sizeUnits`: `'meters'` (default for most), `'pixels'`,
-  `'common'`. Meter radii disappear at world zoom; pair meter sizes with `radiusMinPixels` /
+- `radiusUnits` and `lineWidthUnits` default to `'meters'`; `sizeUnits` defaults to `'pixels'` in
+  `IconLayer`, `TextLayer` and `PointCloudLayer`. All accept `'meters'`, `'pixels'` or `'common'`.
+  Meter radii disappear at world zoom; pair meter sizes with `radiusMinPixels` /
   `lineWidthMinPixels`, or use pixel units for symbol-like marks.
 - `pickable: true` is required for hover and click. Provide `getTooltip` on `Deck`/`DeckGL`
   or the overlay, returning `null` or a string/`{html, style}` object.
@@ -25,7 +26,8 @@
 
 - Do not build millions of JavaScript objects. Pass binary attributes:
   `data: {length: n, attributes: {getPosition: {value: Float32Array, size: 2},
-  getFillColor: {value: Uint8Array, size: 3, normalized: false}}}`. Or use Arrow / GeoArrow
+  getFillColor: {value: Uint8Array, size: 3}}}`. Color attributes are normalized by default, so
+  0-255 `Uint8Array` values are correct as they are; do not pass `normalized: false`. Or use Arrow / GeoArrow
   layers, or tiled data (`MVTLayer`, `TileLayer`, `GeoJsonLayer` over tiles) so only the
   viewport is loaded.
 - Fetch and parse with loaders.gl when a format is involved; deck.gl `data` accepts a URL, a
@@ -34,9 +36,11 @@
 ## Aggregation layers (`@deck.gl/aggregation-layers`)
 
 - `HexagonLayer` and `GridLayer`: `radius` / `cellSize` in meters, `extruded`, `elevationScale`,
-  `getColorValue` / `getElevationValue` (or `getColorWeight` + `colorAggregation`), `colorRange`
-  (array of RGBA arrays), `colorScaleType` (`'quantize'`, `'quantile'`, `'ordinal'`),
-  `upperPercentile` / `lowerPercentile` to clip long tails.
+  `colorRange` (array of RGB or RGBA arrays), `upperPercentile` / `lowerPercentile` to clip long
+  tails. Prefer `getColorWeight` + `colorAggregation` (`'SUM' | 'MEAN' | 'MIN' | 'MAX' | 'COUNT'`)
+  and the elevation equivalents: they keep GPU aggregation. `getColorValue` / `getElevationValue`
+  override them and fall back to CPU aggregation. `colorScaleType`: `'quantize'` (default),
+  `'linear'`, `'quantile'`, `'ordinal'`; the last two read results back from the GPU once.
 - Count-like data is heavily right-skewed: with defaults nearly every cell lands in the lowest
   color bin. Use `colorScaleType: 'quantile'` or lower `upperPercentile`, and say so in a legend.
 - `HeatmapLayer`: `getWeight`, `radiusPixels`, `intensity`, `colorRange`, `colorDomain`; it

--- a/skills/deckgl/references/layers-and-data.md
+++ b/skills/deckgl/references/layers-and-data.md
@@ -1,0 +1,62 @@
+# Layers, styling and data
+
+## The layer contract
+
+- Layers are **immutable descriptions**. To change anything, create a new layer instance with the
+  same `id` and new props, and hand the new array to `deck.setProps({layers})`,
+  `overlay.setProps({layers})` or the React `layers` prop. deck.gl diffs old and new props and
+  updates the GPU only where needed.
+- Never mutate `layer.props`, call `layer.setState`, or keep a layer instance around to "update"
+  it. Animation loops recreate the layer every frame with a new `currentTime` or similar prop.
+- Accessors (`getPosition`, `getFillColor`, `getRadius`, ...) receive one datum. When an accessor
+  closes over external state, list that state in `updateTriggers` so deck.gl recomputes
+  attributes: `updateTriggers: {getFillColor: [selectedYear]}`.
+- Constant accessors accept plain values: `getFillColor: [255, 140, 0]`.
+
+## Sizes and units
+
+- `radiusUnits`, `lineWidthUnits`, `sizeUnits`: `'meters'` (default for most), `'pixels'`,
+  `'common'`. Meter radii disappear at world zoom; pair meter sizes with `radiusMinPixels` /
+  `lineWidthMinPixels`, or use pixel units for symbol-like marks.
+- `pickable: true` is required for hover and click. Provide `getTooltip` on `Deck`/`DeckGL`
+  or the overlay, returning `null` or a string/`{html, style}` object.
+
+## Large data
+
+- Do not build millions of JavaScript objects. Pass binary attributes:
+  `data: {length: n, attributes: {getPosition: {value: Float32Array, size: 2},
+  getFillColor: {value: Uint8Array, size: 3, normalized: false}}}`. Or use Arrow / GeoArrow
+  layers, or tiled data (`MVTLayer`, `TileLayer`, `GeoJsonLayer` over tiles) so only the
+  viewport is loaded.
+- Fetch and parse with loaders.gl when a format is involved; deck.gl `data` accepts a URL, a
+  promise, an iterable or an array.
+
+## Aggregation layers (`@deck.gl/aggregation-layers`)
+
+- `HexagonLayer` and `GridLayer`: `radius` / `cellSize` in meters, `extruded`, `elevationScale`,
+  `getColorValue` / `getElevationValue` (or `getColorWeight` + `colorAggregation`), `colorRange`
+  (array of RGBA arrays), `colorScaleType` (`'quantize'`, `'quantile'`, `'ordinal'`),
+  `upperPercentile` / `lowerPercentile` to clip long tails.
+- Count-like data is heavily right-skewed: with defaults nearly every cell lands in the lowest
+  color bin. Use `colorScaleType: 'quantile'` or lower `upperPercentile`, and say so in a legend.
+- `HeatmapLayer`: `getWeight`, `radiusPixels`, `intensity`, `colorRange`, `colorDomain`; it
+  ignores `getFillColor`.
+- For 3D, add lighting: `new LightingEffect({ambientLight, directionalLight})` passed via
+  `effects`, plus `material` on the layer, and a `pitch` above 0 or extrusion reads flat.
+
+## Animation (`TripsLayer` in `@deck.gl/geo-layers`)
+
+- `getPath`, `getTimestamps` (same length as the path), `currentTime`, `trailLength`,
+  `fadeTrail`, `widthMinPixels`, `capRounded`, `jointRounded`.
+- Drive `currentTime` from `requestAnimationFrame`, recreating the layer each frame. Loop with
+  `(elapsed * speed) % (maxTimestamp)`. In headless or throttled tabs the frame rate may be very
+  low; verify with two screenshots that the time actually advances.
+
+## Cartography defaults to question
+
+- A sequential scheme for a categorical field, or a categorical palette for a magnitude, is a
+  bug even when it renders.
+- Legends belong to every data-driven encoding (color and size); build them from the same
+  domain and colors the layer uses.
+- On dark basemaps, light low-end colors read as "more", not "less"; on light basemaps, pale
+  low ends vanish. Choose the palette after the basemap.

--- a/skills/deckgl/references/single-file-page.md
+++ b/skills/deckgl/references/single-file-page.md
@@ -2,10 +2,9 @@
 
 Use this when the deliverable is one HTML file: an artifact, a demo, a gist, a slide.
 
-## Choose the tool honestly
+## Choose the tool
 
-- A few markers with popups on a slippy map: a plain base map library is smaller and simpler;
-  deck.gl adds nothing there.
+- A few static markers with popups: the base map library's own markers may suffice.
 - Thousands of features, data-driven color or size, aggregation, 3D, animation, or anything
   that must stay smooth while panning: MapLibre for the basemap, deck.gl for the data.
 

--- a/skills/deckgl/references/single-file-page.md
+++ b/skills/deckgl/references/single-file-page.md
@@ -1,0 +1,61 @@
+# A single self-contained page
+
+Use this when the deliverable is one HTML file: an artifact, a demo, a gist, a slide.
+
+## Choose the tool honestly
+
+- A few markers with popups on a slippy map: a plain base map library is smaller and simpler;
+  deck.gl adds nothing there.
+- Thousands of features, data-driven color or size, aggregation, 3D, animation, or anything
+  that must stay smooth while panning: MapLibre for the basemap, deck.gl for the data.
+
+## The recipe (deck.gl 9.4, MapLibre 5, no tokens)
+
+```html
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet">
+  <style>html, body, #map { margin: 0; height: 100%; }</style>
+</head>
+<body>
+<div id="map"></div>
+<script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+<script src="https://unpkg.com/deck.gl@9.4.0/dist.min.js"></script>
+<script>
+  const map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json', // token-free
+    center: [10, 20], zoom: 1.5
+  });
+  const overlay = new deck.MapLibreOverlay({ // deck.MapboxOverlay on 9.3 and earlier
+    layers: [
+      new deck.ScatterplotLayer({
+        id: 'points',
+        data: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/line/airports.json',
+        getPosition: d => d.coordinates,
+        getFillColor: d => d.type === 'major' ? [255, 90, 60] : [255, 200, 60],
+        getRadius: d => d.type === 'major' ? 6 : 3,
+        radiusUnits: 'pixels',
+        pickable: true
+      })
+    ],
+    getTooltip: ({object}) => object && `${object.name} (${object.abbrev})`
+  });
+  map.addControl(overlay);
+</script>
+</body>
+</html>
+```
+
+## Checklist
+
+- Pin exact, existing versions. `deck.gl@8.10.1` does not exist; the CDN returns an HTML page
+  and the script never runs.
+- `map.addControl(overlay)`, never `map.addLayer(overlay)`.
+- Do not name a variable `deck` when the bundle's global is `deck`.
+- Set `pickable: true` for tooltips; put a legend on the page for every encoded field.
+- Some sandboxed hosts allow scripts only from specific CDNs (often cdnjs and jsdelivr) and
+  block tile and data requests. Check the host's policy before promising a basemap.
+- Open the file in a browser and look at it before declaring it done.

--- a/skills/deckgl/references/versions-and-integration.md
+++ b/skills/deckgl/references/versions-and-integration.md
@@ -1,0 +1,61 @@
+# Versions and base map integration
+
+## Which deck.gl is current
+
+- deck.gl **9.x** is the current major (9.4 released September 2026). Training data is dominated by
+  8.x examples; do not pin `deck.gl@8` unless the project already depends on it. Check
+  `npm view deck.gl version` or the installed lockfile instead of assuming.
+- deck.gl 9 runs on luma.gl 9 with WebGL 2 and WebGPU. All official layers support WebGPU in 9.4.
+- The umbrella `deck.gl` package re-exports the modules; scoped packages (`@deck.gl/core`,
+  `@deck.gl/layers`, `@deck.gl/geo-layers`, `@deck.gl/aggregation-layers`, `@deck.gl/react`,
+  `@deck.gl/maplibre`, `@deck.gl/mapbox`, `@deck.gl/google-maps`, `@deck.gl/json`, `@deck.gl/carto`)
+  must all be on the same version. Do not add `@luma.gl/*` packages by hand; they come as
+  dependencies.
+
+## v8 to v9 patterns to leave behind
+
+- `new deck.DeckGL({mapLib, mapStyle, ...})` from the 8.x scripting bundle still works in 9.x for
+  quick pages, but the recommended integration is an **overlay control** on a base map (below).
+- `window.mapboxgl = maplibregl` shims and `@deck.gl/mapbox` with MapLibre are 8.x-era habits.
+- `rounded` on `PathLayer`/`TripsLayer` is deprecated: use `capRounded` and `jointRounded`.
+- `getColor` on `ScatterplotLayer` is a legacy alias: use `getFillColor` and `getLineColor`.
+- Read `docs/upgrade-guide` for the installed major before touching existing code.
+
+## Base map integration
+
+| Base map | Package (9.4+) | Class | Attach |
+| --- | --- | --- | --- |
+| MapLibre GL JS v4.5.1, v5, v6 | `@deck.gl/maplibre` | `MapLibreOverlay` | `map.addControl(overlay)` |
+| MapLibre on deck.gl ≤ 9.3 | `@deck.gl/mapbox` | `MapboxOverlay` | `map.addControl(overlay)` (works; module is named for Mapbox) |
+| Mapbox GL JS | `@deck.gl/mapbox` | `MapboxOverlay` | `map.addControl(overlay)`; needs a Mapbox access token |
+| Google Maps | `@deck.gl/google-maps` | `GoogleMapsOverlay` | `overlay.setMap(map)` |
+| React | `@deck.gl/react` `DeckGL` + `react-map-gl/maplibre` (or `/mapbox`) | | `<DeckGL><Map/></DeckGL>` |
+
+- `interleaved: false` (default) draws deck.gl in its own canvas above the base map: simplest,
+  most robust. `interleaved: true` renders into the base map's context so 3D layers can sit under
+  labels and buildings; then use `beforeId` on layers to slot them below a base map layer.
+- Update layers with `overlay.setProps({layers: [...]})`, passing new layer instances.
+- Never attach an overlay with `map.addLayer(overlay)`; it is a control, not a style layer.
+- There is no `MaplibreLayer` class and no `@deck.gl/maplibre` before 9.4; do not invent names.
+- `react-map-gl` v7+ requires the `/maplibre` or `/mapbox` subpath import; the default export
+  is gone.
+
+## Token-free basemaps
+
+Prefer these when the project has no provider account:
+
+- CARTO: `https://basemaps.cartocdn.com/gl/positron-gl-style/style.json`,
+  `.../dark-matter-gl-style/style.json`, `.../voyager-gl-style/style.json` (append `-nolabels`
+  to the style name for label-free variants). In `@deck.gl/carto` they are the `BASEMAP` constants.
+- MapLibre demo tiles: `https://demotiles.maplibre.org/style.json` (low detail, fine for tests).
+- `mapbox://` style URLs and Mapbox GL JS itself require an access token; do not use them in a
+  "no keys" brief.
+
+## CDN bundles
+
+- `https://unpkg.com/deck.gl@<version>/dist.min.js` (also on jsdelivr) exposes everything under
+  the global `deck` (`deck.ScatterplotLayer`, `deck.MapLibreOverlay`, `deck.MapboxOverlay`,
+  `deck.DeckGL`, `deck.TripsLayer`, ...). Pin an exact, existing version; a non-existent version
+  returns an HTML 404 that the browser refuses to execute and the map stays empty.
+- deck.gl is not published on cdnjs; MapLibre and Leaflet are. In hosts that only allow cdnjs
+  scripts, use jsdelivr if permitted, otherwise say deck.gl cannot load there.

--- a/skills/deckgl/references/versions-and-integration.md
+++ b/skills/deckgl/references/versions-and-integration.md
@@ -5,12 +5,16 @@
 - deck.gl **9.x** is the current major (9.4 released September 2026). Training data is dominated by
   8.x examples; do not pin `deck.gl@8` unless the project already depends on it. Check
   `npm view deck.gl version` or the installed lockfile instead of assuming.
-- deck.gl 9 runs on luma.gl 9 with WebGL 2 and WebGPU. All official layers support WebGPU in 9.4.
+- deck.gl 9 runs on luma.gl 9 with WebGL 2 and experimental WebGPU. In 9.4 every layer in the
+  official layer catalog has a WebGPU path, but `@deck.gl/carto` layers and most extensions do not,
+  WebGPU is opt-in via `deviceProps` and is not production ready. See the WebGPU developer guide.
 - The umbrella `deck.gl` package re-exports the modules; scoped packages (`@deck.gl/core`,
   `@deck.gl/layers`, `@deck.gl/geo-layers`, `@deck.gl/aggregation-layers`, `@deck.gl/react`,
   `@deck.gl/maplibre`, `@deck.gl/mapbox`, `@deck.gl/google-maps`, `@deck.gl/json`, `@deck.gl/carto`)
-  must all be on the same version. Do not add `@luma.gl/*` packages by hand; they come as
-  dependencies.
+  must all be on the same version. `@luma.gl/core` is a peer dependency that must match the deck.gl
+  release; do not install other `@luma.gl/*` packages unless a feature needs them, for example
+  `@luma.gl/webgpu` when opting into WebGPU with
+  `deviceProps: {type: 'webgpu', adapters: [webgpuAdapter]}`.
 
 ## v8 to v9 patterns to leave behind
 
@@ -26,11 +30,14 @@
 | Base map | Package (9.4+) | Class | Attach |
 | --- | --- | --- | --- |
 | MapLibre GL JS v4.5.1, v5, v6 | `@deck.gl/maplibre` | `MapLibreOverlay` | `map.addControl(overlay)` |
-| MapLibre on deck.gl ≤ 9.3 | `@deck.gl/mapbox` | `MapboxOverlay` | `map.addControl(overlay)` (works; module is named for Mapbox) |
+| MapLibre, any 9.x | `@deck.gl/mapbox` | `MapboxOverlay` | `map.addControl(overlay)`; still supported with MapLibre in 9.4, but `@deck.gl/maplibre` is now the recommended integration |
 | Mapbox GL JS | `@deck.gl/mapbox` | `MapboxOverlay` | `map.addControl(overlay)`; needs a Mapbox access token |
 | Google Maps | `@deck.gl/google-maps` | `GoogleMapsOverlay` | `overlay.setMap(map)` |
 | React | `@deck.gl/react` `DeckGL` + `react-map-gl/maplibre` (or `/mapbox`) | | `<DeckGL><Map/></DeckGL>` |
 
+- `@deck.gl/maplibre` is distributed as ES modules only. Bundled applications must configure the
+  MapLibre worker (`setWorkerUrl` from `maplibre-gl` with the bundler's worker URL); direct browser
+  ES module imports and the CDN bundle configure it automatically.
 - `interleaved: false` (default) draws deck.gl in its own canvas above the base map: simplest,
   most robust. `interleaved: true` renders into the base map's context so 3D layers can sit under
   labels and buildings; then use `beforeId` on layers to slot them below a base map layer.


### PR DESCRIPTION
## Summary

Adds an in-repo **Agent Skill** for deck.gl (`skills/deckgl`) and a developer-guide page, **Working with AI Coding Agents** (`docs/developer-guide/working-with-ai.md`), mirroring the structure luma.gl already ships (`skills/lumagl`, its `working-with-ai` page). Installable with:

```bash
npx skills add visgl/deck.gl --skill deckgl
```

The skill is progressive: `SKILL.md` establishes local truth (installed version, matching docs), routes to four references, and requires browser-based verification. The references are:

- `versions-and-integration.md`: 9.x as current, v8 patterns to leave behind, the base map integration table (`@deck.gl/maplibre` `MapLibreOverlay` on 9.4, `MapboxOverlay` on ≤9.3, Google Maps, React), token-free basemaps, CDN bundle pitfalls.
- `layers-and-data.md`: the immutable-layer contract and `updateTriggers`, units, binary attributes, aggregation layers and skewed data, `TripsLayer` animation, cartography defaults to question.
- `declarative-json.md`: `@deck.gl/json` syntax, the registry as the schema, what fails silently and how a host should compensate.
- `single-file-page.md`: an honest routing rule (a few markers vs data-driven maps) and a copy-paste page on deck.gl 9.4 + MapLibre 5 with a token-free style.

## Why

For a summit talk ("Making deck.gl AI-Ready", Zürich, 9 Sept 2026) I had seven frontier models build deck.gl maps one-shot with no docs (all outputs, screenshots and scores in https://github.com/jatorre/deckgl-ai-ready). The maps mostly rendered, and the code was consistently a generation behind and made the same mistakes: 27 of 35 files loaded a deck.gl 8.9 bundle; six of seven used the pre-9.4 MapLibre integration; one mutated layer props and called internal state instead of replacing layers; two invented `@deck.gl/json` helpers; one pinned a deck.gl version that does not exist. Every one of those is a rule this skill states. MapLibre launched an official skills repo in February for the same reason; luma.gl has the pattern in this TSC already.

## Changes

- `skills/deckgl/SKILL.md` and `skills/deckgl/references/*.md` (new)
- `docs/developer-guide/working-with-ai.md` (new) and its entry in `docs/table-of-contents.json`

The guide links `https://deck.gl/llms.txt`, which is added by #10677.

## Validation

Docs-only change; `docs/table-of-contents.json` parses. After opening, I had an independent reviewer fact-check every API claim against `docs/` and `modules/**/src` in this tree; the second commit applies the corrections (binary color attributes are normalized by default; WebGPU is experimental and opt-in; `@luma.gl/core` is a peer dependency; aggregation-layer accessor semantics and `colorScaleType` values; `@@=` array literals; `@deck.gl/maplibre` is ESM-only and needs the MapLibre worker configured when bundled; `MapboxOverlay` still works with MapLibre in 9.4). Reviewers who know the layer catalog better than I do, please still flag any rule that is too strong.

The guide links `https://deck.gl/llms.txt`, added by #10677; merge that first or drop the link.

## Disclosure

Drafted with an AI coding agent (Claude Code) from my research notes and reviewed by me; the commit carries an `Assisted-by:` trailer. Opened as a draft for discussion at the summit.

https://claude.ai/code/session_01RszQw7B8p94Hyxy4LFsxYj
