### PR TITLE
fix(core): reuse existing device when attaching Deck to an external WebGL context

### DIFF
--- a/modules/core/src/lib/deck.ts
+++ b/modules/core/src/lib/deck.ts
@@ -432,6 +432,9 @@ export default class Deck<ViewsT extends ViewOrViews = null> {
         log.error('WebGL1 context not supported.')();
       }
       deviceOrPromise = webgl2Adapter.attach(props.gl, {
+        // Attach is async: a Deck recreated on the same context (e.g. React StrictMode)
+        // can attach again before the first attach settles. See _createDevice.
+        _reuseDevices: true,
         // Enable shader and pipeline caching for attached devices (matches _createDevice defaults)
         // Without this, interleaved mode (e.g., MapboxOverlay) creates new pipelines every frame
         _cacheShaders: true,

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -7,7 +7,8 @@ import {Deck, log, MapView} from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {FullscreenWidget} from '@deck.gl/widgets';
 import {device} from '@deck.gl/test-utils/vitest';
-import type {CanvasContext, CanvasContextProps} from '@luma.gl/core';
+import {webgl2Adapter} from '@luma.gl/webgl';
+import type {CanvasContext, CanvasContextProps, Device} from '@luma.gl/core';
 import {sleep} from './async-iterator-test-utils';
 
 function createDeferred<T>() {
@@ -329,6 +330,55 @@ webglTest('Deck#attached gl resize syncs canvas context drawing buffer', async (
   } finally {
     canvasContext.setDrawingBufferSize = originalSetDrawingBufferSize;
     deck.finalize();
+  }
+});
+
+webglTest('Deck#attached gl reuses a device already attached to the context', async () => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const gl = canvas.getContext('webgl2');
+  expect(gl, 'WebGL2 context is created').toBeTruthy();
+
+  const props = {
+    gl,
+    width: 1,
+    height: 1,
+    viewState: {longitude: 0, latitude: 0, zoom: 0},
+    layers: []
+  };
+
+  // A Deck recreated on the same context (e.g. React StrictMode) attaches again before
+  // the first attach settles; luma throws unless told to reuse the device.
+  const attach = vi.spyOn(webgl2Adapter, 'attach');
+  const initialized = createDeferred<Device>();
+  const deck = new Deck({
+    ...props,
+    onDeviceInitialized: initialized.resolve,
+    onError: initialized.reject
+  });
+
+  try {
+    expect(attach, 'attach is called once').toHaveBeenCalledTimes(1);
+    expect(attach.mock.calls[0][1], 'attach reuses existing device').toMatchObject({
+      _reuseDevices: true,
+      _cacheShaders: true,
+      _cachePipelines: true
+    });
+    expect(await initialized.promise, 'device is attached').toBe(deck.device);
+  } finally {
+    deck.finalize();
+  }
+
+  attach.mockClear();
+  const deck2 = new Deck({...props, deviceProps: {_reuseDevices: false}});
+  try {
+    expect(attach.mock.calls[0][1], 'deviceProps override defaults').toMatchObject({
+      _reuseDevices: false
+    });
+  } finally {
+    deck2.finalize();
+    attach.mockRestore();
   }
 });
 

--- a/test/modules/core/lib/deck.spec.ts
+++ b/test/modules/core/lib/deck.spec.ts
@@ -7,8 +7,8 @@ import {Deck, log, MapView} from '@deck.gl/core';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import {FullscreenWidget} from '@deck.gl/widgets';
 import {device} from '@deck.gl/test-utils/vitest';
-import {webgl2Adapter} from '@luma.gl/webgl';
-import type {CanvasContext, CanvasContextProps, Device} from '@luma.gl/core';
+import {webgl2Adapter, WebGLDevice} from '@luma.gl/webgl';
+import type {CanvasContext, CanvasContextProps, Device, DeviceProps} from '@luma.gl/core';
 import {sleep} from './async-iterator-test-utils';
 
 function createDeferred<T>() {
@@ -380,6 +380,47 @@ webglTest('Deck#attached gl reuses a device already attached to the context', as
     deck2.finalize();
     attach.mockRestore();
   }
+});
+
+webglTest('Deck#attached gl props let luma reuse a device already on the context', async () => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const gl = canvas.getContext('webgl2');
+  expect(gl, 'WebGL2 context is created').toBeTruthy();
+
+  const attach = vi.spyOn(webgl2Adapter, 'attach');
+  const initialized = createDeferred<Device>();
+  const deck = new Deck({
+    gl,
+    width: 1,
+    height: 1,
+    viewState: {longitude: 0, latitude: 0, zoom: 0},
+    layers: [],
+    onDeviceInitialized: initialized.resolve,
+    onError: initialized.reject
+  });
+
+  let first: Device;
+  let attachProps: DeviceProps;
+  try {
+    first = await initialized.promise;
+    attachProps = attach.mock.calls[0][1]!;
+  } finally {
+    attach.mockRestore();
+    deck.finalize();
+  }
+
+  // The attach race cannot be reproduced here: the test runner loads luma's device module
+  // per request, which serializes concurrent attaches. Replay what attach() does once its
+  // "already attached" check has passed instead, with the props Deck supplied: construct
+  // a device on a context that already has one.
+  const second = new WebGLDevice({
+    ...attachProps,
+    _handle: gl,
+    createCanvasContext: {canvas: gl!.canvas, autoResize: false}
+  });
+  expect(second, 'existing device is reused').toBe(first);
 });
 
 test('Deck#useDevicePixels forwards to canvas context', async () => {


### PR DESCRIPTION
Closes #10681

#### Background

`Deck` passes `_reuseDevices: true` to `luma.createDevice()` on the owned-canvas path, with a comment explaining that asynchronous device creation can complete after `finalize()` and that luma throws by default if a device is already attached. The attach path (`props.gl`, used by every basemap overlay) does not pass the flag.

`webgl2Adapter.attach()` is asynchronous. When a `Deck` is finalized and recreated on the same context in one synchronous sequence, as `MapLibreOverlay`/`MapboxOverlay` in interleaved mode are under React StrictMode's add/remove/add of effects, the second attach passes luma's "already attached" check before the first attach has registered its device. Both then reach the `WebGLDevice` constructor and the second one throws `WebGL context already attached to device`. The overlay is left without a deck, so `pickObject()` and friends fail on an assertion.

Passing `deviceProps: {_reuseDevices: true}` through the overlay props works around it today, which confirms the flag is honoured on this path. This PR makes it the default on the attach path, matching `_createDevice`. Same mechanism as #9379, which only covered the owned-canvas path.

#### Change List

- `Deck`: pass `_reuseDevices: true` in the props given to `webgl2Adapter.attach()`. User `deviceProps` still override it.
- Add a test asserting the attach props include `_reuseDevices`, and that `deviceProps` can override it.