### PR TITLE
Improve TextLayer collision bounds and add optional greedy placement

### DIFF
--- a/docs/api-reference/extensions/collision-filter-extension.md
+++ b/docs/api-reference/extensions/collision-filter-extension.md
@@ -157,6 +157,7 @@ iconMapping: {
 
 ## Limitations
 
+- Each collision group supports at most 16,777,215 source objects. Groups containing text are also limited to `floor(maxTextureDimension2D / 4)² - 1` objects, where `maxTextureDimension2D` is the device's maximum 2D texture dimension. Counts include non-text objects in the group; text characters and backgrounds share their label's ID. If either limit is exceeded, a warning is logged and collision filtering is disabled for the entire group until its object count is within the limits again.
 - Accessors are not supported in `collisionTestProps`
 - The layers of `@deck.gl/aggregation-layers` module that does aggregation on the CPU, for example `CPUGridLayer` and `HexagonLayer`, are not supported.
 - Non-text layers use point-in-polygon collision tests: the feature's anchor is compared with the rasterized areas of other features. TextLayer tests full projected rectangles at the collision map’s pixel resolution by default. In greedy mode, it compares projected rectangles with other text and tests non-text geometry at the collision map’s pixel resolution.

--- a/docs/api-reference/extensions/collision-filter-extension.md
+++ b/docs/api-reference/extensions/collision-filter-extension.md
@@ -114,17 +114,17 @@ The priority is a number in the range -1000 -> 1000, values outside will be clam
 
 ## Using with TextLayer
 
-Text labels are tested at the center of their glyph bounds, after applying `getPixelOffset`, `getTextAnchor`, `getAlignmentBaseline`, `getAngle`, and the layer's size settings. Every character in a label shares the same visibility. This also applies to `GeoJsonLayer` with `pointType: 'text'` and its corresponding text accessors.
+Text labels are tested over their entire projected glyph bounds, after applying `getPixelOffset`, `getTextAnchor`, `getAlignmentBaseline`, `getAngle`, and the layer's size settings. Every character in a label shares the same visibility. This also applies to `GeoJsonLayer` with `pointType: 'text'` and its corresponding text accessors.
 
 TextLayer writes a rectangle covering each label into the collision map. Whitespace and empty lines do not enlarge the glyph bounds. When `background: true`, the background rectangle, including `backgroundPadding`, is used instead. No visible background or `alphaCutoff` override is required for text collision filtering.
 
-Use `collisionTestProps: {sizeScale: 1.5}` to enlarge the collision rectangles. The sample point follows the overridden size settings, including `sizeMinPixels` and `sizeMaxPixels`, so labels remain visible when using a non-centered anchor.
+Use `collisionTestProps: {sizeScale: 1.5}` to enlarge the collision rectangles. The tested bounds follow the overridden size settings, including `sizeMinPixels` and `sizeMaxPixels`, so labels remain visible when using a non-centered anchor.
 
-As with other layers, this is a point-in-rectangle test: overlapping edges alone do not necessarily hide a label. Higher-priority labels win when their collision area covers another label's sample point.
+A text label is hidden when any part of its collision rectangle overlaps higher-priority geometry, at the collision map's pixel resolution. This includes overlaps at the edges of multiline labels and smaller labels contained inside larger ones. The rectangles include the spaces between lines, so this is conservative: labels may hide before their visible glyphs touch.
 
 ## Using with transparent layers
 
-The `CollisionFilterExtension` samples at the anchor point of a feature when calculating collisions. Layers must ensure that a pixel is rendered at this location when the picking pass is drawn.
+For layers other than TextLayer, the `CollisionFilterExtension` samples at the anchor point of a feature when calculating collisions. Layers must ensure that a pixel is rendered at this location when the picking pass is drawn.
 
 A common issue is with the `IconLayer`, which [discards transparent pixels](https://deck.gl/docs/api-reference/layers/icon-layer#alphacutoff). To avoid this, use `alphaCutoff: -1`. A similar issue occurs when the anchor point of the `IconLayer` is too close to the edge of the image, to be safe include a few pixels of padding, e.g.
 
@@ -138,7 +138,7 @@ iconMapping: {
 
 - Accessors are not supported in `collisionTestProps`
 - Given that collisions is performed on the GPU, the layers of `@deck.gl/aggregation-layers` module that does aggregation on the CPU, for example `CPUGridLayer` and `HexagonLayer`, are not supported.
-- The collision is point-in-polygon, specifically is computed by comparing the anchor point of a feature with the rasterized screen-space areas of other features. While good for realtime applications, generally this will not give the same results as a full collision test would.
+- Non-text layers use point-in-polygon collision tests: the feature's anchor is compared with the rasterized areas of other features. TextLayer tests the full projected label rectangle. Both methods operate at pixel resolution, rather than performing exact vector geometry intersections.
 
 ## Source
 

--- a/docs/api-reference/extensions/collision-filter-extension.md
+++ b/docs/api-reference/extensions/collision-filter-extension.md
@@ -112,6 +112,16 @@ The priority is a number in the range -1000 -> 1000, values outside will be clam
 * If a number is provided, it is used for all objects in the layer.
 * If a function is provided, it is called on each object to retrieve its priority.
 
+## Using with TextLayer
+
+Text labels are tested at the center of their glyph bounds, after applying `getPixelOffset`, `getTextAnchor`, `getAlignmentBaseline`, `getAngle`, and the layer's size settings. Every character in a label shares the same visibility. This also applies to `GeoJsonLayer` with `pointType: 'text'` and its corresponding text accessors.
+
+TextLayer writes a rectangle covering each label into the collision map. Whitespace and empty lines do not enlarge the glyph bounds. When `background: true`, the background rectangle, including `backgroundPadding`, is used instead. No visible background or `alphaCutoff` override is required for text collision filtering.
+
+Use `collisionTestProps: {sizeScale: 1.5}` to enlarge the collision rectangles. The sample point follows the overridden size settings, including `sizeMinPixels` and `sizeMaxPixels`, so labels remain visible when using a non-centered anchor.
+
+As with other layers, this is a point-in-rectangle test: overlapping edges alone do not necessarily hide a label. Higher-priority labels win when their collision area covers another label's sample point.
+
 ## Using with transparent layers
 
 The `CollisionFilterExtension` samples at the anchor point of a feature when calculating collisions. Layers must ensure that a pixel is rendered at this location when the picking pass is drawn.

--- a/docs/api-reference/extensions/collision-filter-extension.md
+++ b/docs/api-reference/extensions/collision-filter-extension.md
@@ -1,7 +1,7 @@
 
 # CollisionFilterExtension
 
-The `CollisionFilterExtension` allows layers to hide features which overlap with other features. An example is a dense `ScatterplotLayer` with many points which overlap: by using this extension points that collide with others are hidden such that only one of the colliding points is shown. Collisions update as the viewport and layer data change. Most layers use a GPU collision map; text combines GPU projection with priority-ordered placement.
+The `CollisionFilterExtension` allows layers to hide features which overlap with other features. An example is a dense `ScatterplotLayer` with many points which overlap: by using this extension points that collide with others are hidden such that only one of the colliding points is shown. Collisions update as the viewport and layer data change. Layers use a GPU collision map by default; text can opt into priority-ordered placement with `collisionGreedy`.
 
 To use this extension on a layer, add the `CollisionFilterExtension` to the layer's `extensions` prop.
 
@@ -70,6 +70,23 @@ When added to a layer via the `extensions` prop, the `CollisionFilterExtension` 
 
 Enable/disable collisions. If collisions are disabled, all objects are rendered. Defaults to `true`.
 
+#### `collisionGreedy` (boolean, optional) {#collisiongreedy}
+
+Enable priority-ordered text placement. Defaults to `false`.
+
+* `false`: use GPU-only collision filtering for the lowest overhead. All candidates participate in the collision map, so rejected labels can still hide other labels in an overlap chain.
+* `true`: place text labels in descending priority and reserve space only for accepted labels. This can display more labels in dense scenes, at the cost of GPU readback and CPU placement when collisions update.
+
+Enabling this on any TextLayer (including GeoJSON text) applies to all text layers in its `collisionGroup`. Groups without text are unaffected. Use separate groups when independent placement modes are needed.
+
+```js
+new TextLayer({
+  ...,
+  extensions: [new CollisionFilterExtension()],
+  collisionGreedy: true
+})
+```
+
 #### `collisionGroup` (string, optional) {#collisiongroup}
 
 Collision group this layer belongs to. If it is not set, the 'default' collision group is used. Two (or more) layers that share the same `collisionGroup` will be considered together when calculating collisions.
@@ -120,9 +137,9 @@ TextLayer projects a rectangle covering each label. Whitespace and empty lines d
 
 Use `collisionTestProps: {sizeScale: 1.5}` to enlarge the collision rectangles. The tested bounds follow the overridden size settings, including `sizeMinPixels` and `sizeMaxPixels`, so labels remain visible when using a non-centered anchor.
 
-Text labels are placed in descending priority, with later source draw order breaking ties. A label is accepted if its projected rectangle does not overlap an already accepted label. Rejected labels do not reserve space, so a chain of overlapping candidates can display several separated labels. This is greedy placement: it fills available space while honoring priority, rather than guaranteeing the mathematically largest number of labels.
+With `collisionGreedy: true`, text labels are placed in descending priority, with later source draw order breaking ties. A label is accepted if its projected rectangle does not overlap an already accepted label. Rejected labels do not reserve space, so a chain of overlapping candidates can display several separated labels. This is greedy placement: it fills available space while honoring priority, rather than guaranteeing the mathematically largest number of labels.
 
-The GPU supplies projected bounds to a CPU spatial grid, which checks nearby accepted labels and uploads their visibility. This requires a compact GPU readback when collisions update. Labels in the same group as non-text geometry also test that geometry at the collision map's pixel resolution. Non-text features retain their anchor-based filtering and can still conservatively block labels even if another feature hides them.
+In greedy mode, the GPU supplies projected bounds to a CPU spatial grid, which checks nearby accepted labels and uploads their visibility. This requires a compact GPU readback when collisions update. Labels in the same group as non-text geometry also test that geometry at the collision map's pixel resolution. Non-text features retain their anchor-based filtering and can still conservatively block labels even if another feature hides them.
 
 The rectangles include the spaces between lines, so labels may hide before their visible glyphs touch. Multiline edge overlaps and smaller labels contained inside larger ones are both detected.
 
@@ -142,7 +159,7 @@ iconMapping: {
 
 - Accessors are not supported in `collisionTestProps`
 - The layers of `@deck.gl/aggregation-layers` module that does aggregation on the CPU, for example `CPUGridLayer` and `HexagonLayer`, are not supported.
-- Non-text layers use point-in-polygon collision tests: the feature's anchor is compared with the rasterized areas of other features. TextLayer compares full projected rectangles with other text, and tests non-text geometry at the collision map’s pixel resolution.
+- Non-text layers use point-in-polygon collision tests: the feature's anchor is compared with the rasterized areas of other features. TextLayer tests full projected rectangles at the collision map’s pixel resolution by default. In greedy mode, it compares projected rectangles with other text and tests non-text geometry at the collision map’s pixel resolution.
 
 ## Source
 

--- a/docs/api-reference/extensions/collision-filter-extension.md
+++ b/docs/api-reference/extensions/collision-filter-extension.md
@@ -1,7 +1,7 @@
 
 # CollisionFilterExtension
 
-The `CollisionFilterExtension` allows layers to hide features which overlap with other features. An example is a dense `ScatterplotLayer` with many points which overlap: by using this extension points that collide with others are hidden such that only one of the colliding points is shown. The collisions are computed on the GPU in realtime, allowing the collisions to be updated smoothly on every frame.
+The `CollisionFilterExtension` allows layers to hide features which overlap with other features. An example is a dense `ScatterplotLayer` with many points which overlap: by using this extension points that collide with others are hidden such that only one of the colliding points is shown. Collisions update as the viewport and layer data change. Most layers use a GPU collision map; text combines GPU projection with priority-ordered placement.
 
 To use this extension on a layer, add the `CollisionFilterExtension` to the layer's `extensions` prop.
 
@@ -116,11 +116,15 @@ The priority is a number in the range -1000 -> 1000, values outside will be clam
 
 Text labels are tested over their entire projected glyph bounds, after applying `getPixelOffset`, `getTextAnchor`, `getAlignmentBaseline`, `getAngle`, and the layer's size settings. Every character in a label shares the same visibility. This also applies to `GeoJsonLayer` with `pointType: 'text'` and its corresponding text accessors.
 
-TextLayer writes a rectangle covering each label into the collision map. Whitespace and empty lines do not enlarge the glyph bounds. When `background: true`, the background rectangle, including `backgroundPadding`, is used instead. No visible background or `alphaCutoff` override is required for text collision filtering.
+TextLayer projects a rectangle covering each label. Whitespace and empty lines do not enlarge the glyph bounds. When `background: true`, the background rectangle, including `backgroundPadding`, is used instead. No visible background or `alphaCutoff` override is required for text collision filtering.
 
 Use `collisionTestProps: {sizeScale: 1.5}` to enlarge the collision rectangles. The tested bounds follow the overridden size settings, including `sizeMinPixels` and `sizeMaxPixels`, so labels remain visible when using a non-centered anchor.
 
-A text label is hidden when any part of its collision rectangle overlaps higher-priority geometry, at the collision map's pixel resolution. This includes overlaps at the edges of multiline labels and smaller labels contained inside larger ones. The rectangles include the spaces between lines, so this is conservative: labels may hide before their visible glyphs touch.
+Text labels are placed in descending priority, with later source draw order breaking ties. A label is accepted if its projected rectangle does not overlap an already accepted label. Rejected labels do not reserve space, so a chain of overlapping candidates can display several separated labels. This is greedy placement: it fills available space while honoring priority, rather than guaranteeing the mathematically largest number of labels.
+
+The GPU supplies projected bounds to a CPU spatial grid, which checks nearby accepted labels and uploads their visibility. This requires a compact GPU readback when collisions update. Labels in the same group as non-text geometry also test that geometry at the collision map's pixel resolution. Non-text features retain their anchor-based filtering and can still conservatively block labels even if another feature hides them.
+
+The rectangles include the spaces between lines, so labels may hide before their visible glyphs touch. Multiline edge overlaps and smaller labels contained inside larger ones are both detected.
 
 ## Using with transparent layers
 
@@ -137,8 +141,8 @@ iconMapping: {
 ## Limitations
 
 - Accessors are not supported in `collisionTestProps`
-- Given that collisions is performed on the GPU, the layers of `@deck.gl/aggregation-layers` module that does aggregation on the CPU, for example `CPUGridLayer` and `HexagonLayer`, are not supported.
-- Non-text layers use point-in-polygon collision tests: the feature's anchor is compared with the rasterized areas of other features. TextLayer tests the full projected label rectangle. Both methods operate at pixel resolution, rather than performing exact vector geometry intersections.
+- The layers of `@deck.gl/aggregation-layers` module that does aggregation on the CPU, for example `CPUGridLayer` and `HexagonLayer`, are not supported.
+- Non-text layers use point-in-polygon collision tests: the feature's anchor is compared with the rasterized areas of other features. TextLayer compares full projected rectangles with other text, and tests non-text geometry at the collision map’s pixel resolution.
 
 ## Source
 

--- a/docs/api-reference/layers/text-layer.md
+++ b/docs/api-reference/layers/text-layer.md
@@ -482,7 +482,9 @@ The border thickness of each text label, in pixels. Only effective if `backgroun
 The TextLayer renders the following sublayers:
 
 * `characters` - an `IconLayer` rendering all the characters.
-* `background` - the background for each text block, if `background: true`.
+* `background` - the background for each text block, if `background: true`. With [CollisionFilterExtension](../extensions/collision-filter-extension.md), this sublayer also renders one collision rectangle per label, even when backgrounds are disabled. These rectangles are hidden during normal rendering and picking unless `background: true`.
+
+When collision filtering is enabled, the collision pass uses the `background` sublayer instead of individual characters. Binary data without `data.attributes.background` uses the `characters` sublayer for collision rectangles so that supplied GPU attributes can be reused directly.
 
 
 ## Use binary attributes

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -80,7 +80,7 @@ New [`@deck.gl/maplibre`](./api-reference/maplibre/overview.md) module is forked
 
 ### Layers and Extensions
 
-- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels test their full projected glyph bounds for collision detection, including multiline edge overlaps, and priorities are respected across source layers in the same collision group.
+- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels test their full projected glyph bounds for collision detection, including multiline edge overlaps, and priorities are respected across source layers in the same collision group. Priority-ordered text placement reuses space from rejected labels, preventing dense overlap chains from hiding all but one label.
 
 
 <table style={{border: 0}} align="center">

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -80,6 +80,8 @@ New [`@deck.gl/maplibre`](./api-reference/maplibre/overview.md) module is forked
 
 ### Layers and Extensions
 
+- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels use shared glyph bounds for collision detection, and priorities are respected across source layers in the same collision group.
+
 
 <table style={{border: 0}} align="center">
   <tbody>

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -80,7 +80,7 @@ New [`@deck.gl/maplibre`](./api-reference/maplibre/overview.md) module is forked
 
 ### Layers and Extensions
 
-- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels use shared glyph bounds for collision detection, and priorities are respected across source layers in the same collision group.
+- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels test their full projected glyph bounds for collision detection, including multiline edge overlaps, and priorities are respected across source layers in the same collision group.
 
 
 <table style={{border: 0}} align="center">

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -80,7 +80,7 @@ New [`@deck.gl/maplibre`](./api-reference/maplibre/overview.md) module is forked
 
 ### Layers and Extensions
 
-- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels test their full projected glyph bounds for collision detection, including multiline edge overlaps, and priorities are respected across source layers in the same collision group. Priority-ordered text placement reuses space from rejected labels, preventing dense overlap chains from hiding all but one label.
+- [CollisionFilterExtension](./api-reference/extensions/collision-filter-extension.md) now supports TextLayer pixel offsets, anchors, baselines, and rotation, including GeoJSON text. Labels test their full projected glyph bounds for collision detection, including multiline edge overlaps, and priorities are respected across source layers in the same collision group. Opt-in `collisionGreedy` text placement reuses space from rejected labels, preventing dense overlap chains from hiding all but one label.
 
 
 <table style={{border: 0}} align="center">

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -33,6 +33,11 @@ function getCollisionSourceId(layer: Layer): string {
   return layer.parent?.id || layer.id;
 }
 
+// Character and background sublayers expose the bounds used by text collision shaders.
+function isTextCollisionLayer(layer: Layer): boolean {
+  return 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props;
+}
+
 export default class CollisionFilterEffect implements Effect {
   id = 'collision-filter-effect';
   props = null;
@@ -162,9 +167,7 @@ export default class CollisionFilterEffect implements Effect {
       this.lastViewport = viewport;
       const collisionFBO = this.collisionFBOs[collisionGroup];
 
-      const textLayers = renderInfo.layers.filter(
-        layer => 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props
-      );
+      const textLayers = renderInfo.layers.filter(isTextCollisionLayer);
       const otherLayers = renderInfo.layers.filter(layer => !textLayers.includes(layer));
       const renderOptions = {
         pass: 'collision-filter',
@@ -266,7 +269,7 @@ export default class CollisionFilterEffect implements Effect {
         };
         channelMap[collisionGroup] = channelInfo;
       }
-      const isTextLayer = 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props;
+      const isTextLayer = isTextCollisionLayer(layer);
       channelInfo.hasText ||= isTextLayer;
       channelInfo.greedy ||= isTextLayer && Boolean(layer.props.collisionGreedy);
       const sourceId = getCollisionSourceId(layer);
@@ -345,7 +348,7 @@ export default class CollisionFilterEffect implements Effect {
     const {collisionFBOs, dummyCollisionMap} = this;
     const collisionFBO = collisionFBOs[collisionGroup!];
     const enabled = collisionEnabled && Boolean(collisionFBO);
-    const isTextLayer = 'getCollisionRect' in props || 'getBoundingRect' in props;
+    const isTextLayer = isTextCollisionLayer(layer);
     return {
       collision: {
         enabled,

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -4,7 +4,7 @@
 
 import {Device, Framebuffer, Texture} from '@luma.gl/core';
 import {equals} from '@math.gl/core';
-import {_deepEqual as deepEqual} from '@deck.gl/core';
+import {_deepEqual as deepEqual, log} from '@deck.gl/core';
 import type {Effect, EffectContext, Layer, PreRenderOptions, Viewport} from '@deck.gl/core';
 import CollisionFilterPass from './collision-filter-pass';
 import {placeTextLabels} from './text-collision-placement';
@@ -16,6 +16,8 @@ import type {CollisionModuleProps} from './shader-module';
 
 // Factor by which to downscale Collision FBO relative to canvas
 const DOWNSCALE = 2;
+// RGB picking colors reserve zero for no object.
+const MAX_PICKING_COLOR = 0xffffff;
 
 type RenderInfo = {
   collisionGroup: string;
@@ -298,11 +300,21 @@ export default class CollisionFilterEffect implements Effect {
         offset += count;
       }
       channelMap[collisionGroup].objectCount = offset;
+      // Each object uses a 4x4 visibility cell, including the reserved zero ID.
+      const maxVisibilityColumns = Math.floor(device.limits.maxTextureDimension2D / 4);
+      const maxObjectCount = channelMap[collisionGroup].hasText
+        ? Math.min(MAX_PICKING_COLOR, maxVisibilityColumns ** 2 - 1)
+        : MAX_PICKING_COLOR;
+      if (offset > maxObjectCount) {
+        log.warn(
+          `CollisionFilterExtension: collision group "${collisionGroup}" exceeds the supported object count (${maxObjectCount}); collision filtering is disabled.`
+        )();
+        delete channelMap[collisionGroup];
+        delete this.channels[collisionGroup];
+        continue;
+      }
       if (channelMap[collisionGroup].hasText) {
-        const width = Math.min(
-          device.limits.maxTextureDimension2D,
-          Math.ceil(Math.sqrt(offset + 1)) * 4
-        );
+        const width = Math.min(maxVisibilityColumns * 4, Math.ceil(Math.sqrt(offset + 1)) * 4);
         const height = Math.ceil((offset + 1) / (width / 4)) * 4;
         if (!this.visibilityFBOs[collisionGroup]) {
           this.visibilityFBOs[collisionGroup] = device.createFramebuffer({

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -7,6 +7,7 @@ import {equals} from '@math.gl/core';
 import {_deepEqual as deepEqual} from '@deck.gl/core';
 import type {Effect, EffectContext, Layer, PreRenderOptions, Viewport} from '@deck.gl/core';
 import CollisionFilterPass from './collision-filter-pass';
+import {placeTextLabels} from './text-collision-placement';
 import {MaskPreRenderStats} from '../mask/mask-effect';
 // import {debugFBO} from '../utils/debug';
 
@@ -23,6 +24,7 @@ type RenderInfo = {
   allLayersLoaded: boolean;
   pickingColorOffsets: Record<string, number>;
   hasText: boolean;
+  objectCount: number;
 };
 
 // Sublayers of a composite share source object indices (e.g. text and its background).
@@ -159,8 +161,11 @@ export default class CollisionFilterEffect implements Effect {
       this.lastViewport = viewport;
       const collisionFBO = this.collisionFBOs[collisionGroup];
 
-      // Rerender collision FBO
-      this.collisionFilterPass!.renderCollisionMap(collisionFBO, {
+      const textLayers = renderInfo.layers.filter(
+        layer => 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props
+      );
+      const otherLayers = renderInfo.layers.filter(layer => !textLayers.includes(layer));
+      const renderOptions = {
         pass: 'collision-filter',
         isPicking: true,
         layers: renderInfo.layers,
@@ -181,16 +186,20 @@ export default class CollisionFilterEffect implements Effect {
               (renderInfo.hasText ? 1 : DOWNSCALE)
           }
         }
-      });
+      };
+      if (otherLayers.length) {
+        this.collisionFilterPass!.renderCollisionMap(collisionFBO, {
+          ...renderOptions,
+          layers: otherLayers
+        });
+      }
       if (renderInfo.hasText) {
         const visibilityFBO = this.visibilityFBOs[collisionGroup];
         const pixelRatio = collisionFBO.device.canvasContext!.cssToDeviceRatio();
         this.collisionFilterPass!.renderCollisionVisibility(visibilityFBO, {
           pass: 'collision',
           isPicking: true,
-          layers: renderInfo.layers.filter(
-            layer => 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props
-          ),
+          layers: textLayers,
           effects: [...(effects || []), this],
           layerFilter,
           viewports: [viewport],
@@ -199,11 +208,32 @@ export default class CollisionFilterEffect implements Effect {
           shaderModuleProps: {
             collision: {
               enabled: true,
+              hasColliders: otherLayers.length > 0,
               dummyCollisionMap: this.dummyCollisionMap
             },
             project: {devicePixelRatio: pixelRatio}
           }
         });
+        const pixels = collisionFBO.device.readPixelsToArrayWebGL(visibilityFBO) as Uint8Array;
+        placeTextLabels(
+          pixels,
+          visibilityFBO.width,
+          renderInfo.objectCount,
+          viewport.width * pixelRatio,
+          viewport.height * pixelRatio
+        );
+        visibilityFBO.colorAttachments[0].texture.writeData(pixels);
+        // Non-text layers retain their existing collision-map sampling. Only accepted
+        // labels may write into that map, so rejected labels cannot hide those features.
+        if (otherLayers.length) {
+          this.collisionFilterPass!.renderCollisionMap(collisionFBO, {
+            ...renderOptions,
+            shaderModuleProps: {
+              ...renderOptions.shaderModuleProps,
+              collision: {...renderOptions.shaderModuleProps.collision, filterByVisibility: true}
+            }
+          });
+        }
       }
     }
   }
@@ -227,7 +257,8 @@ export default class CollisionFilterEffect implements Effect {
           layerBounds: [],
           allLayersLoaded: true,
           pickingColorOffsets: {},
-          hasText: false
+          hasText: false,
+          objectCount: 0
         };
         channelMap[collisionGroup] = channelInfo;
       }
@@ -235,7 +266,9 @@ export default class CollisionFilterEffect implements Effect {
       const sourceId = getCollisionSourceId(layer);
       channelInfo.pickingColorOffsets[sourceId] = Math.max(
         channelInfo.pickingColorOffsets[sourceId] || 0,
-        layer.getNumInstances()
+        'getCollisionRect' in layer.props && layer.props.startIndices
+          ? layer.props.startIndices.length - 1
+          : layer.getNumInstances()
       );
       channelInfo.layers.push(layer);
       channelInfo.layerBounds.push(layer.getBounds());
@@ -255,6 +288,7 @@ export default class CollisionFilterEffect implements Effect {
         offsets[sourceId] = offset;
         offset += count;
       }
+      channelMap[collisionGroup].objectCount = offset;
       if (channelMap[collisionGroup].hasText) {
         const width = Math.min(
           device.limits.maxTextureDimension2D,

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -21,7 +21,13 @@ type RenderInfo = {
   layers: Layer<CollisionFilterExtensionProps>[];
   layerBounds: ([number[], number[]] | null)[];
   allLayersLoaded: boolean;
+  pickingColorOffsets: Record<string, number>;
 };
+
+// Sublayers of a composite share source object indices (e.g. text and its background).
+function getCollisionSourceId(layer: Layer): string {
+  return layer.parent?.id || layer.id;
+}
 
 export default class CollisionFilterEffect implements Effect {
   id = 'collision-filter-effect';
@@ -63,7 +69,8 @@ export default class CollisionFilterEffect implements Effect {
 
     const collisionLayers = layers.filter(
       // @ts-ignore
-      ({props: {visible, collisionEnabled}}) => visible && collisionEnabled
+      ({isComposite, props: {visible, collisionEnabled}}) =>
+        !isComposite && visible && collisionEnabled
     ) as Layer<CollisionFilterExtensionProps>[];
     if (collisionLayers.length === 0) {
       this.channels = {};
@@ -152,7 +159,7 @@ export default class CollisionFilterEffect implements Effect {
         pass: 'collision-filter',
         isPicking: true,
         layers: renderInfo.layers,
-        effects,
+        effects: [...(effects || []), this],
         layerFilter,
         viewports: viewport ? [viewport] : [],
         onViewportActive,
@@ -185,9 +192,20 @@ export default class CollisionFilterEffect implements Effect {
       const collisionGroup = layer.props.collisionGroup!;
       let channelInfo = channelMap[collisionGroup];
       if (!channelInfo) {
-        channelInfo = {collisionGroup, layers: [], layerBounds: [], allLayersLoaded: true};
+        channelInfo = {
+          collisionGroup,
+          layers: [],
+          layerBounds: [],
+          allLayersLoaded: true,
+          pickingColorOffsets: {}
+        };
         channelMap[collisionGroup] = channelInfo;
       }
+      const sourceId = getCollisionSourceId(layer);
+      channelInfo.pickingColorOffsets[sourceId] = Math.max(
+        channelInfo.pickingColorOffsets[sourceId] || 0,
+        layer.getNumInstances()
+      );
       channelInfo.layers.push(layer);
       channelInfo.layerBounds.push(layer.getBounds());
       if (!layer.isLoaded) {
@@ -197,6 +215,15 @@ export default class CollisionFilterEffect implements Effect {
 
     // Create any new passes and remove any old ones
     for (const collisionGroup of Object.keys(channelMap)) {
+      // Reserve disjoint picking colors for each source layer. Object 0 from one
+      // layer must not match object 0 from another layer in the same group.
+      const offsets = channelMap[collisionGroup].pickingColorOffsets;
+      let offset = 0;
+      for (const sourceId in offsets) {
+        const count = offsets[sourceId];
+        offsets[sourceId] = offset;
+        offset += count;
+      }
       if (!this.collisionFBOs[collisionGroup]) {
         this.createFBO(device, collisionGroup);
       }
@@ -216,16 +243,25 @@ export default class CollisionFilterEffect implements Effect {
   getShaderModuleProps(layer: Layer): {
     collision: CollisionModuleProps;
   } {
-    const {collisionGroup, collisionEnabled} = (layer as Layer<CollisionFilterExtensionProps>)
+    const props = (layer as Layer<CollisionFilterExtensionProps & Partial<CollisionModuleProps>>)
       .props;
+    const {collisionGroup, collisionEnabled} = props;
+    const testProps = props.collisionTestProps as Partial<CollisionModuleProps>;
     const {collisionFBOs, dummyCollisionMap} = this;
     const collisionFBO = collisionFBOs[collisionGroup!];
     const enabled = collisionEnabled && Boolean(collisionFBO);
     return {
       collision: {
         enabled,
+        pickingColorOffset:
+          this.channels[collisionGroup!]?.pickingColorOffsets[getCollisionSourceId(layer)] || 0,
         collisionFBO,
-        dummyCollisionMap: dummyCollisionMap!
+        dummyCollisionMap: dummyCollisionMap!,
+        // Match collisionTestProps sizing when projecting a text label's sample point.
+        sizeScale: testProps?.sizeScale ?? props.sizeScale,
+        sizeMinPixels: testProps?.sizeMinPixels ?? props.sizeMinPixels,
+        sizeMaxPixels: testProps?.sizeMaxPixels ?? props.sizeMaxPixels,
+        sizeUnits: testProps?.sizeUnits ?? props.sizeUnits
       }
     };
   }

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -22,6 +22,7 @@ type RenderInfo = {
   layerBounds: ([number[], number[]] | null)[];
   allLayersLoaded: boolean;
   pickingColorOffsets: Record<string, number>;
+  hasText: boolean;
 };
 
 // Sublayers of a composite share source object indices (e.g. text and its background).
@@ -39,6 +40,7 @@ export default class CollisionFilterEffect implements Effect {
   private channels: Record<string, RenderInfo> = {};
   private collisionFilterPass?: CollisionFilterPass;
   private collisionFBOs: Record<string, Framebuffer> = {};
+  private visibilityFBOs: Record<string, Framebuffer> = {};
   private dummyCollisionMap?: Texture;
   private lastViewport?: Viewport;
 
@@ -93,10 +95,12 @@ export default class CollisionFilterEffect implements Effect {
       const collisionFBO = this.collisionFBOs[collisionGroup];
       const renderInfo = channels[collisionGroup];
       // @ts-expect-error TODO - assuming WebGL context
-      const [width, height] = device.canvasContext.getPixelSize();
+      const [width, height] = device.canvasContext.getDrawingBufferSize();
+      const oldWidth = collisionFBO.width;
+      const oldHeight = collisionFBO.height;
       collisionFBO.resize({
-        width: width / DOWNSCALE,
-        height: height / DOWNSCALE
+        width: width / (renderInfo.hasText ? 1 : DOWNSCALE),
+        height: height / (renderInfo.hasText ? 1 : DOWNSCALE)
       });
       this._render(renderInfo, {
         effects,
@@ -104,7 +108,8 @@ export default class CollisionFilterEffect implements Effect {
         onViewportActive,
         views,
         viewport,
-        viewportChanged
+        viewportChanged:
+          viewportChanged || oldWidth !== collisionFBO.width || oldHeight !== collisionFBO.height
       });
     }
 
@@ -171,11 +176,35 @@ export default class CollisionFilterEffect implements Effect {
             dummyCollisionMap: this.dummyCollisionMap
           },
           project: {
-            // @ts-expect-error TODO - assuming WebGL context
-            devicePixelRatio: collisionFBO.device.canvasContext.getDevicePixelRatio() / DOWNSCALE
+            devicePixelRatio:
+              collisionFBO.device.canvasContext!.cssToDeviceRatio() /
+              (renderInfo.hasText ? 1 : DOWNSCALE)
           }
         }
       });
+      if (renderInfo.hasText) {
+        const visibilityFBO = this.visibilityFBOs[collisionGroup];
+        const pixelRatio = collisionFBO.device.canvasContext!.cssToDeviceRatio();
+        this.collisionFilterPass!.renderCollisionVisibility(visibilityFBO, {
+          pass: 'collision',
+          isPicking: true,
+          layers: renderInfo.layers.filter(
+            layer => 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props
+          ),
+          effects: [...(effects || []), this],
+          layerFilter,
+          viewports: [viewport],
+          onViewportActive,
+          views,
+          shaderModuleProps: {
+            collision: {
+              enabled: true,
+              dummyCollisionMap: this.dummyCollisionMap
+            },
+            project: {devicePixelRatio: pixelRatio}
+          }
+        });
+      }
     }
   }
 
@@ -197,10 +226,12 @@ export default class CollisionFilterEffect implements Effect {
           layers: [],
           layerBounds: [],
           allLayersLoaded: true,
-          pickingColorOffsets: {}
+          pickingColorOffsets: {},
+          hasText: false
         };
         channelMap[collisionGroup] = channelInfo;
       }
+      channelInfo.hasText ||= 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props;
       const sourceId = getCollisionSourceId(layer);
       channelInfo.pickingColorOffsets[sourceId] = Math.max(
         channelInfo.pickingColorOffsets[sourceId] || 0,
@@ -223,6 +254,30 @@ export default class CollisionFilterEffect implements Effect {
         const count = offsets[sourceId];
         offsets[sourceId] = offset;
         offset += count;
+      }
+      if (channelMap[collisionGroup].hasText) {
+        const width = Math.min(
+          device.limits.maxTextureDimension2D,
+          Math.ceil(Math.sqrt(offset + 1)) * 4
+        );
+        const height = Math.ceil((offset + 1) / (width / 4)) * 4;
+        if (!this.visibilityFBOs[collisionGroup]) {
+          this.visibilityFBOs[collisionGroup] = device.createFramebuffer({
+            id: `collision-visibility-${collisionGroup}`,
+            width,
+            height,
+            colorAttachments: [
+              device.createTexture({
+                width,
+                height,
+                format: 'rgba8unorm',
+                sampler: {minFilter: 'nearest', magFilter: 'nearest'}
+              })
+            ]
+          });
+        } else {
+          this.visibilityFBOs[collisionGroup].resize({width, height});
+        }
       }
       if (!this.collisionFBOs[collisionGroup]) {
         this.createFBO(device, collisionGroup);
@@ -250,14 +305,17 @@ export default class CollisionFilterEffect implements Effect {
     const {collisionFBOs, dummyCollisionMap} = this;
     const collisionFBO = collisionFBOs[collisionGroup!];
     const enabled = collisionEnabled && Boolean(collisionFBO);
+    const isTextLayer = 'getCollisionRect' in props || 'getBoundingRect' in props;
     return {
       collision: {
         enabled,
+        isTextLayer,
         pickingColorOffset:
           this.channels[collisionGroup!]?.pickingColorOffsets[getCollisionSourceId(layer)] || 0,
         collisionFBO,
+        visibilityFBO: isTextLayer ? this.visibilityFBOs[collisionGroup!] : undefined,
         dummyCollisionMap: dummyCollisionMap!,
-        // Match collisionTestProps sizing when projecting a text label's sample point.
+        // Match collisionTestProps sizing when projecting text collision bounds.
         sizeScale: testProps?.sizeScale ?? props.sizeScale,
         sizeMinPixels: testProps?.sizeMinPixels ?? props.sizeMinPixels,
         sizeMaxPixels: testProps?.sizeMaxPixels ?? props.sizeMaxPixels,
@@ -296,7 +354,8 @@ export default class CollisionFilterEffect implements Effect {
     const depthStencilAttachment = device.createTexture({
       format: 'depth16unorm',
       width,
-      height
+      height,
+      sampler: {minFilter: 'nearest', magFilter: 'nearest'}
     });
     this.collisionFBOs[collisionGroup] = device.createFramebuffer({
       id: `collision-${collisionGroup}`,
@@ -313,5 +372,11 @@ export default class CollisionFilterEffect implements Effect {
     fbo.depthStencilAttachment?.destroy();
     fbo.destroy();
     delete this.collisionFBOs[collisionGroup];
+    const visibilityFBO = this.visibilityFBOs[collisionGroup];
+    if (visibilityFBO) {
+      visibilityFBO.colorAttachments[0].destroy();
+      visibilityFBO.destroy();
+      delete this.visibilityFBOs[collisionGroup];
+    }
   }
 }

--- a/modules/extensions/src/collision-filter/collision-filter-effect.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-effect.ts
@@ -24,6 +24,7 @@ type RenderInfo = {
   allLayersLoaded: boolean;
   pickingColorOffsets: Record<string, number>;
   hasText: boolean;
+  greedy: boolean;
   objectCount: number;
 };
 
@@ -187,10 +188,10 @@ export default class CollisionFilterEffect implements Effect {
           }
         }
       };
-      if (otherLayers.length) {
+      if (!renderInfo.greedy || otherLayers.length) {
         this.collisionFilterPass!.renderCollisionMap(collisionFBO, {
           ...renderOptions,
-          layers: otherLayers
+          layers: renderInfo.greedy ? otherLayers : renderInfo.layers
         });
       }
       if (renderInfo.hasText) {
@@ -208,31 +209,33 @@ export default class CollisionFilterEffect implements Effect {
           shaderModuleProps: {
             collision: {
               enabled: true,
-              hasColliders: otherLayers.length > 0,
+              hasColliders: !renderInfo.greedy || otherLayers.length > 0,
               dummyCollisionMap: this.dummyCollisionMap
             },
             project: {devicePixelRatio: pixelRatio}
           }
         });
-        const pixels = collisionFBO.device.readPixelsToArrayWebGL(visibilityFBO) as Uint8Array;
-        placeTextLabels(
-          pixels,
-          visibilityFBO.width,
-          renderInfo.objectCount,
-          viewport.width * pixelRatio,
-          viewport.height * pixelRatio
-        );
-        visibilityFBO.colorAttachments[0].texture.writeData(pixels);
-        // Non-text layers retain their existing collision-map sampling. Only accepted
-        // labels may write into that map, so rejected labels cannot hide those features.
-        if (otherLayers.length) {
-          this.collisionFilterPass!.renderCollisionMap(collisionFBO, {
-            ...renderOptions,
-            shaderModuleProps: {
-              ...renderOptions.shaderModuleProps,
-              collision: {...renderOptions.shaderModuleProps.collision, filterByVisibility: true}
-            }
-          });
+        if (renderInfo.greedy) {
+          const pixels = collisionFBO.device.readPixelsToArrayWebGL(visibilityFBO) as Uint8Array;
+          placeTextLabels(
+            pixels,
+            visibilityFBO.width,
+            renderInfo.objectCount,
+            viewport.width * pixelRatio,
+            viewport.height * pixelRatio
+          );
+          visibilityFBO.colorAttachments[0].texture.writeData(pixels);
+          // Non-text layers retain their existing collision-map sampling. Only accepted
+          // labels may write into that map, so rejected labels cannot hide those features.
+          if (otherLayers.length) {
+            this.collisionFilterPass!.renderCollisionMap(collisionFBO, {
+              ...renderOptions,
+              shaderModuleProps: {
+                ...renderOptions.shaderModuleProps,
+                collision: {...renderOptions.shaderModuleProps.collision, filterByVisibility: true}
+              }
+            });
+          }
         }
       }
     }
@@ -258,11 +261,14 @@ export default class CollisionFilterEffect implements Effect {
           allLayersLoaded: true,
           pickingColorOffsets: {},
           hasText: false,
+          greedy: false,
           objectCount: 0
         };
         channelMap[collisionGroup] = channelInfo;
       }
-      channelInfo.hasText ||= 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props;
+      const isTextLayer = 'getCollisionRect' in layer.props || 'getBoundingRect' in layer.props;
+      channelInfo.hasText ||= isTextLayer;
+      channelInfo.greedy ||= isTextLayer && Boolean(layer.props.collisionGreedy);
       const sourceId = getCollisionSourceId(layer);
       channelInfo.pickingColorOffsets[sourceId] = Math.max(
         channelInfo.pickingColorOffsets[sourceId] || 0,
@@ -343,6 +349,7 @@ export default class CollisionFilterEffect implements Effect {
     return {
       collision: {
         enabled,
+        greedy: this.channels[collisionGroup!]?.greedy || false,
         isTextLayer,
         pickingColorOffset:
           this.channels[collisionGroup!]?.pickingColorOffsets[getCollisionSourceId(layer)] || 0,

--- a/modules/extensions/src/collision-filter/collision-filter-extension.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-extension.ts
@@ -48,9 +48,15 @@ export default class CollisionFilterExtension extends LayerExtension {
   /* eslint-disable camelcase */
   draw(this: Layer<CollisionFilterExtensionProps>, {shaderModuleProps}: any) {
     if (shaderModuleProps.collision?.drawToCollisionMap) {
-      // Override any props with those defined in collisionTestProps
-      // @ts-ignore
-      this.props = this.clone(this.props.collisionTestProps).props;
+      // Avoid constructing a layer when the overrides are empty or unchanged.
+      const {collisionTestProps} = this.props;
+      for (const key in collisionTestProps) {
+        if (collisionTestProps[key] !== this.props[key]) {
+          // @ts-ignore
+          this.props = this.clone(collisionTestProps).props;
+          break;
+        }
+      }
     }
   }
 
@@ -64,6 +70,16 @@ export default class CollisionFilterExtension extends LayerExtension {
     }
     this.context.deck?._addDefaultEffect(new CollisionFilterEffect());
     const attributeManager = this.getAttributeManager();
+    // Text glyphs share one sample point per label. Allocate it only when the extension is used.
+    if ('getCollisionRect' in this.props) {
+      attributeManager!.add({
+        instanceCollisionRects: {
+          size: 4,
+          stepMode: 'dynamic',
+          accessor: 'getCollisionRect'
+        }
+      });
+    }
     attributeManager!.add({
       collisionPriorities: {
         size: 1,

--- a/modules/extensions/src/collision-filter/collision-filter-extension.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-extension.ts
@@ -47,6 +47,12 @@ export default class CollisionFilterExtension extends LayerExtension {
 
   /* eslint-disable camelcase */
   draw(this: Layer<CollisionFilterExtensionProps>, {shaderModuleProps}: any) {
+    if (shaderModuleProps.collision?.drawToCollisionVisibility) {
+      const {visibilityFBO} = shaderModuleProps.collision;
+      this.context.renderPass.setParameters({
+        viewport: [0, 0, visibilityFBO.width, visibilityFBO.height]
+      });
+    }
     if (shaderModuleProps.collision?.drawToCollisionMap) {
       // Avoid constructing a layer when the overrides are empty or unchanged.
       const {collisionTestProps} = this.props;
@@ -70,9 +76,14 @@ export default class CollisionFilterExtension extends LayerExtension {
     }
     this.context.deck?._addDefaultEffect(new CollisionFilterEffect());
     const attributeManager = this.getAttributeManager();
-    // Text glyphs share one sample point per label. Allocate it only when the extension is used.
+    // Text glyphs share collision bounds and visibility per label. Allocate it only when the extension is used.
     if ('getCollisionRect' in this.props) {
       attributeManager!.add({
+        collisionStartIndices: {
+          size: 1,
+          stepMode: 'dynamic',
+          accessor: (_, {index}) => this.props.startIndices?.[index] ?? index
+        },
         instanceCollisionRects: {
           size: 4,
           stepMode: 'dynamic',

--- a/modules/extensions/src/collision-filter/collision-filter-extension.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-extension.ts
@@ -16,7 +16,7 @@ const defaultProps = {
 
 export type CollisionFilterExtensionProps<DataT = any> = {
   /**
-   * Accessor for collision priority. Must return a number in the range -1000 -> 1000. Features with higher values are shown preferentially.
+   * Accessor for collision priority, clamped to the range [-1000, 1000]. Features with higher values are shown preferentially.
    */
   getCollisionPriority?: Accessor<DataT, number>;
 

--- a/modules/extensions/src/collision-filter/collision-filter-extension.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-extension.ts
@@ -9,6 +9,7 @@ import CollisionFilterEffect from './collision-filter-effect';
 const defaultProps = {
   getCollisionPriority: {type: 'accessor', value: 0},
   collisionEnabled: true,
+  collisionGreedy: false,
   collisionGroup: {type: 'string', value: 'default'},
   collisionTestProps: {}
 };
@@ -29,6 +30,14 @@ export type CollisionFilterExtensionProps<DataT = any> = {
    * Collision group this layer belongs to. If it is not set, the 'default' collision group is used
    */
   collisionGroup?: string;
+
+  /**
+   * Place text in priority order, allowing labels to reuse space from rejected labels.
+   * Uses GPU readback and CPU placement. Enabling this on any text layer applies to
+   * all text layers in its collisionGroup. Has no effect on groups without text.
+   * @default false
+   */
+  collisionGreedy?: boolean;
 
   /**
    * Props to override when rendering collision map

--- a/modules/extensions/src/collision-filter/collision-filter-pass.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-pass.ts
@@ -31,6 +31,9 @@ export default class CollisionFilterPass extends LayersPass {
     return {
       ...layer.props.parameters,
       blend: false,
+      // Collision depth encodes priority, independent of the layer's display order.
+      depthBias: 0,
+      depthBiasSlopeScale: 0,
       depthWriteEnabled: !this.drawToCollisionVisibility,
       depthCompare: this.drawToCollisionVisibility ? 'always' : 'less-equal'
     };

--- a/modules/extensions/src/collision-filter/collision-filter-pass.ts
+++ b/modules/extensions/src/collision-filter/collision-filter-pass.ts
@@ -8,6 +8,8 @@ import {Layer, _LayersPass as LayersPass, LayersPassRenderOptions, Viewport} fro
 type CollisionFilterPassRenderOptions = LayersPassRenderOptions & {};
 
 export default class CollisionFilterPass extends LayersPass {
+  private drawToCollisionVisibility = false;
+
   renderCollisionMap(target: Framebuffer, options: CollisionFilterPassRenderOptions) {
     const padding = 1;
     const clearColor = [0, 0, 0, 0];
@@ -16,12 +18,21 @@ export default class CollisionFilterPass extends LayersPass {
     this.render({...options, clearColor, scissorRect, target, pass: 'collision'});
   }
 
+  renderCollisionVisibility(target: Framebuffer, options: CollisionFilterPassRenderOptions) {
+    this.drawToCollisionVisibility = true;
+    try {
+      this.render({...options, clearColor: [0, 0, 0, 0], target, pass: 'collision'});
+    } finally {
+      this.drawToCollisionVisibility = false;
+    }
+  }
+
   protected getLayerParameters(layer: Layer, layerIndex: number, viewport: Viewport): Parameters {
     return {
       ...layer.props.parameters,
       blend: false,
-      depthWriteEnabled: true,
-      depthCompare: 'less-equal'
+      depthWriteEnabled: !this.drawToCollisionVisibility,
+      depthCompare: this.drawToCollisionVisibility ? 'always' : 'less-equal'
     };
   }
 
@@ -29,7 +40,8 @@ export default class CollisionFilterPass extends LayersPass {
     // Draw picking colors into collision FBO
     return {
       collision: {
-        drawToCollisionMap: true
+        drawToCollisionMap: !this.drawToCollisionVisibility,
+        drawToCollisionVisibility: this.drawToCollisionVisibility
       },
       picking: {
         isActive: 1,

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -10,6 +10,8 @@ const uniformBlock = /* glsl */ `
 layout(std140) uniform collisionUniforms {
   bool sort;
   bool enabled;
+  bool visibilityPass;
+  vec2 visibilitySize;
   highp float sizeScale;
   highp float sizeMinPixels;
   highp float sizeMaxPixels;
@@ -21,14 +23,17 @@ layout(std140) uniform collisionUniforms {
 const vs = /* glsl */ `
 in float collisionPriorities;
 flat out highp vec3 collision_pickingColor;
+flat out float collision_priority;
 
 uniform sampler2D collision_texture;
+uniform sampler2D collision_visibilityTexture;
 
 ${uniformBlock}
 
-// Layers with screen-space offsets can supply the projected label center.
-vec4 collision_position = vec4(0.0);
-bool collision_usePosition = false;
+// Text layers supply their projected footprint for the visibility pass.
+flat out vec4 collision_position;
+bool collision_useBounds = false;
+flat out vec2 collision_corners[4];
 
 float collision_getSize(float size) {
   return clamp(project_size_to_pixel(size * collision.sizeScale, collision.sizeUnits),
@@ -55,26 +60,30 @@ float collision_match(vec2 tex, vec3 pickingColor) {
   return step(delta, e);
 }
 
+ivec2 collision_getVisibilityPixel(vec3 pickingColor) {
+  float index = dot(round(pickingColor * 255.0), vec3(1.0, 256.0, 65536.0));
+  float columns = collision.visibilitySize.x / 4.0;
+  return ivec2(mod(index, columns), floor(index / columns)) * 4;
+}
+
+vec4 collision_getVisibilityPosition(vec2 corner) {
+  vec2 pixel = vec2(collision_getVisibilityPixel(collision_pickingColor)) + corner * 4.0;
+  return vec4(pixel / collision.visibilitySize * 2.0 - 1.0, 0.0, 1.0);
+}
+
 float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
   if (!collision.enabled) {
     return 1.0;
   }
 
-  // Rectangle-backed text has a shared interior sample point. Interpolate the
-  // four neighboring texels for a stable edge fade, without the 25-tap kernel
-  // needed by point/line geometry. Half coverage is sufficient for full opacity.
-  if (collision_usePosition) {
-    vec2 texSize = vec2(textureSize(collision_texture, 0));
-    vec2 texel = texCoords * texSize - 0.5;
-    vec2 fraction = fract(texel);
-    vec2 origin = (floor(texel) + 0.5) / texSize;
-    vec2 step = 1.0 / texSize;
-    float coverage = mix(
-      mix(collision_match(origin, pickingColor), collision_match(origin + vec2(step.x, 0.0), pickingColor), fraction.x),
-      mix(collision_match(origin + vec2(0.0, step.y), pickingColor), collision_match(origin + step, pickingColor), fraction.x),
-      fraction.y
-    );
-    return smoothstep(0.0, 0.5, coverage);
+  if (collision_useBounds) {
+    ivec2 first = collision_getVisibilityPixel(pickingColor);
+    for (int y = 0; y < 4; y++) {
+      for (int x = 0; x < 4; x++) {
+        if (texelFetch(collision_visibilityTexture, first + ivec2(x, y), 0).r < 0.5) return 0.0;
+      }
+    }
+    return 1.0;
   }
 
   // Visibility test, sample area of 5x5 pixels in order to fade in/out.
@@ -103,6 +112,64 @@ float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
 const fs = /* glsl */ `
 ${uniformBlock}
 flat in highp vec3 collision_pickingColor;
+flat in float collision_priority;
+flat in vec4 collision_position;
+flat in vec2 collision_corners[4];
+uniform sampler2D collision_texture;
+uniform highp sampler2D collision_depthTexture;
+bool collision_isOccluded(ivec2 pixel, vec3 pickingColor) {
+  vec4 color = texelFetch(collision_texture, pixel, 0);
+  if (color.a == 0.0 || all(lessThan(abs(color.rgb - pickingColor), vec3(0.5 / 255.0)))) {
+    return false;
+  }
+  // Ignore lower-priority geometry visible through rounded corners or clipping.
+  // The depth buffer is 16-bit; equal depths use the collision pass's draw order.
+  float depth = texelFetch(collision_depthTexture, pixel, 0).r;
+  float ownDepth = 0.5 - 0.0005 * collision_priority;
+  return depth <= ownDepth + 0.5 / 65535.0;
+}
+
+float collision_testBounds(vec3 pickingColor) {
+  ivec2 size = textureSize(collision_texture, 0);
+  vec2 minCorner = min(min(collision_corners[0], collision_corners[1]), min(collision_corners[2], collision_corners[3]));
+  vec2 maxCorner = max(max(collision_corners[0], collision_corners[1]), max(collision_corners[2], collision_corners[3]));
+  ivec2 first = max(ivec2(floor(minCorner * vec2(size))), ivec2(0));
+  ivec2 last = min(ivec2(ceil(maxCorner * vec2(size))), size - 1);
+
+  // Check the center first: densely packed labels usually reject in one lookup.
+  vec2 center = (collision_position.xy / collision_position.w + 1.0) / 2.0;
+  ivec2 centerPixel = ivec2(center * vec2(size));
+  if (all(greaterThanEqual(centerPixel, first)) && all(lessThanEqual(centerPixel, last)) &&
+      collision_isOccluded(centerPixel, pickingColor)) return 0.0;
+
+  // Distribute a label's footprint across a 4x4 block of fragments. This bounds
+  // the serial work per shader invocation even for long, multiline labels.
+  ivec2 extent = (last - first + 4) / 4;
+  ivec2 tile = ivec2(gl_FragCoord.xy) % 4;
+  first += tile * extent;
+  last = min(last, first + extent - 1);
+
+  // Test every covered map pixel, rather than a fixed sample grid that can miss
+  // edge intersections or a small, higher-priority label inside a larger label.
+  vec3 edges[4];
+  for (int i = 0; i < 4; i++) {
+    vec2 a = collision_corners[i] * vec2(size);
+    vec2 b = collision_corners[(i + 1) % 4] * vec2(size);
+    vec2 normal = vec2(a.y - b.y, b.x - a.x);
+    edges[i] = vec3(normal, -dot(normal, a));
+  }
+  for (int y = first.y; y <= last.y; y++) {
+    for (int x = first.x; x <= last.x; x++) {
+      vec3 point = vec3(vec2(x, y) + 0.5, 1.0);
+      vec4 distances = vec4(dot(edges[0], point), dot(edges[1], point), dot(edges[2], point), dot(edges[3], point));
+      bool inside = all(greaterThanEqual(distances, vec4(0.0))) || all(lessThanEqual(distances, vec4(0.0)));
+      if (inside && collision_isOccluded(ivec2(x, y), pickingColor)) return 0.0;
+    }
+  }
+  return 1.0;
+}
+
+
 `;
 
 const inject = {
@@ -111,6 +178,7 @@ const inject = {
 `,
   'vs:DECKGL_FILTER_GL_POSITION': /* glsl */ `
   if (collision.sort || collision.enabled) {
+    collision_priority = collisionPriorities;
     collision_pickingColor = collision_getPickingColor(geometry.pickingColor);
   }
   if (collision.sort) {
@@ -118,11 +186,9 @@ const inject = {
     position.z = -0.001 * collisionPriority * position.w; // Support range -1000 -> 1000
   }
 
-  if (collision.enabled) {
+  if (collision.enabled && !collision.visibilityPass) {
     vec4 collision_common_position = project_position(vec4(geometry.worldPosition, 1.0));
-    vec2 collision_texCoords = collision_usePosition
-      ? (1.0 + collision_position.xy / collision_position.w) / 2.0
-      : collision_getCoords(collision_common_position);
+    vec2 collision_texCoords = collision_getCoords(collision_common_position);
     collision_fade = collision_isVisible(collision_texCoords, collision_pickingColor);
     if (collision_fade < 0.0001) {
       // Position outside clip space bounds to discard
@@ -143,8 +209,11 @@ const inject = {
 
 export type CollisionModuleProps = {
   enabled: boolean;
+  isTextLayer?: boolean;
   collisionFBO?: Framebuffer;
   drawToCollisionMap?: boolean;
+  drawToCollisionVisibility?: boolean;
+  visibilityFBO?: Framebuffer;
   dummyCollisionMap?: Texture;
   pickingColorOffset?: number;
   sizeScale?: number;
@@ -157,6 +226,8 @@ export type CollisionModuleProps = {
 type CollisionUniforms = {
   enabled?: boolean;
   sort?: boolean;
+  visibilityPass?: boolean;
+  visibilitySize?: [number, number];
   pickingColorOffset?: number;
   sizeScale?: number;
   sizeMinPixels?: number;
@@ -166,6 +237,8 @@ type CollisionUniforms = {
 
 type CollisionBindings = {
   collision_texture?: TextureView | Texture;
+  collision_depthTexture?: TextureView | Texture;
+  collision_visibilityTexture?: TextureView | Texture;
 };
 
 const getCollisionUniforms = (
@@ -174,15 +247,34 @@ const getCollisionUniforms = (
   if (!opts || !('dummyCollisionMap' in opts)) {
     return {};
   }
-  const {enabled, collisionFBO, drawToCollisionMap, dummyCollisionMap} = opts;
+  const {
+    enabled,
+    collisionFBO,
+    drawToCollisionMap,
+    drawToCollisionVisibility,
+    visibilityFBO,
+    dummyCollisionMap
+  } = opts;
   return {
     enabled: enabled && !drawToCollisionMap,
     sort: Boolean(drawToCollisionMap),
+    visibilityPass: Boolean(drawToCollisionVisibility),
+    visibilitySize: visibilityFBO ? [visibilityFBO.width, visibilityFBO.height] : [1, 1],
     pickingColorOffset: opts.pickingColorOffset ?? 0,
     sizeScale: opts.sizeScale ?? 1,
     sizeMinPixels: opts.sizeMinPixels ?? 0,
     sizeMaxPixels: opts.sizeMaxPixels ?? Number.MAX_SAFE_INTEGER,
     sizeUnits: UNIT[opts.sizeUnits || 'pixels'],
+    collision_visibilityTexture:
+      !drawToCollisionVisibility && visibilityFBO
+        ? visibilityFBO.colorAttachments[0]
+        : dummyCollisionMap,
+    ...(opts.isTextLayer && {
+      collision_depthTexture:
+        !drawToCollisionMap && collisionFBO
+          ? collisionFBO.depthStencilAttachment!
+          : dummyCollisionMap
+    }),
     collision_texture:
       !drawToCollisionMap && collisionFBO ? collisionFBO.colorAttachments[0] : dummyCollisionMap
   };
@@ -199,6 +291,8 @@ export default {
   uniformTypes: {
     sort: 'i32',
     enabled: 'i32',
+    visibilityPass: 'i32',
+    visibilitySize: 'vec2<f32>',
     sizeScale: 'f32',
     sizeMinPixels: 'f32',
     sizeMaxPixels: 'f32',

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -12,6 +12,7 @@ layout(std140) uniform collisionUniforms {
   bool enabled;
   bool visibilityPass;
   bool hasColliders;
+  bool greedy;
   vec2 visibilitySize;
   highp float sizeScale;
   highp float sizeMinPixels;
@@ -79,7 +80,15 @@ float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
 
   if (collision_useBounds) {
     ivec2 first = collision_getVisibilityPixel(pickingColor);
-    return texelFetch(collision_visibilityTexture, first + ivec2(3, 3), 0).r;
+    if (collision.greedy) {
+      return texelFetch(collision_visibilityTexture, first + ivec2(3, 3), 0).r;
+    }
+    for (int y = 0; y < 4; y++) {
+      for (int x = 0; x < 4; x++) {
+        if (texelFetch(collision_visibilityTexture, first + ivec2(x, y), 0).r < 0.5) return 0.0;
+      }
+    }
+    return 1.0;
   }
 
   // Visibility test, sample area of 5x5 pixels in order to fade in/out.
@@ -139,9 +148,10 @@ float collision_testBounds(vec3 pickingColor, int tileIndex) {
   if (all(greaterThanEqual(centerPixel, first)) && all(lessThanEqual(centerPixel, last)) &&
       collision_isOccluded(centerPixel, pickingColor)) return 0.0;
 
-  // Six fragments test disjoint portions of the footprint against non-text geometry.
-  ivec2 extent = (last - first + ivec2(2, 3)) / ivec2(2, 3);
-  ivec2 tile = ivec2(tileIndex % 2, tileIndex / 2);
+  // Greedy mode reserves ten texels for metadata; the GPU-only path uses all sixteen.
+  ivec2 tiles = collision.greedy ? ivec2(2, 3) : ivec2(4);
+  ivec2 extent = (last - first + tiles) / tiles;
+  ivec2 tile = ivec2(tileIndex % tiles.x, tileIndex / tiles.x);
   first += tile * extent;
   last = min(last, first + extent - 1);
 
@@ -168,6 +178,7 @@ float collision_testBounds(vec3 pickingColor, int tileIndex) {
 vec4 collision_getBoundsData() {
   ivec2 tile = ivec2(gl_FragCoord.xy) % 4;
   int component = tile.y * 4 + tile.x;
+  if (!collision.greedy) return vec4(collision_testBounds(collision_pickingColor, component), 0.0, 0.0, 1.0);
   if (component >= 10) return vec4(collision_testBounds(collision_pickingColor, component - 10), 0.0, 0.0, 1.0);
   float value = 0.0;
   if (component < 8) value = collision_corners[component / 2][component % 2];
@@ -221,6 +232,7 @@ export type CollisionModuleProps = {
   drawToCollisionVisibility?: boolean;
   filterByVisibility?: boolean;
   hasColliders?: boolean;
+  greedy?: boolean;
   visibilityFBO?: Framebuffer;
   dummyCollisionMap?: Texture;
   pickingColorOffset?: number;
@@ -236,6 +248,7 @@ type CollisionUniforms = {
   sort?: boolean;
   visibilityPass?: boolean;
   hasColliders?: boolean;
+  greedy?: boolean;
   visibilitySize?: [number, number];
   pickingColorOffset?: number;
   sizeScale?: number;
@@ -269,6 +282,7 @@ const getCollisionUniforms = (
     sort: Boolean(drawToCollisionMap),
     visibilityPass: Boolean(drawToCollisionVisibility),
     hasColliders: Boolean(opts.hasColliders),
+    greedy: Boolean(opts.greedy),
     visibilitySize: visibilityFBO ? [visibilityFBO.width, visibilityFBO.height] : [1, 1],
     pickingColorOffset: opts.pickingColorOffset ?? 0,
     sizeScale: opts.sizeScale ?? 1,
@@ -303,6 +317,7 @@ export default {
     enabled: 'i32',
     visibilityPass: 'i32',
     hasColliders: 'i32',
+    greedy: 'i32',
     visibilitySize: 'vec2<f32>',
     sizeScale: 'f32',
     sizeMinPixels: 'f32',

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -11,6 +11,7 @@ layout(std140) uniform collisionUniforms {
   bool sort;
   bool enabled;
   bool visibilityPass;
+  bool hasColliders;
   vec2 visibilitySize;
   highp float sizeScale;
   highp float sizeMinPixels;
@@ -78,12 +79,7 @@ float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
 
   if (collision_useBounds) {
     ivec2 first = collision_getVisibilityPixel(pickingColor);
-    for (int y = 0; y < 4; y++) {
-      for (int x = 0; x < 4; x++) {
-        if (texelFetch(collision_visibilityTexture, first + ivec2(x, y), 0).r < 0.5) return 0.0;
-      }
-    }
-    return 1.0;
+    return texelFetch(collision_visibilityTexture, first + ivec2(3, 3), 0).r;
   }
 
   // Visibility test, sample area of 5x5 pixels in order to fade in/out.
@@ -129,7 +125,8 @@ bool collision_isOccluded(ivec2 pixel, vec3 pickingColor) {
   return depth <= ownDepth + 0.5 / 65535.0;
 }
 
-float collision_testBounds(vec3 pickingColor) {
+float collision_testBounds(vec3 pickingColor, int tileIndex) {
+  if (!collision.hasColliders) return 1.0;
   ivec2 size = textureSize(collision_texture, 0);
   vec2 minCorner = min(min(collision_corners[0], collision_corners[1]), min(collision_corners[2], collision_corners[3]));
   vec2 maxCorner = max(max(collision_corners[0], collision_corners[1]), max(collision_corners[2], collision_corners[3]));
@@ -142,10 +139,9 @@ float collision_testBounds(vec3 pickingColor) {
   if (all(greaterThanEqual(centerPixel, first)) && all(lessThanEqual(centerPixel, last)) &&
       collision_isOccluded(centerPixel, pickingColor)) return 0.0;
 
-  // Distribute a label's footprint across a 4x4 block of fragments. This bounds
-  // the serial work per shader invocation even for long, multiline labels.
-  ivec2 extent = (last - first + 4) / 4;
-  ivec2 tile = ivec2(gl_FragCoord.xy) % 4;
+  // Six fragments test disjoint portions of the footprint against non-text geometry.
+  ivec2 extent = (last - first + ivec2(2, 3)) / ivec2(2, 3);
+  ivec2 tile = ivec2(tileIndex % 2, tileIndex / 2);
   first += tile * extent;
   last = min(last, first + extent - 1);
 
@@ -168,8 +164,18 @@ float collision_testBounds(vec3 pickingColor) {
   }
   return 1.0;
 }
-
-
+// Store projected bounds in RGBA8, avoiding a floating-point render-target requirement.
+vec4 collision_getBoundsData() {
+  ivec2 tile = ivec2(gl_FragCoord.xy) % 4;
+  int component = tile.y * 4 + tile.x;
+  if (component >= 10) return vec4(collision_testBounds(collision_pickingColor, component - 10), 0.0, 0.0, 1.0);
+  float value = 0.0;
+  if (component < 8) value = collision_corners[component / 2][component % 2];
+  if (component == 8) value = collision_priority;
+  if (component == 9) value = 1.0;
+  uint bits = floatBitsToUint(value);
+  return vec4(uvec4(bits, bits >> 8, bits >> 16, bits >> 24) & 255u) / 255.0;
+}
 `;
 
 const inject = {
@@ -186,7 +192,7 @@ const inject = {
     position.z = -0.001 * collisionPriority * position.w; // Support range -1000 -> 1000
   }
 
-  if (collision.enabled && !collision.visibilityPass) {
+  if (collision.enabled && !collision.visibilityPass && (!collision.sort || collision_useBounds)) {
     vec4 collision_common_position = project_position(vec4(geometry.worldPosition, 1.0));
     vec2 collision_texCoords = collision_getCoords(collision_common_position);
     collision_fade = collision_isVisible(collision_texCoords, collision_pickingColor);
@@ -213,6 +219,8 @@ export type CollisionModuleProps = {
   collisionFBO?: Framebuffer;
   drawToCollisionMap?: boolean;
   drawToCollisionVisibility?: boolean;
+  filterByVisibility?: boolean;
+  hasColliders?: boolean;
   visibilityFBO?: Framebuffer;
   dummyCollisionMap?: Texture;
   pickingColorOffset?: number;
@@ -227,6 +235,7 @@ type CollisionUniforms = {
   enabled?: boolean;
   sort?: boolean;
   visibilityPass?: boolean;
+  hasColliders?: boolean;
   visibilitySize?: [number, number];
   pickingColorOffset?: number;
   sizeScale?: number;
@@ -256,9 +265,10 @@ const getCollisionUniforms = (
     dummyCollisionMap
   } = opts;
   return {
-    enabled: enabled && !drawToCollisionMap,
+    enabled: enabled && (!drawToCollisionMap || Boolean(opts.filterByVisibility)),
     sort: Boolean(drawToCollisionMap),
     visibilityPass: Boolean(drawToCollisionVisibility),
+    hasColliders: Boolean(opts.hasColliders),
     visibilitySize: visibilityFBO ? [visibilityFBO.width, visibilityFBO.height] : [1, 1],
     pickingColorOffset: opts.pickingColorOffset ?? 0,
     sizeScale: opts.sizeScale ?? 1,
@@ -292,6 +302,7 @@ export default {
     sort: 'i32',
     enabled: 'i32',
     visibilityPass: 'i32',
+    hasColliders: 'i32',
     visibilitySize: 'vec2<f32>',
     sizeScale: 'f32',
     sizeMinPixels: 'f32',

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -26,7 +26,7 @@ const priorityDepth = /* glsl */ `
 float collision_getPriorityDepth(float priority) {
   // Keep the supported range [-1000, 1000] inside the clip planes. A power-of-two
   // divisor also avoids rounding the scale itself when comparing equal priorities.
-  return -priority / 1024.0;
+  return -clamp(priority, -1000.0, 1000.0) / 1024.0;
 }
 `;
 
@@ -205,11 +205,11 @@ const inject = {
 `,
   'vs:DECKGL_FILTER_GL_POSITION': /* glsl */ `
   if (collision.sort || collision.enabled) {
-    collision_priority = collisionPriorities;
+    collision_priority = clamp(collisionPriorities, -1000.0, 1000.0);
     collision_pickingColor = collision_getPickingColor(geometry.pickingColor);
   }
   if (collision.sort) {
-    position.z = collision_getPriorityDepth(collisionPriorities) * position.w;
+    position.z = collision_getPriorityDepth(collision_priority) * position.w;
   }
 
   if (collision.enabled && !collision.visibilityPass && (!collision.sort || collision_useBounds)) {

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -22,7 +22,16 @@ layout(std140) uniform collisionUniforms {
 } collision;
 `;
 
+const priorityDepth = /* glsl */ `
+float collision_getPriorityDepth(float priority) {
+  // Keep the supported range [-1000, 1000] inside the clip planes. A power-of-two
+  // divisor also avoids rounding the scale itself when comparing equal priorities.
+  return -priority / 1024.0;
+}
+`;
+
 const vs = /* glsl */ `
+${priorityDepth}
 in float collisionPriorities;
 flat out highp vec3 collision_pickingColor;
 flat out float collision_priority;
@@ -116,6 +125,7 @@ float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
 
 const fs = /* glsl */ `
 ${uniformBlock}
+${priorityDepth}
 flat in highp vec3 collision_pickingColor;
 flat in float collision_priority;
 flat in vec4 collision_position;
@@ -130,7 +140,7 @@ bool collision_isOccluded(ivec2 pixel, vec3 pickingColor) {
   // Ignore lower-priority geometry visible through rounded corners or clipping.
   // The depth buffer is 16-bit; equal depths use the collision pass's draw order.
   float depth = texelFetch(collision_depthTexture, pixel, 0).r;
-  float ownDepth = 0.5 - 0.0005 * collision_priority;
+  float ownDepth = (1.0 + collision_getPriorityDepth(collision_priority)) * 0.5;
   return depth <= ownDepth + 0.5 / 65535.0;
 }
 
@@ -199,8 +209,7 @@ const inject = {
     collision_pickingColor = collision_getPickingColor(geometry.pickingColor);
   }
   if (collision.sort) {
-    float collisionPriority = collisionPriorities;
-    position.z = -0.001 * collisionPriority * position.w; // Support range -1000 -> 1000
+    position.z = collision_getPriorityDepth(collisionPriorities) * position.w;
   }
 
   if (collision.enabled && !collision.visibilityPass && (!collision.sort || collision_useBounds)) {

--- a/modules/extensions/src/collision-filter/shader-module.ts
+++ b/modules/extensions/src/collision-filter/shader-module.ts
@@ -4,17 +4,44 @@
 
 import {Framebuffer, Texture, TextureView} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
-import {project} from '@deck.gl/core';
+import {project, picking, UNIT} from '@deck.gl/core';
 
-const vs = /* glsl */ `
-in float collisionPriorities;
-
-uniform sampler2D collision_texture;
-
+const uniformBlock = /* glsl */ `
 layout(std140) uniform collisionUniforms {
   bool sort;
   bool enabled;
+  highp float sizeScale;
+  highp float sizeMinPixels;
+  highp float sizeMaxPixels;
+  highp int sizeUnits;
+  highp float pickingColorOffset;
 } collision;
+`;
+
+const vs = /* glsl */ `
+in float collisionPriorities;
+flat out highp vec3 collision_pickingColor;
+
+uniform sampler2D collision_texture;
+
+${uniformBlock}
+
+// Layers with screen-space offsets can supply the projected label center.
+vec4 collision_position = vec4(0.0);
+bool collision_usePosition = false;
+
+float collision_getSize(float size) {
+  return clamp(project_size_to_pixel(size * collision.sizeScale, collision.sizeUnits),
+    collision.sizeMinPixels, collision.sizeMaxPixels);
+}
+
+vec3 collision_getPickingColor(vec3 color) {
+  vec3 normalizedColor = picking_normalizeColor(color);
+  if (collision.pickingColorOffset == 0.0) return normalizedColor;
+  vec3 bytes = round(normalizedColor * 255.0);
+  float index = dot(bytes, vec3(1.0, 256.0, 65536.0)) + collision.pickingColorOffset;
+  return vec3(mod(index, 256.0), mod(floor(index / 256.0), 256.0), floor(index / 65536.0)) / 255.0;
+}
 
 vec2 collision_getCoords(vec4 position) {
   vec4 collision_clipspace = project_common_position_to_clipspace(position);
@@ -24,13 +51,30 @@ vec2 collision_getCoords(vec4 position) {
 float collision_match(vec2 tex, vec3 pickingColor) {
   vec4 collision_pickingColor = texture(collision_texture, tex);
   float delta = dot(abs(collision_pickingColor.rgb - pickingColor), vec3(1.0));
-  float e = 0.001;
+  float e = 0.5 / 255.0;
   return step(delta, e);
 }
 
 float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
   if (!collision.enabled) {
     return 1.0;
+  }
+
+  // Rectangle-backed text has a shared interior sample point. Interpolate the
+  // four neighboring texels for a stable edge fade, without the 25-tap kernel
+  // needed by point/line geometry. Half coverage is sufficient for full opacity.
+  if (collision_usePosition) {
+    vec2 texSize = vec2(textureSize(collision_texture, 0));
+    vec2 texel = texCoords * texSize - 0.5;
+    vec2 fraction = fract(texel);
+    vec2 origin = (floor(texel) + 0.5) / texSize;
+    vec2 step = 1.0 / texSize;
+    float coverage = mix(
+      mix(collision_match(origin, pickingColor), collision_match(origin + vec2(step.x, 0.0), pickingColor), fraction.x),
+      mix(collision_match(origin + vec2(0.0, step.y), pickingColor), collision_match(origin + step, pickingColor), fraction.x),
+      fraction.y
+    );
+    return smoothstep(0.0, 0.5, coverage);
   }
 
   // Visibility test, sample area of 5x5 pixels in order to fade in/out.
@@ -56,11 +100,19 @@ float collision_isVisible(vec2 texCoords, vec3 pickingColor) {
 }
 `;
 
+const fs = /* glsl */ `
+${uniformBlock}
+flat in highp vec3 collision_pickingColor;
+`;
+
 const inject = {
   'vs:#decl': /* glsl */ `
   float collision_fade = 1.0;
 `,
   'vs:DECKGL_FILTER_GL_POSITION': /* glsl */ `
+  if (collision.sort || collision.enabled) {
+    collision_pickingColor = collision_getPickingColor(geometry.pickingColor);
+  }
   if (collision.sort) {
     float collisionPriority = collisionPriorities;
     position.z = -0.001 * collisionPriority * position.w; // Support range -1000 -> 1000
@@ -68,8 +120,10 @@ const inject = {
 
   if (collision.enabled) {
     vec4 collision_common_position = project_position(vec4(geometry.worldPosition, 1.0));
-    vec2 collision_texCoords = collision_getCoords(collision_common_position);
-    collision_fade = collision_isVisible(collision_texCoords, geometry.pickingColor / 255.0);
+    vec2 collision_texCoords = collision_usePosition
+      ? (1.0 + collision_position.xy / collision_position.w) / 2.0
+      : collision_getCoords(collision_common_position);
+    collision_fade = collision_isVisible(collision_texCoords, collision_pickingColor);
     if (collision_fade < 0.0001) {
       // Position outside clip space bounds to discard
       position = vec4(0.0, 0.0, 2.0, 1.0);
@@ -78,7 +132,13 @@ const inject = {
   `,
   'vs:DECKGL_FILTER_COLOR': /* glsl */ `
   color.a *= collision_fade;
-  `
+  `,
+  'fs:DECKGL_FILTER_COLOR': {
+    order: 101,
+    injection: /* glsl */ `
+    if (collision.sort) color = vec4(collision_pickingColor, 1.0);
+    `
+  }
 };
 
 export type CollisionModuleProps = {
@@ -86,12 +146,22 @@ export type CollisionModuleProps = {
   collisionFBO?: Framebuffer;
   drawToCollisionMap?: boolean;
   dummyCollisionMap?: Texture;
+  pickingColorOffset?: number;
+  sizeScale?: number;
+  sizeMinPixels?: number;
+  sizeMaxPixels?: number;
+  sizeUnits?: string;
 };
 
 /* eslint-disable camelcase */
 type CollisionUniforms = {
   enabled?: boolean;
   sort?: boolean;
+  pickingColorOffset?: number;
+  sizeScale?: number;
+  sizeMinPixels?: number;
+  sizeMaxPixels?: number;
+  sizeUnits?: number;
 };
 
 type CollisionBindings = {
@@ -108,6 +178,11 @@ const getCollisionUniforms = (
   return {
     enabled: enabled && !drawToCollisionMap,
     sort: Boolean(drawToCollisionMap),
+    pickingColorOffset: opts.pickingColorOffset ?? 0,
+    sizeScale: opts.sizeScale ?? 1,
+    sizeMinPixels: opts.sizeMinPixels ?? 0,
+    sizeMaxPixels: opts.sizeMaxPixels ?? Number.MAX_SAFE_INTEGER,
+    sizeUnits: UNIT[opts.sizeUnits || 'pixels'],
     collision_texture:
       !drawToCollisionMap && collisionFBO ? collisionFBO.colorAttachments[0] : dummyCollisionMap
   };
@@ -116,12 +191,18 @@ const getCollisionUniforms = (
 // @ts-ignore
 export default {
   name: 'collision',
-  dependencies: [project],
+  dependencies: [project, picking],
   vs,
+  fs,
   inject,
   getUniforms: getCollisionUniforms,
   uniformTypes: {
     sort: 'i32',
-    enabled: 'i32'
+    enabled: 'i32',
+    sizeScale: 'f32',
+    sizeMinPixels: 'f32',
+    sizeMaxPixels: 'f32',
+    sizeUnits: 'i32',
+    pickingColorOffset: 'f32'
   }
 } as ShaderModule<CollisionModuleProps>;

--- a/modules/extensions/src/collision-filter/text-collision-placement.ts
+++ b/modules/extensions/src/collision-filter/text-collision-placement.ts
@@ -1,0 +1,195 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+type Candidate = {
+  index: number;
+  pixel: number;
+  priority: number;
+  polygon: number[] | null;
+  axisAligned: boolean;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+  checkedBy: number;
+};
+
+const CELL_SIZE = 64;
+
+// Clip only labels crossing the viewport boundary. Intersections outside the
+// viewport must not prevent two visible portions from being placed together.
+function clipPolygon(polygon: number[], width: number, height: number): number[] {
+  for (let edge = 0; edge < 4 && polygon.length; edge++) {
+    const axis = edge % 2;
+    const limit = edge < 2 ? 0 : axis === 0 ? width : height;
+    const sign = edge < 2 ? 1 : -1;
+    const clipped: number[] = [];
+    let previous = polygon.length - 2;
+    for (let current = 0; current < polygon.length; current += 2) {
+      const previousDistance = (polygon[previous + axis] - limit) * sign;
+      const currentDistance = (polygon[current + axis] - limit) * sign;
+      if (previousDistance >= 0 !== currentDistance >= 0) {
+        const t = previousDistance / (previousDistance - currentDistance);
+        clipped.push(
+          polygon[previous] + t * (polygon[current] - polygon[previous]),
+          polygon[previous + 1] + t * (polygon[current + 1] - polygon[previous + 1])
+        );
+      }
+      if (currentDistance >= 0) clipped.push(polygon[current], polygon[current + 1]);
+      previous = current;
+    }
+    polygon = clipped;
+  }
+  let area = 0;
+  for (let i = 0; i < polygon.length; i += 2) {
+    const next = (i + 2) % polygon.length;
+    area += polygon[i] * polygon[next + 1] - polygon[next] * polygon[i + 1];
+  }
+  return area === 0 ? [] : polygon;
+}
+
+// Separating-axis test for convex projected/clipped label rectangles.
+function hasSeparatingAxis(a: number[], b: number[]): boolean {
+  for (let i = 0; i < a.length; i += 2) {
+    const next = (i + 2) % a.length;
+    const x = a[i + 1] - a[next + 1];
+    const y = a[next] - a[i];
+    if (x === 0 && y === 0) continue;
+    let minA = Infinity;
+    let maxA = -Infinity;
+    let minB = Infinity;
+    let maxB = -Infinity;
+    for (let j = 0; j < a.length; j += 2) {
+      const value = x * a[j] + y * a[j + 1];
+      minA = Math.min(minA, value);
+      maxA = Math.max(maxA, value);
+    }
+    for (let j = 0; j < b.length; j += 2) {
+      const value = x * b[j] + y * b[j + 1];
+      minB = Math.min(minB, value);
+      maxB = Math.max(maxB, value);
+    }
+    if (maxA <= minB || maxB <= minA) return true;
+  }
+  return false;
+}
+
+function overlaps(a: Candidate, b: Candidate): boolean {
+  if (a.maxX <= b.minX || b.maxX <= a.minX || a.maxY <= b.minY || b.maxY <= a.minY) {
+    return false;
+  }
+  if (a.axisAligned && b.axisAligned) return true;
+  a.polygon ||= [a.minX, a.minY, a.maxX, a.minY, a.maxX, a.maxY, a.minX, a.maxY];
+  b.polygon ||= [b.minX, b.minY, b.maxX, b.minY, b.maxX, b.maxY, b.minX, b.maxY];
+  return !hasSeparatingAxis(a.polygon, b.polygon) && !hasSeparatingAxis(b.polygon, a.polygon);
+}
+
+/**
+ * Place labels in descending priority, breaking ties by source draw order.
+ * The GPU supplies projected corners and eligibility against non-text geometry
+ * in 4x4 RGBA8 blocks: eight corner coordinates, priority, presence, then six
+ * non-text collision results. Floats are encoded least-significant byte first.
+ * Update the last texel of each block with its final visibility.
+ */
+export function placeTextLabels(
+  pixels: Uint8Array,
+  textureWidth: number,
+  objectCount: number,
+  viewportWidth: number,
+  viewportHeight: number
+): number {
+  const floats = new DataView(pixels.buffer, pixels.byteOffset, pixels.byteLength);
+  const rowStride = textureWidth * 4;
+  const columns = textureWidth / 4;
+  const candidates: Candidate[] = [];
+  for (let index = 1; index <= objectCount; index++) {
+    const base = Math.floor(index / columns) * 4 * rowStride + (index % columns) * 16;
+    const pixel = base + 3 * rowStride + 12;
+    let eligible = floats.getFloat32(base + 2 * rowStride + 4, true) === 1;
+    for (let component = 10; eligible && component < 16; component++) {
+      if (pixels[base + Math.floor(component / 4) * rowStride + (component % 4) * 4] === 0)
+        eligible = false;
+    }
+    pixels[pixel] = 0;
+    if (!eligible) continue;
+    const x0 = floats.getFloat32(base, true) * viewportWidth;
+    const y0 = floats.getFloat32(base + 4, true) * viewportHeight;
+    const x1 = floats.getFloat32(base + 8, true) * viewportWidth;
+    const y1 = floats.getFloat32(base + 12, true) * viewportHeight;
+    const x2 = floats.getFloat32(base + rowStride, true) * viewportWidth;
+    const y2 = floats.getFloat32(base + rowStride + 4, true) * viewportHeight;
+    const x3 = floats.getFloat32(base + rowStride + 8, true) * viewportWidth;
+    const y3 = floats.getFloat32(base + rowStride + 12, true) * viewportHeight;
+    const minX = Math.min(x0, x1, x2, x3);
+    const minY = Math.min(y0, y1, y2, y3);
+    const maxX = Math.max(x0, x1, x2, x3);
+    const maxY = Math.max(y0, y1, y2, y3);
+    if (
+      !(
+        minX < maxX &&
+        minY < maxY &&
+        minX < viewportWidth &&
+        minY < viewportHeight &&
+        maxX > 0 &&
+        maxY > 0
+      )
+    )
+      continue;
+    const axisAligned =
+      (x0 === x3 && x1 === x2 && y0 === y1 && y2 === y3) ||
+      (x0 === x1 && x2 === x3 && y0 === y3 && y1 === y2);
+    let polygon = axisAligned ? null : [x0, y0, x1, y1, x2, y2, x3, y3];
+    if (polygon && (minX < 0 || minY < 0 || maxX > viewportWidth || maxY > viewportHeight)) {
+      polygon = clipPolygon(polygon, viewportWidth, viewportHeight);
+      if (polygon.length < 6) continue;
+    }
+    candidates.push({
+      index,
+      pixel,
+      priority: floats.getFloat32(base + 2 * rowStride, true),
+      polygon,
+      axisAligned,
+      minX: Math.max(0, minX),
+      minY: Math.max(0, minY),
+      maxX: Math.min(viewportWidth, maxX),
+      maxY: Math.min(viewportHeight, maxY),
+      checkedBy: -1
+    });
+  }
+  candidates.sort((a, b) => b.priority - a.priority || b.index - a.index);
+
+  const gridWidth = Math.ceil(viewportWidth / CELL_SIZE);
+  const cells: Candidate[][] = [];
+  let visibleCount = 0;
+  for (const candidate of candidates) {
+    const firstX = Math.floor(candidate.minX / CELL_SIZE);
+    const firstY = Math.floor(candidate.minY / CELL_SIZE);
+    const lastX = Math.min(gridWidth - 1, Math.floor(candidate.maxX / CELL_SIZE));
+    const lastY = Math.ceil(candidate.maxY / CELL_SIZE) - 1;
+    let blocked = false;
+    for (let y = firstY; !blocked && y <= lastY; y++) {
+      for (let x = firstX; !blocked && x <= lastX; x++) {
+        const cell = cells[y * gridWidth + x];
+        if (!cell) continue;
+        for (const accepted of cell) {
+          if (accepted.checkedBy === candidate.index) continue;
+          accepted.checkedBy = candidate.index;
+          if (overlaps(candidate, accepted)) {
+            blocked = true;
+            break;
+          }
+        }
+      }
+    }
+    if (blocked) continue;
+    pixels[candidate.pixel] = 255;
+    visibleCount++;
+    for (let y = firstY; y <= lastY; y++) {
+      for (let x = firstX; x <= lastX; x++) {
+        (cells[y * gridWidth + x] ||= []).push(candidate);
+      }
+    }
+  }
+  return visibleCount;
+}

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.ts
@@ -17,6 +17,12 @@ in vec2 uv;
 out vec4 fragColor;
 
 void main(void) {
+#ifdef MODULE_COLLISION
+  if (collision.visibilityPass) {
+    fragColor = vec4(collision_testBounds(collision_pickingColor), 0.0, 0.0, 1.0);
+    return;
+  }
+#endif
   geometry.uv = uv;
 
   if (!bool(picking.isActive)) {

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-fragment.glsl.ts
@@ -19,7 +19,7 @@ out vec4 fragColor;
 void main(void) {
 #ifdef MODULE_COLLISION
   if (collision.visibilityPass) {
-    fragColor = vec4(collision_testBounds(collision_pickingColor), 0.0, 0.0, 1.0);
+    fragColor = collision_getBoundsData();
     return;
   }
 #endif

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import collision from '../text-layer-collision.glsl';
+
 export default /* glsl */ `\
 #version 300 es
 #define SHADER_NAME multi-icon-layer-vertex-shader
@@ -21,6 +23,7 @@ in vec2 instancePixelOffset;
 in vec4 instanceClipRect;
 #ifdef MODULE_COLLISION
 in vec4 instanceCollisionRects;
+in float collisionStartIndices;
 #endif
 
 out float vColorMode;
@@ -52,7 +55,16 @@ float getPixelOffsetFromAlignment(float anchor, float extent, float clipStart, f
   return 0.0;
 }
 
+${collision}
+
 void main(void) {
+#ifdef MODULE_COLLISION
+  // Binary input renders through the character layer. Evaluate only its first glyph.
+  if (collision.visibilityPass && gl_InstanceID != int(collisionStartIndices)) {
+    gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+    return;
+  }
+#endif
   geometry.worldPosition = instancePositions;
   geometry.uv = positions;
   geometry.pickingColor = picking_getPickingColorFromIndex(rowIndexes);
@@ -100,21 +112,9 @@ void main(void) {
   }
 
 #ifdef MODULE_COLLISION
-  vec2 collisionOffset = rotate_by_angle(instanceCollisionRects.xy + instanceCollisionRects.zw / 2.0, instanceAngles) * collision_getSize(instanceSizes) / text.fontSize;
-  collisionOffset += instancePixelOffset;
-  collisionOffset.y *= -1.0;
-  // A clipped background occupies the content box, independently of text alignment.
-  if (instanceClipRect.z >= 0.0) collisionOffset.x = xy.x + wh.x / 2.0;
-  if (instanceClipRect.w >= 0.0) collisionOffset.y = xy.y + wh.y / 2.0;
-  collision_usePosition = true;
-  if (icon.billboard) {
-    collision_position = anchorPos;
-    collision_position.xy += project_pixel_size_to_clipspace(collisionOffset);
-  } else {
-    vec3 collisionOffsetCommon = vec3(project_pixel_size(collisionOffset), 0.0);
-    if (text.flipY) collisionOffsetCommon.y *= -1.0;
-    collision_position = project_position_to_clipspace(instancePositions, instancePositions64Low, collisionOffsetCommon);
-  }
+  text_setCollisionBounds(instancePositions, instancePositions64Low,
+    instanceCollisionRects * collision_getSize(instanceSizes) / text.fontSize,
+    instancePixelOffset, instanceAngles, vec4(xy, wh), icon.billboard, text.flipY);
 #endif
 
   if (icon.billboard) {
@@ -170,5 +170,10 @@ void main(void) {
   DECKGL_FILTER_COLOR(vColor, geometry);
 
   vColorMode = instanceColorModes;
+#ifdef MODULE_COLLISION
+  if (collision.visibilityPass) {
+    gl_Position = collision_getVisibilityPosition(positions / 2.0 + 0.5);
+  }
+#endif
 }
 `;

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
@@ -172,6 +172,8 @@ void main(void) {
   vColorMode = instanceColorModes;
 #ifdef MODULE_COLLISION
   if (collision.visibilityPass) {
+    // Preserve culling by the projection and other vertex extensions.
+    if (gl_Position.w <= 0.0 || abs(gl_Position.z) > gl_Position.w) return;
     gl_Position = collision_getVisibilityPosition(positions / 2.0 + 0.5);
   }
 #endif

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer-vertex.glsl.ts
@@ -19,6 +19,9 @@ in float instanceColorModes;
 in vec2 instanceOffsets;
 in vec2 instancePixelOffset;
 in vec4 instanceClipRect;
+#ifdef MODULE_COLLISION
+in vec4 instanceCollisionRects;
+#endif
 
 out float vColorMode;
 out vec4 vColor;
@@ -68,45 +71,67 @@ void main(void) {
 
   // scale and rotate vertex in "pixel" value and convert back to fraction in clipspace
   vec2 pixelOffset = positions / 2.0 * iconSize + instanceOffsets;
+#ifdef MODULE_COLLISION
+  // Binary input can supply per-character GPU attributes without per-label
+  // background attributes. In that case this layer writes the label rectangle.
+  if (collision.sort) {
+    pixelOffset = instanceCollisionRects.xy + (positions / 2.0 + 0.5) * instanceCollisionRects.zw;
+  }
+#endif
   pixelOffset = rotate_by_angle(pixelOffset, instanceAngles) * instanceScale;
   pixelOffset += instancePixelOffset;
   pixelOffset.y *= -1.0;
 
-  vec2 anchorPosScreen;
-  if (icon.billboard)  {
-    gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
-    anchorPosScreen = gl_Position.xy / gl_Position.w;
-    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
-    vec3 offset = vec3(pixelOffset, 0.0);
-    DECKGL_FILTER_SIZE(offset, geometry);
-    gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
-  } else {
-    vec3 offset_common = vec3(project_pixel_size(pixelOffset), 0.0);
-    if (text.flipY) {
-      offset_common.y *= -1.;
-    }
-    DECKGL_FILTER_SIZE(offset_common, geometry);
-    vec4 anchorPos = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0));
-    anchorPosScreen = anchorPos.xy / anchorPos.w;
-    gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset_common, geometry.position); 
-    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
-  }
-
+  vec4 anchorPos = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
+  vec2 anchorPosScreen = anchorPos.xy / anchorPos.w;
   anchorPosScreen = vec2(anchorPosScreen.x + 1.0, 1.0 - anchorPosScreen.y) / 2.0 * project.viewportSize / project.devicePixelRatio;
   vec2 xy = project_size_to_pixel(instanceClipRect.xy);
   vec2 wh = project_size_to_pixel(instanceClipRect.zw);
   if (text.flipY) {
     xy.y = -xy.y - wh.y;
   }
+  vec2 scrollPixels = vec2(0.0);
   if (text.align.x > 0 || text.align.y > 0) {
     vec2 viewportPixels = project.viewportSize / project.devicePixelRatio;
-    vec2 scrollPixels = vec2(
+    scrollPixels = vec2(
       getPixelOffsetFromAlignment(anchorPosScreen.x, viewportPixels.x, xy.x, xy.x + wh.x, text.align.x),
       -getPixelOffsetFromAlignment(anchorPosScreen.y, viewportPixels.y, -xy.y - wh.y, -xy.y, text.align.y)
     );
-    pixelOffset += scrollPixels;
-    gl_Position.xy += project_pixel_size_to_clipspace(scrollPixels);
   }
+
+#ifdef MODULE_COLLISION
+  vec2 collisionOffset = rotate_by_angle(instanceCollisionRects.xy + instanceCollisionRects.zw / 2.0, instanceAngles) * collision_getSize(instanceSizes) / text.fontSize;
+  collisionOffset += instancePixelOffset;
+  collisionOffset.y *= -1.0;
+  // A clipped background occupies the content box, independently of text alignment.
+  if (instanceClipRect.z >= 0.0) collisionOffset.x = xy.x + wh.x / 2.0;
+  if (instanceClipRect.w >= 0.0) collisionOffset.y = xy.y + wh.y / 2.0;
+  collision_usePosition = true;
+  if (icon.billboard) {
+    collision_position = anchorPos;
+    collision_position.xy += project_pixel_size_to_clipspace(collisionOffset);
+  } else {
+    vec3 collisionOffsetCommon = vec3(project_pixel_size(collisionOffset), 0.0);
+    if (text.flipY) collisionOffsetCommon.y *= -1.0;
+    collision_position = project_position_to_clipspace(instancePositions, instancePositions64Low, collisionOffsetCommon);
+  }
+#endif
+
+  if (icon.billboard) {
+    gl_Position = anchorPos;
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
+    vec3 offset = vec3(pixelOffset, 0.0);
+    DECKGL_FILTER_SIZE(offset, geometry);
+    gl_Position.xy += project_pixel_size_to_clipspace(offset.xy);
+  } else {
+    vec3 offset_common = vec3(project_pixel_size(pixelOffset), 0.0);
+    if (text.flipY) offset_common.y *= -1.0;
+    DECKGL_FILTER_SIZE(offset_common, geometry);
+    gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset_common, geometry.position);
+    DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
+  }
+  pixelOffset += scrollPixels;
+  gl_Position.xy += project_pixel_size_to_clipspace(scrollPixels);
 
   if (instanceClipRect.z >= 0.) {
     if (pixelOffset.x < xy.x || pixelOffset.x > xy.x + wh.x) {

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -185,7 +185,12 @@ export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends 
     super.draw(params);
 
     // draw text without outline on top to ensure a thick outline won't occlude other characters
-    if (sdf && outlineWidth && !params.shaderModuleProps?.collision?.drawToCollisionMap) {
+    if (
+      sdf &&
+      outlineWidth &&
+      !params.shaderModuleProps?.collision?.drawToCollisionMap &&
+      !params.shaderModuleProps?.collision?.drawToCollisionVisibility
+    ) {
       const {iconManager} = this.state;
       const iconsTexture = iconManager.getTexture();
 

--- a/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
+++ b/modules/layers/src/text-layer/multi-icon-layer/multi-icon-layer.ts
@@ -28,6 +28,8 @@ const DEFAULT_BUFFER = 192.0 / 256;
 const EMPTY_ARRAY = [];
 
 type _MultiIconLayerProps<DataT> = {
+  /** Internal label bounds shared by every glyph, in font-atlas pixels. */
+  getCollisionRect?: Accessor<DataT, Readonly<[number, number, number, number]>>;
   getIconOffsets?: AccessorFunction<DataT, number[]>;
   getContentBox?: Accessor<DataT, [x: number, y: number, width: number, height: number]>;
 
@@ -46,6 +48,7 @@ export type MultiIconLayerProps<DataT = unknown> = _MultiIconLayerProps<DataT> &
   IconLayerProps<DataT>;
 
 const defaultProps: DefaultProps<MultiIconLayerProps> = {
+  getCollisionRect: {type: 'accessor', value: [0, 0, 0, 0]},
   getIconOffsets: {type: 'accessor', value: (x: any) => x.offsets},
   getContentBox: {type: 'accessor', value: [0, 0, -1, -1]},
   fontSize: 1,
@@ -182,7 +185,7 @@ export default class MultiIconLayer<DataT, ExtraPropsT extends {} = {}> extends 
     super.draw(params);
 
     // draw text without outline on top to ensure a thick outline won't occlude other characters
-    if (sdf && outlineWidth) {
+    if (sdf && outlineWidth && !params.shaderModuleProps?.collision?.drawToCollisionMap) {
       const {iconManager} = this.state;
       const iconsTexture = iconManager.getTexture();
 

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-fragment.glsl.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-fragment.glsl.ts
@@ -44,6 +44,12 @@ vec4 get_stroked_fragColor(float dist) {
 }
 
 void main(void) {
+#ifdef MODULE_COLLISION
+  if (collision.visibilityPass) {
+    fragColor = vec4(collision_testBounds(collision_pickingColor), 0.0, 0.0, 1.0);
+    return;
+  }
+#endif
   geometry.uv = uv;
 
   if (textBackground.borderRadius != vec4(0.0)) {

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-fragment.glsl.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-fragment.glsl.ts
@@ -46,7 +46,7 @@ vec4 get_stroked_fragColor(float dist) {
 void main(void) {
 #ifdef MODULE_COLLISION
   if (collision.visibilityPass) {
-    fragColor = vec4(collision_testBounds(collision_pickingColor), 0.0, 0.0, 1.0);
+    fragColor = collision_getBoundsData();
     return;
   }
 #endif

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
@@ -115,6 +115,8 @@ void main(void) {
   DECKGL_FILTER_COLOR(vLineColor, geometry);
 #ifdef MODULE_COLLISION
   if (collision.visibilityPass) {
+    // Preserve culling by the projection and other vertex extensions.
+    if (gl_Position.w <= 0.0 || abs(gl_Position.z) > gl_Position.w) return;
     gl_Position = collision_getVisibilityPosition(positions);
   }
 #endif

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import collision from '../text-layer-collision.glsl';
+
 export default /* glsl */ `\
 #version 300 es
 #define SHADER_NAME text-background-layer-vertex-shader
@@ -32,6 +34,8 @@ vec2 rotate_by_angle(vec2 vertex, float angle) {
   mat2 rotationMatrix = mat2(cos_angle, -sin_angle, sin_angle, cos_angle);
   return rotationMatrix * vertex;
 }
+
+${collision}
 
 void main(void) {
   geometry.worldPosition = instancePositions;
@@ -72,20 +76,20 @@ void main(void) {
   }
 
 #ifdef MODULE_COLLISION
-  vec2 collisionOffset = (instanceRects.xy + instanceRects.zw / 2.0) * collision_getSize(instanceSizes) / text.fontSize;
-  collisionOffset = rotate_by_angle(collisionOffset, instanceAngles) + instancePixelOffsets;
-  collisionOffset.y *= -1.0;
-  if (instanceClipRect.z >= 0.0) collisionOffset.x = xy.x + wh.x / 2.0;
-  if (instanceClipRect.w >= 0.0) collisionOffset.y = xy.y + wh.y / 2.0;
-  collision_usePosition = true;
-  if (textBackground.billboard) {
-    collision_position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0));
-    collision_position.xy += project_pixel_size_to_clipspace(collisionOffset);
-  } else {
-    vec3 collisionOffsetCommon = vec3(project_pixel_size(collisionOffset), 0.0);
-    if (text.flipY) collisionOffsetCommon.y *= -1.0;
-    collision_position = project_position_to_clipspace(instancePositions, instancePositions64Low, collisionOffsetCommon);
+  vec4 collisionRect = instanceRects * collision_getSize(instanceSizes) / text.fontSize;
+  collisionRect.xy -= textBackground.padding.xy;
+  collisionRect.zw += textBackground.padding.xy + textBackground.padding.zw;
+  vec4 collisionClipRect = vec4(xy, wh);
+  if (instanceClipRect.z >= 0.0) {
+    collisionClipRect.x -= textBackground.padding.x;
+    collisionClipRect.z += textBackground.padding.x + textBackground.padding.z;
   }
+  if (instanceClipRect.w >= 0.0) {
+    collisionClipRect.y -= textBackground.padding.y;
+    collisionClipRect.w += textBackground.padding.y + textBackground.padding.w;
+  }
+  text_setCollisionBounds(instancePositions, instancePositions64Low,
+    collisionRect, instancePixelOffsets, instanceAngles, collisionClipRect, textBackground.billboard, text.flipY);
 #endif
 
   if (textBackground.billboard)  {
@@ -109,5 +113,10 @@ void main(void) {
   DECKGL_FILTER_COLOR(vFillColor, geometry);
   vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * layer.opacity);
   DECKGL_FILTER_COLOR(vLineColor, geometry);
+#ifdef MODULE_COLLISION
+  if (collision.visibilityPass) {
+    gl_Position = collision_getVisibilityPosition(positions);
+  }
+#endif
 }
 `;

--- a/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
+++ b/modules/layers/src/text-layer/text-background-layer/text-background-layer-vertex.glsl.ts
@@ -71,6 +71,23 @@ void main(void) {
     pixelOffset.y = xy.y + uv.y * wh.y + mix(-textBackground.padding.y, textBackground.padding.w, uv.y);
   }
 
+#ifdef MODULE_COLLISION
+  vec2 collisionOffset = (instanceRects.xy + instanceRects.zw / 2.0) * collision_getSize(instanceSizes) / text.fontSize;
+  collisionOffset = rotate_by_angle(collisionOffset, instanceAngles) + instancePixelOffsets;
+  collisionOffset.y *= -1.0;
+  if (instanceClipRect.z >= 0.0) collisionOffset.x = xy.x + wh.x / 2.0;
+  if (instanceClipRect.w >= 0.0) collisionOffset.y = xy.y + wh.y / 2.0;
+  collision_usePosition = true;
+  if (textBackground.billboard) {
+    collision_position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0));
+    collision_position.xy += project_pixel_size_to_clipspace(collisionOffset);
+  } else {
+    vec3 collisionOffsetCommon = vec3(project_pixel_size(collisionOffset), 0.0);
+    if (text.flipY) collisionOffsetCommon.y *= -1.0;
+    collision_position = project_position_to_clipspace(instancePositions, instancePositions64Low, collisionOffsetCommon);
+  }
+#endif
+
   if (textBackground.billboard)  {
     gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, vec3(0.0), geometry.position);
     DECKGL_FILTER_GL_POSITION(gl_Position, geometry);

--- a/modules/layers/src/text-layer/text-layer-collision.glsl.ts
+++ b/modules/layers/src/text-layer/text-layer-collision.glsl.ts
@@ -1,0 +1,37 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// Shared by the background and character shaders so both test the same label footprint.
+export default /* glsl */ `
+#ifdef MODULE_COLLISION
+void text_setCollisionBounds(
+  vec3 worldPosition, vec3 position64Low, vec4 rect, vec2 pixelOffset,
+  float angle, vec4 clipRect, bool billboard, bool flipY
+) {
+  if (!collision.enabled) return;
+  collision_useBounds = true;
+  if (!collision.visibilityPass) return;
+  for (int i = 0; i < 4; i++) {
+    vec2 corner = vec2(i == 1 || i == 2 ? 1.0 : 0.0, i >= 2 ? 1.0 : 0.0);
+    vec2 offset = rotate_by_angle(rect.xy + corner * rect.zw, angle) + pixelOffset;
+    offset.y *= -1.0;
+    if (clipRect.z >= 0.0) offset.x = clipRect.x + corner.x * clipRect.z;
+    if (clipRect.w >= 0.0) offset.y = clipRect.y + corner.y * clipRect.w;
+    vec4 position;
+    if (billboard) {
+      position = project_position_to_clipspace(worldPosition, position64Low, vec3(0.0));
+      position.xy += project_pixel_size_to_clipspace(offset);
+    } else {
+      vec3 offsetCommon = vec3(project_pixel_size(offset), 0.0);
+      if (flipY) offsetCommon.y *= -1.0;
+      position = project_position_to_clipspace(worldPosition, position64Low, offsetCommon);
+    }
+    collision_corners[i] = (position.xy / position.w + 1.0) / 2.0;
+  }
+  // The projected corners' mean is inside the convex footprint, including under perspective.
+  vec2 center = (collision_corners[0] + collision_corners[1] + collision_corners[2] + collision_corners[3]) / 4.0;
+  collision_position = vec4(center * 2.0 - 1.0, 0.0, 1.0);
+}
+#endif
+`;

--- a/modules/layers/src/text-layer/text-layer.ts
+++ b/modules/layers/src/text-layer/text-layer.ts
@@ -26,7 +26,8 @@ import type {
   UpdateParameters,
   GetPickingInfoParams,
   PickingInfo,
-  DefaultProps
+  DefaultProps,
+  FilterContext
 } from '@deck.gl/core';
 
 const TEXT_ANCHOR = {
@@ -327,6 +328,25 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
     return info;
   }
 
+  /** Render one rectangle per label in the collision pass, and glyphs in other passes. */
+  filterSubLayer({layer, renderPass}: FilterContext): boolean {
+    if (!(this.props as {collisionEnabled?: boolean}).collisionEnabled) {
+      return true;
+    }
+    const isBackground = layer.id === `${this.id}-background`;
+    if (renderPass === 'collision') {
+      return this.hasBinaryCollisionAttributes() ? !isBackground : isBackground;
+    }
+    return !isBackground || this.props.background;
+  }
+
+  // Binary character attributes may be GPU buffers. Reuse them directly rather
+  // than reading them back to create per-label background attributes.
+  private hasBinaryCollisionAttributes(): boolean {
+    const attributes = (this.props.data as {attributes?: Record<string, unknown>}).attributes;
+    return Boolean(attributes && !attributes.background);
+  }
+
   /** Returns true if font has changed */
   private _updateFontAtlas(): boolean {
     const {fontSettings, fontFamily, fontWeight, _getFontRenderer} = this.props;
@@ -466,6 +486,35 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
     return [((anchorX - 1) * width) / 2, ((anchorY - 1) * height) / 2, width, height];
   };
 
+  /** Glyph bounds in font-atlas pixels, excluding whitespace and empty lines. */
+  private getCollisionRect: AccessorFunction<DataT, [number, number, number, number]> = (
+    object,
+    objectInfo
+  ) => {
+    if (this.props.background) {
+      return this.getBoundingRect(object, objectInfo);
+    }
+    const text = Array.from(this.state.getText!(object, objectInfo) || '');
+    const offsets = this.getIconOffsets(object, objectInfo);
+    const mapping = this.state.fontAtlasManager.mapping!;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (let i = 0; i < text.length; i++) {
+      const frame = mapping[text[i]];
+      if (!text[i].trim() || !frame || frame.width <= 0 || frame.height <= 0) continue;
+      // MultiIconLayer centers the glyph horizontally at its paragraph offset.
+      const x = offsets[i * 2] - frame.width / 2;
+      const y = offsets[i * 2 + 1] - frame.anchorY;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + frame.width);
+      maxY = Math.max(maxY, y + frame.height);
+    }
+    return Number.isFinite(minX) ? [minX, minY, maxX - minX, maxY - minY] : [0, 0, 0, 0];
+  };
+
   /** Returns the x, y offsets of each character in a text string, in texture size.
    * Used to layout characters in the vertex shader.
    */
@@ -541,20 +590,29 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
       updateTriggers
     } = this.props;
 
+    const collisionEnabled = Boolean((this.props as {collisionEnabled?: boolean}).collisionEnabled);
+    const layoutUpdateTriggers = {
+      getText: updateTriggers.getText,
+      getTextAnchor: [this.props.getTextAnchor, updateTriggers.getTextAnchor],
+      getAlignmentBaseline: [this.props.getAlignmentBaseline, updateTriggers.getAlignmentBaseline],
+      background,
+      styleVersion
+    };
+
     const CharactersLayerClass = this.getSubLayerClass('characters', MultiIconLayer);
     const BackgroundLayerClass = this.getSubLayerClass('background', TextBackgroundLayer);
     const {fontSize} = this.state.fontAtlasManager.props;
 
     return [
-      background &&
+      (background || (collisionEnabled && !this.hasBinaryCollisionAttributes())) &&
         new BackgroundLayerClass(
           {
             // background props
             getFillColor: getBackgroundColor,
             getLineColor: getBorderColor,
-            getLineWidth: getBorderWidth,
-            borderRadius: backgroundBorderRadius,
-            padding: backgroundPadding,
+            getLineWidth: background ? getBorderWidth : 0,
+            borderRadius: background ? backgroundBorderRadius : 0,
+            padding: background ? backgroundPadding : [0, 0, 0, 0],
 
             // props shared with characters layer
             getPosition,
@@ -589,12 +647,8 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
               getLineColor: updateTriggers.getBorderColor,
               getLineWidth: updateTriggers.getBorderWidth,
               getPixelOffset: updateTriggers.getPixelOffset,
-              getBoundingRect: {
-                getText: updateTriggers.getText,
-                getTextAnchor: updateTriggers.getTextAnchor,
-                getAlignmentBaseline: updateTriggers.getAlignmentBaseline,
-                styleVersion
-              }
+              getClipRect: updateTriggers.getContentBox,
+              getBoundingRect: layoutUpdateTriggers
             }
           }),
           {
@@ -607,7 +661,7 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
             _dataDiff,
             // Maintain the same background behavior as <=8.3. Remove in v9?
             autoHighlight: false,
-            getBoundingRect: this.getBoundingRect
+            getBoundingRect: collisionEnabled ? this.getCollisionRect : this.getBoundingRect
           }
         ),
       new CharactersLayerClass(
@@ -627,6 +681,7 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
           getAngle,
           getPixelOffset,
           getContentBox,
+          getCollisionRect: this.getCollisionRect,
 
           billboard,
           sizeScale,
@@ -657,11 +712,8 @@ export default class TextLayer<DataT = any, ExtraPropsT extends {} = {}> extends
             getSize: updateTriggers.getSize,
             getPixelOffset: updateTriggers.getPixelOffset,
             getContentBox: updateTriggers.getContentBox,
-            getIconOffsets: {
-              getTextAnchor: updateTriggers.getTextAnchor,
-              getAlignmentBaseline: updateTriggers.getAlignmentBaseline,
-              styleVersion
-            }
+            getCollisionRect: layoutUpdateTriggers,
+            getIconOffsets: layoutUpdateTriggers
           }
         }),
         {

--- a/test/apps/collision/README.md
+++ b/test/apps/collision/README.md
@@ -24,4 +24,4 @@ RENDER_TEST_DEVICE=webgl yarn test-render --reporter=dot test/render/text-collis
 
 The Benchmark button measures 150 animation frames after a 30-frame warmup while panning and zooming. It reports median and p95 frame intervals. For useful FPS measurements, use a foreground browser with hardware acceleration, keep the viewport and device pixel ratio fixed, and close other GPU workloads. Compare the same scene with collisions enabled and disabled. These timings include browser scheduling and may be capped by display refresh rate.
 
-The benchmark reports the number of visible labels alongside median and p95 frame times. Use the stress scene to check both packing and speed; rejected labels should leave room for separated neighbors. Toggle Anchor points to inspect text without the underlying grid of dots.
+The benchmark reports the number of visible labels alongside median and p95 frame times. Use the stress scene to check both packing and speed. Greedy placement (`collisionGreedy`, off by default) reuses space from rejected labels; disabling it restores GPU-only filtering for lower overhead. Toggle Anchor points to inspect text without the underlying grid of dots.

--- a/test/apps/collision/README.md
+++ b/test/apps/collision/README.md
@@ -16,7 +16,7 @@ Run the browser matrix with the server running:
 node test/apps/collision/test-text.mjs
 ```
 
-It checks 648 combinations of TextLayer/GeoJSON, billboard mode, anchor, baseline, offsets, zoom and reversed priority. At low zoom only the higher-priority member of each pair is pickable; at high zoom both separated labels are pickable. The render suite additionally checks sizing overrides, rotation, wrapping, clipping, outlines, backgrounds, narrow glyphs, and priority across separate layers:
+It checks 1,296 combinations of single-line/multiline scenes and TextLayer/GeoJSON, billboard mode, anchor, baseline, offsets, zoom and reversed priority. At low zoom only the higher-priority member of each pair is pickable; at high zoom both separated labels are pickable. For a hardware browser run on macOS, use `COLLISION_TEST_GPU=metal node test/apps/collision/test-text.mjs`. The render suite additionally checks sizing overrides, rotation, wrapping, clipping, outlines, backgrounds, narrow glyphs, and priority across separate layers:
 
 ```sh
 RENDER_TEST_DEVICE=webgl yarn test-render --reporter=dot test/render/text-collision.spec.ts

--- a/test/apps/collision/README.md
+++ b/test/apps/collision/README.md
@@ -23,3 +23,5 @@ RENDER_TEST_DEVICE=webgl yarn test-render --reporter=dot test/render/text-collis
 ```
 
 The Benchmark button measures 150 animation frames after a 30-frame warmup while panning and zooming. It reports median and p95 frame intervals. For useful FPS measurements, use a foreground browser with hardware acceleration, keep the viewport and device pixel ratio fixed, and close other GPU workloads. Compare the same scene with collisions enabled and disabled. These timings include browser scheduling and may be capped by display refresh rate.
+
+The benchmark reports the number of visible labels alongside median and p95 frame times. Use the stress scene to check both packing and speed; rejected labels should leave room for separated neighbors. Toggle Anchor points to inspect text without the underlying grid of dots.

--- a/test/apps/collision/README.md
+++ b/test/apps/collision/README.md
@@ -1,0 +1,25 @@
+# Collision development apps
+
+From the repository root, install dependencies with `yarn`, then run:
+
+```sh
+yarn vite test/apps/collision --config test/apps/vite.config.local.mjs --port 8080 --open false
+```
+
+Open [the text collision app](http://localhost:8080/text.html). It uses local synthetic data and needs no basemap, network data, or access token. The original geographic, CARTO, and mask examples remain at `/` and require their app dependencies and network access.
+
+The text app includes paired labels with explicit priorities, multiline and whitespace scenes, and a 10,000-label stress scene. Change anchors, baselines, offsets, rotation, size, collision scale, background, SDF, billboard mode, zoom, or device pixel ratio. Toggle GeoJSON to exercise the corresponding text accessors. Dots show unshifted geographic anchors. Use the mouse to pan and zoom; Reset view restores the camera.
+
+Run the browser matrix with the server running:
+
+```sh
+node test/apps/collision/test-text.mjs
+```
+
+It checks 648 combinations of TextLayer/GeoJSON, billboard mode, anchor, baseline, offsets, zoom and reversed priority. At low zoom only the higher-priority member of each pair is pickable; at high zoom both separated labels are pickable. The render suite additionally checks sizing overrides, rotation, wrapping, clipping, outlines, backgrounds, narrow glyphs, and priority across separate layers:
+
+```sh
+RENDER_TEST_DEVICE=webgl yarn test-render --reporter=dot test/render/text-collision.spec.ts
+```
+
+The Benchmark button measures 150 animation frames after a 30-frame warmup while panning and zooming. It reports median and p95 frame intervals. For useful FPS measurements, use a foreground browser with hardware acceleration, keep the viewport and device pixel ratio fixed, and close other GPU workloads. Compare the same scene with collisions enabled and disabled. These timings include browser scheduling and may be capped by display refresh rate.

--- a/test/apps/collision/README.md
+++ b/test/apps/collision/README.md
@@ -10,13 +10,17 @@ Open [the text collision app](http://localhost:8080/text.html). It uses local sy
 
 The text app includes paired labels with explicit priorities, multiline and whitespace scenes, and a 10,000-label stress scene. Change anchors, baselines, offsets, rotation, size, collision scale, background, SDF, billboard mode, zoom, or device pixel ratio. Toggle GeoJSON to exercise the corresponding text accessors. Dots show unshifted geographic anchors. Use the mouse to pan and zoom; Reset view restores the camera.
 
+Toggle **Two layers, shared group** to put the high- and low-priority labels in separate layers that share a collision group. This also works with GeoJSON text and the stress scene. Device pixel ratio supports fractional values, including 1.25 and 1.5.
+
+Font family and weight controls include `Inter, sans-serif` at weight 700. The selector uses fonts installed or already loaded in the page; selecting Inter does not download it. An unavailable family falls back according to its CSS font stack.
+
 Run the browser matrix with the server running:
 
 ```sh
 node test/apps/collision/test-text.mjs
 ```
 
-It checks 1,296 combinations of single-line/multiline scenes and TextLayer/GeoJSON, billboard mode, anchor, baseline, offsets, zoom and reversed priority. At low zoom only the higher-priority member of each pair is pickable; at high zoom both separated labels are pickable. For a hardware browser run on macOS, use `COLLISION_TEST_GPU=metal node test/apps/collision/test-text.mjs`. The render suite additionally checks sizing overrides, rotation, wrapping, clipping, outlines, backgrounds, narrow glyphs, and priority across separate layers:
+It checks 1,356 combinations of single-line/multiline scenes and TextLayer/GeoJSON, billboard mode, anchor, baseline, offsets, zoom and reversed priority, including both GPU-only filtering and CPU greedy placement across separate layers at pixel ratios 1, 1.5 and 2. The shared-group cases use priorities 1 and 0 to catch layer depth offsets overriding small priority differences. Geographic cases also check displayed pixels and picking at priorities 999, 1000 and -1000, where clipping-plane rounding can differ between hardware GPUs and software rendering. At low zoom only the higher-priority member of each pair is pickable; at high zoom both separated labels are pickable. For a hardware browser run on macOS, use `COLLISION_TEST_GPU=metal node test/apps/collision/test-text.mjs`. The render suite additionally checks sizing overrides, rotation, wrapping, clipping, outlines, backgrounds, narrow glyphs, and priority across separate layers:
 
 ```sh
 RENDER_TEST_DEVICE=webgl yarn test-render --reporter=dot test/render/text-collision.spec.ts
@@ -25,3 +29,9 @@ RENDER_TEST_DEVICE=webgl yarn test-render --reporter=dot test/render/text-collis
 The Benchmark button measures 150 animation frames after a 30-frame warmup while panning and zooming. It reports median and p95 frame intervals. For useful FPS measurements, use a foreground browser with hardware acceleration, keep the viewport and device pixel ratio fixed, and close other GPU workloads. Compare the same scene with collisions enabled and disabled. These timings include browser scheduling and may be capped by display refresh rate.
 
 The benchmark reports the number of visible labels alongside median and p95 frame times. Use the stress scene to check both packing and speed. Greedy placement (`collisionGreedy`, off by default) reuses space from rejected labels; disabling it restores GPU-only filtering for lower overhead. Toggle Anchor points to inspect text without the underlying grid of dots.
+
+## Comparing operating systems
+
+Serve the same checkout to both browsers by adding `--host 0.0.0.0` to the development server command, then open `http://<server-ip>:8080/text.html` from the other machine. Set `COLLISION_TEST_URL` to that URL when running the browser matrix against a remote server. Match the viewport, device pixel ratio, font settings and scene before comparing results.
+
+System fonts with the same family name can have different glyph metrics across operating systems. Collision rectangles follow those glyph bounds, so labels close to touching can produce different placements, especially with greedy placement in dense scenes. For a controlled comparison, load the same webfont file on both machines and wait for it to finish loading before creating the TextLayer. Font rasterization can still produce small differences in glyph bounds. Matching a family name such as `Arial` alone does not guarantee matching font metrics.

--- a/test/apps/collision/app.jsx
+++ b/test/apps/collision/app.jsx
@@ -36,6 +36,10 @@ export default function App() {
   const [showCarto, setShowCarto] = useState(false);
   const [showPoints, setShowPoints] = useState(true);
   const [showLabels, setShowLabels] = useState(false);
+  const [offsetX, setOffsetX] = useState(0);
+  const [offsetY, setOffsetY] = useState(0);
+  const [textAnchor, setTextAnchor] = useState('middle');
+  const [alignmentBaseline, setAlignmentBaseline] = useState('center');
   const [selectedCounty, selectCounty] = useState(null);
 
   const props = {
@@ -151,6 +155,9 @@ export default function App() {
         getColor: [0, 155, 0],
         getSize: 24,
         getPosition: f => f.geometry.coordinates,
+        getTextAnchor: textAnchor,
+        getAlignmentBaseline: alignmentBaseline,
+        getPixelOffset: [offsetX, offsetY],
         ...props,
 
         extensions: [new CollisionFilterExtension(), new MaskExtension()],
@@ -198,6 +205,55 @@ export default function App() {
           <input type="checkbox" checked={showLabels} onChange={() => setShowLabels(!showLabels)} />
           Show labels
         </label>
+        {showLabels && (
+          <>
+            <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+              <span style={{width: 72, whiteSpace: 'nowrap'}}>Anchor</span>
+              <select value={textAnchor} onChange={event => setTextAnchor(event.target.value)}>
+                <option value="start">start</option>
+                <option value="middle">middle</option>
+                <option value="end">end</option>
+              </select>
+            </div>
+            <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+              <span style={{width: 72, whiteSpace: 'nowrap'}}>Baseline</span>
+              <select
+                value={alignmentBaseline}
+                onChange={event => setAlignmentBaseline(event.target.value)}
+              >
+                <option value="top">top</option>
+                <option value="center">center</option>
+                <option value="bottom">bottom</option>
+              </select>
+            </div>
+            <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+              <span style={{width: 72, whiteSpace: 'nowrap'}}>Offset X</span>
+              <input
+                style={{width: 180}}
+                type="range"
+                min="-200"
+                max="200"
+                step="1"
+                value={offsetX}
+                onChange={event => setOffsetX(Number(event.target.value))}
+              />
+              <span style={{width: 40, textAlign: 'right'}}>{offsetX}</span>
+            </div>
+            <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+              <span style={{width: 72, whiteSpace: 'nowrap'}}>Offset Y</span>
+              <input
+                style={{width: 180}}
+                type="range"
+                min="-200"
+                max="200"
+                step="1"
+                value={offsetY}
+                onChange={event => setOffsetY(Number(event.target.value))}
+              />
+              <span style={{width: 40, textAlign: 'right'}}>{offsetY}</span>
+            </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/test/apps/collision/app.jsx
+++ b/test/apps/collision/app.jsx
@@ -40,6 +40,7 @@ export default function App() {
   const [offsetY, setOffsetY] = useState(0);
   const [textAnchor, setTextAnchor] = useState('middle');
   const [alignmentBaseline, setAlignmentBaseline] = useState('center');
+  const [textCollisionScale, setTextCollisionScale] = useState(1);
   const [selectedCounty, selectCounty] = useState(null);
 
   const props = {
@@ -165,7 +166,7 @@ export default function App() {
         collisionEnabled,
         collisionGroup: 'labels',
         collisionTestProps: {
-          sizeScale: 2 // Enlarge text to increase hit area
+          sizeScale: textCollisionScale
         },
         ...maskProps
       })
@@ -207,6 +208,22 @@ export default function App() {
         </label>
         {showLabels && (
           <>
+            <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+              <label htmlFor="text-collision-scale" style={{whiteSpace: 'nowrap'}}>
+                Collision scale
+              </label>
+              <input
+                id="text-collision-scale"
+                style={{width: 180}}
+                type="range"
+                min="1"
+                max="3"
+                step="0.1"
+                value={textCollisionScale}
+                onChange={event => setTextCollisionScale(Number(event.target.value))}
+              />
+              <span style={{width: 40, textAlign: 'right'}}>{textCollisionScale.toFixed(1)}×</span>
+            </div>
             <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
               <span style={{width: 72, whiteSpace: 'nowrap'}}>Anchor</span>
               <select value={textAnchor} onChange={event => setTextAnchor(event.target.value)}>

--- a/test/apps/collision/app.jsx
+++ b/test/apps/collision/app.jsx
@@ -32,6 +32,7 @@ const cartoData = vectorTableSource({
 /* eslint-disable react/no-deprecated */
 export default function App() {
   const [collisionEnabled, setCollisionEnabled] = useState(true);
+  const [collisionGreedy, setCollisionGreedy] = useState(false);
   const [maskEnabled, setMaskEnabled] = useState(false);
   const [showCarto, setShowCarto] = useState(false);
   const [showPoints, setShowPoints] = useState(true);
@@ -164,6 +165,7 @@ export default function App() {
         extensions: [new CollisionFilterExtension(), new MaskExtension()],
         getCollisionPriority: d => -d.properties.scalerank,
         collisionEnabled,
+        collisionGreedy,
         collisionGroup: 'labels',
         collisionTestProps: {
           sizeScale: textCollisionScale
@@ -208,6 +210,16 @@ export default function App() {
         </label>
         {showLabels && (
           <>
+            <div>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={collisionGreedy}
+                  onChange={event => setCollisionGreedy(event.target.checked)}
+                />
+                Greedy placement
+              </label>
+            </div>
             <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
               <label htmlFor="text-collision-scale" style={{whiteSpace: 'nowrap'}}>
                 Collision scale

--- a/test/apps/collision/index.html
+++ b/test/apps/collision/index.html
@@ -21,6 +21,7 @@
     </head>
     <body>
         <div id="app"></div>
+        <a href="text.html" style="position: absolute; bottom: 16px; left: 16px; background: white; padding: 8px">Text collision development</a>
     </body>
     <script type="module" src="app.jsx"></script>
 </html>

--- a/test/apps/collision/test-text.mjs
+++ b/test/apps/collision/test-text.mjs
@@ -1,0 +1,71 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// Start the local app first, then run: node test/apps/collision/test-text.mjs
+import assert from 'node:assert/strict';
+import {chromium} from 'playwright';
+
+const browser = await chromium.launch({headless: true});
+const page = await browser.newPage({viewport: {width: 1200, height: 800}});
+const errors = [];
+page.on('pageerror', error => errors.push(error.message));
+page.on('console', message => {
+  if (message.type() === 'error') errors.push(message.text());
+});
+let count = 0;
+try {
+  await page.goto('http://localhost:8080/text.html');
+  await page.waitForFunction(() => window.collisionTest?.deck.isInitialized);
+  await page.waitForTimeout(500);
+  for (const geojson of [false, true]) {
+    for (const billboard of [true, false]) {
+      for (const anchor of ['start', 'middle', 'end']) {
+        for (const baseline of ['top', 'center', 'bottom']) {
+          for (const [offsetX, offsetY] of [
+            [0, 0],
+            [100, -70],
+            [-100, 70]
+          ]) {
+            for (const zoom of [-1, 0, 3]) {
+              for (const reversePriority of [false, true]) {
+                const settings = {
+                  geojson,
+                  billboard,
+                  anchor,
+                  baseline,
+                  offsetX,
+                  offsetY,
+                  reversePriority
+                };
+                const indexes = await page.evaluate(
+                  async ({settings, zoom}) => {
+                    const {deck, settings: current, update} = window.collisionTest;
+                    Object.assign(current, settings);
+                    update();
+                    deck.setProps({viewState: {target: [150, -180, 0], zoom}});
+                    await new Promise(requestAnimationFrame);
+                    deck.redraw('collision assertion');
+                    return deck
+                      .pickObjects({x: 0, y: 0, width: 1200, height: 800})
+                      .map(({object}) => (object.properties || object).index)
+                      .filter(index => index < 2)
+                      .sort();
+                  },
+                  {settings, zoom}
+                );
+                const expected = zoom === 3 ? [0, 1] : [reversePriority ? 1 : 0];
+                assert.deepEqual(indexes, expected, JSON.stringify({...settings, zoom}));
+                count++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  assert.deepEqual(errors, [], 'Browser errors');
+  console.log(`Passed ${count} text collision combinations.`);
+} finally {
+  await browser.close();
+}

--- a/test/apps/collision/test-text.mjs
+++ b/test/apps/collision/test-text.mjs
@@ -120,6 +120,30 @@ try {
       assert.equal(green > 0, zoom === 2.8 || !reversePriority, `Green pixels: zoom=${zoom}`);
     }
   }
+  // Dense chains must leave room for many separated labels, at either priority order.
+  await page.selectOption('#scene', 'stress');
+  for (const reversePriority of [false, true]) {
+    for (const zoom of [-5, -4, -3]) {
+      const visible = await page.evaluate(
+        async ({reversePriority, zoom}) => {
+          const {deck, settings, update} = window.collisionTest;
+          Object.assign(settings, {reversePriority, angle: 0, collisionScale: 1});
+          update();
+          deck.setProps({viewState: {target: [11040, 2025, 0], zoom}});
+          await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          return (await deck.pickObjectsAsync({x: 0, y: 0, width: 1200, height: 800})).map(
+            ({object}) => ({high: object.high, index: object.index})
+          );
+        },
+        {reversePriority, zoom}
+      );
+      assert.ok(visible.length >= 30, `Dense packing: zoom=${zoom}, count=${visible.length}`);
+      assert.ok(
+        visible.every(label => label.high !== reversePriority),
+        'Dense packing priorities'
+      );
+    }
+  }
   assert.deepEqual(errors, [], 'Browser errors');
   console.log(`Passed ${count} text collision combinations.`);
 } finally {

--- a/test/apps/collision/test-text.mjs
+++ b/test/apps/collision/test-text.mjs
@@ -5,8 +5,13 @@
 // Start the local app first, then run: node test/apps/collision/test-text.mjs
 import assert from 'node:assert/strict';
 import {chromium} from 'playwright';
+import {PNG} from 'pngjs';
 
-const browser = await chromium.launch({headless: true});
+const gpu = process.env.COLLISION_TEST_GPU;
+const browser = await chromium.launch({
+  headless: !gpu,
+  args: gpu ? [`--use-angle=${gpu}`] : []
+});
 const page = await browser.newPage({viewport: {width: 1200, height: 800}});
 const errors = [];
 page.on('pageerror', error => errors.push(error.message));
@@ -18,50 +23,101 @@ try {
   await page.goto('http://localhost:8080/text.html');
   await page.waitForFunction(() => window.collisionTest?.deck.isInitialized);
   await page.waitForTimeout(500);
-  for (const geojson of [false, true]) {
-    for (const billboard of [true, false]) {
-      for (const anchor of ['start', 'middle', 'end']) {
-        for (const baseline of ['top', 'center', 'bottom']) {
-          for (const [offsetX, offsetY] of [
-            [0, 0],
-            [100, -70],
-            [-100, 70]
-          ]) {
-            for (const zoom of [-1, 0, 3]) {
-              for (const reversePriority of [false, true]) {
-                const settings = {
-                  geojson,
-                  billboard,
-                  anchor,
-                  baseline,
-                  offsetX,
-                  offsetY,
-                  reversePriority
-                };
-                const indexes = await page.evaluate(
-                  async ({settings, zoom}) => {
-                    const {deck, settings: current, update} = window.collisionTest;
-                    Object.assign(current, settings);
-                    update();
-                    deck.setProps({viewState: {target: [150, -180, 0], zoom}});
-                    await new Promise(requestAnimationFrame);
-                    deck.redraw('collision assertion');
-                    return deck
-                      .pickObjects({x: 0, y: 0, width: 1200, height: 800})
-                      .map(({object}) => (object.properties || object).index)
-                      .filter(index => index < 2)
-                      .sort();
-                  },
-                  {settings, zoom}
-                );
-                const expected = zoom === 3 ? [0, 1] : [reversePriority ? 1 : 0];
-                assert.deepEqual(indexes, expected, JSON.stringify({...settings, zoom}));
-                count++;
+  for (const scene of ['pairs', 'multiline']) {
+    await page.selectOption('#scene', scene);
+    for (const geojson of [false, true]) {
+      for (const billboard of [true, false]) {
+        for (const anchor of ['start', 'middle', 'end']) {
+          for (const baseline of ['top', 'center', 'bottom']) {
+            for (const [offsetX, offsetY] of [
+              [0, 0],
+              [100, -70],
+              [-100, 70]
+            ]) {
+              // Keep neighboring pairs separate; multiline labels are wider than the single-line scene.
+              for (const zoom of [scene === 'multiline' ? -0.5 : -1, 0, 3]) {
+                for (const reversePriority of [false, true]) {
+                  const settings = {
+                    geojson,
+                    billboard,
+                    anchor,
+                    baseline,
+                    offsetX,
+                    offsetY,
+                    reversePriority
+                  };
+                  const indexes = await page.evaluate(
+                    async ({settings, zoom}) => {
+                      const {deck, settings: current, update} = window.collisionTest;
+                      Object.assign(current, settings);
+                      update();
+                      deck.setProps({viewState: {target: [150, -180, 0], zoom}});
+                      await new Promise(resolve => {
+                        const onAfterRender = deck.props.onAfterRender;
+                        deck.setProps({
+                          onAfterRender: () => {
+                            if (deck.props.layers.every(layer => layer.isLoaded)) {
+                              deck.setProps({onAfterRender});
+                              resolve();
+                            }
+                          }
+                        });
+                        deck.redraw('collision assertion');
+                      });
+                      return deck
+                        .pickObjects({x: 0, y: 0, width: 1200, height: 800})
+                        .map(({object}) => (object.properties || object).index)
+                        .filter(index => index < 2)
+                        .sort();
+                    },
+                    {settings, zoom}
+                  );
+                  const expected = zoom === 3 ? [0, 1] : [reversePriority ? 1 : 0];
+                  assert.deepEqual(indexes, expected, JSON.stringify({scene, ...settings, zoom}));
+                  count++;
+                }
               }
             }
           }
         }
       }
+    }
+  }
+  // Check displayed pixels as well as picking: the screen and picking passes must agree.
+  for (const reversePriority of [false, true]) {
+    for (const zoom of [2.4, 2.8]) {
+      await page.evaluate(
+        ({reversePriority, zoom}) => {
+          const {deck, settings, update} = window.collisionTest;
+          Object.assign(settings, {
+            geojson: false,
+            billboard: true,
+            anchor: 'middle',
+            baseline: 'center',
+            offsetX: 0,
+            offsetY: 0,
+            reversePriority
+          });
+          update();
+          deck.setProps({viewState: {target: [160, -180, 0], zoom}});
+        },
+        {reversePriority, zoom}
+      );
+      await page.evaluate(
+        () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+      );
+      const png = PNG.sync.read(
+        await page.screenshot({clip: {x: 400, y: 300, width: 400, height: 200}})
+      );
+      let red = 0;
+      let green = 0;
+      for (let i = 0; i < png.data.length; i += 4) {
+        const [r, g, b] = png.data.subarray(i, i + 3);
+        if (r > g * 1.4 && r > b * 1.4) red++;
+        if (g > r * 1.4 && g > b * 1.4) green++;
+      }
+      assert.equal(red > 0, zoom === 2.8 || reversePriority, `Red pixels: zoom=${zoom}`);
+      assert.equal(green > 0, zoom === 2.8 || !reversePriority, `Green pixels: zoom=${zoom}`);
     }
   }
   assert.deepEqual(errors, [], 'Browser errors');

--- a/test/apps/collision/test-text.mjs
+++ b/test/apps/collision/test-text.mjs
@@ -20,7 +20,7 @@ page.on('console', message => {
 });
 let count = 0;
 try {
-  await page.goto('http://localhost:8080/text.html');
+  await page.goto(process.env.COLLISION_TEST_URL || 'http://localhost:8080/text.html');
   await page.waitForFunction(() => window.collisionTest?.deck.isInitialized);
   await page.waitForTimeout(500);
   for (const scene of ['pairs', 'multiline']) {
@@ -120,6 +120,74 @@ try {
       assert.equal(green > 0, zoom === 2.8 || !reversePriority, `Green pixels: zoom=${zoom}`);
     }
   }
+  // The same multiline pairs must collide when their members belong to separate layers.
+  await page.check('#splitLayers');
+  for (const collisionGreedy of [false, true]) {
+    for (const geojson of [true, false]) {
+      for (const devicePixels of [1, 1.5, 2]) {
+        for (const reversePriority of [false, true]) {
+          for (const zoom of [0, 3]) {
+            const actual = await page.evaluate(
+              async ({geojson, devicePixels, reversePriority, zoom, collisionGreedy}) => {
+                const {deck, settings, update} = window.collisionTest;
+                Object.assign(settings, {
+                  geojson,
+                  devicePixels,
+                  reversePriority,
+                  collisionGreedy
+                });
+                update();
+                // A one-point priority gap must win over the default layer depth offsets.
+                deck.setProps({
+                  layers: deck.props.layers.map(layer =>
+                    layer.clone({
+                      getCollisionPriority: object =>
+                        (object.properties || object).high !== reversePriority ? 1 : 0
+                    })
+                  )
+                });
+                deck.setProps({viewState: {target: [160, -180, 0], zoom}});
+                await new Promise(resolve => {
+                  deck.setProps({
+                    onAfterRender: () => {
+                      if (deck.props.layers.every(layer => layer.isLoaded)) {
+                        deck.setProps({onAfterRender: () => {}});
+                        resolve();
+                      }
+                    }
+                  });
+                  deck.redraw('shared group assertion');
+                });
+                return (await deck.pickObjectsAsync({x: 0, y: 0, width: 1200, height: 800}))
+                  .map(({object}) => (object.properties || object).index)
+                  .filter(index => index < 2)
+                  .sort();
+              },
+              {geojson, devicePixels, reversePriority, zoom, collisionGreedy}
+            );
+            assert.deepEqual(
+              actual,
+              zoom === 3 ? [0, 1] : [reversePriority ? 1 : 0],
+              JSON.stringify({
+                splitLayers: true,
+                geojson,
+                devicePixels,
+                reversePriority,
+                zoom,
+                collisionGreedy
+              })
+            );
+            count++;
+          }
+        }
+      }
+    }
+  }
+  await page.uncheck('#splitLayers');
+  await page.evaluate(() => {
+    window.collisionTest.settings.devicePixels = 1;
+    window.collisionTest.update();
+  });
   // Dense chains must leave room for many separated labels, at either priority order.
   await page.selectOption('#scene', 'stress');
   for (const reversePriority of [false, true]) {
@@ -135,7 +203,17 @@ try {
           });
           update();
           deck.setProps({viewState: {target: [11040, 2025, 0], zoom}});
-          await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          await new Promise(resolve => {
+            deck.setProps({
+              onAfterRender: () => {
+                if (deck.props.layers.every(layer => layer.isLoaded)) {
+                  deck.setProps({onAfterRender: () => {}});
+                  resolve();
+                }
+              }
+            });
+            deck.redraw('dense packing assertion');
+          });
           return (await deck.pickObjectsAsync({x: 0, y: 0, width: 1200, height: 800})).map(
             ({object}) => ({high: object.high, index: object.index})
           );
@@ -155,10 +233,140 @@ try {
   const fastCount = await page.evaluate(async () => {
     const {deck} = window.collisionTest;
     deck.setProps({viewState: {target: [11040, 2025, 0], zoom: -5}});
-    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    await new Promise(resolve => {
+      deck.setProps({
+        onAfterRender: () => {
+          if (deck.props.layers.every(layer => layer.isLoaded)) {
+            deck.setProps({onAfterRender: () => {}});
+            resolve();
+          }
+        }
+      });
+      deck.redraw('GPU-only assertion');
+    });
     return (await deck.pickObjectsAsync({x: 0, y: 0, width: 1200, height: 800})).length;
   });
   assert.equal(fastCount, 1, 'GPU-only overlap-chain behavior');
+  // Priority endpoints must stay inside the clipping planes on hardware GPUs.
+  for (const priority of [999, 1000, -1000]) {
+    for (const collisionGreedy of [false, true]) {
+      for (const splitLayers of [false, true]) {
+        const actual = await page.evaluate(
+          async ({priority, collisionGreedy, splitLayers}) => {
+            const {deck, MapView} = window.collisionTest;
+            const source = deck.props.layers.find(
+              layer => layer.constructor.layerName === 'TextLayer'
+            );
+            const TextLayer = source.constructor;
+            const data = [
+              {
+                index: 0,
+                text: 'Short label',
+                position: [0, 0],
+                size: 23,
+                offset: [0, -20.5],
+                baseline: 'bottom',
+                priority
+              },
+              {
+                index: 1,
+                text: 'Long label with several words wrapping onto three lines',
+                position: [0.0597593335, 0.006976],
+                size: 26,
+                offset: [0, 0],
+                baseline: 'center',
+                priority
+              }
+            ];
+            const props = {
+              ...source.props,
+              id: 'priority-boundary',
+              data,
+              collisionGreedy,
+              coordinateSystem: 'lnglat',
+              fontFamily: 'Arial',
+              fontWeight: 700,
+              maxWidth: 10,
+              wordBreak: 'break-word',
+              lineHeight: 1,
+              getPosition: d => d.position,
+              getText: d => d.text,
+              getSize: d => d.size,
+              getCollisionPriority: d => d.priority,
+              getPixelOffset: d => d.offset,
+              getAlignmentBaseline: d => d.baseline,
+              getTextAnchor: 'middle',
+              getAngle: 0,
+              collisionTestProps: {},
+              updateTriggers: {},
+              getColor: d => (d.index ? [0, 145, 85] : [215, 55, 45])
+            };
+            const layers = splitLayers
+              ? data.map(
+                  d => new TextLayer({...props, id: `priority-boundary-${d.index}`, data: [d]})
+                )
+              : [new TextLayer(props)];
+            let screen;
+            await new Promise(resolve => {
+              deck.setProps({
+                layers,
+                views: new MapView({id: 'main'}),
+                // Preserve the fractional viewport that reproduced near-plane clipping on D3D11.
+                width: 1109.328125,
+                height: 975.328125,
+                useDevicePixels: 1.5,
+                viewState: {
+                  longitude: 0,
+                  latitude: 0,
+                  zoom: 10.42516610807454,
+                  pitch: 0,
+                  bearing: 0
+                },
+                onAfterRender: () => {
+                  if (!layers.every(layer => layer.isLoaded)) return;
+                  const gl = deck.device.gl;
+                  const pixels = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
+                  gl.readPixels(
+                    0,
+                    0,
+                    gl.drawingBufferWidth,
+                    gl.drawingBufferHeight,
+                    gl.RGBA,
+                    gl.UNSIGNED_BYTE,
+                    pixels
+                  );
+                  let red = 0;
+                  let green = 0;
+                  for (let i = 0; i < pixels.length; i += 4) {
+                    const [r, g, b] = pixels.subarray(i, i + 3);
+                    if (r > g * 1.4 && r > b * 1.4) red++;
+                    if (g > r * 1.4 && g > b * 1.4) green++;
+                  }
+                  screen = [...(red ? [0] : []), ...(green ? [1] : [])];
+                  deck.setProps({onAfterRender: () => {}});
+                  resolve();
+                }
+              });
+              deck.redraw('priority boundary assertion');
+            });
+            const visible = (
+              await deck.pickObjectsAsync({x: 0, y: 0, width: deck.width, height: deck.height})
+            )
+              .map(({object}) => object.index)
+              .sort();
+            return {visible, screen};
+          },
+          {priority, collisionGreedy, splitLayers}
+        );
+        assert.deepEqual(
+          actual,
+          {visible: [1], screen: [1]},
+          JSON.stringify({priority, collisionGreedy, splitLayers})
+        );
+        count++;
+      }
+    }
+  }
   assert.deepEqual(errors, [], 'Browser errors');
   console.log(`Passed ${count} text collision combinations.`);
 } finally {

--- a/test/apps/collision/test-text.mjs
+++ b/test/apps/collision/test-text.mjs
@@ -127,7 +127,12 @@ try {
       const visible = await page.evaluate(
         async ({reversePriority, zoom}) => {
           const {deck, settings, update} = window.collisionTest;
-          Object.assign(settings, {reversePriority, angle: 0, collisionScale: 1});
+          Object.assign(settings, {
+            reversePriority,
+            angle: 0,
+            collisionScale: 1,
+            collisionGreedy: true
+          });
           update();
           deck.setProps({viewState: {target: [11040, 2025, 0], zoom}});
           await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
@@ -144,6 +149,16 @@ try {
       );
     }
   }
+  // Toggling back restores the GPU-only path without recreating the layer.
+  await page.check('#collisionGreedy');
+  await page.uncheck('#collisionGreedy');
+  const fastCount = await page.evaluate(async () => {
+    const {deck} = window.collisionTest;
+    deck.setProps({viewState: {target: [11040, 2025, 0], zoom: -5}});
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    return (await deck.pickObjectsAsync({x: 0, y: 0, width: 1200, height: 800})).length;
+  });
+  assert.equal(fastCount, 1, 'GPU-only overlap-chain behavior');
   assert.deepEqual(errors, [], 'Browser errors');
   console.log(`Passed ${count} text collision combinations.`);
 } finally {

--- a/test/apps/collision/text.html
+++ b/test/apps/collision/text.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Text collision development</title>
+    <style>
+      body {margin: 0; font: 13px system-ui; background: #f4f6f8;}
+      aside {position: absolute; top: 12px; left: 12px; width: 250px; padding: 16px; background: white; border-radius: 8px; max-height: calc(100vh - 56px); overflow: auto;}
+      label {display: flex; justify-content: space-between; align-items: center; margin: 9px 0; gap: 8px;}
+      input[type=range] {width: 125px;}
+      select {max-width: 150px;}
+      h1 {font-size: 17px; margin: 0 0 10px;}
+      p, output {line-height: 1.5;}
+      button {margin-right: 8px;}
+    </style>
+  </head>
+  <body>
+    <canvas id="deck"></canvas>
+    <aside>
+      <h1>Text collision development</h1>
+      <p>Green labels have higher priority; red labels should disappear when they overlap. Dots mark geographic anchors.</p>
+      <div id="controls"></div>
+      <button id="reset">Reset view</button><button id="benchmark">Benchmark</button>
+      <p><output id="metrics">Ready</output></p>
+      <a href="/">Geographic / mask examples</a>
+    </aside>
+    <script type="module" src="text.js"></script>
+  </body>
+</html>

--- a/test/apps/collision/text.html
+++ b/test/apps/collision/text.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:," />
     <title>Text collision development</title>
     <style>
       body {margin: 0; font: 13px system-ui; background: #f4f6f8;}

--- a/test/apps/collision/text.js
+++ b/test/apps/collision/text.js
@@ -12,6 +12,7 @@ const settings = {
   scene: 'pairs',
   geojson: false,
   collisionEnabled: true,
+  showAnchors: true,
   reversePriority: false,
   anchor: 'middle',
   baseline: 'center',
@@ -92,6 +93,7 @@ function getLayers() {
   return [
     new ScatterplotLayer({
       id: 'anchors',
+      visible: settings.showAnchors,
       data,
       getPosition: d => d.position,
       getRadius: 3,
@@ -180,6 +182,7 @@ function addControl(key, title, options) {
   label.append(input);
   controls.append(label);
 }
+addControl('showAnchors', 'Anchor points');
 addControl('scene', 'Scene', ['pairs', 'multiline', 'whitespace', 'stress']);
 addControl('geojson', 'GeoJSON text');
 addControl('collisionEnabled', 'Collisions');
@@ -227,15 +230,19 @@ async function benchmark() {
       }
     });
   }
+  const visibleLabels = (
+    await deck.pickObjectsAsync({x: 0, y: 0, width: deck.width, height: deck.height})
+  ).length;
   deck.setProps({viewState: null, initialViewState: getSceneViewState()});
   samples.sort((a, b) => a - b);
   const result = {
     labels: data.length,
+    visibleLabels,
     medianMs: samples[Math.floor(samples.length / 2)],
     p95Ms: samples[Math.floor(samples.length * 0.95)]
   };
   document.getElementById('metrics').textContent =
-    `${result.labels} labels: median ${result.medianMs.toFixed(1)} ms, p95 ${result.p95Ms.toFixed(1)} ms`;
+    `${result.visibleLabels} / ${result.labels} labels visible: median ${result.medianMs.toFixed(1)} ms, p95 ${result.p95Ms.toFixed(1)} ms`;
   return result;
 }
 document.getElementById('benchmark').onclick = benchmark;

--- a/test/apps/collision/text.js
+++ b/test/apps/collision/text.js
@@ -169,7 +169,10 @@ function addControl(key, title, options) {
           ? Number(input.value)
           : input.value;
     if (typeof settings[key] === 'number') caption.textContent = `${title}: ${settings[key]}`;
-    if (key === 'scene') updateData();
+    if (key === 'scene') {
+      updateData();
+      resetView();
+    }
     if (key === 'zoom')
       deck.setProps({initialViewState: {...initialViewState, zoom: settings.zoom}});
     update();
@@ -188,15 +191,28 @@ addControl('offsetY', 'Offset Y', {min: -200, max: 200, step: 1});
 addControl('angle', 'Angle', {min: -180, max: 180, step: 15});
 addControl('size', 'Size', {min: 8, max: 64, step: 1});
 addControl('collisionScale', 'Collision scale', {min: 1, max: 3, step: 0.25});
-addControl('zoom', 'Zoom', {min: -2, max: 3, step: 0.1});
+addControl('zoom', 'Zoom', {min: -5, max: 3, step: 0.1});
 addControl('devicePixels', 'Device pixel ratio', {min: 1, max: 2, step: 1});
 addControl('background', 'Background');
 addControl('billboard', 'Billboard');
 addControl('sdf', 'SDF');
-document.getElementById('reset').onclick = () => deck.setProps({initialViewState});
+function getSceneViewState() {
+  return settings.scene === 'stress' ? {target: [11040, 2025, 0], zoom: -5} : initialViewState;
+}
+
+function resetView() {
+  const viewState = getSceneViewState();
+  settings.zoom = viewState.zoom;
+  const zoomInput = document.getElementById('zoom');
+  zoomInput.value = settings.zoom;
+  zoomInput.parentElement.firstChild.textContent = `Zoom: ${settings.zoom}`;
+  deck.setProps({initialViewState: viewState});
+}
+document.getElementById('reset').onclick = resetView;
 
 async function benchmark() {
   const samples = [];
+  const {target} = getSceneViewState();
   const start = performance.now();
   let previous = start;
   for (let frame = 0; frame < 180; frame++) {
@@ -205,10 +221,13 @@ async function benchmark() {
     if (frame >= 30) samples.push(now - previous);
     previous = now;
     deck.setProps({
-      viewState: {target: [frame * 0.5, 0, 0], zoom: settings.zoom + Math.sin(frame / 30) * 0.2}
+      viewState: {
+        target: [target[0] + frame * 0.5, target[1], 0],
+        zoom: settings.zoom + Math.sin(frame / 30) * 0.2
+      }
     });
   }
-  deck.setProps({viewState: null, initialViewState});
+  deck.setProps({viewState: null, initialViewState: getSceneViewState()});
   samples.sort((a, b) => a - b);
   const result = {
     labels: data.length,

--- a/test/apps/collision/text.js
+++ b/test/apps/collision/text.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, OrthographicView, COORDINATE_SYSTEM} from '@deck.gl/core';
+import {Deck, MapView, OrthographicView, COORDINATE_SYSTEM} from '@deck.gl/core';
 import {TextLayer, GeoJsonLayer, ScatterplotLayer} from '@deck.gl/layers';
 import {CollisionFilterExtension} from '@deck.gl/extensions';
 
@@ -11,6 +11,7 @@ const initialViewState = {target: [0, 0, 0], zoom: 0};
 const settings = {
   scene: 'pairs',
   geojson: false,
+  splitLayers: false,
   collisionEnabled: true,
   collisionGreedy: false,
   showAnchors: true,
@@ -21,6 +22,8 @@ const settings = {
   offsetY: 0,
   angle: 0,
   size: 24,
+  fontFamily: 'Arial',
+  fontWeight: 400,
   collisionScale: 1,
   background: false,
   billboard: true,
@@ -81,12 +84,14 @@ function getLayers() {
     billboard: settings.billboard,
     background: settings.background,
     getBackgroundColor: [210, 220, 230],
-    fontFamily: 'Arial',
+    fontFamily: settings.fontFamily,
+    fontWeight: settings.fontWeight,
     fontSettings: {sdf: settings.sdf},
     extensions,
     getCollisionPriority: getPriority,
     collisionEnabled: settings.collisionEnabled,
     collisionGreedy: settings.collisionGreedy,
+    collisionGroup: 'labels',
     collisionTestProps: {sizeScale: settings.collisionScale},
     updateTriggers: {getCollisionPriority: settings.reversePriority},
     pickable: true,
@@ -102,26 +107,42 @@ function getLayers() {
       radiusUnits: 'pixels',
       getFillColor: [80, 90, 100]
     }),
-    settings.geojson
-      ? new GeoJsonLayer({
-          ...textProps,
-          id: 'labels',
-          data: geojson,
-          pointType: 'text',
-          getText: f => f.properties.text,
-          getTextColor: f => getColor(f.properties),
-          getTextSize: settings.size,
-          getTextAnchor: settings.anchor,
-          getTextAlignmentBaseline: settings.baseline,
-          getTextPixelOffset: [settings.offsetX, settings.offsetY],
-          getTextAngle: settings.angle,
-          textBillboard: settings.billboard,
-          textBackground: settings.background,
-          textFontFamily: 'Arial',
-          textFontSettings: {sdf: settings.sdf},
-          getCollisionPriority: f => getPriority(f.properties)
-        })
-      : new TextLayer({...textProps, id: 'labels', data})
+    ...(settings.splitLayers ? [0, 1] : [null]).map(group => {
+      // Different layer classes must not inherit each other's state when toggling GeoJSON.
+      const prefix = settings.geojson ? 'geojson-labels' : 'labels';
+      const id = group === null ? prefix : `${prefix}-${group}`;
+      return settings.geojson
+        ? new GeoJsonLayer({
+            ...textProps,
+            id,
+            data:
+              group === null
+                ? geojson
+                : {
+                    ...geojson,
+                    features: geojson.features.filter((_, index) => index % 2 === group)
+                  },
+            pointType: 'text',
+            getText: f => f.properties.text,
+            getTextColor: f => getColor(f.properties),
+            getTextSize: settings.size,
+            getTextAnchor: settings.anchor,
+            getTextAlignmentBaseline: settings.baseline,
+            getTextPixelOffset: [settings.offsetX, settings.offsetY],
+            getTextAngle: settings.angle,
+            textBillboard: settings.billboard,
+            textBackground: settings.background,
+            textFontFamily: settings.fontFamily,
+            textFontWeight: settings.fontWeight,
+            textFontSettings: {sdf: settings.sdf},
+            getCollisionPriority: f => getPriority(f.properties)
+          })
+        : new TextLayer({
+            ...textProps,
+            id,
+            data: group === null ? data : data.filter((_, index) => index % 2 === group)
+          });
+    })
   ];
 }
 
@@ -187,6 +208,7 @@ function addControl(key, title, options) {
 addControl('showAnchors', 'Anchor points');
 addControl('scene', 'Scene', ['pairs', 'multiline', 'whitespace', 'stress']);
 addControl('geojson', 'GeoJSON text');
+addControl('splitLayers', 'Two layers, shared group');
 addControl('collisionEnabled', 'Collisions');
 addControl('collisionGreedy', 'Greedy placement');
 addControl('reversePriority', 'Reverse priority');
@@ -196,9 +218,11 @@ addControl('offsetX', 'Offset X', {min: -200, max: 200, step: 1});
 addControl('offsetY', 'Offset Y', {min: -200, max: 200, step: 1});
 addControl('angle', 'Angle', {min: -180, max: 180, step: 15});
 addControl('size', 'Size', {min: 8, max: 64, step: 1});
+addControl('fontFamily', 'Font family', ['Arial', 'Inter, sans-serif', 'sans-serif', 'monospace']);
+addControl('fontWeight', 'Font weight', [400, 700]);
 addControl('collisionScale', 'Collision scale', {min: 1, max: 3, step: 0.25});
 addControl('zoom', 'Zoom', {min: -5, max: 3, step: 0.1});
-addControl('devicePixels', 'Device pixel ratio', {min: 1, max: 2, step: 1});
+addControl('devicePixels', 'Device pixel ratio', {min: 1, max: 2, step: 0.25});
 addControl('background', 'Background');
 addControl('billboard', 'Billboard');
 addControl('sdf', 'SDF');
@@ -241,6 +265,7 @@ async function benchmark() {
   const result = {
     labels: data.length,
     collisionGreedy: settings.collisionGreedy,
+    splitLayers: settings.splitLayers,
     visibleLabels,
     medianMs: samples[Math.floor(samples.length / 2)],
     p95Ms: samples[Math.floor(samples.length * 0.95)]
@@ -251,4 +276,4 @@ async function benchmark() {
 }
 document.getElementById('benchmark').onclick = benchmark;
 // Development/automation API: stable data, explicit updates, and repeatable camera motion.
-window.collisionTest = {deck, settings, update, benchmark};
+window.collisionTest = {deck, settings, update, benchmark, MapView};

--- a/test/apps/collision/text.js
+++ b/test/apps/collision/text.js
@@ -12,6 +12,7 @@ const settings = {
   scene: 'pairs',
   geojson: false,
   collisionEnabled: true,
+  collisionGreedy: false,
   showAnchors: true,
   reversePriority: false,
   anchor: 'middle',
@@ -85,6 +86,7 @@ function getLayers() {
     extensions,
     getCollisionPriority: getPriority,
     collisionEnabled: settings.collisionEnabled,
+    collisionGreedy: settings.collisionGreedy,
     collisionTestProps: {sizeScale: settings.collisionScale},
     updateTriggers: {getCollisionPriority: settings.reversePriority},
     pickable: true,
@@ -186,6 +188,7 @@ addControl('showAnchors', 'Anchor points');
 addControl('scene', 'Scene', ['pairs', 'multiline', 'whitespace', 'stress']);
 addControl('geojson', 'GeoJSON text');
 addControl('collisionEnabled', 'Collisions');
+addControl('collisionGreedy', 'Greedy placement');
 addControl('reversePriority', 'Reverse priority');
 addControl('anchor', 'Anchor', ['start', 'middle', 'end']);
 addControl('baseline', 'Baseline', ['top', 'center', 'bottom']);
@@ -237,6 +240,7 @@ async function benchmark() {
   samples.sort((a, b) => a - b);
   const result = {
     labels: data.length,
+    collisionGreedy: settings.collisionGreedy,
     visibleLabels,
     medianMs: samples[Math.floor(samples.length / 2)],
     p95Ms: samples[Math.floor(samples.length * 0.95)]

--- a/test/apps/collision/text.js
+++ b/test/apps/collision/text.js
@@ -1,0 +1,224 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Deck, OrthographicView, COORDINATE_SYSTEM} from '@deck.gl/core';
+import {TextLayer, GeoJsonLayer, ScatterplotLayer} from '@deck.gl/layers';
+import {CollisionFilterExtension} from '@deck.gl/extensions';
+
+const extensions = [new CollisionFilterExtension()];
+const initialViewState = {target: [0, 0, 0], zoom: 0};
+const settings = {
+  scene: 'pairs',
+  geojson: false,
+  collisionEnabled: true,
+  reversePriority: false,
+  anchor: 'middle',
+  baseline: 'center',
+  offsetX: 0,
+  offsetY: 0,
+  angle: 0,
+  size: 24,
+  collisionScale: 1,
+  background: false,
+  billboard: true,
+  sdf: false,
+  zoom: 0,
+  devicePixels: 1
+};
+
+function createData(scene) {
+  const count = scene === 'stress' ? 10000 : 12;
+  return Array.from({length: count}, (_, index) => {
+    const pair = Math.floor(index / 2);
+    const high = index % 2 === 0;
+    const columns = scene === 'stress' ? 100 : 2;
+    return {
+      position: [
+        150 + (pair % columns) * 220 + (high ? 0 : 20),
+        Math.floor(pair / columns) * 90 - 180
+      ],
+      text:
+        scene === 'multiline'
+          ? 'Label\nsecond line'
+          : scene === 'whitespace'
+            ? '  Label  '
+            : `Label ${pair}`,
+      high,
+      index
+    };
+  });
+}
+let data = createData(settings.scene);
+let geojson;
+function updateData() {
+  data = createData(settings.scene);
+  geojson = {
+    type: 'FeatureCollection',
+    features: data.map(d => ({
+      type: 'Feature',
+      properties: d,
+      geometry: {type: 'Point', coordinates: d.position}
+    }))
+  };
+}
+updateData();
+const getPriority = d => (d.high !== settings.reversePriority ? 100 : -100);
+const getColor = d => (d.high ? [0, 145, 85] : [215, 55, 45]);
+
+function getLayers() {
+  const textProps = {
+    getText: d => d.text,
+    getPosition: d => d.position,
+    getColor,
+    getSize: settings.size,
+    getTextAnchor: settings.anchor,
+    getAlignmentBaseline: settings.baseline,
+    getPixelOffset: [settings.offsetX, settings.offsetY],
+    getAngle: settings.angle,
+    billboard: settings.billboard,
+    background: settings.background,
+    getBackgroundColor: [210, 220, 230],
+    fontFamily: 'Arial',
+    fontSettings: {sdf: settings.sdf},
+    extensions,
+    getCollisionPriority: getPriority,
+    collisionEnabled: settings.collisionEnabled,
+    collisionTestProps: {sizeScale: settings.collisionScale},
+    updateTriggers: {getCollisionPriority: settings.reversePriority},
+    pickable: true,
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
+  };
+  return [
+    new ScatterplotLayer({
+      id: 'anchors',
+      data,
+      getPosition: d => d.position,
+      getRadius: 3,
+      radiusUnits: 'pixels',
+      getFillColor: [80, 90, 100]
+    }),
+    settings.geojson
+      ? new GeoJsonLayer({
+          ...textProps,
+          id: 'labels',
+          data: geojson,
+          pointType: 'text',
+          getText: f => f.properties.text,
+          getTextColor: f => getColor(f.properties),
+          getTextSize: settings.size,
+          getTextAnchor: settings.anchor,
+          getTextAlignmentBaseline: settings.baseline,
+          getTextPixelOffset: [settings.offsetX, settings.offsetY],
+          getTextAngle: settings.angle,
+          textBillboard: settings.billboard,
+          textBackground: settings.background,
+          textFontFamily: 'Arial',
+          textFontSettings: {sdf: settings.sdf},
+          getCollisionPriority: f => getPriority(f.properties)
+        })
+      : new TextLayer({...textProps, id: 'labels', data})
+  ];
+}
+
+const deck = new Deck({
+  canvas: 'deck',
+  views: new OrthographicView({id: 'main'}),
+  initialViewState,
+  controller: true,
+  useDevicePixels: settings.devicePixels,
+  layers: getLayers(),
+  getTooltip: ({object}) =>
+    object &&
+    `${(object.properties || object).text}: priority ${getPriority(object.properties || object)}`
+});
+
+function update() {
+  deck.setProps({layers: getLayers(), useDevicePixels: settings.devicePixels});
+}
+
+const controls = document.getElementById('controls');
+function addControl(key, title, options) {
+  const label = document.createElement('label');
+  const caption = document.createElement('span');
+  caption.textContent = typeof settings[key] === 'number' ? `${title}: ${settings[key]}` : title;
+  label.append(caption);
+  const input = document.createElement(Array.isArray(options) ? 'select' : 'input');
+  input.id = key;
+  input.setAttribute('aria-label', title);
+  if (Array.isArray(options)) {
+    for (const value of options) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value;
+      input.append(option);
+    }
+    input.value = settings[key];
+  } else if (typeof settings[key] === 'boolean') {
+    input.type = 'checkbox';
+    input.checked = settings[key];
+  } else {
+    input.type = 'range';
+    Object.assign(input, options, {value: settings[key]});
+  }
+  input.oninput = () => {
+    settings[key] =
+      input.type === 'checkbox'
+        ? input.checked
+        : typeof settings[key] === 'number'
+          ? Number(input.value)
+          : input.value;
+    if (typeof settings[key] === 'number') caption.textContent = `${title}: ${settings[key]}`;
+    if (key === 'scene') updateData();
+    if (key === 'zoom')
+      deck.setProps({initialViewState: {...initialViewState, zoom: settings.zoom}});
+    update();
+  };
+  label.append(input);
+  controls.append(label);
+}
+addControl('scene', 'Scene', ['pairs', 'multiline', 'whitespace', 'stress']);
+addControl('geojson', 'GeoJSON text');
+addControl('collisionEnabled', 'Collisions');
+addControl('reversePriority', 'Reverse priority');
+addControl('anchor', 'Anchor', ['start', 'middle', 'end']);
+addControl('baseline', 'Baseline', ['top', 'center', 'bottom']);
+addControl('offsetX', 'Offset X', {min: -200, max: 200, step: 1});
+addControl('offsetY', 'Offset Y', {min: -200, max: 200, step: 1});
+addControl('angle', 'Angle', {min: -180, max: 180, step: 15});
+addControl('size', 'Size', {min: 8, max: 64, step: 1});
+addControl('collisionScale', 'Collision scale', {min: 1, max: 3, step: 0.25});
+addControl('zoom', 'Zoom', {min: -2, max: 3, step: 0.1});
+addControl('devicePixels', 'Device pixel ratio', {min: 1, max: 2, step: 1});
+addControl('background', 'Background');
+addControl('billboard', 'Billboard');
+addControl('sdf', 'SDF');
+document.getElementById('reset').onclick = () => deck.setProps({initialViewState});
+
+async function benchmark() {
+  const samples = [];
+  const start = performance.now();
+  let previous = start;
+  for (let frame = 0; frame < 180; frame++) {
+    await new Promise(requestAnimationFrame);
+    const now = performance.now();
+    if (frame >= 30) samples.push(now - previous);
+    previous = now;
+    deck.setProps({
+      viewState: {target: [frame * 0.5, 0, 0], zoom: settings.zoom + Math.sin(frame / 30) * 0.2}
+    });
+  }
+  deck.setProps({viewState: null, initialViewState});
+  samples.sort((a, b) => a - b);
+  const result = {
+    labels: data.length,
+    medianMs: samples[Math.floor(samples.length / 2)],
+    p95Ms: samples[Math.floor(samples.length * 0.95)]
+  };
+  document.getElementById('metrics').textContent =
+    `${result.labels} labels: median ${result.medianMs.toFixed(1)} ms, p95 ${result.p95Ms.toFixed(1)} ms`;
+  return result;
+}
+document.getElementById('benchmark').onclick = benchmark;
+// Development/automation API: stable data, explicit updates, and repeatable camera motion.
+window.collisionTest = {deck, settings, update, benchmark};

--- a/test/modules/extensions/collision-filter/collision-filter-effect.spec.ts
+++ b/test/modules/extensions/collision-filter/collision-filter-effect.spec.ts
@@ -60,6 +60,87 @@ test('CollisionFilterEffect#constructor', () => {
   collisionFilterEffect.cleanup();
 });
 
+test.each([false, true])('CollisionFilterEffect#visibility capacity (greedy=%s)', greedy => {
+  const collisionFilterEffect = new CollisionFilterEffect();
+  const limitsSpy = vi.spyOn(device, 'limits', 'get').mockReturnValue({
+    ...device.limits,
+    maxTextureDimension2D: 8
+  });
+  const textLayer = TEST_LAYER.clone({
+    id: 'text',
+    getCollisionRect: () => [0, 0, 1, 1],
+    collisionGreedy: greedy
+  });
+  const otherLayer = TEST_LAYER.clone({id: 'other'});
+  vi.spyOn(textLayer, 'getNumInstances').mockReturnValue(1);
+  const countSpy = vi.spyOn(otherLayer, 'getNumInstances').mockReturnValue(2);
+  const group = TEST_LAYER.props.collisionGroup;
+
+  try {
+    // Three objects plus the reserved zero ID fill all four atlas cells.
+    collisionFilterEffect._groupByCollisionGroup(device, [otherLayer, textLayer]);
+    const visibilityFBO = collisionFilterEffect.visibilityFBOs[group];
+    const collisionFBO = collisionFilterEffect.collisionFBOs[group];
+    expect([visibilityFBO.width, visibilityFBO.height]).toEqual([8, 8]);
+    expect(collisionFilterEffect.getShaderModuleProps(textLayer).collision.enabled).toBe(true);
+
+    const resizeSpy = vi.spyOn(visibilityFBO, 'resize');
+    const destroyVisibilitySpy = vi.spyOn(visibilityFBO, 'destroy');
+    const destroyCollisionSpy = vi.spyOn(collisionFBO, 'destroy');
+    countSpy.mockReturnValue(3);
+    expect(
+      Object.keys(collisionFilterEffect._groupByCollisionGroup(device, [otherLayer, textLayer]))
+    ).toEqual([]);
+    expect(resizeSpy).not.toHaveBeenCalled();
+    expect(destroyVisibilitySpy).toHaveBeenCalledOnce();
+    expect(destroyCollisionSpy).toHaveBeenCalledOnce();
+    expect(collisionFilterEffect.channels[group]).toBeUndefined();
+    for (const layer of [otherLayer, textLayer]) {
+      expect(collisionFilterEffect.getShaderModuleProps(layer).collision.enabled).toBe(false);
+    }
+
+    // A rejected group must also be safe when it has no existing resources.
+    const createTextureSpy = vi.spyOn(device, 'createTexture');
+    collisionFilterEffect._groupByCollisionGroup(device, [otherLayer, textLayer]);
+    expect(createTextureSpy).not.toHaveBeenCalled();
+
+    countSpy.mockReturnValue(2);
+    collisionFilterEffect._groupByCollisionGroup(device, [otherLayer, textLayer]);
+    expect(collisionFilterEffect.getShaderModuleProps(textLayer).collision.enabled).toBe(true);
+    expect(collisionFilterEffect.visibilityFBOs[group]).not.toBe(visibilityFBO);
+    expect(collisionFilterEffect.channels[group].objectCount).toBe(3);
+  } finally {
+    collisionFilterEffect.cleanup();
+    limitsSpy.mockRestore();
+    vi.restoreAllMocks();
+  }
+});
+
+test('CollisionFilterEffect#picking ID capacity', () => {
+  const collisionFilterEffect = new CollisionFilterEffect();
+  const firstLayer = TEST_LAYER.clone({id: 'first'});
+  const secondLayer = TEST_LAYER.clone({id: 'second'});
+  vi.spyOn(firstLayer, 'getNumInstances').mockReturnValue(0xfffffe);
+  const countSpy = vi.spyOn(secondLayer, 'getNumInstances').mockReturnValue(1);
+  const group = TEST_LAYER.props.collisionGroup;
+
+  try {
+    collisionFilterEffect._groupByCollisionGroup(device, [firstLayer, secondLayer]);
+    expect(collisionFilterEffect.channels[group].objectCount).toBe(0xffffff);
+    expect(collisionFilterEffect.getShaderModuleProps(secondLayer).collision.enabled).toBe(true);
+
+    countSpy.mockReturnValue(2);
+    expect(
+      Object.keys(collisionFilterEffect._groupByCollisionGroup(device, [firstLayer, secondLayer]))
+    ).toEqual([]);
+    expect(collisionFilterEffect.channels[group]).toBeUndefined();
+    expect(collisionFilterEffect.getShaderModuleProps(secondLayer).collision.enabled).toBe(false);
+  } finally {
+    collisionFilterEffect.cleanup();
+    vi.restoreAllMocks();
+  }
+});
+
 test('CollisionFilterEffect#cleanup', () => {
   const collisionFilterEffect = new CollisionFilterEffect();
 

--- a/test/modules/extensions/collision-filter/text-collision-placement.node.spec.ts
+++ b/test/modules/extensions/collision-filter/text-collision-placement.node.spec.ts
@@ -1,0 +1,93 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {placeTextLabels} from '@deck.gl/extensions/collision-filter/text-collision-placement';
+
+type Label = {corners: number[]; priority?: number; eligible?: boolean};
+const WIDTH = 400;
+const HEIGHT = 200;
+
+function rectangle(x: number, y: number, width: number, height: number): number[] {
+  return [x, y, x + width, y, x + width, y + height, x, y + height];
+}
+
+function place(labels: Label[]): number[] {
+  const columns = Math.ceil(Math.sqrt(labels.length + 1));
+  const width = columns * 4;
+  const stride = width * 4;
+  const pixels = new Uint8Array(Math.ceil((labels.length + 1) / columns) * 4 * stride);
+  const view = new DataView(pixels.buffer);
+  const base = (index: number) => Math.floor(index / columns) * 4 * stride + (index % columns) * 16;
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i];
+    const values = [
+      ...label.corners.map((value, axis) => value / (axis % 2 ? HEIGHT : WIDTH)),
+      label.priority || 0,
+      1
+    ];
+    values.forEach((value, component) => {
+      view.setFloat32(
+        base(i + 1) + Math.floor(component / 4) * stride + (component % 4) * 4,
+        value,
+        true
+      );
+    });
+    for (let component = 10; component < 16; component++) {
+      pixels[base(i + 1) + Math.floor(component / 4) * stride + (component % 4) * 4] =
+        label.eligible === false ? 0 : 255;
+    }
+  }
+  const count = placeTextLabels(pixels, width, labels.length, WIDTH, HEIGHT);
+  const result = labels.flatMap((_, i) => (pixels[base(i + 1) + 3 * stride + 12] ? [i] : []));
+  expect(count).toBe(result.length);
+  return result;
+}
+
+test('text placement releases space occupied by rejected candidates', () => {
+  expect(
+    place([0, 1, 2].map(index => ({corners: rectangle(index * 80, 0, 100, 30), priority: index})))
+  ).toEqual([0, 2]);
+});
+
+test('text placement fills a dense grid with stable tie breaking', () => {
+  const labels = Array.from({length: 200}, (_, index) => ({
+    corners: rectangle((index % 20) * 12, Math.floor(index / 20) * 7, 35, 18)
+  }));
+  const expected: number[] = [];
+  for (let row = 9; row >= 0; row -= 3) {
+    for (let column = 19; column >= 0; column -= 3) expected.push(row * 20 + column);
+  }
+  expect(place(labels)).toEqual(expected.sort((a, b) => a - b));
+});
+
+test('text placement compares polygons when rotated bounds overlap', () => {
+  expect(
+    place([
+      {corners: [10, 20, 20, 10, 30, 20, 20, 30]},
+      {corners: [25, 35, 35, 25, 45, 35, 35, 45]}
+    ])
+  ).toEqual([0, 1]);
+});
+
+test('text placement respects fractional priorities and contained labels', () => {
+  expect(
+    place([
+      {corners: rectangle(0, 0, 100, 100), priority: 20},
+      {corners: rectangle(20, 20, 10, 10), priority: 20.001}
+    ])
+  ).toEqual([1]);
+});
+
+test('text placement excludes offscreen, empty and ineligible labels', () => {
+  expect(
+    place([
+      {corners: rectangle(0, 0, 10, 10)},
+      {corners: rectangle(0, 0, 100, 100), priority: 100, eligible: false},
+      {corners: rectangle(-30, 0, 10, 10)},
+      {corners: rectangle(0, 0, 0, 0)},
+      {corners: [-10, 0, 0, -10, 10, -10, -10, 10]}
+    ])
+  ).toEqual([0]);
+});

--- a/test/modules/layers/text-layer/text-layer.spec.ts
+++ b/test/modules/layers/text-layer/text-layer.spec.ts
@@ -5,6 +5,7 @@
 import {test, expect} from 'vitest';
 
 import {TextLayer} from '@deck.gl/layers';
+import {CollisionFilterExtension} from '@deck.gl/extensions';
 import * as FIXTURES from 'deck.gl-test/data';
 import {testLayer, generateLayerTests} from '@deck.gl/test-utils/vitest';
 
@@ -260,4 +261,71 @@ test('TextLayer - fontAtlasCacheLimit', () => {
     }
   });
   testLayer({Layer: TextLayer, testCases, onError: err => expect(err).toBeFalsy()});
+});
+
+test('TextLayer - collision layout and accessor updates', () => {
+  const data = [
+    {text: 'Hello\nworld', position: [0, 0]},
+    {text: '   ', position: [0, 0]}
+  ];
+  const layouts: number[][] = [];
+  testLayer({
+    Layer: TextLayer,
+    onError: err => expect(err).toBeFalsy(),
+    testCases: [
+      {
+        props: {data, extensions: [new CollisionFilterExtension()]},
+        onAfterUpdate: ({layer}) => {
+          const [background, characters] = layer.getSubLayers();
+          expect(background.id).toBe(`${layer.id}-background`);
+          const rect = background.props.getBoundingRect(data[0], {index: 0});
+          layouts.push(rect);
+          expect(rect[2]).toBeGreaterThan(0);
+          expect(rect[3]).toBeGreaterThan(0);
+          expect(background.props.getBoundingRect(data[1], {index: 1})).toEqual([0, 0, 0, 0]);
+          expect(characters.props.getCollisionRect(data[0], {index: 0})).toEqual(rect);
+          for (const renderPass of ['screen', 'picking:hover', 'collision']) {
+            expect(layer.filterSubLayer({layer: background, renderPass})).toBe(
+              renderPass === 'collision'
+            );
+            expect(layer.filterSubLayer({layer: characters, renderPass})).toBe(
+              renderPass !== 'collision'
+            );
+          }
+        }
+      },
+      {
+        updateProps: {getTextAnchor: 'end', getAlignmentBaseline: 'bottom'},
+        onAfterUpdate: ({layer}) => {
+          const [background, characters] = layer.getSubLayers();
+          const rect = background.props.getBoundingRect(data[0], {index: 0});
+          expect(rect[0]).toBeLessThan(layouts[0][0]);
+          expect(rect[1]).toBeLessThan(layouts[0][1]);
+          const attributes = characters.getAttributeManager().getAttributes();
+          const offset = characters.props.getCollisionRect(data[0], {index: 0});
+          Array.from(attributes.instanceCollisionRects.value.slice(0, 4)).forEach(
+            (value, index) => {
+              expect(value).toBeCloseTo(offset[index], 4);
+            }
+          );
+          layouts.push(rect);
+        }
+      },
+      {
+        updateProps: {background: true},
+        onAfterUpdate: ({layer}) => {
+          const [background] = layer.getSubLayers();
+          expect(layer.filterSubLayer({layer: background, renderPass: 'screen'})).toBe(true);
+          expect(background.props.getBoundingRect(data[1], {index: 1})[2]).toBeGreaterThan(0);
+        }
+      },
+      {
+        updateProps: {collisionEnabled: false, background: false},
+        onAfterUpdate: ({layer}) => {
+          expect(layer.getSubLayers()).toHaveLength(1);
+          expect(layer.getSubLayers()[0].id).toBe(`${layer.id}-characters`);
+        }
+      }
+    ]
+  });
 });

--- a/test/render/test-cases/text-layer.spec.ts
+++ b/test/render/test-cases/text-layer.spec.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {describe} from 'vitest';
-import {runRenderTestSuite} from '../render-test-suite';
+import {describe, expect, test} from 'vitest';
+import {isRenderTestDeviceEnabled, runRenderTestSuite} from '../render-test-suite';
 import type {TestCase} from '../deck-test-utils';
 
 import {COORDINATE_SYSTEM, OrthographicView} from '@deck.gl/core';
@@ -11,7 +11,10 @@ import {TextLayer, PathLayer} from '@deck.gl/layers';
 import {PathStyleExtension} from '@deck.gl/extensions';
 import {points} from 'deck.gl-test/data';
 import fontMapping from '../../data/font-atlas.json';
+import FontAtlasManager from '../../../modules/layers/src/text-layer/font-atlas-manager';
 
+// Keep fixture glyphs separate from system-font atlases created by other render tests.
+const PREPACKED_FONT_FAMILY = 'Render Test Prepacked';
 const TextAnchors = ['start', 'middle', 'end'];
 const TextBaselines = ['top', 'center', 'bottom'];
 const ContentAlignment = ['start', 'center', 'end'];
@@ -220,7 +223,7 @@ const testCases = [
         id: 'text-layer',
         data: points.slice(0, 50),
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getText: x => `${x.PLACEMENT}-${x.YR_INSTALLED}`,
         getPosition: x => x.COORDINATES,
         getColor: x => [255, 0, 0],
@@ -284,7 +287,7 @@ const testCases = [
         id: 'text-layer',
         data: points.slice(0, 50),
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getText: x => `${x.PLACEMENT}-${x.YR_INSTALLED}`,
         getPosition: x => x.COORDINATES,
         getColor: x => [255, 0, 0],
@@ -316,7 +319,7 @@ const testCases = [
           getColor: {accessor: x => [1, 0, 0], size: 3, normalized: false}
         }),
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getSize: 20,
         getAngle: 0,
         sizeScale: 1,
@@ -344,7 +347,7 @@ const testCases = [
         id: 'labels',
         data: alignmentTestData,
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getPosition: ({anchor: [x, y]}) => (flipY ? [x, y] : [x, -y]),
         getText: d => 'Hello TextLayer',
         billboard,
@@ -388,7 +391,7 @@ const testCases = [
           id: `labels-${i}`,
           data: [0],
           _getFontRenderer: () => fontRenderer,
-          fontFamily: 'Arial',
+          fontFamily: PREPACKED_FONT_FAMILY,
           getPosition: _ => [-x * 2, -y * 2],
           getText: _ => 'Hello',
           getSize: 16,
@@ -417,7 +420,7 @@ const testCases = [
         id: 'labels',
         data: points.slice(2, 5),
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getPosition: (_, {index}) => [0, (index - 1) * 160],
         getText: d => `${d.ADDRESS}\n${d.LOCATION_NAME}\n${d.RACKS} racks - ${d.SPACES} spaces`,
         getSize: 20,
@@ -441,7 +444,7 @@ const testCases = [
         id: 'labels',
         data: points.slice(0, 10),
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getPosition: (_, {index}) => [0, index * 60],
         getText: d => d.ADDRESS,
         getAngle: 30,
@@ -472,7 +475,7 @@ const testCases = [
         id: 'labels',
         data: [0],
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getPosition: d => [40, 40],
         getText: d => `The TextLayer renders text labels at given coordinates.
 TextLayer is a CompositeLayer that wraps around the IconLayer. It automatically creates an atlas texture from the specified font settings and characterSet.`,
@@ -511,7 +514,7 @@ TextLayer is a CompositeLayer that wraps around the IconLayer. It automatically 
           {text: 'Dense dots', anchor: 'end', baseline: 'bottom', dash: [1, 1]}
         ],
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getPosition: (_, {index}) => [-120, (index - 0.5) * 120],
         getText: d => d.text,
         getSize: 18,
@@ -540,7 +543,7 @@ TextLayer is a CompositeLayer that wraps around the IconLayer. It automatically 
           }
         ],
         _getFontRenderer: () => fontRenderer,
-        fontFamily: 'Arial',
+        fontFamily: PREPACKED_FONT_FAMILY,
         getPosition: (_, {index}) => [120, (index - 0.5) * 120],
         getText: d => d.text,
         getSize: 18,
@@ -565,4 +568,18 @@ describe.each(['webgl', 'webgpu'] as const)('%s', deviceType => {
   runRenderTestSuite(testCases as TestCase[], deviceType, {
     beforeAll: loadPrepackedFontAtlas
   });
+
+  test.skipIf(!isRenderTestDeviceEnabled(deviceType))(
+    'prepacked font atlas is independent of system Arial',
+    () => {
+      const systemAtlas = new FontAtlasManager();
+      systemAtlas.setProps({fontFamily: 'Arial'});
+      const prepackedAtlas = new FontAtlasManager();
+      prepackedAtlas.setProps({
+        fontFamily: PREPACKED_FONT_FAMILY,
+        _getFontRenderer: () => fontRenderer
+      });
+      expect(prepackedAtlas.atlas).not.toBe(systemAtlas.atlas);
+    }
+  );
 });

--- a/test/render/text-collision.spec.ts
+++ b/test/render/text-collision.spec.ts
@@ -143,6 +143,36 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
 );
 
 test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision priorities are independent of layer depth offsets',
+  async () => {
+    for (const collisionGreedy of [false, true]) {
+      const high = new TextLayer({
+        id: 'priority-high',
+        data: [{position: [0, 0], text: 'Label\nsecond line', priority: 1}],
+        getSize: 24,
+        collisionGroup: 'shared-priority',
+        collisionGreedy,
+        getCollisionPriority: d => d.priority,
+        extensions,
+        pickable: true
+      });
+      const low = high.clone({
+        id: 'priority-low',
+        data: [{position: [12, 0], text: 'Label\nsecond line', priority: 0}]
+      });
+      expect(await drawLayers([high, low]), `greedy=${collisionGreedy}`).toEqual([1]);
+      expect(await drawLayers([low.clone(), high.clone()])).toEqual([1]);
+      expect(
+        await drawLayers([
+          high.clone({getPolygonOffset: () => [0, 1000]}),
+          low.clone({getPolygonOffset: () => [0, -1000]})
+        ])
+      ).toEqual([1]);
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
   'text collision size, rotation, background and font settings',
   async () => {
     const layer = new TextLayer({
@@ -376,6 +406,50 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
       } finally {
         deck.setProps({useDevicePixels: false});
       }
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'greedy multiline placement agrees within and across layers at fractional pixel ratios',
+  async () => {
+    try {
+      for (const devicePixels of [1, 1.5, 2]) {
+        deck.setProps({useDevicePixels: devicePixels});
+        for (const splitLayers of [false, true]) {
+          for (const reverse of [false, true]) {
+            const labels = [
+              {position: [-30, 0], text: 'Label\nsecond line', priority: reverse ? -100 : 100},
+              {position: [30, 0], text: 'Much longer line\nshort', priority: reverse ? 100 : -100}
+            ];
+            const text = new TextLayer({
+              id: 'multiline-greedy',
+              data: labels,
+              collisionGreedy: true,
+              collisionGroup: 'multiline',
+              getSize: 24,
+              fontFamily: 'Arial',
+              extensions,
+              pickable: true,
+              getPixelOffset: [40, -25],
+              getCollisionPriority: d => d.priority
+            });
+            const layers = splitLayers
+              ? labels.map((label, index) => text.clone({id: `multiline-${index}`, data: [label]}))
+              : [text];
+            // Leave room around the collision threshold: system font metrics can differ by OS.
+            expect(await drawLayers(layers, 0)).toEqual([100]);
+            expect(
+              await drawLayers(
+                layers.map(layer => layer.clone()),
+                2
+              )
+            ).toEqual([-100, 100]);
+          }
+        }
+      }
+    } finally {
+      deck.setProps({useDevicePixels: false});
     }
   }
 );

--- a/test/render/text-collision.spec.ts
+++ b/test/render/text-collision.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {afterAll, beforeAll, expect, test} from 'vitest';
+import {afterAll, beforeAll, expect, test, vi} from 'vitest';
 import {Deck, OrthographicView, MapView} from '@deck.gl/core';
 import {TextLayer, GeoJsonLayer, ScatterplotLayer} from '@deck.gl/layers';
 import {CollisionFilterExtension, DataFilterExtension} from '@deck.gl/extensions';
@@ -47,17 +47,20 @@ afterAll(() => {
 
 const cases = ['start', 'middle', 'end'].flatMap(anchor =>
   ['top', 'center', 'bottom'].flatMap(baseline =>
-    [false, true].map(useGeoJson => ({anchor, baseline, useGeoJson}))
+    [false, true].flatMap(useGeoJson =>
+      [false, true].map(collisionGreedy => ({anchor, baseline, useGeoJson, collisionGreedy}))
+    )
   )
 );
 
 test.skipIf(!isRenderTestDeviceEnabled('webgl')).each(cases)(
-  'text collision: $anchor / $baseline / GeoJSON=$useGeoJson',
-  async ({anchor, baseline, useGeoJson}) => {
+  'text collision: $anchor / $baseline / GeoJSON=$useGeoJson / greedy=$collisionGreedy',
+  async ({anchor, baseline, useGeoJson, collisionGreedy}) => {
     for (const reverse of [false, true]) {
       for (const zoom of [-1, 0, 5]) {
         const props = {
           id: 'collision-text',
+          collisionGreedy,
           data,
           getSize: 20,
           getTextAnchor: anchor,
@@ -432,7 +435,23 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
       pickable: true,
       getCollisionPriority: d => d.priority
     });
-    expect(await drawLayers([layer])).toEqual([10, 30]);
+    const readPixels = vi.spyOn(device, 'readPixelsToArrayWebGL');
+    const readCollisionBounds = () =>
+      readPixels.mock.calls.some(([target]) =>
+        (target as {id?: string}).id?.startsWith('collision-visibility-')
+      );
+    try {
+      expect(await drawLayers([layer])).toEqual([30]);
+      expect(readCollisionBounds()).toBe(false);
+      readPixels.mockClear();
+      expect(await drawLayers([layer.clone({collisionGreedy: true})])).toEqual([10, 30]);
+      expect(readCollisionBounds()).toBe(true);
+      readPixels.mockClear();
+      expect(await drawLayers([layer.clone({collisionGreedy: false})])).toEqual([30]);
+      expect(readCollisionBounds()).toBe(false);
+    } finally {
+      readPixels.mockRestore();
+    }
   }
 );
 
@@ -441,6 +460,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
   async () => {
     const layer = new TextLayer({
       id: 'long-collision-chain',
+      collisionGreedy: true,
       data: Array.from({length: 10}, (_, index) => ({
         position: [index * 60 - 270, 0],
         text: 'XXXXX',
@@ -462,6 +482,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
   async () => {
     const text = new TextLayer({
       id: 'mixed-text',
+      collisionGreedy: true,
       data: [data[0]],
       getSize: 24,
       extensions,
@@ -489,6 +510,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
   async () => {
     const layer = new TextLayer({
       id: 'filtered-collision-text',
+      collisionGreedy: true,
       data,
       getSize: 24,
       extensions: [...extensions, new DataFilterExtension({filterSize: 1})],
@@ -498,5 +520,33 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
       getCollisionPriority: d => d.priority
     });
     expect(await drawLayers([layer])).toEqual([-100]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'greedy placement applies to its collision group only',
+  async () => {
+    const low = new TextLayer({
+      id: 'group-low',
+      data: [{position: [-60, 0], text: 'XXXXX', priority: 10}],
+      getSize: 24,
+      fontFamily: 'Arial',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    const middle = low.clone({
+      id: 'group-middle',
+      data: [{position: [0, 0], text: 'XXXXX', priority: 20}]
+    });
+    const high = low.clone({
+      id: 'group-high',
+      data: [{position: [60, 0], text: 'XXXXX', priority: 30}],
+      collisionGreedy: true
+    });
+    expect(await drawLayers([low, middle, high])).toEqual([10, 30]);
+    expect(
+      await drawLayers([low.clone(), middle.clone(), high.clone({collisionGroup: 'other'})])
+    ).toEqual([20, 30]);
   }
 );

--- a/test/render/text-collision.spec.ts
+++ b/test/render/text-collision.spec.ts
@@ -55,7 +55,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl')).each(cases)(
   'text collision: $anchor / $baseline / GeoJSON=$useGeoJson',
   async ({anchor, baseline, useGeoJson}) => {
     for (const reverse of [false, true]) {
-      for (const zoom of [-1, 0, 4]) {
+      for (const zoom of [-1, 0, 5]) {
         const props = {
           id: 'collision-text',
           data,
@@ -87,7 +87,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl')).each(cases)(
         await new Promise<void>((resolve, reject) => {
           deck.setProps({
             layers: [layer],
-            viewState: {target: [0, 0, 0], zoom},
+            viewState: {target: [6, 0, 0], zoom},
             onError: reject,
             onAfterRender: () => {
               if (layer.isLoaded) resolve();
@@ -99,7 +99,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl')).each(cases)(
           .map(({object}) => (object.properties || object).priority)
           .sort((a, b) => a - b);
         expect(priorities, `zoom=${zoom}, reverse=${reverse}`).toEqual(
-          zoom === 4 ? [-100, 100] : [reverse ? -100 : 100]
+          zoom === 5 ? [-100, 100] : [reverse ? -100 : 100]
         );
       }
     }
@@ -266,5 +266,152 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
     } finally {
       deck.setProps({views: new OrthographicView(), useDevicePixels: false});
     }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'multiline collision rejects overlap away from label centers',
+  async () => {
+    const layer = new TextLayer({
+      id: 'multiline-edge-overlap',
+      data: [
+        {position: [-40, 0], text: 'Label\nsecond line', priority: 100},
+        {position: [40, 0], text: 'Label\nsecond line', priority: -100}
+      ],
+      getSize: 24,
+      fontFamily: 'Arial',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([layer])).toEqual([100]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision checks edges and contained labels',
+  async () => {
+    const commonProps = {
+      extensions,
+      pickable: true,
+      getSize: 24,
+      fontFamily: 'Arial',
+      getCollisionPriority: d => d.priority
+    };
+    for (const [name, first, second] of [
+      [
+        'long second line',
+        {text: 'Label\nsecond line', position: [-40, 0]},
+        {text: 'Label\nsecond line', position: [40, 0]}
+      ],
+      [
+        'long first line',
+        {text: 'second line\nLabel', position: [-40, 0]},
+        {text: 'second line\nLabel', position: [40, 0]}
+      ],
+      [
+        'vertical edge',
+        {text: 'Label\nsecond line', position: [0, -15]},
+        {text: 'Label\nsecond line', position: [0, 15]}
+      ],
+      [
+        'contained small label',
+        {text: 'i', position: [50, 0]},
+        {text: 'XXXXXXXXXXXX', position: [0, 0]}
+      ],
+      [
+        'different line widths',
+        {text: 'Second line', position: [-50, 0]},
+        {text: 'Much longer second line', position: [50, 0]}
+      ]
+    ]) {
+      const layer = new TextLayer({
+        ...commonProps,
+        id: 'overlap-cases',
+        data: [
+          {...first, priority: 100},
+          {...second, priority: -100}
+        ]
+      });
+      expect(await drawLayers([layer]), name).toEqual([100]);
+      expect(
+        await drawLayers([
+          layer.clone({
+            getCollisionPriority: d => -d.priority,
+            updateTriggers: {getCollisionPriority: 'reversed'}
+          })
+        ]),
+        `${name}: reversed`
+      ).toEqual([-100]);
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'multiline collision switches visibility at the longest line edge',
+  async () => {
+    for (const devicePixels of [1, 2]) {
+      deck.setProps({useDevicePixels: devicePixels});
+      try {
+        for (const distance of [120, 124]) {
+          const layer = new TextLayer({
+            id: 'multiline-touching',
+            data: [
+              {position: [-distance / 2, 0], text: 'Label\nsecond line', priority: 100},
+              {position: [distance / 2, 0], text: 'Label\nsecond line', priority: -100}
+            ],
+            getSize: 24,
+            fontFamily: 'Arial',
+            extensions,
+            pickable: true,
+            getCollisionPriority: d => d.priority
+          });
+          expect(await drawLayers([layer]), `distance=${distance}, DPR=${devicePixels}`).toEqual(
+            distance === 120 ? [100] : [-100, 100]
+          );
+        }
+      } finally {
+        deck.setProps({useDevicePixels: false});
+      }
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'long wrapped labels share visibility across every glyph',
+  async () => {
+    const layer = new TextLayer({
+      id: 'long-paragraph',
+      data: [{position: [0, 0], text: 'Label text '.repeat(45), priority: 100}],
+      getSize: 24,
+      maxWidth: 20,
+      wordBreak: 'break-word',
+      fontFamily: 'Arial',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([layer])).toEqual([100]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text and padded backgrounds share the same collision result',
+  async () => {
+    const layer = new TextLayer({
+      id: 'padded-labels',
+      data: [
+        {position: [-40, 0], text: 'Label', priority: 100},
+        {position: [40, 0], text: 'Label', priority: -100}
+      ],
+      getSize: 24,
+      background: true,
+      backgroundPadding: [20, 10],
+      fontFamily: 'Arial',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([layer])).toEqual([100]);
   }
 );

--- a/test/render/text-collision.spec.ts
+++ b/test/render/text-collision.spec.ts
@@ -173,6 +173,39 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
 );
 
 test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision clamps priorities consistently in GPU and greedy placement',
+  async () => {
+    for (const collisionGreedy of [false, true]) {
+      const layer = new TextLayer({
+        id: 'clamped-priorities',
+        data: [
+          {position: [0, 0], text: 'Label', priority: 2000},
+          {position: [0, 0], text: 'Label', priority: 1000}
+        ],
+        getSize: 24,
+        collisionGreedy,
+        extensions,
+        pickable: true,
+        getCollisionPriority: d => d.priority
+      });
+      // Both priorities clamp to 1000, so the later label wins the tie.
+      expect(await drawLayers([layer]), `greedy=${collisionGreedy}`).toEqual([1000]);
+      expect(
+        await drawLayers([
+          layer.clone({data: layer.props.data.map(d => ({...d, priority: d.priority + 1000}))})
+        ])
+      ).toEqual([2000]);
+      // A priority below the supported range must remain visible when isolated.
+      expect(
+        await drawLayers([
+          layer.clone({data: [{position: [0, 0], text: 'Label', priority: -2000}]})
+        ])
+      ).toEqual([-2000]);
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
   'text collision size, rotation, background and font settings',
   async () => {
     const layer = new TextLayer({

--- a/test/render/text-collision.spec.ts
+++ b/test/render/text-collision.spec.ts
@@ -1,0 +1,270 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {afterAll, beforeAll, expect, test} from 'vitest';
+import {Deck, OrthographicView, MapView} from '@deck.gl/core';
+import {TextLayer, GeoJsonLayer} from '@deck.gl/layers';
+import {CollisionFilterExtension} from '@deck.gl/extensions';
+import {createContainer, createTestDevice, removeContainer} from './deck-test-utils';
+import {isRenderTestDeviceEnabled} from './render-test-suite';
+
+const data = [
+  {position: [0, 0], text: 'Collision label', priority: 100},
+  {position: [12, 0], text: 'Collision label', priority: -100}
+];
+const geojson = {
+  type: 'FeatureCollection',
+  features: data.map(d => ({
+    type: 'Feature',
+    properties: d,
+    geometry: {type: 'Point', coordinates: d.position}
+  }))
+};
+const extensions = [new CollisionFilterExtension()];
+let deck: Deck;
+let container: HTMLDivElement;
+let device;
+
+beforeAll(async () => {
+  if (!isRenderTestDeviceEnabled('webgl')) return;
+  container = createContainer('text-collision');
+  device = await createTestDevice('webgl', container);
+  deck = new Deck({
+    device,
+    container,
+    width: 800,
+    height: 450,
+    views: new OrthographicView(),
+    useDevicePixels: false
+  });
+});
+afterAll(() => {
+  deck?.finalize();
+  device?.destroy();
+  removeContainer(container);
+});
+
+const cases = ['start', 'middle', 'end'].flatMap(anchor =>
+  ['top', 'center', 'bottom'].flatMap(baseline =>
+    [false, true].map(useGeoJson => ({anchor, baseline, useGeoJson}))
+  )
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl')).each(cases)(
+  'text collision: $anchor / $baseline / GeoJSON=$useGeoJson',
+  async ({anchor, baseline, useGeoJson}) => {
+    for (const reverse of [false, true]) {
+      for (const zoom of [-1, 0, 4]) {
+        const props = {
+          id: 'collision-text',
+          data,
+          getSize: 20,
+          getTextAnchor: anchor,
+          getAlignmentBaseline: baseline,
+          getPixelOffset: [40, -35],
+          getCollisionPriority: d => d.priority * (reverse ? -1 : 1),
+          getColor: d => (d.priority > 0 ? [0, 150, 0] : [220, 0, 0]),
+          collisionTestProps: {sizeScale: 1.5},
+          extensions,
+          pickable: true,
+          fontFamily: 'Arial',
+          updateTriggers: {getCollisionPriority: reverse}
+        };
+        const layer = useGeoJson
+          ? new GeoJsonLayer({
+              ...props,
+              data: geojson,
+              pointType: 'text',
+              getText: f => f.properties.text,
+              getTextSize: 20,
+              getTextAlignmentBaseline: baseline,
+              getTextPixelOffset: [40, -35],
+              getCollisionPriority: f => props.getCollisionPriority(f.properties),
+              getTextColor: f => props.getColor(f.properties)
+            })
+          : new TextLayer(props);
+        await new Promise<void>((resolve, reject) => {
+          deck.setProps({
+            layers: [layer],
+            viewState: {target: [0, 0, 0], zoom},
+            onError: reject,
+            onAfterRender: () => {
+              if (layer.isLoaded) resolve();
+            }
+          });
+        });
+        const objects = await deck.pickObjectsAsync({x: 0, y: 0, width: 800, height: 450});
+        const priorities = objects
+          .map(({object}) => (object.properties || object).priority)
+          .sort((a, b) => a - b);
+        expect(priorities, `zoom=${zoom}, reverse=${reverse}`).toEqual(
+          zoom === 4 ? [-100, 100] : [reverse ? -100 : 100]
+        );
+      }
+    }
+  }
+);
+
+async function drawLayers(layers, zoom = 0) {
+  await new Promise<void>((resolve, reject) => {
+    deck.setProps({
+      layers,
+      viewState: {target: [0, 0, 0], zoom},
+      onError: reject,
+      onAfterRender: () => {
+        if (layers.every(layer => layer.isLoaded)) resolve();
+      }
+    });
+  });
+  const objects = await deck.pickObjectsAsync({x: 0, y: 0, width: 800, height: 450});
+  return objects.map(({object}) => object.priority).sort((a, b) => a - b);
+}
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision distinguishes source layers',
+  async () => {
+    const high = new TextLayer({
+      id: 'high',
+      data: [data[0]],
+      getSize: 24,
+      extensions,
+      pickable: true,
+      getPixelOffset: [60, -30],
+      getCollisionPriority: d => d.priority
+    });
+    const low = high.clone({id: 'low', data: [{...data[0], priority: -100}]});
+    expect(await drawLayers([high, low])).toEqual([100]);
+    expect(await drawLayers([low.clone(), high.clone()])).toEqual([100]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision size, rotation, background and font settings',
+  async () => {
+    const layer = new TextLayer({
+      id: 'variants',
+      data: data.map(d => ({...d, position: [0, 0]})),
+      extensions,
+      pickable: true,
+      getSize: 24,
+      getCollisionPriority: d => d.priority,
+      getPixelOffset: d => [40, -20],
+      getTextAnchor: d => 'end',
+      getAlignmentBaseline: d => 'bottom'
+    });
+    for (const props of [
+      {getAngle: 90},
+      {getAngle: -45, billboard: false},
+      {sizeUnits: 'common', getSize: 10, sizeMinPixels: 20},
+      {getSize: 100, sizeMaxPixels: 30, collisionTestProps: {sizeScale: 3, sizeMaxPixels: 45}},
+      {background: true, backgroundPadding: [10, 5, 30, 20], backgroundBorderRadius: 5},
+      {fontSettings: {sdf: true}, outlineWidth: 2},
+      {getText: () => '  multiline\nlabel  ', lineHeight: 1.5},
+      {maxWidth: 3, wordBreak: 'break-all'},
+      {getContentBox: [-80, -40, 160, 80], contentAlignHorizontal: 'center'},
+      {getText: () => 'i', getSize: 8},
+      {collisionEnabled: false}
+    ]) {
+      expect(await drawLayers([layer.clone(props)]), JSON.stringify(props)).toEqual(
+        props.collisionEnabled === false ? [-100] : [100]
+      );
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision with binary GPU attributes',
+  async () => {
+    const texts = ['First', 'Second label', 'Third'];
+    const priorities = [10, 100, -100];
+    const startIndices = [0];
+    const positions: number[] = [];
+    texts.forEach((text, index) => {
+      startIndices.push(startIndices[index] + text.length);
+      for (const char of text) positions.push(index === 0 ? -150 : 80, 0, 0);
+    });
+    const buffer = device.createBuffer({data: new Float32Array(positions)});
+    const layer = new TextLayer({
+      id: 'binary-collision',
+      data: {
+        length: texts.length,
+        startIndices,
+        attributes: {
+          getText: new Uint8Array(Array.from(texts.join('')).map(char => char.charCodeAt(0))),
+          getPosition: {buffer, size: 3}
+        }
+      },
+      extensions,
+      pickable: true,
+      getSize: 24,
+      getPixelOffset: [40, -20],
+      getTextAnchor: 'start',
+      getAlignmentBaseline: 'top',
+      getCollisionPriority: (_, {index}) => priorities[index]
+    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        deck.setProps({
+          layers: [layer],
+          viewState: {target: [0, 0, 0], zoom: 0},
+          onError: reject,
+          onAfterRender: () => {
+            if (layer.isLoaded) resolve();
+          }
+        });
+      });
+      const objects = await deck.pickObjectsAsync({x: 0, y: 0, width: 800, height: 450});
+      expect(objects.map(({index}) => index).sort()).toEqual([0, 1]);
+    } finally {
+      deck.setProps({layers: []});
+      await new Promise(requestAnimationFrame);
+      buffer.destroy();
+    }
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text collision on pitched geographic views and HiDPI',
+  async () => {
+    deck.setProps({views: new MapView(), useDevicePixels: 2});
+    try {
+      for (const billboard of [true, false]) {
+        for (const zoom of [8, 14, 18]) {
+          for (const pitch of [0, 45, 70]) {
+            const layer = new TextLayer({
+              id: 'geographic-text',
+              data: data.map(d => ({...d, position: [-122.4, 37.8]})),
+              extensions,
+              pickable: true,
+              getSize: 24,
+              getPixelOffset: [40, -20],
+              getTextAnchor: 'end',
+              getAlignmentBaseline: 'bottom',
+              getAngle: 30,
+              billboard,
+              getCollisionPriority: d => d.priority
+            });
+            await new Promise<void>((resolve, reject) => {
+              deck.setProps({
+                layers: [layer],
+                viewState: {longitude: -122.4, latitude: 37.8, zoom, pitch, bearing: 30},
+                onError: reject,
+                onAfterRender: () => {
+                  if (layer.isLoaded) resolve();
+                }
+              });
+            });
+            const objects = await deck.pickObjectsAsync({x: 0, y: 0, width: 800, height: 450});
+            expect(
+              objects.map(({object}) => object.priority),
+              JSON.stringify({billboard, zoom, pitch})
+            ).toEqual([100]);
+          }
+        }
+      }
+    } finally {
+      deck.setProps({views: new OrthographicView(), useDevicePixels: false});
+    }
+  }
+);

--- a/test/render/text-collision.spec.ts
+++ b/test/render/text-collision.spec.ts
@@ -4,8 +4,8 @@
 
 import {afterAll, beforeAll, expect, test} from 'vitest';
 import {Deck, OrthographicView, MapView} from '@deck.gl/core';
-import {TextLayer, GeoJsonLayer} from '@deck.gl/layers';
-import {CollisionFilterExtension} from '@deck.gl/extensions';
+import {TextLayer, GeoJsonLayer, ScatterplotLayer} from '@deck.gl/layers';
+import {CollisionFilterExtension, DataFilterExtension} from '@deck.gl/extensions';
 import {createContainer, createTestDevice, removeContainer} from './deck-test-utils';
 import {isRenderTestDeviceEnabled} from './render-test-suite';
 
@@ -192,7 +192,7 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
         startIndices,
         attributes: {
           getText: new Uint8Array(Array.from(texts.join('')).map(char => char.charCodeAt(0))),
-          getPosition: {buffer, size: 3}
+          getPosition: {buffer, type: 'float32', size: 3, stride: 12}
         }
       },
       extensions,
@@ -413,5 +413,90 @@ test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
       getCollisionPriority: d => d.priority
     });
     expect(await drawLayers([layer])).toEqual([100]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'rejected labels do not block non-overlapping neighbors',
+  async () => {
+    const layer = new TextLayer({
+      id: 'collision-chain',
+      data: [
+        {position: [-60, 0], text: 'XXXXX', priority: 10},
+        {position: [0, 0], text: 'XXXXX', priority: 20},
+        {position: [60, 0], text: 'XXXXX', priority: 30}
+      ],
+      getSize: 24,
+      fontFamily: 'Arial',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([layer])).toEqual([10, 30]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text placement fills a long chain at different zoom levels',
+  async () => {
+    const layer = new TextLayer({
+      id: 'long-collision-chain',
+      data: Array.from({length: 10}, (_, index) => ({
+        position: [index * 60 - 270, 0],
+        text: 'XXXXX',
+        priority: index
+      })),
+      getSize: 24,
+      fontFamily: 'Arial',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([layer], 0)).toEqual([1, 3, 5, 7, 9]);
+    expect(await drawLayers([layer.clone()], -1)).toEqual([0, 3, 6, 9]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'text placement respects non-text collision priorities',
+  async () => {
+    const text = new TextLayer({
+      id: 'mixed-text',
+      data: [data[0]],
+      getSize: 24,
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    const point = new ScatterplotLayer({
+      id: 'mixed-point',
+      data: [{position: [0, 0], priority: 200}],
+      getRadius: 8,
+      radiusUnits: 'pixels',
+      extensions,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([text, point])).toEqual([200]);
+    expect(
+      await drawLayers([text.clone(), point.clone({data: [{position: [0, 0], priority: -200}]})])
+    ).toEqual([100]);
+  }
+);
+
+test.skipIf(!isRenderTestDeviceEnabled('webgl'))(
+  'filtered text does not reserve placement space',
+  async () => {
+    const layer = new TextLayer({
+      id: 'filtered-collision-text',
+      data,
+      getSize: 24,
+      extensions: [...extensions, new DataFilterExtension({filterSize: 1})],
+      filterRange: [-100, 0],
+      getFilterValue: d => d.priority,
+      pickable: true,
+      getCollisionPriority: d => d.priority
+    });
+    expect(await drawLayers([layer])).toEqual([-100]);
   }
 );


### PR DESCRIPTION
#### Background

Make `CollisionFilterExtension` work with TextLayer's rendered label bounds, including offsets, anchors, multiline layout, rotation, and GeoJSON text. Add optional greedy placement so rejected labels do not prevent separated neighbors from appearing in dense overlap chains.

#### Change List

- Render and test one projected collision rectangle per text label; share visibility across its characters and optional padded background.
- Support binary text attributes without reading character buffers back to create background attributes.
- Keep source-layer picking IDs distinct within a shared collision group, remove display-order depth offsets from priority comparisons, and keep priority depths inside the clipping planes.
- Add `collisionGreedy` (default `false`) to place text in descending priority using GPU-projected bounds and CPU overlap tests. Enabling it on one text layer applies to the text in that collision group.
- Clamp collision priorities to the documented `[-1000, 1000]` range in both GPU filtering and greedy placement.
- Document the new behavior, performance tradeoff, and TextLayer sublayer selection.
- Add a deterministic collision development app, browser matrix, CPU placement tests, TextLayer lifecycle tests, and render regressions.

Fixes:
https://github.com/visgl/deck.gl/issues/8104
https://github.com/visgl/deck.gl/issues/7824

Maybe fixes (untested):
https://github.com/visgl/deck.gl/issues/10486
https://github.com/visgl/deck.gl/issues/6417
https://github.com/visgl/deck.gl/issues/9479
https://github.com/visgl/deck.gl/issues/10386

#### Examples:
offsets, baselines, anchor changes not affecting label collisions:
<img width="1305" height="890" alt="image" src="https://github.com/user-attachments/assets/09e1e391-fa7c-4362-b90a-642fbfcd739c" />

Greedy placement filling a bunch of holes where labels could fit if they weren't colliding with other labels that were already hidden:
<img width="1305" height="890" alt="image" src="https://github.com/user-attachments/assets/50c8280b-d5b3-4ade-bd57-bb4cccc70234" />

Greedy stress test.  A grid of 5000 labels in ascending priority means if they all collide, only the last one will render even though the screen is mostly empty. Greedy mode fixes it
|greedy off|greedy on|
 |----|----|
 |<img width="1995" height="842" alt="image" src="https://github.com/user-attachments/assets/e2d7d7e9-2562-4a03-926d-2d1e00a5c3c9" />|<img width="1995" height="842" alt="image" src="https://github.com/user-attachments/assets/8bf11efe-d8a0-45d1-9952-4fc53a7046f3" />|

Works great with multiline labels
|colllision scale 1|collision scale 1.5|
|---|---|
|<img width="1200" height="842" alt="image" src="https://github.com/user-attachments/assets/82fc3b3a-918f-40ad-99a6-e0b6bb4321af" />|<img width="1200" height="842" alt="image" src="https://github.com/user-attachments/assets/e2105fd2-90f1-4293-8845-3d29cdcb8928" />|

