### PR TITLE
feat(core, maplibre): add camera roll support

### DIFF
--- a/docs/api-reference/core/fly-to-interpolator.md
+++ b/docs/api-reference/core/fly-to-interpolator.md
@@ -2,6 +2,8 @@
 
 Performs "fly to" style interpolation between two geospatial view states. Implements [TransitionInterpolator](./transition-interpolator.md).
 
+The camera's `longitude`, `latitude`, and `zoom` follow a smooth flight path that combines panning and zooming. For distant destinations, the camera can zoom out to show more of the route, then zoom in to the target zoom level as it approaches the destination. The `curve` option controls how much zooming occurs along the path.
+
 The camera’s `bearing`, `pitch`, `roll`, and `position` are interpolated linearly during the flight.
 
 See [View State Transitions](../../developer-guide/animations-and-transitions.md#camera-transitions) for usage examples.

--- a/docs/api-reference/core/fly-to-interpolator.md
+++ b/docs/api-reference/core/fly-to-interpolator.md
@@ -2,7 +2,7 @@
 
 Performs "fly to" style interpolation between two geospatial view states. Implements [TransitionInterpolator](./transition-interpolator.md).
 
-The camera’s `bearing`, `pitch`, `roll`, and `position` are interpolated linearly during the flight. Omitted `roll` is treated as `0`.
+The camera’s `bearing`, `pitch`, `roll`, and `position` are interpolated linearly during the flight.
 
 See [View State Transitions](../../developer-guide/animations-and-transitions.md#camera-transitions) for usage examples.
 

--- a/docs/api-reference/core/fly-to-interpolator.md
+++ b/docs/api-reference/core/fly-to-interpolator.md
@@ -2,6 +2,8 @@
 
 Performs "fly to" style interpolation between two geospatial view states. Implements [TransitionInterpolator](./transition-interpolator.md).
 
+The camera’s `bearing`, `pitch`, `roll`, and `position` are interpolated linearly during the flight. Omitted `roll` is treated as `0`.
+
 See [View State Transitions](../../developer-guide/animations-and-transitions.md#camera-transitions) for usage examples.
 
 

--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -72,6 +72,7 @@ To render, `GlobeView` needs to be used together with a `viewState` with the fol
 - `zoom` (number) - zoom level
 - `bearing` (number, optional) - bearing angle in degrees. Default `0` (north up).
 - `pitch` (number, optional) - pitch angle in degrees. `0` looks straight down at the earth. Default `0`.
+- `roll` (number, optional) - camera bank angle in degrees. Positive values rotate the image counter-clockwise on screen, matching MapLibre. Default `0`.
 - `maxZoom` (number, optional) - max zoom level. Default `20`.
 - `minZoom` (number, optional) - min zoom level. Default `0`.
 - `maxPitch` (number, optional) - max pitch angle. Default `60`.
@@ -81,6 +82,10 @@ The globe behaves like a physical ball. Dragging and pointer-anchored zoom rotat
 
 To limit how far the camera can travel, set the shared controller [`maxBounds`](./controller.md#options) option. For example, `maxBounds: [[-180, -85], [180, 85]]` keeps the viewport center between `±85°` latitude.
 
+
+Roll is applied around the camera's forward axis after pitch and bearing, including
+the Mercator projection used at high zoom. The controller preserves it during
+interaction but does not provide a roll gesture.
 
 ## Controller
 

--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -72,7 +72,7 @@ To render, `GlobeView` needs to be used together with a `viewState` with the fol
 - `zoom` (number) - zoom level
 - `bearing` (number, optional) - bearing angle in degrees. Default `0` (north up).
 - `pitch` (number, optional) - pitch angle in degrees. `0` looks straight down at the earth. Default `0`.
-- `roll` (number, optional) - camera bank angle in degrees. Positive values rotate the image counter-clockwise on screen, matching MapLibre. Default `0`.
+- `roll` (number, optional) - camera bank angle in degrees. Positive values rotate the image counter-clockwise on screen. Default `0`.
 - `maxZoom` (number, optional) - max zoom level. Default `20`.
 - `minZoom` (number, optional) - min zoom level. Default `0`.
 - `maxPitch` (number, optional) - max pitch angle. Default `60`.

--- a/docs/api-reference/core/globe-view.md
+++ b/docs/api-reference/core/globe-view.md
@@ -83,10 +83,6 @@ The globe behaves like a physical ball. Dragging and pointer-anchored zoom rotat
 To limit how far the camera can travel, set the shared controller [`maxBounds`](./controller.md#options) option. For example, `maxBounds: [[-180, -85], [180, 85]]` keeps the viewport center between `±85°` latitude.
 
 
-Roll is applied around the camera's forward axis after pitch and bearing, including
-the Mercator projection used at high zoom. The controller preserves it during
-interaction but does not provide a roll gesture.
-
 ## Controller
 
 By default, `GlobeView` uses the `GlobeController` to handle interactivity. To enable the controller, use:

--- a/docs/api-reference/core/linear-interpolator.md
+++ b/docs/api-reference/core/linear-interpolator.md
@@ -16,7 +16,7 @@ new LinearInterpolator({transitionProps: ['target', 'zoom']});
 Parameters:
 
 - options (object)
-  * `transitionProps` (string[], optional) - Array of prop names that should be linearly interpolated. Default `['longitude', 'latitude', 'zoom', 'bearing', 'pitch']`.
+  * `transitionProps` (string[], optional) - Array of prop names that should be linearly interpolated. Default `['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'roll']`.
   * `around` (number[2], optional) - A point to zoom/rotate around, `[x, y]` in screen pixels. If provided, the location at this point will not move during the transition.
   * `makeViewport` (Function, optional) - Called to construct a [viewport](./viewport.md), e.g. `props => new WebMercatorViewport(props)`. Must be provided if `around` is used.
 

--- a/docs/api-reference/core/map-view.md
+++ b/docs/api-reference/core/map-view.md
@@ -62,7 +62,7 @@ To render, `MapView` needs to be used together with a `viewState` with the follo
 - `zoom` (number) - zoom level
 - `pitch` (number, optional) - pitch angle in degrees. Default `0` (top-down).
 - `bearing` (number, optional) - bearing angle in degrees. Default `0` (north).
-- `roll` (number, optional) - camera bank angle in degrees. Positive values rotate the image counter-clockwise on screen, matching MapLibre. Default `0`.
+- `roll` (number, optional) - camera bank angle in degrees. Positive values rotate the image counter-clockwise on screen. Default `0`.
 - `maxZoom` (number, optional) - max zoom level. Default `20`.
 - `minZoom` (number, optional) - min zoom level. Default `0`.
 - `maxPitch` (number, optional) - max pitch angle. Default `60`.

--- a/docs/api-reference/core/map-view.md
+++ b/docs/api-reference/core/map-view.md
@@ -62,11 +62,16 @@ To render, `MapView` needs to be used together with a `viewState` with the follo
 - `zoom` (number) - zoom level
 - `pitch` (number, optional) - pitch angle in degrees. Default `0` (top-down).
 - `bearing` (number, optional) - bearing angle in degrees. Default `0` (north).
+- `roll` (number, optional) - camera bank angle in degrees. Positive values rotate the image counter-clockwise on screen, matching MapLibre. Default `0`.
 - `maxZoom` (number, optional) - max zoom level. Default `20`.
 - `minZoom` (number, optional) - min zoom level. Default `0`.
 - `maxPitch` (number, optional) - max pitch angle. Default `60`.
 - `minPitch` (number, optional) - min pitch angle. Default `0`.
 - `position` (number[3], optional) - Viewport center offsets from lng, lat in meters. Default: `[0,0,0]`.
+
+Roll is applied around the camera's forward axis after pitch and bearing. It can be
+set or transitioned programmatically; the controller preserves it during
+interaction but does not provide a roll gesture.
 
 ## Controller
 

--- a/docs/api-reference/core/map-view.md
+++ b/docs/api-reference/core/map-view.md
@@ -69,10 +69,6 @@ To render, `MapView` needs to be used together with a `viewState` with the follo
 - `minPitch` (number, optional) - min pitch angle. Default `0`.
 - `position` (number[3], optional) - Viewport center offsets from lng, lat in meters. Default: `[0,0,0]`.
 
-Roll is applied around the camera's forward axis after pitch and bearing. It can be
-set or transitioned programmatically; the controller preserves it during
-interaction but does not provide a roll gesture.
-
 ## Controller
 
 By default, `MapView` uses the `MapController` to handle interactivity. To enable the controller, use:

--- a/docs/api-reference/core/web-mercator-viewport.md
+++ b/docs/api-reference/core/web-mercator-viewport.md
@@ -44,6 +44,7 @@ Parameters:
   + `zoom` (number, optional) - Map zoom (scale is calculated as `2^zoom`). Default to `11`.
   + `pitch` (number, optional) - The pitch (tilt) of the map from the screen, in degrees (0 is straight down). Default to `0`.
   + `bearing` (number, optional) - The bearing (rotation) of the map from north, in degrees counter-clockwise (0 means north is up). Default to `0`.
+  + `roll` (number, optional) - Camera rotation around the forward axis, applied after pitch and bearing. Positive values rotate the image counter-clockwise on screen. Default `0`.
   + `altitude` (number, optional) - Altitude of camera in screen units. Default to `1.5`.
 
   projection matrix arguments:

--- a/docs/api-reference/extensions/fp64-extension.md
+++ b/docs/api-reference/extensions/fp64-extension.md
@@ -56,6 +56,9 @@ new Fp64Extension();
 
 When added to a layer via the `extensions` prop, the `Fp64Extension` requires the `coordinateSystem` prop of the layer to be `'lnglat'`.
 
+## Limitations
+
+- Only `MapView` (and other Web Mercator based viewports) are supported. `GlobeView` and Non-geospatial views such as `OrthographicView` and `OrbitView` are not supported.
 
 ## Source
 

--- a/docs/api-reference/maplibre/overview.md
+++ b/docs/api-reference/maplibre/overview.md
@@ -88,8 +88,23 @@ new ScatterplotLayer({
 - Interleaved mode only works when WebGL2 is available.
 - Camera target elevation is synchronized. deck.gl layers are not draped over MapLibre terrain.
 - Mercator is supported. Globe integration uses deck.gl's experimental [`GlobeView`](../core/globe-view.md). With default back-face culling, `TextLayer` and non-billboard `IconLayer` do not render. Disabling culling makes them visible, but non-billboard icons render rotated 180°.
-- Non-default vertical field of view and camera roll are not synchronized.
+- Camera roll is synchronized through `getRoll()` in MapLibre v5 and v6, in both overlaid and interleaved modes. MapLibre v4.5.1 uses zero roll.
+- Non-default vertical field of view is not synchronized.
 - One interleaved overlay may be attached to a map.
+
+### Camera roll
+
+MapLibre remains the camera source of truth. Changing its roll updates both the
+base map and deck.gl layers, including picking:
+
+```typescript
+map.addControl(new MapLibreOverlay({interleaved: true, layers}));
+map.setRoll(28);
+```
+
+The same synchronization applies to Mercator and globe projections. Zero or
+omitted roll retains the existing projection. No additional deck.gl view or
+controller configuration is required.
 
 ### Antialiasing
 

--- a/docs/api-reference/maplibre/overview.md
+++ b/docs/api-reference/maplibre/overview.md
@@ -88,7 +88,7 @@ new ScatterplotLayer({
 - Interleaved mode only works when WebGL2 is available.
 - Camera target elevation is synchronized. deck.gl layers are not draped over MapLibre terrain.
 - Mercator is supported. Globe integration uses deck.gl's experimental [`GlobeView`](../core/globe-view.md). With default back-face culling, `TextLayer` and non-billboard `IconLayer` do not render. Disabling culling makes them visible, but non-billboard icons render rotated 180°.
-- Camera roll is synchronized through `getRoll()` in MapLibre v5 and v6, in both overlaid and interleaved modes. MapLibre v4.5.1 uses zero roll.
+- Camera roll is synchronized in MapLibre v5+. Older versions will ignore roll.
 - Non-default vertical field of view is not synchronized.
 - One interleaved overlay may be attached to a map.
 

--- a/docs/api-reference/maplibre/overview.md
+++ b/docs/api-reference/maplibre/overview.md
@@ -92,20 +92,6 @@ new ScatterplotLayer({
 - Non-default vertical field of view is not synchronized.
 - One interleaved overlay may be attached to a map.
 
-### Camera roll
-
-MapLibre remains the camera source of truth. Changing its roll updates both the
-base map and deck.gl layers, including picking:
-
-```typescript
-map.addControl(new MapLibreOverlay({interleaved: true, layers}));
-map.setRoll(28);
-```
-
-The same synchronization applies to Mercator and globe projections. Zero or
-omitted roll retains the existing projection. No additional deck.gl view or
-controller configuration is required.
-
 ### Antialiasing
 
 MapLibre creates its WebGL context with `antialias: false` by default. In interleaved mode, deck.gl shares that context, so layers whose edges depend on MSAA — including [PathLayer](../layers/path-layer.md), [LineLayer](../layers/line-layer.md), [ArcLayer](../layers/arc-layer.md), and [PointCloudLayer](../layers/point-cloud-layer.md) — render with hard, aliased edges.

--- a/modules/core/src/controllers/globe-controller.ts
+++ b/modules/core/src/controllers/globe-controller.ts
@@ -90,8 +90,10 @@ class GlobeState extends MapState {
     const dx = startPanPos[0] - pos[0];
     const dy = startPanPos[1] - pos[1];
 
-    const hAngle = dx * rate;
-    const vAngle = -dy * rate;
+    // Convert screen deltas back into the camera frame before roll.
+    const roll = (this.getViewportProps().roll || 0) * DEGREES_TO_RADIANS;
+    const hAngle = (Math.cos(roll) * dx - Math.sin(roll) * dy) * rate;
+    const vAngle = -(Math.sin(roll) * dx + Math.cos(roll) * dy) * rate;
     const rotated = Globe.rotateFrame(frame, hAngle, vAngle);
     const zoom = startZoom + zoomAdjust(rotated.latitude, true) - zoomAdjust(frame.latitude, true);
 
@@ -152,6 +154,9 @@ class GlobeState extends MapState {
     if (props.bearing < -180 || props.bearing > 180) {
       props.bearing = mod(props.bearing + 180, 360) - 180;
     }
+    if (props.roll < -180 || props.roll > 180) {
+      props.roll = mod(props.roll + 180, 360) - 180;
+    }
     props.latitude = clamp(props.latitude, -90, 90);
     props.pitch = clamp(props.pitch, props.minPitch, props.maxPitch);
 
@@ -169,7 +174,7 @@ class GlobeState extends MapState {
     }
 
     if (maxBounds && maxBoundsRect) {
-      const viewport = this.makeViewport({...props, bearing: 0, pitch: 0});
+      const viewport = this.makeViewport({...props, bearing: 0, pitch: 0, roll: 0});
       const screenExtents = getMaxBoundsExtents(
         viewport,
         [props.longitude, props.latitude],
@@ -271,7 +276,7 @@ export default class GlobeController extends Controller<MapState> {
     transitionDuration: 300,
     transitionInterpolator: new LinearInterpolator({
       transitionProps: {
-        compare: ['longitude', 'latitude', 'zoom', 'bearing', 'pitch'],
+        compare: ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'roll'],
         required: ['longitude', 'latitude', 'zoom']
       }
     })

--- a/modules/core/src/controllers/map-controller.ts
+++ b/modules/core/src/controllers/map-controller.ts
@@ -56,6 +56,8 @@ export type MapStateProps = {
   bearing?: number;
   /** The pitch of the viewport in degrees */
   pitch?: number;
+  /** Camera roll in degrees. Preserved by interactions. Default `0`. */
+  roll?: number;
   /**
    * Specify the altitude of the viewport camera
    * Unit: map heights, default 1.5
@@ -132,6 +134,7 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
       bearing = 0,
       /** The pitch of the viewport in degrees */
       pitch = 0,
+      roll = 0,
       /**
        * Specify the altitude of the viewport camera
        * Unit: map heights, default 1.5
@@ -185,6 +188,7 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
         zoom,
         bearing,
         pitch,
+        roll,
         altitude,
         maxZoom,
         minZoom,
@@ -460,7 +464,11 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
     // const endViewStateProps = new this.ControllerState(endProps).shortestPathFrom(startViewstate);
     const fromProps = viewState.getViewportProps();
     const props = {...this.getViewportProps()};
-    const {bearing, longitude} = props;
+    const {bearing, longitude, roll} = props;
+
+    if (Math.abs(roll - fromProps.roll) > 180) {
+      props.roll = roll < 0 ? roll + 360 : roll - 360;
+    }
 
     if (Math.abs(bearing - fromProps.bearing) > 180) {
       props.bearing = bearing < 0 ? bearing + 360 : bearing - 360;
@@ -484,6 +492,9 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
     const {maxPitch, minPitch, pitch, bearing, normalize, maxBounds, rubberBand} = props;
 
     if (normalize) {
+      if (props.roll < -180 || props.roll > 180) {
+        props.roll = mod(props.roll + 180, 360) - 180;
+      }
       if (bearing < -180 || bearing > 180) {
         props.bearing = mod(bearing + 180, 360) - 180;
       }
@@ -516,7 +527,7 @@ export class MapState extends ViewState<MapState, MapStateProps, MapStateInterna
       const maxBoundsRect = getMaxBoundsRect(props.width, props.height, props.maxBoundsPadding);
       // Resolve the semantic center through the viewport because view padding can
       // place it away from the canvas' geometric center.
-      const viewport = this.makeViewport({...props, bearing: 0, pitch: 0});
+      const viewport = this.makeViewport({...props, bearing: 0, pitch: 0, roll: 0});
       const screenExtents = getMaxBoundsExtents(
         viewport,
         [props.longitude, props.latitude],
@@ -702,7 +713,7 @@ export default class MapController extends Controller<MapState> {
     transitionDuration: 300,
     transitionInterpolator: new LinearInterpolator({
       transitionProps: {
-        compare: ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'],
+        compare: ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'roll', 'position'],
         required: ['longitude', 'latitude', 'zoom']
       }
     })

--- a/modules/core/src/transitions/fly-to-interpolator.ts
+++ b/modules/core/src/transitions/fly-to-interpolator.ts
@@ -10,6 +10,7 @@ import {flyToViewport, getFlyToDuration} from '@math.gl/web-mercator';
 const LINEARLY_INTERPOLATED_PROPS = {
   bearing: 0,
   pitch: 0,
+  roll: 0,
   position: [0, 0, 0]
 };
 const DEFAULT_OPTS = {
@@ -45,17 +46,35 @@ export default class FlyToInterpolator extends TransitionInterpolator {
     } = {}
   ) {
     super({
-      compare: ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'],
-      extract: ['width', 'height', 'longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'position'],
+      compare: ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'roll', 'position'],
+      extract: [
+        'width',
+        'height',
+        'longitude',
+        'latitude',
+        'zoom',
+        'bearing',
+        'pitch',
+        'roll',
+        'position'
+      ],
       required: ['width', 'height', 'latitude', 'longitude', 'zoom']
     });
     this.opts = {...DEFAULT_OPTS, ...opts};
   }
 
+  /** Treat omitted roll as zero when comparing legacy view states. */
+  arePropsEqual(startProps: Record<string, any>, endProps: Record<string, any>): boolean {
+    return super.arePropsEqual(
+      {...startProps, roll: startProps.roll ?? 0},
+      {...endProps, roll: endProps.roll ?? 0}
+    );
+  }
+
   interpolateProps(startProps, endProps, t) {
     const viewport = flyToViewport(startProps, endProps, t, this.opts);
 
-    // Linearly interpolate 'bearing', 'pitch' and 'position'.
+    // Linearly interpolate 'bearing', 'pitch', 'roll' and 'position'.
     // If they are not supplied, they are interpreted as zeros in viewport calculation
     // (fallback defined in WebMercatorViewport)
     // Because there is no guarantee that the current controller's ViewState normalizes

--- a/modules/core/src/transitions/fly-to-interpolator.ts
+++ b/modules/core/src/transitions/fly-to-interpolator.ts
@@ -63,7 +63,10 @@ export default class FlyToInterpolator extends TransitionInterpolator {
     this.opts = {...DEFAULT_OPTS, ...opts};
   }
 
-  /** Treat omitted roll as zero when comparing legacy view states. */
+  /**
+   * Preserve equality for existing view states that include pitch/bearing but omit roll.
+   * Otherwise the new comparison prop triggers transitions even when the camera is unchanged.
+   */
   arePropsEqual(startProps: Record<string, any>, endProps: Record<string, any>): boolean {
     return super.arePropsEqual(
       {...startProps, roll: startProps.roll ?? 0},

--- a/modules/core/src/transitions/linear-interpolator.ts
+++ b/modules/core/src/transitions/linear-interpolator.ts
@@ -7,7 +7,7 @@ import {lerp} from '@math.gl/core';
 
 import type Viewport from '../viewports/viewport';
 
-const DEFAULT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch'];
+const DEFAULT_PROPS = ['longitude', 'latitude', 'zoom', 'bearing', 'pitch', 'roll'];
 const DEFAULT_REQUIRED_PROPS = ['longitude', 'latitude', 'zoom'];
 
 type PropsWithAnchor = {
@@ -62,6 +62,14 @@ export default class LinearInterpolator extends TransitionInterpolator {
 
     super(normalizedOpts.transitionProps);
     this.opts = normalizedOpts;
+  }
+
+  /** Treat omitted roll as zero when comparing legacy view states. */
+  arePropsEqual(startProps: Record<string, any>, endProps: Record<string, any>): boolean {
+    return super.arePropsEqual(
+      {...startProps, roll: startProps.roll ?? 0},
+      {...endProps, roll: endProps.roll ?? 0}
+    );
   }
 
   initializeProps(

--- a/modules/core/src/transitions/linear-interpolator.ts
+++ b/modules/core/src/transitions/linear-interpolator.ts
@@ -64,7 +64,10 @@ export default class LinearInterpolator extends TransitionInterpolator {
     this.opts = normalizedOpts;
   }
 
-  /** Treat omitted roll as zero when comparing legacy view states. */
+  /**
+   * Preserve equality for existing view states that include pitch/bearing but omit roll.
+   * Otherwise the new comparison prop triggers transitions even when the camera is unchanged.
+   */
   arePropsEqual(startProps: Record<string, any>, endProps: Record<string, any>): boolean {
     return super.arePropsEqual(
       {...startProps, roll: startProps.roll ?? 0},

--- a/modules/core/src/viewports/globe-viewport.ts
+++ b/modules/core/src/viewports/globe-viewport.ts
@@ -88,7 +88,6 @@ export default class GlobeViewport extends Viewport {
   latitude: number;
   bearing: number;
   pitch: number;
-  /** Camera roll in degrees. */
   roll: number;
   fovy: number;
   resolution: number;

--- a/modules/core/src/viewports/globe-viewport.ts
+++ b/modules/core/src/viewports/globe-viewport.ts
@@ -57,6 +57,8 @@ export type GlobeViewportOptions = {
   bearing?: number;
   /** Pitch in degrees. Default `0` */
   pitch?: number;
+  /** Camera roll in degrees, positive counter-clockwise on screen. Default `0`. */
+  roll?: number;
   /** Camera altitude relative to the viewport height, used to control the FOV. Default `1.5` */
   altitude?: number;
   /* Meter offsets of the viewport center from lng, lat, elevation */
@@ -86,6 +88,8 @@ export default class GlobeViewport extends Viewport {
   latitude: number;
   bearing: number;
   pitch: number;
+  /** Camera roll in degrees. */
+  roll: number;
   fovy: number;
   resolution: number;
 
@@ -94,6 +98,7 @@ export default class GlobeViewport extends Viewport {
       longitude = 0,
       bearing = 0,
       pitch = 0,
+      roll = 0,
       zoom = 0,
       // Matches Maplibre defaults
       // https://github.com/maplibre/maplibre-gl-js/blob/f8ab4b48d59ab8fe7b068b102538793bbdd4c848/src/geo/projection/globe_transform.ts#L632-L633
@@ -145,6 +150,12 @@ export default class GlobeViewport extends Viewport {
       .rotateZ(-longitude * DEGREES_TO_RADIANS)
       .scale(scale / height);
 
+    // Premultiply in view space: roll acts around the camera forward axis after
+    // pitch, bearing and globe orientation, matching WebMercatorViewport.
+    if (roll) {
+      viewMatrix.multiplyLeft(new Matrix4().rotateZ(roll * DEGREES_TO_RADIANS));
+    }
+
     super({
       ...opts,
       // x, y, width,
@@ -169,6 +180,7 @@ export default class GlobeViewport extends Viewport {
     this.longitude = longitude;
     this.bearing = bearing;
     this.pitch = pitch;
+    this.roll = roll;
     this.fovy = fovy;
     this.resolution = resolution;
   }

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -38,6 +38,8 @@ export type WebMercatorViewportOptions = {
   latitude?: number;
   /** Tilt of the camera in degrees */
   pitch?: number;
+  /** Camera roll in degrees, positive counter-clockwise on screen. Default `0`. */
+  roll?: number;
   /** Heading of the camera in degrees */
   bearing?: number;
   /** Camera altitude relative to the viewport height, legacy property used to control the FOV. Default `1.5` */
@@ -81,6 +83,8 @@ export default class WebMercatorViewport extends Viewport {
   longitude: number;
   latitude: number;
   pitch: number;
+  /** Camera roll in degrees. */
+  roll: number;
   bearing: number;
   altitude: number;
   fovy: number;
@@ -98,6 +102,7 @@ export default class WebMercatorViewport extends Viewport {
       longitude = 0,
       zoom = 0,
       pitch = 0,
+      roll = 0,
       bearing = 0,
       nearZMultiplier = 0.1,
       farZMultiplier = 1.01,
@@ -142,6 +147,21 @@ export default class WebMercatorViewport extends Viewport {
         offset = [0, clamp((top + height - bottom) / 2, 0, height) - height / 2];
       }
 
+      if (roll) {
+        // Roll can bring a side or bottom corner closer to the horizon. Use the
+        // upper extent of the rotated viewport when calculating the far plane.
+        // Padding shifts the projection center in screen space, after roll.
+        const angle = (roll * Math.PI) / 180;
+        const {left = 0, right = 0} = padding || {};
+        const offsetX = clamp((left + width - right) / 2, 0, width) - width / 2;
+        const offsetY = offset?.[1] || 0;
+        const upperExtent =
+          (Math.abs(Math.sin(angle)) * width + Math.abs(Math.cos(angle)) * height) / 2 +
+          Math.sin(angle) * offsetX +
+          Math.cos(angle) * offsetY;
+        offset = [0, upperExtent - height / 2];
+      }
+
       projectionParameters = getProjectionParameters({
         width,
         height,
@@ -174,6 +194,14 @@ export default class WebMercatorViewport extends Viewport {
       altitude
     });
 
+    // Roll around the camera forward axis after bearing and pitch. Premultiplying
+    // in view space keeps projection, unprojection, picking and shader math aligned.
+    if (roll) {
+      viewMatrixUncentered = new Matrix4()
+        .rotateZ((roll * Math.PI) / 180)
+        .multiplyRight(viewMatrixUncentered);
+    }
+
     if (worldOffset) {
       const viewOffset = new Matrix4().translate([512 * worldOffset, 0, 0]);
       viewMatrixUncentered = viewOffset.multiplyLeft(viewMatrixUncentered);
@@ -202,6 +230,7 @@ export default class WebMercatorViewport extends Viewport {
     this.longitude = longitude;
     this.zoom = zoom;
     this.pitch = pitch;
+    this.roll = roll;
     this.bearing = bearing;
     this.altitude = altitude;
     this.fovy = fovy;
@@ -305,14 +334,16 @@ export default class WebMercatorViewport extends Viewport {
   }
 
   getBounds(options: {z?: number} = {}): [number, number, number, number] {
-    // @ts-ignore
-    const corners = getBounds(this, options.z || 0);
+    const corners = this.roll
+      ? getRolledBounds(this, options.z || 0)
+      : // @ts-ignore math.gl only reads the shared viewport properties
+        getBounds(this, options.z || 0);
 
     return [
-      Math.min(corners[0][0], corners[1][0], corners[2][0], corners[3][0]),
-      Math.min(corners[0][1], corners[1][1], corners[2][1], corners[3][1]),
-      Math.max(corners[0][0], corners[1][0], corners[2][0], corners[3][0]),
-      Math.max(corners[0][1], corners[1][1], corners[2][1], corners[3][1])
+      Math.min(...corners.map(p => p[0])),
+      Math.min(...corners.map(p => p[1])),
+      Math.max(...corners.map(p => p[0])),
+      Math.max(...corners.map(p => p[1]))
     ];
   }
 
@@ -342,4 +373,36 @@ export default class WebMercatorViewport extends Viewport {
     const {longitude, latitude, zoom} = fitBounds({width, height, bounds, ...options});
     return new WebMercatorViewport({width, height, longitude, latitude, zoom});
   }
+}
+
+// A rolled horizon can cross any screen edge. Intersect all twelve frustum
+// edges with the requested elevation instead of assuming a horizontal horizon.
+function getRolledBounds(viewport: WebMercatorViewport, z: number): number[][] {
+  const inverseMatrix = new Matrix4(viewport.pixelUnprojectionMatrix);
+  const targetZ = z * viewport.distanceScales.unitsPerMeter[2];
+  const corners = Array.from({length: 8}, (_, i) =>
+    inverseMatrix.transformAsPoint([
+      i & 1 ? viewport.width : 0,
+      i & 2 ? viewport.height : 0,
+      i & 4 ? 1 : -1
+    ])
+  );
+  const intersections: number[][] = [];
+  for (let i = 0; i < 8; i++) {
+    for (const axis of [1, 2, 4]) {
+      if (i & axis) continue;
+      const start = corners[i];
+      const end = corners[i | axis];
+      const t = (targetZ - start[2]) / (end[2] - start[2]);
+      if (t >= 0 && t <= 1) {
+        intersections.push(
+          viewport.unprojectFlat([
+            start[0] + t * (end[0] - start[0]),
+            start[1] + t * (end[1] - start[1])
+          ])
+        );
+      }
+    }
+  }
+  return intersections.length ? intersections : [[viewport.longitude, viewport.latitude]];
 }

--- a/modules/core/src/viewports/web-mercator-viewport.ts
+++ b/modules/core/src/viewports/web-mercator-viewport.ts
@@ -83,7 +83,6 @@ export default class WebMercatorViewport extends Viewport {
   longitude: number;
   latitude: number;
   pitch: number;
-  /** Camera roll in degrees. */
   roll: number;
   bearing: number;
   altitude: number;

--- a/modules/core/src/views/globe-view.ts
+++ b/modules/core/src/views/globe-view.ts
@@ -19,6 +19,8 @@ export type GlobeViewState = {
   latitude: number;
   /** Zoom level */
   zoom: number;
+  /** Camera roll in degrees, positive counter-clockwise on screen. Default `0`. */
+  roll?: number;
   /** Min zoom, default `0` */
   minZoom?: number;
   /** Max zoom, default `20` */

--- a/modules/core/src/views/map-view.ts
+++ b/modules/core/src/views/map-view.ts
@@ -19,6 +19,8 @@ export type MapViewState = {
   pitch?: number;
   /** Bearing (rotation) of the map, in degrees. `0` is north up */
   bearing?: number;
+  /** Camera roll in degrees, positive counter-clockwise on screen. Default `0`. */
+  roll?: number;
   /** Min zoom, default `0` */
   minZoom?: number;
   /** Max zoom, default `20` */

--- a/modules/maplibre/src/deck-utils.ts
+++ b/modules/maplibre/src/deck-utils.ts
@@ -160,8 +160,6 @@ export function createMapLibreDeckInstance(map: MapLibreMap, deck: Deck): Deck {
       onLoad?.();
       if (MAPLIBRE_DECK_STATES.get(map) === state) {
         startWatchingMove(map, state);
-        // The camera may have moved while Deck was initializing.
-        onMapLibreMove(deck, map);
       }
     };
   }

--- a/modules/maplibre/src/deck-utils.ts
+++ b/modules/maplibre/src/deck-utils.ts
@@ -94,6 +94,7 @@ export function getMapLibreViewState(map: MapLibreMap): MapViewState & {
     zoom: map.getZoom(),
     bearing: map.getBearing(),
     pitch: map.getPitch(),
+    roll: map.getRoll?.() ?? 0,
     padding: {
       top: padding.top ?? 0,
       bottom: padding.bottom ?? 0,
@@ -159,6 +160,8 @@ export function createMapLibreDeckInstance(map: MapLibreMap, deck: Deck): Deck {
       onLoad?.();
       if (MAPLIBRE_DECK_STATES.get(map) === state) {
         startWatchingMove(map, state);
+        // The camera may have moved while Deck was initializing.
+        onMapLibreMove(deck, map);
       }
     };
   }

--- a/test/modules/core/controllers/camera-roll.spec.ts
+++ b/test/modules/core/controllers/camera-roll.spec.ts
@@ -1,0 +1,109 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {
+  MapController,
+  _GlobeController as GlobeController,
+  WebMercatorViewport,
+  LinearInterpolator,
+  FlyToInterpolator
+} from '@deck.gl/core';
+import GlobeViewport from '@deck.gl/core/viewports/globe-viewport';
+
+for (const ControllerClass of [MapController, GlobeController]) {
+  const State = new ControllerClass({} as any).ControllerState;
+  const ViewportClass = ControllerClass === MapController ? WebMercatorViewport : GlobeViewport;
+  const props = {
+    width: 800,
+    height: 600,
+    longitude: 8.5,
+    latitude: 47.3,
+    zoom: 6,
+    bearing: 25,
+    pitch: 35,
+    makeViewport: (options: any) => new ViewportClass(options)
+  };
+
+  test(`${ControllerClass.name} preserves roll during camera updates`, () => {
+    const state = new State({...props, roll: 28});
+    const updates = [
+      state
+        .panStart({pos: [400, 300]})
+        .pan({pos: [430, 315]})
+        .panEnd(),
+      state
+        .zoomStart({pos: [400, 300]})
+        .zoom({pos: [400, 300], scale: 2})
+        .zoomEnd(),
+      state.rotateLeft(),
+      state.rotateUp(),
+      state.zoomIn(),
+      state.moveLeft()
+    ];
+    for (const updated of updates) {
+      expect(updated.getViewportProps().roll).toBe(28);
+    }
+    expect(new State(props).getViewportProps().roll).toBe(0);
+    expect(new State({...props, roll: 390}).getViewportProps().roll).toBe(30);
+  });
+
+  test(`${ControllerClass.name} transitions take the shortest roll path`, () => {
+    for (const [from, to, middle] of [
+      [170, -170, 180],
+      [-170, 170, -180]
+    ]) {
+      const start = new State({...props, roll: from});
+      const end = new State({...props, roll: to});
+      for (const interpolator of [new LinearInterpolator(), new FlyToInterpolator()]) {
+        const transition = interpolator.initializeProps(
+          start.getViewportProps(),
+          end.shortestPathFrom(start)
+        );
+        expect(interpolator.interpolateProps(transition.start, transition.end, 0.5).roll).toBe(
+          middle
+        );
+      }
+    }
+  });
+}
+
+for (const interpolator of [new LinearInterpolator(), new FlyToInterpolator()]) {
+  test(`${interpolator.constructor.name} compares and interpolates optional roll`, () => {
+    const props = {
+      width: 800,
+      height: 600,
+      longitude: 8.5,
+      latitude: 47.3,
+      zoom: 6,
+      bearing: 25,
+      pitch: 35,
+      position: [0, 0, 0]
+    };
+    expect(interpolator.arePropsEqual(props, {...props})).toBe(true);
+    expect(interpolator.arePropsEqual(props, {...props, roll: 0})).toBe(true);
+    expect(interpolator.arePropsEqual(props, {...props, roll: 28})).toBe(false);
+    const transition = interpolator.initializeProps(props, {...props, roll: 28});
+    expect(interpolator.interpolateProps(transition.start, transition.end, 0.5).roll).toBe(14);
+  });
+}
+
+test('GlobeController pans along the rolled screen axes', () => {
+  const State = new GlobeController({} as any).ControllerState;
+  const props = {
+    width: 800,
+    height: 600,
+    longitude: 0,
+    latitude: 0,
+    zoom: 3,
+    bearing: 0,
+    pitch: 0,
+    makeViewport: (options: any) => new GlobeViewport(options)
+  };
+  const level = new State(props).panStart({pos: [400, 300]}).pan({pos: [400, 330]});
+  const rolled = new State({...props, roll: 90}).panStart({pos: [400, 300]}).pan({pos: [430, 300]});
+  expect(rolled.getViewportProps().longitude).toBeCloseTo(level.getViewportProps().longitude, 6);
+  expect(rolled.getViewportProps().latitude).toBeCloseTo(level.getViewportProps().latitude, 6);
+  expect(rolled.getViewportProps().roll).toBe(90);
+});

--- a/test/modules/core/controllers/camera-roll.spec.ts
+++ b/test/modules/core/controllers/camera-roll.spec.ts
@@ -83,9 +83,12 @@ for (const interpolator of [new LinearInterpolator(), new FlyToInterpolator()]) 
     };
     expect(interpolator.arePropsEqual(props, {...props})).toBe(true);
     expect(interpolator.arePropsEqual(props, {...props, roll: 0})).toBe(true);
-    expect(interpolator.arePropsEqual(props, {...props, roll: 28})).toBe(false);
+    expect(interpolator.arePropsEqual({...props, roll: 0}, {...props, roll: 0})).toBe(true);
+    expect(interpolator.arePropsEqual({...props, roll: 0}, {...props, roll: 28})).toBe(false);
     const transition = interpolator.initializeProps(props, {...props, roll: 28});
     expect(interpolator.interpolateProps(transition.start, transition.end, 0.5).roll).toBe(14);
+    const reverse = interpolator.initializeProps({...props, roll: 28}, props);
+    expect(interpolator.interpolateProps(reverse.start, reverse.end, 0.5).roll).toBe(14);
   });
 }
 

--- a/test/modules/core/transitions/fly-to-interpolator.spec.ts
+++ b/test/modules/core/transitions/fly-to-interpolator.spec.ts
@@ -65,6 +65,7 @@ const TEST_CASES = [
     transition: {
       0.25: {
         bearing: 0,
+        roll: 0,
         pitch: 5,
         longitude: -122.4017,
         latitude: 37.78297,
@@ -73,6 +74,7 @@ const TEST_CASES = [
       },
       0.5: {
         bearing: 0,
+        roll: 0,
         pitch: 10,
         longitude: -106.3,
         latitude: 38.76683,
@@ -81,6 +83,7 @@ const TEST_CASES = [
       },
       0.75: {
         bearing: 0,
+        roll: 0,
         pitch: 15,
         longitude: -74.19253,
         latitude: 40.68864,

--- a/test/modules/core/transitions/linear-interpolator.spec.ts
+++ b/test/modules/core/transitions/linear-interpolator.spec.ts
@@ -36,7 +36,7 @@ const TEST_CASES = [
       end: {longitude: -74, latitude: 40.7, zoom: 11, pitch: undefined, bearing: 10}
     },
     transition: {
-      0.5: {longitude: -98.225, latitude: 39.24, zoom: 11.5, pitch: 0, bearing: 5}
+      0.5: {longitude: -98.225, latitude: 39.24, zoom: 11.5, pitch: 0, bearing: 5, roll: 0}
     }
   },
   {

--- a/test/modules/core/viewports/camera-roll.spec.ts
+++ b/test/modules/core/viewports/camera-roll.spec.ts
@@ -28,7 +28,7 @@ for (const ViewportClass of [WebMercatorViewport, GlobeViewport]) {
     expect(new ViewportClass({...VIEW_STATE, roll: 30}).equals(legacy)).toBe(false);
   });
 
-  test.each([-45, 30, 90])(
+  test.each([-450, -45, 30, 90, 390, 750])(
     `${ViewportClass.displayName} rotates screen coordinates at %s degrees after bearing and pitch`,
     roll => {
       const level = new ViewportClass(VIEW_STATE);
@@ -91,7 +91,7 @@ test('repeated Mercator worlds retain roll', () => {
   }
 });
 
-test.each([30, -45, 90, 180])(
+test.each([30, -45, 90, 180, -450, 390, 750])(
   'rolled Mercator bounds contain the visible ground at %s degrees',
   roll => {
     const viewport = new WebMercatorViewport({...VIEW_STATE, pitch: 75, roll});
@@ -112,7 +112,7 @@ test.each([30, -45, 90, 180])(
   }
 );
 
-test.each([30, -45, 90, 180])(
+test.each([30, -45, 90, 180, -450, 390, 750])(
   'rolled Mercator far plane includes the ground corners at %s degrees',
   roll => {
     const viewport = new WebMercatorViewport({...VIEW_STATE, pitch: 45, roll});

--- a/test/modules/core/viewports/camera-roll.spec.ts
+++ b/test/modules/core/viewports/camera-roll.spec.ts
@@ -1,0 +1,128 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {test, expect} from 'vitest';
+import {MapView, _GlobeView as GlobeView, WebMercatorViewport} from '@deck.gl/core';
+import GlobeViewport from '@deck.gl/core/viewports/globe-viewport';
+
+const VIEW_STATE = {
+  width: 960,
+  height: 540,
+  longitude: 8.5,
+  latitude: 47.3,
+  zoom: 6,
+  pitch: 55,
+  bearing: 25
+};
+
+for (const ViewportClass of [WebMercatorViewport, GlobeViewport]) {
+  test(`${ViewportClass.displayName} preserves matrices for omitted or zero roll`, () => {
+    const legacy = new ViewportClass(VIEW_STATE);
+    const level = new ViewportClass({...VIEW_STATE, roll: 0});
+    expect(level.roll).toBe(0);
+    expect(level.viewMatrix).toEqual(legacy.viewMatrix);
+    expect(level.projectionMatrix).toEqual(legacy.projectionMatrix);
+    expect(level.pixelProjectionMatrix).toEqual(legacy.pixelProjectionMatrix);
+    expect(level.equals(legacy)).toBe(true);
+    expect(new ViewportClass({...VIEW_STATE, roll: 30}).equals(legacy)).toBe(false);
+  });
+
+  test.each([-45, 30, 90])(
+    `${ViewportClass.displayName} rotates screen coordinates at %s degrees after bearing and pitch`,
+    roll => {
+      const level = new ViewportClass(VIEW_STATE);
+      const banked = new ViewportClass({...VIEW_STATE, roll});
+      const angle = (roll * Math.PI) / 180;
+      for (const position of [
+        [8.7, 47.4, 0],
+        [8.3, 47.2, 500]
+      ]) {
+        const original = level.project(position);
+        const projected = banked.project(position);
+        const x = original[0] - VIEW_STATE.width / 2;
+        const y = original[1] - VIEW_STATE.height / 2;
+        expect(projected[0]).toBeCloseTo(
+          VIEW_STATE.width / 2 + Math.cos(angle) * x + Math.sin(angle) * y,
+          6
+        );
+        expect(projected[1]).toBeCloseTo(
+          VIEW_STATE.height / 2 - Math.sin(angle) * x + Math.cos(angle) * y,
+          6
+        );
+        const restored = banked.unproject(projected);
+        expect(restored[0]).toBeCloseTo(position[0], 6);
+        expect(restored[1]).toBeCloseTo(position[1], 6);
+        expect(restored[2]).toBeCloseTo(position[2], 2);
+      }
+      const groundPoint = [8.7, 47.4];
+      const restored = banked.unproject(banked.project(groundPoint).slice(0, 2));
+      expect(restored[0]).toBeCloseTo(groundPoint[0], 6);
+      expect(restored[1]).toBeCloseTo(groundPoint[1], 6);
+    }
+  );
+}
+
+test('MapView and both GlobeView projection paths forward roll', () => {
+  for (const view of [new MapView(), new GlobeView()]) {
+    for (const zoom of [4, 13]) {
+      const viewport = view.makeViewport({
+        width: 800,
+        height: 600,
+        viewState: {...VIEW_STATE, zoom, roll: -32}
+      }) as WebMercatorViewport | GlobeViewport;
+      expect(viewport.roll).toBe(-32);
+    }
+  }
+});
+
+test('repeated Mercator worlds retain roll', () => {
+  const viewport = new WebMercatorViewport({
+    width: 1600,
+    height: 600,
+    longitude: 170,
+    zoom: 0,
+    roll: 30,
+    repeat: true
+  });
+  expect(viewport.subViewports!.length).toBeGreaterThan(1);
+  for (const repeated of viewport.subViewports!) {
+    expect(repeated.roll).toBe(30);
+  }
+});
+
+test.each([30, -45, 90, 180])(
+  'rolled Mercator bounds contain the visible ground at %s degrees',
+  roll => {
+    const viewport = new WebMercatorViewport({...VIEW_STATE, pitch: 75, roll});
+    const bounds = viewport.getBounds();
+    expect(bounds.every(Number.isFinite)).toBe(true);
+    for (let x = 0; x <= viewport.width; x += viewport.width / 8) {
+      for (let y = 0; y <= viewport.height; y += viewport.height / 8) {
+        const ground = viewport.unproject([x, y], {targetZ: 0});
+        const projected = viewport.project(ground);
+        // Exclude rays pointing into the sky or beyond the far plane.
+        if (projected[2] < -1 || projected[2] > 1) continue;
+        expect(ground[0]).toBeGreaterThanOrEqual(bounds[0] - 1e-6);
+        expect(ground[0]).toBeLessThanOrEqual(bounds[2] + 1e-6);
+        expect(ground[1]).toBeGreaterThanOrEqual(bounds[1] - 1e-6);
+        expect(ground[1]).toBeLessThanOrEqual(bounds[3] + 1e-6);
+      }
+    }
+  }
+);
+
+test.each([30, -45, 90, 180])(
+  'rolled Mercator far plane includes the ground corners at %s degrees',
+  roll => {
+    const viewport = new WebMercatorViewport({...VIEW_STATE, pitch: 45, roll});
+    for (const x of [0, viewport.width]) {
+      for (const y of [0, viewport.height]) {
+        const ground = viewport.unproject([x, y], {targetZ: 0});
+        const projected = viewport.project(ground);
+        expect(projected[2]).toBeGreaterThan(-1);
+        expect(projected[2]).toBeLessThanOrEqual(1);
+      }
+    }
+  }
+);

--- a/test/modules/maplibre/overlay.spec.ts
+++ b/test/modules/maplibre/overlay.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {BitmapLayer} from '@deck.gl/layers';
+import {BitmapLayer, ScatterplotLayer} from '@deck.gl/layers';
 import {MapLibreOverlay} from '@deck.gl/maplibre';
 import {device} from '@deck.gl/test-utils';
 import {Map as MapLibreV4Map} from 'maplibre-gl-v4';
@@ -178,6 +178,7 @@ for (const {version, MapClass} of MAPLIBRE_VERSIONS) {
       expect(viewState.longitude).toBeCloseTo(map.getCenter().lng);
       expect(viewState.latitude).toBeCloseTo(map.getCenter().lat);
       expect(viewState.zoom).toBe(map.getZoom());
+      expect(viewState.roll).toBe(0);
 
       map.removeControl(overlay);
       expect(overlay._deck).toBeFalsy();
@@ -186,4 +187,104 @@ for (const {version, MapClass} of MAPLIBRE_VERSIONS) {
     map.remove();
     container.remove();
   });
+}
+
+for (const {version, MapClass} of MAPLIBRE_VERSIONS.slice(1)) {
+  for (const projection of ['mercator', 'globe'] as const) {
+    for (const interleaved of [false, true]) {
+      webglTest(
+        `MapLibre ${version} ${projection} roll aligns rendering and picking (interleaved=${interleaved})`,
+        async () => {
+          const container = document.createElement('div');
+          Object.assign(container.style, {width: '640px', height: '400px'});
+          document.body.append(container);
+          const position: [number, number] = projection === 'globe' ? [20, 55] : [8.53, 47.32];
+          const map = new MapClass({
+            container,
+            style: {version: 8, sources: {}, layers: []},
+            center: [8.5, 47.3],
+            zoom: projection === 'globe' ? 2 : 11,
+            pitch: 45,
+            bearing: 25,
+            attributionControl: false
+          }) as unknown as MapLibreMap;
+          let overlayCanvas: HTMLCanvasElement | null = null;
+          try {
+            await new Promise<void>(resolve => map.once('load', () => resolve()));
+            map.setProjection({type: projection});
+            map.setPadding({left: 70, right: 10, top: 25, bottom: 5});
+            const data = [{position}];
+            let renderedPixel: number[] = [];
+            const overlay = new MapLibreOverlay({
+              interleaved,
+              layers: [
+                new ScatterplotLayer({
+                  id: 'rolled-point',
+                  data,
+                  getPosition: d => d.position,
+                  getRadius: 8,
+                  radiusUnits: 'pixels',
+                  getFillColor: [0, 0, 255],
+                  pickable: true
+                })
+              ],
+              onAfterRender: ({gl}) => {
+                if (!gl) return;
+                const pixelPosition = map.project(position);
+                const pixelRatio = gl.drawingBufferWidth / map.getCanvas().clientWidth;
+                const pixel = new Uint8Array(4);
+                gl.readPixels(
+                  Math.floor(pixelPosition.x * pixelRatio),
+                  Math.floor(gl.drawingBufferHeight - pixelPosition.y * pixelRatio),
+                  1,
+                  1,
+                  gl.RGBA,
+                  gl.UNSIGNED_BYTE,
+                  pixel
+                );
+                if (pixel[2] === 255) {
+                  renderedPixel = Array.from(pixel);
+                }
+              }
+            });
+            map.addControl(overlay);
+            if (!interleaved) overlayCanvas = overlay.getCanvas();
+            // The first roll update also exercises camera changes before Deck loads.
+            for (const roll of [28, -32, 0]) {
+              renderedPixel = [];
+              // Interleaved resize currently leaves luma's default framebuffer
+              // dimensions stale even at zero roll. Exercise resize overlaid.
+              if (roll === -32 && !interleaved) {
+                container.style.width = '740px';
+                container.style.height = '420px';
+                map.resize();
+              }
+              map.setRoll(roll);
+              map.triggerRepaint();
+              await waitForRender(
+                () => overlay._deck?.props.viewState.roll === roll && renderedPixel[2] === 255
+              );
+              expect(renderedPixel).toEqual([0, 0, 255, 255]);
+              const projected = map.project(position);
+              const viewport = overlay._deck!.getViewports()[0];
+              const actual = viewport.project(position);
+              expect(actual[0]).toBeCloseTo(projected.x, 2);
+              expect(actual[1]).toBeCloseTo(projected.y, 2);
+              const picked = overlay.pickObject({x: projected.x, y: projected.y});
+              expect(picked?.object).toBe(data[0]);
+              expect(picked!.coordinate![0]).toBeCloseTo(position[0], 2);
+              expect(picked!.coordinate![1]).toBeCloseTo(position[1], 2);
+            }
+          } finally {
+            map.remove();
+            // Deck.finalize removes its canvas but does not release the WebGL context.
+            // Avoid exhausting the browser context limit in the shared test page.
+            overlayCanvas?.getContext('webgl2')?.getExtension('WEBGL_lose_context')?.loseContext();
+            container.remove();
+            expect(device.isLost).toBe(false);
+          }
+        }
+      );
+    }
+  }
 }

--- a/test/modules/maplibre/overlay.spec.ts
+++ b/test/modules/maplibre/overlay.spec.ts
@@ -249,7 +249,7 @@ for (const {version, MapClass} of MAPLIBRE_VERSIONS.slice(1)) {
             });
             map.addControl(overlay);
             if (!interleaved) overlayCanvas = overlay.getCanvas();
-            // The first roll update also exercises camera changes before Deck loads.
+            await waitForRender(() => Boolean(overlay._deck?.isInitialized));
             for (const roll of [28, -32, 0]) {
               renderedPixel = [];
               // Interleaved resize currently leaves luma's default framebuffer


### PR DESCRIPTION
@chrisgervang  Here's the addition of roll to deck.gl - relevant for e.g. [noodles.gl](https://github.com/joby-aviation/noodles.gl/pull/616)

--- 

<img width="1273" height="710" alt="Screenshot 2026-09-10 at 19 31 27" src="https://github.com/user-attachments/assets/b5ebd88f-61ab-487e-a819-4a1d7b0f42de" />

For #10503

#### Background

Calling `map.setRoll()` currently banks MapLibre's basemap while deck.gl layers remain level. This adds camera roll to geospatial view states and synchronizes it through the new `@deck.gl/maplibre` package, so projected coordinates, rendered layers, and picking follow the same camera.

#### Change List

- Add optional `roll` (degrees, default `0`) to `MapViewState`, `GlobeViewState`, and their viewports. Positive roll rotates the image counter-clockwise, matching MapLibre.
- Apply roll in camera space after bearing and pitch. Account for rolled Mercator frustum bounds and far clipping, including repeated worlds.
- Preserve roll during controller interactions, map globe drag deltas through the rolled screen axes, and support roll in linear/fly-to transitions with shortest-path angle handling.
- Read MapLibre's public `getRoll()` in `@deck.gl/maplibre`, with a zero fallback for v4.5.1. Cover v5/v6, Mercator/globe, and overlaid/interleaved modes.
- Document the API and add regression tests for projection/unprojection, clipping, controllers, transitions, rendered pixel alignment, and picking with padding. Overlaid tests also resize the map while rolled.

#### Draft notes

- The independent startup camera synchronization fix and focused v4/v5/v6 regression tests have been split into #10702.

- No new roll gesture is introduced. Roll is controlled through view state, transitions, or MapLibre's camera API.
- Interleaved resize coverage is held back by an existing framebuffer-size issue: after changing the map container size, the CPU viewport updates but rendering uses stale framebuffer dimensions. Reproduced with zero roll against the unchanged base commit `3aabc11038`. Overlaid resize is covered.
- Terrain-specific integration and the golden-image/website suites have not been validated in this draft.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core camera matrices, bounds, and MapLibre view-state sync, but behavior is guarded by broad new tests and defaults preserve prior zero-roll rendering.
> 
> **Overview**
> Adds optional **`roll`** (degrees, default `0`) to Mercator and globe view states so deck.gl layers bank with the same camera as MapLibre when `setRoll()` is used.
> 
> Roll is applied in the viewport view matrix after bearing and pitch, with Mercator-specific fixes for far-plane clipping, geographic bounds, and repeated worlds. **Map** and **Globe** controllers keep roll through pan/zoom/rotate, normalize angles, and globe panning maps screen drag through the rolled axes. **Linear** and **fly-to** transitions interpolate roll (shortest path) and treat missing `roll` as `0` so existing view states do not spuriously animate.
> 
> `@deck.gl/maplibre` reads `map.getRoll()` (falls back to `0` on older MapLibre). Docs and regression tests cover projection, picking, controllers, transitions, and v5/v6 Mercator/globe overlay alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1969fdcdabd64131f108d6b532b60ebbd5f842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->