### PR TITLE
contributing: AI-assisted contributions section, PR template checkbox, AGENTS.md pointer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,6 @@ Closes #
 <!-- For all the PRs -->
 #### Change List
 -
+
+<!-- For all the PRs. See CONTRIBUTING.md → "AI-assisted contributions". Substantial = anything beyond single-line autocomplete. Disclosure is not penalized. -->
+- [ ] I have read the AI-assisted contributions section of CONTRIBUTING.md and disclosed any substantial AI assistance above (tool, what it did, what I verified).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,16 @@ subdirectories may add local guidance.
 - Use the exact script names from `package.json`; do not substitute spaced forms such as
   `yarn test headless`.
 
+## Contribution Policy
+
+- This repository follows the AI-assisted contributions section of `CONTRIBUTING.md`. Disclosure of
+  substantial AI assistance belongs in the pull request description; where commits are preserved,
+  add an `Assisted-by: LLM` or `Assisted-by: a coding agent` trailer (naming the specific tool is
+  optional in commit messages).
+- Never add `Signed-off-by` tags; only the human contributor certifies a DCO.
+- Do not work on issues labelled for newcomers (for example `good first issue`).
+- Do not open pull requests or issues autonomously; a person reviews, discloses and submits the work.
+
 ## Before Committing
 
 - Run the most relevant tests for the changed packages, integrations, examples, or docs.
@@ -46,7 +56,9 @@ When asked to "get ready for merge", do a full merge-readiness pass:
   and `yarn test-website`.
 - For website or docs changes, run the website check from the repo root with `yarn test-website`.
 - Prepare a copyable Markdown PR description based on the branch diff compared to `master`. Start
-  with the PR goals, then list the actual changes and validation.
+  with the PR goals, then list the actual changes and validation. The contributor edits, verifies
+  and discloses it before opening the PR; include an "AI assistance" note stating what you did and
+  what still needs human verification.
 - In the final handoff, call out which merge-readiness gates passed, which were not run, and any
   remaining risk or unrelated pre-existing failures.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,19 @@
 PRs and bug reports are welcome, and we are actively looking for new maintainers.
 
 
+## AI-assisted contributions
+
+You may use AI coding assistants and agents to help with contributions. deck.gl is an OpenJS Foundation project and the Foundation's [Policy on Use of AI Coding Assistants](https://ai-coding-assistants-policy.openjsf.org/) applies to every submission; the vis.gl [developer process](https://github.com/visgl/tsc/blob/master/developer-process/ai-assisted-contributions.md) describes how it applies here. In short:
+
+- **You are the author.** You are responsible for everything you submit, whatever tools you used. Only humans certify a DCO; agents must not add `Signed-off-by` tags.
+- **Disclose substantial assistance** (anything beyond single-line autocomplete) in the pull request description: the tool, what it did, and what you verified. Tick the box in the PR template. Add an `Assisted-by:` trailer where commits are preserved. Disclosure is not penalized.
+- **Understand and verify.** Be able to explain the change in your own words, answer review comments yourself, and run the relevant tests locally, including render tests for rendering changes. Do not remove or alter tests to make generated code pass without understanding why.
+- **Keep it reviewable.** A contribution should be worth more to the project than the time it takes to review. Split large generated changes. Pull requests whose author cannot explain them, has not tested them, or has misrepresented how they were made may be closed without further review.
+- **Newcomer issues are for people.** Do not use AI tools to fix issues labelled for newcomers.
+- **No unattended agents.** Pull requests and issues are opened by people; an agent-drafted PR description that you have edited, verified and disclosed is fine.
+
+Agents working in this repository should read the root `AGENTS.md`, which describes the commands, quality gates and merge-readiness checklist.
+
 ## Setting Up Dev Environment
 
 The **master** branch is the active development branch.


### PR DESCRIPTION
**Draft: depends on visgl/tsc#20.** This wires the repository side of the AI-assisted contributions page proposed for the vis.gl developer process; it should merge only after the TSC adopts that page, and its link assumes the page lands on `master` there.

## Summary

- `CONTRIBUTING.md`: a short "AI-assisted contributions" section with the rules that matter day to day (you are the author; disclose substantial assistance in the PR description; understand and verify; keep it reviewable; newcomer issues are for people; no unattended agents) and a link to the process page.
- `.github/pull_request_template.md`: one checkbox, "I have read the AI-assisted contributions section of CONTRIBUTING.md and disclosed any substantial AI assistance above", with an HTML comment explaining the threshold. Same weight as MapLibre GL JS's template line.
- `AGENTS.md`: a "Contribution Policy" section so agents include the disclosure, never add `Signed-off-by`, stay off newcomer issues and do not open PRs on their own; the existing "prepare a copyable PR description" instruction now says the contributor edits, verifies and discloses it.

## Why

PR descriptions in this repository have lengthened sharply since late 2025: the monthly median was about 400 characters through mid-2025 and has been 1,200 to 2,500 since (772 human-authored PRs since September 2024, authors anonymized; data and method in https://github.com/jatorre/deckgl-ai-ready). That is consistent with agent-prepared descriptions, which `AGENTS.md` itself asks for, so it is a proxy rather than a measurement of AI-written code. The Foundation policy already applies to every submission; nothing in the repository says so or says how. Disclosure is cheap and is not penalized.

## Validation

Documentation and template changes only. This PR follows the practice it proposes: the commit carries an `Assisted-by:` trailer and this description names the tool.

## Disclosure

Drafted with an AI coding agent (Claude Code) and reviewed by me. Revised once after an independent review pass (link target, template weight, AGENTS.md consistency).

https://claude.ai/code/session_01RszQw7B8p94Hyxy4LFsxYj
