### PR TITLE
fix(maplibre): sync camera changes made during Deck initialization

### DIFF
--- a/modules/maplibre/src/deck-utils.ts
+++ b/modules/maplibre/src/deck-utils.ts
@@ -159,6 +159,7 @@ export function createMapLibreDeckInstance(map: MapLibreMap, deck: Deck): Deck {
       onLoad?.();
       if (MAPLIBRE_DECK_STATES.get(map) === state) {
         startWatchingMove(map, state);
+        onMapLibreMove(deck, map);
       }
     };
   }

--- a/modules/maplibre/src/deck-utils.ts
+++ b/modules/maplibre/src/deck-utils.ts
@@ -156,11 +156,11 @@ export function createMapLibreDeckInstance(map: MapLibreMap, deck: Deck): Deck {
     startWatchingMove(map, state);
   } else {
     deckProps.onLoad = () => {
-      onLoad?.();
       if (MAPLIBRE_DECK_STATES.get(map) === state) {
         startWatchingMove(map, state);
         onMapLibreMove(deck, map);
       }
+      onLoad?.();
     };
   }
 

--- a/test/modules/maplibre/overlay-startup.spec.ts
+++ b/test/modules/maplibre/overlay-startup.spec.ts
@@ -34,17 +34,40 @@ for (const [version, MapClass] of [
 
       try {
         await new Promise<void>(resolve => map.once('load', () => resolve()));
-        let onLoad: () => void;
+        let resolveLoaded: () => void;
         const loaded = new Promise<void>(resolve => {
-          onLoad = resolve;
+          resolveLoaded = resolve;
         });
-        const overlay = new MapLibreOverlay({interleaved: true, layers: [], onLoad: onLoad!});
+        let viewStateAtLoad: unknown;
+        let projectedAtLoad: number[] = [];
+        let zoomAfterMoveAtLoad: number | undefined;
+        const overlay = new MapLibreOverlay({
+          interleaved: true,
+          layers: [],
+          onLoad: () => {
+            viewStateAtLoad = {...overlay._deck!.props.viewState};
+            projectedAtLoad = overlay._deck!.getViewports()[0].project([9, 48]);
+            map.jumpTo({zoom: 9});
+            zoomAfterMoveAtLoad = overlay._deck!.props.viewState.zoom;
+            resolveLoaded();
+          }
+        });
         map.addControl(overlay);
         expect(overlay._deck!.isInitialized).toBe(false);
 
         map.jumpTo({center: [9, 48], zoom: 8, bearing: 25, pitch: 30});
         await loaded;
 
+        expect(viewStateAtLoad).toMatchObject({
+          longitude: 9,
+          latitude: 48,
+          zoom: 8,
+          bearing: 25,
+          pitch: 30
+        });
+        expect(projectedAtLoad[0]).toBeCloseTo(container.clientWidth / 2);
+        expect(projectedAtLoad[1]).toBeCloseTo(container.clientHeight / 2);
+        expect(zoomAfterMoveAtLoad).toBe(9);
         expect(overlay._deck!.props.viewState).toMatchObject({
           longitude: map.getCenter().lng,
           latitude: map.getCenter().lat,

--- a/test/modules/maplibre/overlay-startup.spec.ts
+++ b/test/modules/maplibre/overlay-startup.spec.ts
@@ -1,0 +1,64 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {MapLibreOverlay} from '@deck.gl/maplibre';
+import {device} from '@deck.gl/test-utils';
+import {Map as MapLibreV4Map} from 'maplibre-gl-v4';
+import {Map as MapLibreV5Map} from 'maplibre-gl-v5';
+import {Map as MapLibreV6Map} from 'maplibre-gl-v6';
+import {expect, test} from 'vitest';
+
+import type {Map as MapLibreMap} from 'maplibre-gl-v6';
+
+const webglTest = device.type === 'webgl' ? test : test.skip;
+
+for (const [version, MapClass] of [
+  ['4.5.1', MapLibreV4Map],
+  ['5.0.0', MapLibreV5Map],
+  ['6.0.0', MapLibreV6Map]
+] as const) {
+  webglTest(
+    `MapLibre ${version} synchronizes camera changes before interleaved Deck loads`,
+    async () => {
+      const container = document.createElement('div');
+      Object.assign(container.style, {width: '400px', height: '300px'});
+      document.body.append(container);
+      const map = new MapClass({
+        container,
+        style: {version: 8, sources: {}, layers: []},
+        center: [8.5, 47.3],
+        zoom: 6,
+        attributionControl: false
+      }) as unknown as MapLibreMap;
+
+      try {
+        await new Promise<void>(resolve => map.once('load', () => resolve()));
+        let onLoad: () => void;
+        const loaded = new Promise<void>(resolve => {
+          onLoad = resolve;
+        });
+        const overlay = new MapLibreOverlay({interleaved: true, layers: [], onLoad: onLoad!});
+        map.addControl(overlay);
+        expect(overlay._deck!.isInitialized).toBe(false);
+
+        map.jumpTo({center: [9, 48], zoom: 8, bearing: 25, pitch: 30});
+        await loaded;
+
+        expect(overlay._deck!.props.viewState).toMatchObject({
+          longitude: map.getCenter().lng,
+          latitude: map.getCenter().lat,
+          zoom: map.getZoom(),
+          bearing: map.getBearing(),
+          pitch: map.getPitch()
+        });
+        const projected = overlay._deck!.getViewports()[0].project([9, 48]);
+        expect(projected[0]).toBeCloseTo(container.clientWidth / 2);
+        expect(projected[1]).toBeCloseTo(container.clientHeight / 2);
+      } finally {
+        map.remove();
+        container.remove();
+      }
+    }
+  );
+}


### PR DESCRIPTION
Interleaved overlays retain their initial camera state if the map moves after `map.addControl(overlay)` but before Deck finishes initializing. For example, an immediate `map.jumpTo(...)` leaves Deck's view state and projected coordinates stale until another camera move.

Refresh the view state and register movement listeners before calling the app's `onLoad` callback. Regression tests cover MapLibre 4.5.1, 5.0.0, and 6.0.0, including camera reads and moves inside `onLoad`. All three fail on master and pass with this fix.

Split from #10697 following [review feedback](https://github.com/visgl/deck.gl/pull/10697#discussion_r3992432072).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interleaved overlay startup ordering and view-state sync; behavior change is narrow but affects all MapLibre interleaved integrations at first paint.
> 
> **Overview**
> Fixes interleaved **MapLibreOverlay** keeping a stale Deck camera when the map moves after `addControl` but before Deck finishes loading.
> 
> In `deck-utils`, the wrapped Deck `onLoad` now **starts move listeners**, runs **`onMapLibreMove`** to pull the current MapLibre view into Deck, and only then invokes the app **`onLoad`**. That way `jumpTo` / camera updates during the init window are reflected in view state and projection before consumer code runs.
> 
> Adds WebGL regression tests (`overlay-startup.spec.ts`) for MapLibre **4.5.1**, **5.0.0**, and **6.0.0** that move the camera before load and assert view state and screen projection inside `onLoad`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfc74978201548b6fa4faa2d8410ef6d8f13a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->