### PR TITLE
fix(maplibre): ship a CJS build, like every other @deck.gl/* package

### DIFF
--- a/modules/maplibre/package.json
+++ b/modules/maplibre/package.json
@@ -22,11 +22,13 @@
   },
   "homepage": "https://deck.gl",
   "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/test/modules/maplibre/package-exports.node.spec.ts
+++ b/test/modules/maplibre/package-exports.node.spec.ts
@@ -1,0 +1,40 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'fs';
+import {fileURLToPath} from 'url';
+import {test, expect, describe} from 'vitest';
+
+// vitest aliases every `@deck.gl/*` specifier straight to its `src`, so an
+// `import`/`require` test here would never touch the published package.json
+// (see the `aliases` map in vitest.config.ts) - read the file directly
+// instead, the same way a consumer's package manager would see it.
+function readPackageJson(modulePath: string) {
+  const packageJsonUrl = new URL(`../../../modules/${modulePath}/package.json`, import.meta.url);
+  return JSON.parse(readFileSync(fileURLToPath(packageJsonUrl), 'utf-8'));
+}
+
+describe('@deck.gl/maplibre package.json ships both module formats', () => {
+  // @deck.gl/mapbox is the closest sibling: same "wrap deck.gl layers for a
+  // host map library" shape, same dependency on @deck.gl/core.
+  const mapbox = readPackageJson('mapbox');
+  const maplibre = readPackageJson('maplibre');
+
+  test('declares a CJS "main" entry, like @deck.gl/mapbox', () => {
+    expect(mapbox.main).toMatch(/\.cjs$/);
+    expect(maplibre.main).toMatch(/\.cjs$/);
+  });
+
+  test('exports["."] has a "require" condition, like @deck.gl/mapbox', () => {
+    const mapboxRequire = mapbox.exports['.'].require;
+    const maplibreRequire = maplibre.exports['.'].require;
+
+    expect(mapboxRequire).toMatch(/\.cjs$/);
+    expect(maplibreRequire).toMatch(/\.cjs$/);
+  });
+
+  test('"main" and exports["."].require point at the same file', () => {
+    expect(maplibre.main).toBe(maplibre.exports['.'].require.replace(/^\.\//, ''));
+  });
+});


### PR DESCRIPTION
#### Background

`@deck.gl/maplibre`'s `package.json` has no `"main"` field and no `"require"` condition in `exports["."]` (just `"import"`). Every other public package in the monorepo - including `@deck.gl/mapbox`, `@deck.gl/arcgis`, and `@deck.gl/google-maps`, the closest siblings in shape - ships both a `"main"`/`"require"` CJS entry and an `"import"` ESM one. `@deck.gl/maplibre` is the sole exception (checked all 16 public `modules/*/package.json`).

This isn't just a metadata gap. `ocular-build`'s CJS step (`getCJSEntryPoints` in `@vis.gl/dev-tools`) derives what to build entirely from a package's own `exports["."].require` - if it's missing, nothing gets built, silently. `dist/` never gets an `index.cjs` for this package at all, so any CJS-based `require()` (a Jest project without ESM transforms, plain Node `require()`, etc.) fails with `Cannot find module '@deck.gl/maplibre'`, even though the package installed fine and `dist/index.js` exists.

Ran into this migrating `preset-chart-deckgl` in apache/superset off `@deck.gl/mapbox` (whose `map.transform` usage breaks under `maplibre-gl` 6+) onto this package - Jest couldn't resolve it at all until I patched around it downstream. Figured the actual fix belongs here.

#### Change List
- `modules/maplibre/package.json`: add `"main": "dist/index.cjs"` and a `"require"` condition to `exports["."]`, matching `@deck.gl/mapbox`/`@deck.gl/arcgis`/`@deck.gl/google-maps` exactly.
- Regression test asserting the `package.json` shape directly. vitest aliases every `@deck.gl/*` specifier straight to its `src` in this repo (see `vitest.config.ts`), so an `import`/`require`-based test would never actually touch the published `package.json` - confirmed the existing `test/modules/imports.node.spec.ts`, which already imports `@deck.gl/maplibre`, doesn't catch this.

Verified with the exact `getCJSExportConfig` esbuild options against a real build: `ocular-build maplibre` (after building `core`, its project reference) now produces a working `dist/index.cjs` that exports `MapLibreOverlay` and resolves its `@deck.gl/core`/`@luma.gl/core` imports as real `require()`s, matching `@deck.gl/mapbox`'s shipped `.cjs`. `ocular-lint` and the `node` vitest project (which now includes the new test) both pass.
